### PR TITLE
feat(osint): add crypto wallet tracing tab

### DIFF
--- a/src/app/api/osint/crypto/route.ts
+++ b/src/app/api/osint/crypto/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse } from 'next/server';
+import { isRateLimited, getClientIp } from '@/lib/ssrf-guard';
+import { isSanctioned } from '@/lib/ofac-crypto';
+
+// Crypto wallet intelligence — BTC via blockstream.info, ETH via Blockscout
+// (free, no key for either). Cross-checks the OFAC SDN sanctioned crypto
+// address lists and flags hits with the source so the UI can warn the user.
+
+const BTC_RE = /^([13][a-km-zA-HJ-NP-Z1-9]{25,34}|bc1[ac-hj-np-z02-9]{11,87})$/;
+const ETH_RE = /^0x[a-fA-F0-9]{40}$/;
+
+type Chain = 'BTC' | 'ETH';
+
+function detectChain(addr: string): Chain | null {
+  if (ETH_RE.test(addr)) return 'ETH';
+  if (BTC_RE.test(addr)) return 'BTC';
+  return null;
+}
+
+async function lookupBTC(address: string) {
+  const res = await fetch(`https://blockstream.info/api/address/${address}`, {
+    signal: AbortSignal.timeout(8000),
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) throw new Error(`blockstream HTTP ${res.status}`);
+  const d = await res.json();
+
+  const chainStats = d.chain_stats || {};
+  const memStats = d.mempool_stats || {};
+  const funded = (chainStats.funded_txo_sum || 0) + (memStats.funded_txo_sum || 0);
+  const spent = (chainStats.spent_txo_sum || 0) + (memStats.spent_txo_sum || 0);
+  const txCount = (chainStats.tx_count || 0) + (memStats.tx_count || 0);
+  const balanceSats = funded - spent;
+
+  // Blockstream `/txs` returns at most the latest 25 confirmed txs per call.
+  // For high-volume addresses this means `first_seen` reflects the start of
+  // the most recent activity window rather than the absolute first tx —
+  // good enough for a quick lookup, full history is a future enhancement.
+  let firstSeen: string | undefined;
+  let lastSeen: string | undefined;
+  try {
+    const txRes = await fetch(`https://blockstream.info/api/address/${address}/txs`, {
+      signal: AbortSignal.timeout(8000),
+    });
+    if (txRes.ok) {
+      const txs = (await txRes.json()) as Array<{ status?: { block_time?: number } }>;
+      const times = txs.map((t) => t.status?.block_time).filter((t): t is number => !!t);
+      if (times.length) {
+        lastSeen = new Date(Math.max(...times) * 1000).toISOString();
+        firstSeen = new Date(Math.min(...times) * 1000).toISOString();
+      }
+    }
+  } catch (e) {
+    console.warn('[OSIRIS] BTC tx history fetch failed:', e instanceof Error ? e.message : e);
+  }
+
+  return {
+    chain: 'BTC' as const,
+    balance: (balanceSats / 1e8).toFixed(8),
+    balance_unit: 'BTC',
+    balance_satoshis: balanceSats,
+    tx_count: txCount,
+    total_received: (funded / 1e8).toFixed(8),
+    total_sent: (spent / 1e8).toFixed(8),
+    first_seen: firstSeen,
+    last_seen: lastSeen,
+    explorer: `https://blockstream.info/address/${address}`,
+  };
+}
+
+// ETH lookup via Blockscout — open source, keyless explorer
+// (https://github.com/blockscout/blockscout). Uses the Etherscan-compatible
+// v1 API for balance + tx history and the v2 counters endpoint for tx_count.
+const BLOCKSCOUT_BASE = 'https://eth.blockscout.com';
+
+async function lookupETH(address: string) {
+  const [balRes, firstTxRes, lastTxRes, countersRes] = await Promise.all([
+    fetch(`${BLOCKSCOUT_BASE}/api?module=account&action=balance&address=${address}`, {
+      signal: AbortSignal.timeout(8000),
+    }),
+    fetch(`${BLOCKSCOUT_BASE}/api?module=account&action=txlist&address=${address}&page=1&offset=1&sort=asc`, {
+      signal: AbortSignal.timeout(8000),
+    }),
+    fetch(`${BLOCKSCOUT_BASE}/api?module=account&action=txlist&address=${address}&page=1&offset=1&sort=desc`, {
+      signal: AbortSignal.timeout(8000),
+    }),
+    fetch(`${BLOCKSCOUT_BASE}/api/v2/addresses/${address}/counters`, {
+      signal: AbortSignal.timeout(8000),
+    }),
+  ]);
+
+  if (!balRes.ok) throw new Error(`blockscout balance HTTP ${balRes.status}`);
+  const balData = await balRes.json();
+  const weiStr: string = balData?.result || '0';
+  const wei = BigInt(/^\d+$/.test(weiStr) ? weiStr : '0');
+  const eth = Number(wei) / 1e18;
+
+  let firstSeen: string | undefined;
+  let lastSeen: string | undefined;
+  if (firstTxRes.ok) {
+    const d = await firstTxRes.json();
+    const ts = d?.result?.[0]?.timeStamp;
+    if (ts) firstSeen = new Date(Number(ts) * 1000).toISOString();
+  }
+  if (lastTxRes.ok) {
+    const d = await lastTxRes.json();
+    const ts = d?.result?.[0]?.timeStamp;
+    if (ts) lastSeen = new Date(Number(ts) * 1000).toISOString();
+  }
+
+  let txCount = 0;
+  if (countersRes.ok) {
+    const d = await countersRes.json();
+    if (d?.transactions_count) txCount = parseInt(d.transactions_count, 10) || 0;
+  }
+
+  return {
+    chain: 'ETH' as const,
+    balance: eth.toFixed(8),
+    balance_unit: 'ETH',
+    balance_wei: wei.toString(),
+    tx_count: txCount,
+    first_seen: firstSeen,
+    last_seen: lastSeen,
+    explorer: `${BLOCKSCOUT_BASE}/address/${address}`,
+  };
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const address = (searchParams.get('address') || '').trim();
+  const chainParam = (searchParams.get('chain') || 'auto').toUpperCase();
+
+  if (!address) {
+    return NextResponse.json({ error: 'Missing address parameter' }, { status: 400 });
+  }
+
+  const clientIp = getClientIp(req);
+  if (isRateLimited(clientIp, 20, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  let chain: Chain | null;
+  if (chainParam === 'AUTO') {
+    chain = detectChain(address);
+  } else if (chainParam === 'BTC' || chainParam === 'ETH') {
+    chain = chainParam;
+    const valid = chain === 'BTC' ? BTC_RE.test(address) : ETH_RE.test(address);
+    if (!valid) {
+      return NextResponse.json({ error: `Invalid ${chain} address format` }, { status: 400 });
+    }
+  } else {
+    return NextResponse.json({ error: 'Unsupported chain (use BTC, ETH, or auto)' }, { status: 400 });
+  }
+
+  if (!chain) {
+    return NextResponse.json({ error: 'Unrecognized address format' }, { status: 400 });
+  }
+
+  try {
+    const [data, sanctions] = await Promise.all([
+      chain === 'BTC' ? lookupBTC(address) : lookupETH(address),
+      isSanctioned(address, chain),
+    ]);
+
+    return NextResponse.json({
+      address,
+      ...data,
+      sanctioned: sanctions.sanctioned,
+      sanctions: sanctions.sanctioned ? { source: sanctions.source, list: chain } : null,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (e) {
+    return NextResponse.json(
+      { error: 'Crypto lookup failed', detail: e instanceof Error ? e.message : String(e) },
+      { status: 502 }
+    );
+  }
+}

--- a/src/components/OsintPanel.tsx
+++ b/src/components/OsintPanel.tsx
@@ -7,7 +7,7 @@ import {
   ChevronDown, ChevronUp, Loader2, AlertTriangle, Server,
   Wifi, Lock, MapPin, Bug, Code, Layers, Network, Fingerprint,
   CheckCircle, XCircle, Clock, ExternalLink, Crosshair,
-  Maximize2, Minimize2
+  Maximize2, Minimize2, Bitcoin
 } from 'lucide-react';
 
 const TABS = [
@@ -22,6 +22,7 @@ const TABS = [
   { id: 'ssl', label: 'SSL/TLS', icon: Shield, placeholder: 'Domain name', color: '#76FF03' },
   { id: 'subdomains', label: 'SUBDOMAINS', icon: Layers, placeholder: 'Domain to enumerate', color: '#00BCD4' },
   { id: 'tech', label: 'TECH DETECT', icon: Fingerprint, placeholder: 'URL to fingerprint', color: '#9C27B0' },
+  { id: 'crypto', label: 'CRYPTO TRACE', icon: Bitcoin, placeholder: 'BTC or ETH address', color: '#F7931A' },
   { id: 'sweep', label: 'IP SWEEP', icon: Crosshair, placeholder: 'Enter IP address (e.g. 8.8.8.8)', color: '#FF3D3D' },
 ];
 
@@ -106,6 +107,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
         case 'ssl': url = `/api/scanner?target=${encodeURIComponent(query)}&type=ssl`; break;
         case 'subdomains': url = `/api/scanner?target=${encodeURIComponent(query)}&type=subdomains`; break;
         case 'tech': url = `/api/scanner?target=${encodeURIComponent(query)}&type=tech`; break;
+        case 'crypto': url = `/api/osint/crypto?address=${encodeURIComponent(query)}`; break;
       }
       const res = await fetch(url);
       const data = await res.json();
@@ -114,7 +116,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
         setHistory(prev => [{ tab: activeTab, query, time: new Date().toLocaleTimeString() }, ...prev.slice(0, 9)]);
         
         // Geolocate the target in the background
-        if (activeTab !== 'sweep' && activeTab !== 'vuln') {
+        if (activeTab !== 'sweep' && activeTab !== 'vuln' && activeTab !== 'crypto') {
           fetch(`/api/osint/ip?ip=${encodeURIComponent(query)}`)
             .then(r => r.json())
             .then(locData => {
@@ -344,6 +346,41 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           <ResultRow label="Expires" value={r.expires || r.not_after} />
           <ResultRow label="SANs" value={Array.isArray(r.sans) ? r.sans.join(', ') : r.sans} />
           {renderFallback()}
+        </div>
+      );
+    }
+
+    // ── CRYPTO ──
+    if (activeTab === 'crypto') {
+      const sanctioned = !!r.sanctioned;
+      return (
+        <div>
+          <SectionHeader title="CRYPTO WALLET INTELLIGENCE" icon={Bitcoin} color="#F7931A" />
+          {sanctioned && (
+            <div className="mb-2 px-2 py-1.5 rounded border border-red-500/40 bg-red-500/15 flex items-center gap-2">
+              <AlertTriangle className="w-3.5 h-3.5 text-red-400" />
+              <span className="text-[10px] font-mono font-bold text-red-400 tracking-wider">
+                SANCTIONED — {r.sanctions?.source || 'OFAC SDN'}
+              </span>
+            </div>
+          )}
+          <ResultRow label="Address" value={r.address} color="#F7931A" />
+          <ResultRow label="Chain" value={r.chain} color={r.chain === 'BTC' ? '#F7931A' : '#627EEA'} />
+          <ResultRow label="Balance" value={`${r.balance} ${r.balance_unit}`} />
+          <ResultRow label="TX Count" value={r.tx_count} />
+          {r.total_received !== undefined && <ResultRow label="Total Recv" value={`${r.total_received} ${r.balance_unit}`} />}
+          {r.total_sent !== undefined && <ResultRow label="Total Sent" value={`${r.total_sent} ${r.balance_unit}`} />}
+          <ResultRow label="First Seen" value={r.first_seen} />
+          <ResultRow label="Last Seen" value={r.last_seen} />
+          {r.explorer && (
+            <div className="mt-2">
+              <a href={r.explorer} target="_blank" rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-[10px] font-mono text-[#F7931A] hover:underline">
+                <ExternalLink className="w-2.5 h-2.5" /> Open in block explorer
+              </a>
+            </div>
+          )}
+          {renderFallbackExcluding(['address','chain','balance','balance_unit','balance_satoshis','balance_wei','tx_count','total_received','total_sent','first_seen','last_seen','explorer','sanctioned','sanctions','timestamp'])}
         </div>
       );
     }

--- a/src/lib/ofac-crypto.ts
+++ b/src/lib/ofac-crypto.ts
@@ -1,0 +1,68 @@
+/**
+ * OFAC sanctioned crypto address lookup.
+ *
+ * Source: the community-maintained mirror at
+ * https://github.com/0xB10C/ofac-sanctioned-digital-currency-addresses, which
+ * tracks the Treasury SDN list additions/removals as flat per-chain JSON
+ * arrays. The raw lists are small (low-tens of KB) so we load them whole and
+ * keep a lowercased `Set` for O(1) membership checks.
+ *
+ * The cache is filled lazily on the first lookup per chain and refreshed
+ * every 24h. A second concurrent request that arrives while a fetch is in
+ * flight waits on the same promise (single-flight) to avoid duplicate work.
+ * If a refresh fails after the cache has gone stale we keep serving the
+ * previous snapshot rather than blinding the route — a false negative on
+ * brand-new sanctions is preferable to a sudden gap in coverage.
+ */
+
+const SOURCES: Record<string, string> = {
+  BTC: 'https://raw.githubusercontent.com/0xB10C/ofac-sanctioned-digital-currency-addresses/lists/sanctioned_addresses_BTC.json',
+  ETH: 'https://raw.githubusercontent.com/0xB10C/ofac-sanctioned-digital-currency-addresses/lists/sanctioned_addresses_ETH.json',
+};
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+type ChainList = { fetchedAt: number; set: Set<string> };
+const cache: Record<string, ChainList> = {};
+const inflight: Record<string, Promise<ChainList> | undefined> = {};
+
+async function loadList(chain: 'BTC' | 'ETH'): Promise<ChainList> {
+  const cached = cache[chain];
+  if (cached && Date.now() - cached.fetchedAt < TTL_MS) return cached;
+  if (inflight[chain]) return inflight[chain]!;
+
+  inflight[chain] = (async () => {
+    try {
+      const res = await fetch(SOURCES[chain], { signal: AbortSignal.timeout(8000) });
+      if (!res.ok) throw new Error(`OFAC list ${chain} HTTP ${res.status}`);
+      const arr = (await res.json()) as string[];
+      const set = new Set(arr.map((a) => a.toLowerCase()));
+      const entry = { fetchedAt: Date.now(), set };
+      cache[chain] = entry;
+      return entry;
+    } catch (e) {
+      // On failure, keep stale data if any to avoid leaving the route blind.
+      if (cached) return cached;
+      throw e;
+    } finally {
+      inflight[chain] = undefined;
+    }
+  })();
+
+  return inflight[chain]!;
+}
+
+export async function isSanctioned(
+  address: string,
+  chain: 'BTC' | 'ETH'
+): Promise<{ sanctioned: boolean; source?: string }> {
+  try {
+    const list = await loadList(chain);
+    if (list.set.has(address.toLowerCase())) {
+      return { sanctioned: true, source: 'OFAC SDN' };
+    }
+    return { sanctioned: false };
+  } catch {
+    return { sanctioned: false };
+  }
+}


### PR DESCRIPTION
## Summary
Adds a **CRYPTO TRACE** tab to the RECON toolkit that resolves BTC and ETH wallet addresses against fully keyless, open-source data sources and flags addresses that appear on the OFAC SDN sanctions list.

## Why
- Crypto wallet intelligence is a core OSINT pivot (ransomware payments, sanctioned actor tracing, exchange flows).
- The platform claims to be a real OSINT dashboard but had no on-chain capability.
- All upstream sources are public and keyless to honour the project's "works fully without any API keys" promise.

## Data sources (all keyless, open source)
| Chain | Source | Notes |
|-------|--------|-------|
| BTC | blockstream.info Esplora API | Public, generous rate limits |
| ETH | eth.blockscout.com (v1 Etherscan-compatible + v2 counters) | Self-hosted instance of the open-source [Blockscout](https://github.com/blockscout/blockscout) explorer |
| Sanctions | [0xB10C/ofac-sanctioned-digital-currency-addresses](https://github.com/0xB10C/ofac-sanctioned-digital-currency-addresses) | Community-maintained mirror of OFAC SDN crypto additions |

## What's in the PR
- `src/app/api/osint/crypto/route.ts` — `GET /api/osint/crypto?address=…` with auto chain detection (BTC regex / ETH `0x…`), rate-limited via the existing `ssrf-guard` helpers
- `src/lib/ofac-crypto.ts` — single-flight, 24h-TTL cached loader for the OFAC lists
- `src/components/OsintPanel.tsx` — `CRYPTO TRACE` tab + dedicated result renderer with a red `SANCTIONED — OFAC SDN` badge

## Response shape
```json
{
  "address": "0x...",
  "chain": "ETH",
  "balance": "5.67690954",
  "balance_unit": "ETH",
  "tx_count": 78232,
  "first_seen": "2015-09-28T08:24:43.000Z",
  "last_seen": "2026-05-23T01:15:59.000Z",
  "explorer": "https://eth.blockscout.com/address/0x...",
  "sanctioned": false,
  "sanctions": null,
  "timestamp": "2026-05-24T03:57:40.973Z"
}
```

## Test plan
- [ ] BTC genesis address (`1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa`) — returns balance, tx count, explorer link, `sanctioned: false`
- [ ] ETH high-volume address (`0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`) — returns ~5.67 ETH, 78k+ txs, `sanctioned: false`
- [ ] ETH sanctioned address (`0x0330070FD38Ec3bB94F58FA55D40368271E9e54A`) — returns `sanctioned: true`, `sanctions.source: "OFAC SDN"`, panel shows red badge
- [ ] Invalid address — returns 400 with `Unrecognized address format`
- [ ] Rate limit kicks in after 20 req/min from the same client IP

## Known limitations / future work
- Blockstream `/txs` returns only the latest 25 confirmed txs; for high-volume BTC addresses `first_seen` reflects the most recent activity window rather than the absolute first tx. Full history pagination is left for a follow-up.
- No transaction graph / counterparty expansion yet.
- No mainnet beyond BTC/ETH yet (Tron, Solana, Monero deferred).

## Out of scope
- No new dependencies, no new env vars, no schema changes.
