### PR TITLE
Configure default map view

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ OPENSKY_PASSWORD=your_password
 
 # Optional — satellite tracking
 N2YO_API_KEY=your_key
+
+# Optional — default map starting view
+# Shown values are the built-in defaults.
+NEXT_PUBLIC_OSIRIS_DEFAULT_MAP_LATITUDE=42.70
+NEXT_PUBLIC_OSIRIS_DEFAULT_MAP_LONGITUDE=25.48
+NEXT_PUBLIC_OSIRIS_DEFAULT_MAP_ZOOM=6.5
 ```
 
 > Most features work without any API keys. The platform is designed to be functional out of the box.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import ViewPresets from '@/components/ViewPresets';
 import KeyboardShortcuts from '@/components/KeyboardShortcuts';
 import GlobalStatusBar from '@/components/GlobalStatusBar';
 import LiveAlerts from '@/components/LiveAlerts';
+import { DEFAULT_MAP_VIEW } from '@/config/map';
 
 const OsirisMap = dynamic(() => import('@/components/OsirisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
@@ -58,8 +59,8 @@ export default function Dashboard() {
   const data = dataRef.current;
 
   const [backendStatus, setBackendStatus] = useState<'connecting' | 'connected' | 'error'>('connecting');
-  const [mapView, setMapView] = useState({ zoom: 2.5, latitude: 20 });
-  const [flyToLocation, setFlyToLocation] = useState<{ lat: number; lng: number; ts: number } | null>(null);
+  const [mapView, setMapView] = useState(DEFAULT_MAP_VIEW);
+  const [flyToLocation, setFlyToLocation] = useState<{ lat: number; lng: number; zoom?: number; ts: number } | null>(null);
   const [mouseCoords, setMouseCoords] = useState<{ lat: number; lng: number } | null>(null);
   const [locationLabel, setLocationLabel] = useState('');
   const [regionDossier, setRegionDossier] = useState<any>(null);
@@ -120,8 +121,9 @@ export default function Dashboard() {
     const lon = parseFloat(p.get('lon') || '');
     const zoom = parseFloat(p.get('zoom') || '');
     if (!isNaN(lat) && !isNaN(lon)) {
-      setFlyToLocation({ lat, lng: lon, ts: Date.now() });
-      if (!isNaN(zoom)) setMapView(v => ({ ...v, zoom }));
+      setFlyToLocation({ lat, lng: lon, zoom: !isNaN(zoom) ? zoom : undefined, ts: Date.now() });
+      if (!isNaN(zoom)) setMapView(v => ({ ...v, latitude: lat, longitude: lon, zoom }));
+      else setMapView(v => ({ ...v, latitude: lat, longitude: lon }));
     }
     const layers = p.get('layers');
     if (layers) {
@@ -141,8 +143,8 @@ export default function Dashboard() {
     if (urlTimer.current) clearTimeout(urlTimer.current);
     urlTimer.current = setTimeout(() => {
       const p = new URLSearchParams();
-      p.set('lat', (mouseCoords?.lat ?? mapView.latitude ?? 20).toFixed(4));
-      p.set('lon', (mouseCoords?.lng ?? 0).toFixed(4));
+      p.set('lat', (mouseCoords?.lat ?? mapView.latitude).toFixed(4));
+      p.set('lon', (mouseCoords?.lng ?? mapView.longitude).toFixed(4));
       p.set('zoom', mapView.zoom.toFixed(2));
       const active = Object.entries(activeLayers).filter(([,v]) => v).map(([k]) => k).join(',');
       p.set('layers', active);
@@ -163,7 +165,15 @@ export default function Dashboard() {
       if (e.key === 'l') setShowLayers(p => !p);
       if (e.key === 'm') setShowMarkets(p => !p);
       if (e.key === 'i') setShowIntel(p => !p);
-      if (e.key === 'r') setFlyToLocation({ lat: 20, lng: 0, ts: Date.now() });
+      if (e.key === 'r') {
+        setMapView(DEFAULT_MAP_VIEW);
+        setFlyToLocation({
+          lat: DEFAULT_MAP_VIEW.latitude,
+          lng: DEFAULT_MAP_VIEW.longitude,
+          zoom: DEFAULT_MAP_VIEW.zoom,
+          ts: Date.now(),
+        });
+      }
       if (e.key === 'g') setMapProjection(p => p === 'globe' ? 'mercator' : 'globe');
     };
     window.addEventListener('keydown', handler);
@@ -543,7 +553,7 @@ export default function Dashboard() {
                 <div><div className="hud-label">NUCLEAR</div><div className="hud-value text-[10px]" style={{ color: '#76FF03' }}>{(data.infrastructure?.length||0)}</div></div>
               </div>
             </motion.div>
-            <ViewPresets onNavigate={(lat, lng, zoom) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMapView(v => ({ ...v, zoom })); }} />
+            <ViewPresets onNavigate={(lat, lng, zoom) => { setFlyToLocation({ lat, lng, zoom, ts: Date.now() }); setMapView(v => ({ ...v, latitude: lat, longitude: lng, zoom })); }} />
           </>
         )}
         {showMarkets && <MarketsPanel data={data} spaceWeather={spaceWeather} />}
@@ -713,7 +723,7 @@ export default function Dashboard() {
                       </div>
                       <LayerPanel data={data} activeLayers={activeLayers} setActiveLayers={setActiveLayers} />
                       <div className="mt-2">
-                        <ViewPresets onNavigate={(lat, lng, zoom) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMapView(v => ({ ...v, zoom })); setMobilePanel(null); }} />
+                        <ViewPresets onNavigate={(lat, lng, zoom) => { setFlyToLocation({ lat, lng, zoom, ts: Date.now() }); setMapView(v => ({ ...v, latitude: lat, longitude: lng, zoom })); setMobilePanel(null); }} />
                       </div>
                     </>
                   )}

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback, memo } from 'react';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import { DEFAULT_MAP_VIEW } from '@/config/map';
 
 interface OsirisMapProps {
   data: any;
@@ -10,8 +11,8 @@ interface OsirisMapProps {
   onEntityClick?: (entity: any) => void;
   onMouseCoords?: (coords: { lat: number; lng: number }) => void;
   onRightClick?: (coords: { lat: number; lng: number }) => void;
-  onViewStateChange?: (vs: { zoom: number; latitude: number }) => void;
-  flyToLocation?: { lat: number; lng: number; ts: number } | null;
+  onViewStateChange?: (vs: { zoom: number; latitude: number; longitude: number }) => void;
+  flyToLocation?: { lat: number; lng: number; zoom?: number; ts: number } | null;
   projection?: 'mercator' | 'globe';
   mapStyle?: string;
 }
@@ -86,7 +87,10 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     const map = new maplibregl.Map({
       container: containerRef.current,
       style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
-      center: [25.48, 42.70], zoom: 6.5, minZoom: 1.5, maxZoom: 18,
+      center: [DEFAULT_MAP_VIEW.longitude, DEFAULT_MAP_VIEW.latitude],
+      zoom: DEFAULT_MAP_VIEW.zoom,
+      minZoom: 1.5,
+      maxZoom: 18,
       attributionControl: false,
       maxPitch: 85,
     });
@@ -379,7 +383,10 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       }
     });
     map.on('contextmenu', e => { e.preventDefault(); onRightClick?.({ lat: e.lngLat.lat, lng: e.lngLat.lng }); });
-    map.on('moveend', () => { const c = map.getCenter(); onViewStateChange?.({ zoom: map.getZoom(), latitude: c.lat }); });
+    map.on('moveend', () => {
+      const c = map.getCenter();
+      onViewStateChange?.({ zoom: map.getZoom(), latitude: c.lat, longitude: c.lng });
+    });
 
     // ── POPUP HELPER ──
     const popup = (coords: any, html: string) => {
@@ -830,7 +837,11 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   // Fly-to
   useEffect(() => {
     if (!mapReady || !mapRef.current || !flyToLocation) return;
-    mapRef.current.flyTo({ center: [flyToLocation.lng, flyToLocation.lat], zoom: 8, duration: 2000 });
+    mapRef.current.flyTo({
+      center: [flyToLocation.lng, flyToLocation.lat],
+      zoom: flyToLocation.zoom ?? DEFAULT_MAP_VIEW.zoom,
+      duration: 2000,
+    });
   }, [mapReady, flyToLocation]);
 
   // Dynamic projection switching (lightweight — no terrain DEM)

--- a/src/components/SharePanel.tsx
+++ b/src/components/SharePanel.tsx
@@ -3,9 +3,10 @@
 import { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Share2, Copy, Check, Link2, X, Globe, MapPin } from 'lucide-react';
+import { DEFAULT_MAP_VIEW } from '@/config/map';
 
 interface SharePanelProps {
-  mapView: { zoom: number; latitude: number; longitude?: number };
+  mapView: { zoom: number; latitude: number; longitude: number };
   activeLayers: Record<string, boolean>;
   mouseCoords?: { lat: number; lng: number } | null;
 }
@@ -16,8 +17,8 @@ export default function SharePanel({ mapView, activeLayers, mouseCoords }: Share
 
   const generateShareUrl = useCallback(() => {
     const params = new URLSearchParams();
-    const lat = mouseCoords?.lat ?? mapView.latitude ?? 20;
-    const lng = mouseCoords?.lng ?? mapView.longitude ?? 0;
+    const lat = mouseCoords?.lat ?? mapView.latitude ?? DEFAULT_MAP_VIEW.latitude;
+    const lng = mouseCoords?.lng ?? mapView.longitude ?? DEFAULT_MAP_VIEW.longitude;
     params.set('lat', lat.toFixed(4));
     params.set('lon', lng.toFixed(4));
     params.set('zoom', mapView.zoom.toFixed(2));

--- a/src/config/map.ts
+++ b/src/config/map.ts
@@ -1,0 +1,32 @@
+const FALLBACK_MAP_VIEW = {
+  latitude: 42.70,
+  longitude: 25.48,
+  zoom: 6.5,
+};
+
+function readNumber(value: string | undefined, fallback: number, min: number, max: number) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) return fallback;
+  return parsed;
+}
+
+export const DEFAULT_MAP_VIEW = {
+  latitude: readNumber(
+    process.env.NEXT_PUBLIC_OSIRIS_DEFAULT_MAP_LATITUDE,
+    FALLBACK_MAP_VIEW.latitude,
+    -90,
+    90,
+  ),
+  longitude: readNumber(
+    process.env.NEXT_PUBLIC_OSIRIS_DEFAULT_MAP_LONGITUDE,
+    FALLBACK_MAP_VIEW.longitude,
+    -180,
+    180,
+  ),
+  zoom: readNumber(
+    process.env.NEXT_PUBLIC_OSIRIS_DEFAULT_MAP_ZOOM,
+    FALLBACK_MAP_VIEW.zoom,
+    1.5,
+    18,
+  ),
+};


### PR DESCRIPTION
## Summary
- add env-backed default map view configuration
- use the shared default for initial map state, reset, share links, and fly-to zoom handling
- document the optional NEXT_PUBLIC_OSIRIS_DEFAULT_MAP_* variables

## Tests
- npx tsc --noEmit
- npx eslint src/config/map.ts src/components/SharePanel.tsx

## Notes
- npm run lint still fails due pre-existing repository-wide lint debt unrelated to this change.