### PR TITLE
fix(security): block SSRF in /api/scanner and /api/osint/whois

### DIFF
--- a/src/app/api/osint/whois/route.ts
+++ b/src/app/api/osint/whois/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { safeFetch } from '@/lib/ssrf-guard';
 
 // WHOIS + Domain Intelligence via RDAP (free, standardized)
 export async function GET(req: Request) {
@@ -46,12 +47,15 @@ export async function GET(req: Request) {
       }
     } catch (e) { console.warn('[OSIRIS] Suppressed error:', e instanceof Error ? e.message : e); }
 
-    // HTTP headers for tech fingerprinting
+    // HTTP headers for tech fingerprinting — go through safeFetch so the
+    // attacker can't aim a HEAD request at internal infrastructure with a
+    // hostname that resolves to a reserved range, or chain a redirect from a
+    // public host to one. Redirects are followed manually with re-validation.
     try {
-      const res = await fetch(`https://${domain}`, {
+      const res = await safeFetch(`https://${domain}`, {
         method: 'HEAD',
         signal: AbortSignal.timeout(5000),
-        redirect: 'follow',
+        maxRedirects: 3,
       });
       const headers: Record<string, string> = {};
       ['server', 'x-powered-by', 'x-frame-options', 'strict-transport-security',

--- a/src/app/api/scanner/route.ts
+++ b/src/app/api/scanner/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { validateHost } from '@/lib/ssrf-guard';
 
 /**
  * OSIRIS — Scanner Proxy (Hardened)
@@ -35,25 +36,12 @@ function isRateLimited(ip: string): boolean {
 }
 
 // ── TARGET VALIDATION ──
-function isPrivateOrReserved(target: string): boolean {
-  // Block scanning of private/internal IPs and localhost
-  const blocked = [
-    /^10\./,
-    /^172\.(1[6-9]|2[0-9]|3[01])\./,
-    /^192\.168\./,
-    /^127\./,
-    /^0\./,
-    /^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\./,  // CGNAT / Tailscale
-    /^169\.254\./,   // Link-local
-    /^224\./,        // Multicast
-    /^255\./,
-    /^localhost$/i,
-    /^host\.docker\.internal$/i,
-    /\.local$/i,
-    /\.internal$/i,
-  ];
-  return blocked.some(re => re.test(target));
-}
+// The string-based regex previously here matched only literal dotted-quad
+// IPv4, missed every IPv6 form, and never resolved hostnames — so an attacker
+// could bypass it with `target=metadata.example.com` (DNS A → 169.254.169.254),
+// `target=2130706433` (decimal 127.0.0.1), or `target=::1`. Validation now
+// canonicalises the input and resolves hostnames before deciding. See
+// `src/lib/ssrf-guard.ts`.
 
 // ── ALLOWED SCAN TYPES (safe subset only) ──
 const ALLOWED_SCANS: Record<string, { endpoint: string; timeout: number }> = {
@@ -100,8 +88,11 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'Missing target parameter' }, { status: 400 });
   }
 
-  // 4. Block private/internal targets
-  if (isPrivateOrReserved(target)) {
+  // 4. Block private/internal targets (DNS-resolves before deciding so a
+  //    hostname pointing at a reserved range is rejected, and IPv6 + non-
+  //    canonical IPv4 forms are no longer free bypasses).
+  const guard = await validateHost(target);
+  if (!guard.ok) {
     return NextResponse.json({
       error: 'Target blocked',
       detail: 'Scanning private, internal, or reserved addresses is not permitted.',

--- a/src/lib/ssrf-guard.ts
+++ b/src/lib/ssrf-guard.ts
@@ -1,0 +1,221 @@
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+/**
+ * SSRF guard shared by route handlers that take a user-controlled host / IP
+ * and turn it into a network request.
+ *
+ * The previous string-based regex in scanner/route.ts only matched literal
+ * IPv4 in dotted-quad form, missed every IPv6 address, and never resolved
+ * hostnames — so `?target=metadata.example.com` (DNS A → 169.254.169.254)
+ * bypassed the gate, and `?target=2130706433` (decimal 127.0.0.1) bypassed it
+ * too.
+ *
+ * Defense is two-layered:
+ *   1. Canonicalise the input. Reject non-dotted-quad IPv4 forms and any
+ *      IPv6 address that falls inside a reserved range.
+ *   2. For hostnames, resolve A + AAAA records and reject if *any* answer
+ *      lands in a reserved range. Total Time-Of-Check / Time-Of-Use defence
+ *      requires IP pinning at the socket layer, but rejecting at lookup time
+ *      blocks every non-rebinding attack and forces a rebinder to win a
+ *      TTL=0 race against the downstream consumer.
+ */
+
+const IPV4_BLOCKS_TEXT: Array<[string, number]> = [
+  ['0.0.0.0', 8],          // "this" network
+  ['10.0.0.0', 8],         // RFC1918
+  ['100.64.0.0', 10],      // CGNAT / Tailscale
+  ['127.0.0.0', 8],        // loopback
+  ['169.254.0.0', 16],     // link-local (incl. cloud metadata 169.254.169.254)
+  ['172.16.0.0', 12],      // RFC1918
+  ['192.0.0.0', 24],       // IETF protocol assignments
+  ['192.0.2.0', 24],       // TEST-NET-1
+  ['192.168.0.0', 16],     // RFC1918
+  ['198.18.0.0', 15],      // benchmarking
+  ['198.51.100.0', 24],    // TEST-NET-2
+  ['203.0.113.0', 24],     // TEST-NET-3
+  ['224.0.0.0', 4],        // multicast
+  ['240.0.0.0', 4],        // reserved (incl. 255.255.255.255 broadcast)
+];
+
+const IPV6_BLOCK_PREFIXES = [
+  '::',           // unspecified
+  '::1',          // loopback
+  '::ffff:',      // IPv4-mapped (covers ::ffff:127.0.0.1, ::ffff:10.x, etc.)
+  '64:ff9b::',    // NAT64
+  '64:ff9b:1:',   // local NAT64
+  '100::',        // discard prefix
+  '2001:db8:',    // documentation
+  'fc',           // unique-local (fc00::/7) — any addr starting with fc/fd
+  'fd',
+  'fe8', 'fe9', 'fea', 'feb', // link-local fe80::/10
+  'fec', 'fed', 'fee', 'fef', // site-local fec0::/10 (deprecated but still routable to internal hosts on some stacks)
+  'ff',           // multicast ff00::/8
+];
+
+function ipv4ToInt(ip: string): number {
+  const parts = ip.split('.').map(Number);
+  // Build the 32-bit value via multiplication so the intermediate stays a
+  // safe positive integer; bitwise OR would coerce to a signed int32.
+  return parts[0] * 0x1000000 + parts[1] * 0x10000 + parts[2] * 0x100 + parts[3];
+}
+
+function ipv4InBlocked(ip: string): boolean {
+  const ipInt = ipv4ToInt(ip);
+  for (const [net, bits] of IPV4_BLOCKS_TEXT) {
+    const netInt = ipv4ToInt(net);
+    // 2^(32-bits) is the size of the block; the "network address" must match
+    // after stripping the host bits.
+    const blockSize = bits === 0 ? 0x100000000 : Math.pow(2, 32 - bits);
+    if (Math.floor(ipInt / blockSize) === Math.floor(netInt / blockSize)) return true;
+  }
+  return false;
+}
+
+function ipv6InBlocked(ip: string): boolean {
+  const lower = ip.toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
+  // Exact-match singletons first
+  if (lower === '::' || lower === '::1') return true;
+  for (const prefix of IPV6_BLOCK_PREFIXES) {
+    if (lower.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns the canonical dotted-quad form if `s` looks like an IPv4 address in
+ * any common notation (dotted-quad, dotted-octal, dotted-hex, decimal, hex
+ * single-int), otherwise null. Non-canonical forms (e.g. `2130706433`,
+ * `0177.0.0.1`, `0x7f.0.0.1`) get rejected at the parse step so callers can
+ * decline them rather than try to figure out what the kernel will resolve.
+ */
+export function parseIPv4(s: string): string | null {
+  // Strict dotted-quad first — fast path
+  if (/^(\d{1,3}\.){3}\d{1,3}$/.test(s)) {
+    const parts = s.split('.').map(Number);
+    if (parts.some(p => p < 0 || p > 255)) return null;
+    return parts.join('.');
+  }
+  // Non-canonical forms (decimal, hex, octal, short notation) — reject. The
+  // call sites here only ever want canonical dotted-quad; anything else is
+  // either an attacker probe or a bug upstream.
+  if (/^\d+$/.test(s)) return null;
+  if (/^0x[0-9a-fA-F]+$/.test(s)) return null;
+  if (/^(\d+\.){0,3}\d+$/.test(s) && s.includes('.')) {
+    // Mixed forms — explicitly reject rather than coerce
+    return null;
+  }
+  return null;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  reason?: string;
+  /** Resolved IPs (literal input or DNS answers). Empty if validation failed before resolution. */
+  resolved?: string[];
+}
+
+/**
+ * Validate that `host` (either an IP literal or a hostname) is safe to use as
+ * a network target. Returns ok=false when the literal IP is in a blocked
+ * range, the IP literal uses a non-canonical form, or any resolved A/AAAA
+ * answer lands in a blocked range.
+ */
+export async function validateHost(host: string): Promise<ValidationResult> {
+  const trimmed = host.trim();
+  if (!trimmed) return { ok: false, reason: 'empty host' };
+
+  // Strip brackets for IPv6 literals like [::1]
+  const bracketed = trimmed.replace(/^\[|\]$/g, '');
+
+  // Reject obvious metadata-style hostnames before they ever hit DNS. These
+  // are independent of which IP they resolve to; the names alone are not
+  // legitimate scan / probe targets.
+  const lowerHost = trimmed.toLowerCase();
+  const NAME_BLOCKLIST = [
+    /^localhost$/i,
+    /\.localhost$/i,
+    /^host\.docker\.internal$/i,
+    /\.local$/i,
+    /\.internal$/i,
+    /^metadata\.google\.internal$/i,
+  ];
+  if (NAME_BLOCKLIST.some(re => re.test(lowerHost))) {
+    return { ok: false, reason: 'hostname matches reserved name pattern' };
+  }
+
+  // Literal IP path
+  const ipFamily = isIP(bracketed);
+  if (ipFamily === 4) {
+    const canonical = parseIPv4(bracketed);
+    if (!canonical) return { ok: false, reason: 'non-canonical IPv4 form rejected' };
+    if (ipv4InBlocked(canonical)) return { ok: false, reason: 'IPv4 in reserved range' };
+    return { ok: true, resolved: [canonical] };
+  }
+  if (ipFamily === 6) {
+    if (ipv6InBlocked(bracketed)) return { ok: false, reason: 'IPv6 in reserved range' };
+    return { ok: true, resolved: [bracketed] };
+  }
+
+  // Hostname — basic syntax check then resolve and re-check
+  if (!/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/.test(trimmed)) {
+    return { ok: false, reason: 'invalid hostname syntax' };
+  }
+
+  let answers: Array<{ address: string; family: number }> = [];
+  try {
+    answers = await lookup(trimmed, { all: true });
+  } catch (err) {
+    return { ok: false, reason: `DNS lookup failed: ${(err as Error).message}` };
+  }
+  if (answers.length === 0) {
+    return { ok: false, reason: 'hostname has no A/AAAA records' };
+  }
+  for (const a of answers) {
+    if (a.family === 4) {
+      if (ipv4InBlocked(a.address)) return { ok: false, reason: `hostname resolves to reserved IPv4 ${a.address}` };
+    } else if (a.family === 6) {
+      if (ipv6InBlocked(a.address)) return { ok: false, reason: `hostname resolves to reserved IPv6 ${a.address}` };
+    }
+  }
+  return { ok: true, resolved: answers.map(a => a.address) };
+}
+
+/**
+ * Wrap a fetch call so that:
+ *   - the URL's host is validated before the request (block private targets)
+ *   - redirects are followed manually, with each hop re-validated (block a
+ *     redirect to a private host from a public-looking original)
+ */
+export async function safeFetch(
+  inputUrl: string,
+  init: RequestInit & { maxRedirects?: number } = {},
+): Promise<Response> {
+  const maxRedirects = init.maxRedirects ?? 3;
+  // Spread into a new init we mutate, then explicitly drop our extra prop
+  // so it isn't passed through to fetch().
+  const passInit: RequestInit & { maxRedirects?: number } = { ...init };
+  delete passInit.maxRedirects;
+  let currentUrl = inputUrl;
+  for (let i = 0; i <= maxRedirects; i++) {
+    let parsed: URL;
+    try { parsed = new URL(currentUrl); } catch { throw new Error('safeFetch: invalid URL'); }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`safeFetch: blocked protocol ${parsed.protocol}`);
+    }
+    const check = await validateHost(parsed.hostname);
+    if (!check.ok) {
+      throw new Error(`safeFetch: blocked target — ${check.reason}`);
+    }
+    const res = await fetch(currentUrl, { ...passInit, redirect: 'manual' });
+    if (res.status >= 300 && res.status < 400) {
+      const loc = res.headers.get('location');
+      if (!loc) return res;
+      const nextUrl = new URL(loc, currentUrl).toString();
+      currentUrl = nextUrl;
+      continue;
+    }
+    return res;
+  }
+  throw new Error('safeFetch: too many redirects');
+}


### PR DESCRIPTION
## Summary

Two API routes — `/api/scanner` and `/api/osint/whois` — turn a user-supplied host into a network request. Both gate the request on a string-regex check that only matches literal dotted-quad IPv4, misses every IPv6 form, and never resolves hostnames. That gate is bypassable today with a hostname whose DNS A record points at a reserved range, a non-canonical IPv4 form (decimal / hex / octal), or an IPv6 literal.

The whois route also calls `fetch(..., { redirect: 'follow' })`, so even when the input host is genuinely public, a 302 to an internal host is silently followed.

This PR adds a single SSRF guard (`src/lib/ssrf-guard.ts`) used by both routes — IPv4 + IPv6 range blocklists plus a hostname validator that does an A+AAAA lookup before deciding, and a `safeFetch` helper that re-validates every redirect hop.

## Impact

**`/api/scanner`** — the proxy in front of the upstream scanner backend. The scanner backend at `SCANNER_URL` is the component that actually opens connections to `target`. The Next.js route is what gates *what targets the backend is asked to scan*. Bypassing the gate turns the scanner into a confused-deputy: an unauthenticated request can ask the backend to scan AWS metadata, a Tailscale-internal host, the operator's own LAN, etc. — using the scanner's network identity, not the attacker's. The previous regex misses:

- `target=metadata.example.com` where DNS A → `169.254.169.254`
- `target=2130706433` (decimal `127.0.0.1`)
- `target=0x7f000001` / `target=0177.0.0.1` (hex / octal IPv4)
- `target=::1`, `target=fe80::1`, `target=::ffff:169.254.169.254` (every IPv6 form)

**`/api/osint/whois`** — does a `HEAD https://${domain}` and returns `status`, `redirected`, `final_url`, and a selection of response headers (`server`, `x-powered-by`, etc.) to the client. With no resolution-time check and `redirect: 'follow'`, an attacker can probe internal hosts by hostname or by chaining a public host that 302s to one. The HEAD response leaks enough to confirm reachability and fingerprint internal services.

Severity: medium. The scanner path needs `SCANNER_KEY` set, and the whois path is HEAD-only — both meaningful mitigations — but the bypass is unauthenticated and the attack surface is reachable today.

## Location

- `src/app/api/scanner/route.ts:103-109` — `isPrivateOrReserved` string-regex check
- `src/app/api/osint/whois/route.ts:51-55` — `fetch(\`https://${domain}\`, { redirect: 'follow' })`

## Fix

- **New file `src/lib/ssrf-guard.ts`**: canonical CIDR-style blocklists for IPv4 (`0/8`, `10/8`, `100.64/10`, `127/8`, `169.254/16`, `172.16/12`, `192.168/16`, `198.18/15`, doc/test ranges, `224/4`, `240/4`) and prefix-matched blocklists for IPv6 (`::`, `::1`, `::ffff:*` IPv4-mapped, `64:ff9b:*` NAT64, `fc*`/`fd*` ULA, `fe8*`/`fe9*`/`fea*`/`feb*` link-local, `ff*` multicast, doc + discard prefixes). Hostname validator does an A+AAAA lookup and rejects if any resolved IP lands in a reserved range.
- **`scanner/route.ts`**: replaces the string regex with `await validateHost(target)`. IPv6, non-canonical IPv4, and hostnames-that-resolve-private are all rejected.
- **`osint/whois/route.ts`**: swaps the raw `fetch(...)` for `safeFetch(...)` which sets `redirect: 'manual'` and re-validates each hop before following.

The new module also blocks reserved names (`localhost`, `*.local`, `*.internal`, `host.docker.internal`, `metadata.google.internal`) so they can't reach DNS in the first place.

## Detected by

Aeon + manual review.
- Severity: medium
- CWE-918 (Server-Side Request Forgery), CWE-1333-adjacent (incomplete validation list)

## Verification

- `npx tsc --noEmit` — clean on the patched tree.
- `npx eslint src/lib/ssrf-guard.ts src/app/api/scanner/route.ts src/app/api/osint/whois/route.ts` — no new errors introduced by these changes (pre-existing `no-explicit-any` baseline preserved; verified against `main` before commit).
- Local sanity script exercising `validateHost` against 33 inputs — every IPv4 reserved range, every common IPv6 reserved form, every non-canonical IPv4 form (decimal `2130706433`, hex `0x7f000001`, octal `0177.0.0.1`), every reserved name (`localhost`, `*.local`, `*.internal`), bracketed IPv6 literals, and a handful of public hostnames as the allow-path control — 33/33 pass.
- No new dependencies; everything resolves through Node's built-in `node:dns/promises` and `node:net`.

The project has no test suite (only `lint` in package.json), so verification is type-check + lint + targeted sanity script.

## Compatibility notes

- `output: 'standalone'` in `next.config.ts` and no `export const runtime = 'edge'` in either route mean both run on the Node.js runtime, where `node:dns/promises` is available.
- The new validator is async; the `scanner` GET handler is already `async` and the whois handler awaits inside its `try` block, so no signature changes propagate.

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
