### PR TITLE
feat(map): add Telegram public-channel OSINT layer

### DIFF
--- a/src/app/api/telegram-feed/route.ts
+++ b/src/app/api/telegram-feed/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from 'next/server';
+import { fetchChannel, type TelegramPost } from '@/lib/telegram-scraper';
+import { geoparse, hasConflictKeyword } from '@/lib/geo-dict';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * OSIRIS — Telegram Public-Channel OSINT Feed.
+ *
+ * Aggregates the most recent text posts from a curated set of public
+ * Telegram channels (war reporting, fact-checking, geopolitics), filters
+ * to posts mentioning conflict-relevant keywords, and geoparses them
+ * against the shared place dictionary so they can be plotted on the map.
+ *
+ * All data is fetched via the unauthenticated web preview at `t.me/s/…`
+ * — no Telegram Bot API token, no MTProto API ID, no key of any kind.
+ *
+ * The default channel list can be overridden by setting the
+ * `OSIRIS_TELEGRAM_CHANNELS` env var to a comma-separated list of
+ * channel usernames (without `@`).
+ */
+
+// Balanced default set: multi-source aggregators + one official source
+// from each side of the Ukraine war so the layer surfaces both viewpoints
+// rather than a single narrative. Operators can override via the
+// `OSIRIS_TELEGRAM_CHANNELS` env var.
+const DEFAULT_CHANNELS = [
+  'osintdefender',    // Prominent English-language OSINT aggregator
+  'insiderpaper',     // English breaking-news wire
+  'aljazeeraenglish', // Al Jazeera English — Middle East coverage
+  'nexta_live',       // Belarus / Ukraine OSINT (Cyrillic, multilingual)
+  'war_monitor',      // Ukrainian-language war updates
+];
+
+const POSTS_PER_CHANNEL = 15;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+type CacheEntry = { fetchedAt: number; posts: TelegramPost[] };
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<TelegramPost[]>>();
+
+function activeChannels(): string[] {
+  const env = process.env.OSIRIS_TELEGRAM_CHANNELS;
+  if (!env) return DEFAULT_CHANNELS;
+  return env
+    .split(',')
+    .map((s) => s.trim().replace(/^@/, ''))
+    .filter(Boolean);
+}
+
+async function getChannelCached(channel: string): Promise<TelegramPost[]> {
+  const cached = cache.get(channel);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.posts;
+  }
+  const pending = inflight.get(channel);
+  if (pending) return pending;
+
+  const p = (async () => {
+    try {
+      const posts = await fetchChannel(channel, POSTS_PER_CHANNEL);
+      cache.set(channel, { fetchedAt: Date.now(), posts });
+      return posts;
+    } catch (e) {
+      console.warn(
+        '[OSIRIS] Telegram channel fetch failed:',
+        channel,
+        e instanceof Error ? e.message : e
+      );
+      // Serve stale on transient failure rather than blinding the layer.
+      return cached?.posts ?? [];
+    } finally {
+      inflight.delete(channel);
+    }
+  })();
+
+  inflight.set(channel, p);
+  return p;
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const filterConflict = searchParams.get('all') !== '1';
+
+  const channels = activeChannels();
+  const channelResults = await Promise.all(channels.map(getChannelCached));
+
+  const events: Array<{
+    id: string;
+    lat: number;
+    lng: number;
+    name: string;
+    url: string;
+    html: string;
+    channel: string;
+    datetime: string;
+    type: 'telegram';
+  }> = [];
+
+  for (const posts of channelResults) {
+    for (const post of posts) {
+      if (filterConflict && !hasConflictKeyword(post.text)) continue;
+      const match = geoparse(post.text, 0.6);
+      if (!match) continue;
+
+      const headline = post.text.slice(0, 140).replace(/\s+/g, ' ').trim();
+      events.push({
+        id: `telegram-${post.id.replace('/', '-')}`,
+        lat: match.coords[1],
+        lng: match.coords[0],
+        name: `[@${post.channel}] ${headline}`,
+        url: post.url,
+        html: `<b>@${post.channel}</b><br/>${headline}<br/><a href="${post.url}" target="_blank">Open on Telegram</a>`,
+        channel: post.channel,
+        datetime: post.datetime,
+        type: 'telegram',
+      });
+    }
+  }
+
+  return NextResponse.json(
+    {
+      events,
+      total: events.length,
+      channels,
+      timestamp: new Date().toISOString(),
+      source: 'Telegram public channels (t.me/s)',
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+      },
+    }
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -125,6 +125,7 @@ export default function Dashboard() {
     radiation: false,
     infrastructure: false,
     global_incidents: true,
+    telegram_intel: false,
     war_alerts: false,
     gps_jamming: false,
     day_night: true,
@@ -348,6 +349,11 @@ export default function Dashboard() {
     if (activeLayers.global_incidents && !layerFetchedRef.current.has('gdelt')) {
       fetchEndpoint('/api/gdelt', d => ({ gdelt: d.events }));
       layerFetchedRef.current.add('gdelt');
+    }
+    // Telegram OSINT public-channel feed
+    if (activeLayers.telegram_intel && !layerFetchedRef.current.has('telegram')) {
+      fetchEndpoint('/api/telegram-feed', d => ({ telegram: d.events }));
+      layerFetchedRef.current.add('telegram');
     }
 
   }, [activeLayers]);

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -5,7 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import {
   Plane, Satellite, Activity, Globe, Radio, Eye,
   Shield, Sun, AlertTriangle, Camera, Flame, Target,
-  CloudLightning, Radiation, Tv, Anchor, Ship, Newspaper,
+  CloudLightning, Radiation, Tv, Anchor, Ship, Newspaper, Send,
   ChevronDown, ChevronUp, ToggleLeft, ToggleRight,
 } from 'lucide-react';
 
@@ -44,6 +44,7 @@ const LAYER_GROUPS = [
       { key: 'cctv', label: 'CCTV Cameras', icon: Camera, color: '#39FF14', dataKey: 'cameras' },
       { key: 'live_news', label: 'Live News Feeds', icon: Tv, color: '#FF4081', dataKey: 'live_feeds' },
       { key: 'news_intel', label: 'SIGINT News (RSS)', icon: Newspaper, color: '#D4AF37', dataKey: 'news' },
+      { key: 'telegram_intel', label: 'Telegram OSINT', icon: Send, color: '#00BFFF', dataKey: 'telegram' },
     ],
   },
   {

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -109,7 +109,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       createDot(map, 'dot-cctv', '#39FF14', 10);
 
       // Sources
-      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets'];
+      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','telegram','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets'];
       sources.forEach(s => map.addSource(s, { type: 'geojson', data: EMPTY_FC }));
 
       // ── CONFLICT ZONES — small warning markers (not polygons) ──
@@ -221,6 +221,17 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       // GDELT
       map.addLayer({ id: 'gdelt-dots', type: 'circle', source: 'gdelt', paint: {
         'circle-radius': 4, 'circle-color': '#FF3D3D', 'circle-opacity': 0.5, 'circle-stroke-width': 1, 'circle-stroke-color': '#FF3D3D', 'circle-stroke-opacity': 0.3,
+      }});
+
+      // Telegram OSINT feed — geoparsed posts from public channels
+      map.addLayer({ id: 'telegram-glow', type: 'circle', source: 'telegram', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,6, 5,10, 10,16],
+        'circle-color': '#00BFFF', 'circle-opacity': 0.12, 'circle-blur': 1,
+      }});
+      map.addLayer({ id: 'telegram-dots', type: 'circle', source: 'telegram', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,3.5, 5,5, 10,7],
+        'circle-color': '#00BFFF', 'circle-opacity': 0.85,
+        'circle-stroke-width': 1, 'circle-stroke-color': '#00BFFF', 'circle-stroke-opacity': 0.4,
       }});
 
       // GPS Jamming
@@ -564,6 +575,24 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       </div>`);
     });
 
+    // ── Telegram OSINT feed (geoparsed public-channel posts) ──
+    map.on('click', 'telegram-dots', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      const channel = p.channel || 'channel';
+      const when = p.datetime ? new Date(p.datetime).toUTCString() : '';
+      popup(coords, `<div style="${pStyle}border:1px solid rgba(0,191,255,0.35);">
+        <div style="color:#00BFFF;font-size:12px;font-weight:700;margin-bottom:6px;">✉️ TELEGRAM @${channel}</div>
+        <div style="font-size:9px;color:#E8E6E0;margin-bottom:8px;line-height:1.4;">${p.name||'(no text)'}</div>
+        ${when ? `<div style="font-size:8px;color:#5C5A54;margin-bottom:8px;">${when}</div>` : ''}
+        <div style="display:flex;gap:6px;">
+          ${p.url ? `<a href="${p.url}" target="_blank" style="${linkStyle}color:#00BFFF;border:1px solid rgba(0,191,255,0.4);background:rgba(0,191,255,0.1);">OPEN POST</a>` : ''}
+          <a href="https://www.google.com/maps/@${coords[1]},${coords[0]},12z" target="_blank" style="${linkStyle}color:#448AFF;border:1px solid rgba(68,138,255,0.4);background:rgba(68,138,255,0.1);">MAP</a>
+        </div>
+      </div>`);
+    });
+
     // ── Global Event / Conflict Markers ──
     map.on('click', 'conflict-icons', e => {
       if (!e.features?.length) return;
@@ -582,7 +611,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
 
 
     // ── Generic hover for clickables ──
-    ['conflict-icons','cctv-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots'].forEach(layer => {
+    ['conflict-icons','cctv-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','telegram-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots'].forEach(layer => {
       map.on('mouseenter', layer, () => { map.getCanvas().style.cursor = 'pointer'; });
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
     });
@@ -824,6 +853,15 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
 
   useEffect(() => {
     if (!mapReady) return;
+    setGeo('telegram', activeLayers.telegram_intel && data.telegram ? data.telegram.map((e: any) => ({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [e.lng, e.lat] },
+      properties: { name: e.name, url: e.url, channel: e.channel, datetime: e.datetime },
+    })) : []);
+  }, [mapReady, data.telegram, activeLayers.telegram_intel, setGeo]);
+
+  useEffect(() => {
+    if (!mapReady) return;
     setGeo('gps-jamming', activeLayers.gps_jamming && data.gps_jamming ? data.gps_jamming.map((z: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [z.lng, z.lat] }, properties: { severity: z.severity } })) : []);
   }, [mapReady, data.gps_jamming, activeLayers.gps_jamming, setGeo]);
 
@@ -914,6 +952,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     setVis(['eq-circles','eq-label'], activeLayers.earthquakes);
     setVis(['sat-dots'], activeLayers.satellites);
     setVis(['gdelt-dots'], activeLayers.global_incidents);
+    setVis(['telegram-glow','telegram-dots'], activeLayers.telegram_intel);
     setVis(['jam-fill','jam-label'], activeLayers.gps_jamming);
     setVis(['day-night-fill'], activeLayers.day_night);
     setVis(['fl-commercial'], activeLayers.flights);

--- a/src/lib/geo-dict.ts
+++ b/src/lib/geo-dict.ts
@@ -1,0 +1,305 @@
+/**
+ * Lightweight place-name → coordinate dictionary for OSINT geoparsing of
+ * unstructured text (news headlines, Telegram posts, RSS items).
+ *
+ * Coordinates are `[lng, lat]` to match the GeoJSON convention used by the
+ * map layer code. Names are matched as whole-word, case-insensitive, against
+ * the input text. Multi-word names (e.g. "tel aviv", "san francisco") are
+ * checked before single-word names so the longer label wins when both are
+ * present in the same sentence.
+ *
+ * This is intentionally a curated, hand-maintained list rather than a full
+ * gazetteer — full geocoding requires an external service (Nominatim,
+ * OpenCage) which is out of scope for the keyless OSINT pipeline. The list
+ * covers the regions most heavily reported on by the OSINT channels we
+ * aggregate (active conflicts, geopolitical hotspots, capitals).
+ */
+
+const PLACES: Record<string, [number, number]> = {
+  // Ukraine / Russia conflict
+  'ukraine': [31.1656, 48.3794],
+  'kyiv': [30.5234, 50.4501],
+  'kiev': [30.5234, 50.4501],
+  'kharkiv': [36.2304, 49.9935],
+  'kherson': [32.6175, 46.6354],
+  'odesa': [30.7233, 46.4825],
+  'odessa': [30.7233, 46.4825],
+  'lviv': [24.0297, 49.8397],
+  'mariupol': [37.5407, 47.0971],
+  'donetsk': [37.8028, 48.0159],
+  'luhansk': [39.3344, 48.5740],
+  'crimea': [34.1024, 44.9521],
+  'sevastopol': [33.5256, 44.6166],
+  'zaporizhzhia': [35.1396, 47.8388],
+  'avdiivka': [37.7470, 48.1396],
+  'bakhmut': [38.0001, 48.5957],
+  'belgorod': [36.5853, 50.5972],
+  'kursk': [36.1947, 51.7373],
+  'rostov': [39.7187, 47.2357],
+  'russia': [37.6173, 55.7558],
+  'moscow': [37.6173, 55.7558],
+  'saint petersburg': [30.3158, 59.9343],
+  'st petersburg': [30.3158, 59.9343],
+
+  // Middle East
+  'gaza': [34.4668, 31.5017],
+  'rafah': [34.2553, 31.2968],
+  'khan younis': [34.3026, 31.3470],
+  'west bank': [35.2611, 31.9466],
+  'jerusalem': [35.2137, 31.7683],
+  'tel aviv': [34.7818, 32.0853],
+  'haifa': [34.9896, 32.7940],
+  'israel': [34.8516, 31.0461],
+  'palestine': [35.2332, 31.9522],
+  'lebanon': [35.8623, 33.8547],
+  'beirut': [35.5018, 33.8938],
+  'syria': [38.9968, 34.8021],
+  'damascus': [36.2765, 33.5138],
+  'aleppo': [37.1343, 36.2021],
+  'iran': [53.6880, 32.4279],
+  'tehran': [51.3890, 35.6892],
+  'iraq': [43.6793, 33.2232],
+  'baghdad': [44.3661, 33.3152],
+  'yemen': [47.5868, 15.5527],
+  "sana'a": [44.2066, 15.3694],
+  'sanaa': [44.2066, 15.3694],
+  'houthi': [44.2066, 15.3694],
+  'red sea': [38.0000, 20.0000],
+  'bab el-mandeb': [43.3170, 12.5800],
+  'hormuz': [56.2510, 26.5667],
+  'jordan': [36.2384, 30.5852],
+  'amman': [35.9106, 31.9454],
+  'saudi arabia': [45.0792, 23.8859],
+  'riyadh': [46.6753, 24.7136],
+  'uae': [53.8478, 23.4241],
+  'dubai': [55.2708, 25.2048],
+  'qatar': [51.1839, 25.3548],
+  'doha': [51.5310, 25.2854],
+
+  // Africa
+  'sudan': [30.2176, 12.8628],
+  'khartoum': [32.5599, 15.5007],
+  'darfur': [24.0000, 13.0000],
+  'south sudan': [31.3070, 6.8770],
+  'libya': [17.2283, 26.3351],
+  'tripoli': [13.1913, 32.8872],
+  'mali': [-3.9962, 17.5707],
+  'niger': [8.0817, 17.6078],
+  'burkina faso': [-1.5616, 12.2383],
+  'sahel': [4.0000, 16.0000],
+  'somalia': [46.1996, 5.1521],
+  'mogadishu': [45.3438, 2.0469],
+  'ethiopia': [40.4897, 9.1450],
+  'tigray': [38.9000, 13.5000],
+  'drc': [21.7587, -4.0383],
+  'congo': [21.7587, -4.0383],
+  'goma': [29.2350, -1.6792],
+  'kivu': [28.8500, -1.6800],
+  'nigeria': [8.6753, 9.0820],
+  'lagos': [3.3792, 6.5244],
+  'egypt': [30.8025, 26.8206],
+  'cairo': [31.2357, 30.0444],
+  'morocco': [-7.0926, 31.7917],
+
+  // Asia
+  'china': [116.4074, 39.9042],
+  'beijing': [116.4074, 39.9042],
+  'shanghai': [121.4737, 31.2304],
+  'hong kong': [114.1694, 22.3193],
+  'taiwan': [120.9605, 23.6978],
+  'taipei': [121.5654, 25.0330],
+  'taiwan strait': [119.4500, 24.5000],
+  'korea': [127.7669, 35.9078],
+  'seoul': [126.9780, 37.5665],
+  'pyongyang': [125.7625, 39.0392],
+  'dmz': [126.6800, 38.3200],
+  'japan': [138.2529, 36.2048],
+  'tokyo': [139.6917, 35.6895],
+  'okinawa': [127.6809, 26.2125],
+  'philippines': [121.7740, 12.8797],
+  'manila': [120.9842, 14.5995],
+  'south china sea': [114.0000, 14.0000],
+  'myanmar': [95.9560, 21.9162],
+  'burma': [95.9560, 21.9162],
+  'rakhine': [93.5000, 20.0000],
+  'thailand': [100.9925, 15.8700],
+  'vietnam': [108.2772, 14.0583],
+  'india': [78.9629, 20.5937],
+  'delhi': [77.2090, 28.6139],
+  'pakistan': [69.3451, 30.3753],
+  'kashmir': [76.5762, 33.7782],
+  'afghanistan': [67.7100, 33.9391],
+  'kabul': [69.2075, 34.5553],
+
+  // Americas
+  'usa': [-95.7129, 37.0902],
+  'us': [-95.7129, 37.0902],
+  'washington': [-77.0369, 38.9072],
+  'new york': [-74.0060, 40.7128],
+  'mexico': [-102.5528, 23.6345],
+  'mexico city': [-99.1332, 19.4326],
+  'haiti': [-72.2852, 18.9712],
+  'port-au-prince': [-72.3074, 18.5944],
+  'cuba': [-77.7812, 21.5218],
+  'venezuela': [-66.5897, 6.4238],
+  'caracas': [-66.9036, 10.4806],
+  'colombia': [-74.2973, 4.5709],
+  'brazil': [-51.9253, -14.2350],
+  'argentina': [-63.6167, -38.4161],
+
+  // Europe
+  'germany': [10.4515, 51.1657],
+  'berlin': [13.4050, 52.5200],
+  'france': [2.2137, 46.2276],
+  'paris': [2.3522, 48.8566],
+  'uk': [-3.4359, 55.3781],
+  'london': [-0.1276, 51.5074],
+  'spain': [-3.7492, 40.4637],
+  'madrid': [-3.7038, 40.4168],
+  'italy': [12.5674, 41.8719],
+  'rome': [12.4964, 41.9028],
+  'poland': [19.1451, 51.9194],
+  'warsaw': [21.0122, 52.2297],
+  'baltic': [20.0000, 58.0000],
+  'baltic states': [25.0000, 56.0000],
+  'finland': [25.7482, 61.9241],
+  'helsinki': [24.9384, 60.1699],
+  'sweden': [18.6435, 60.1282],
+  'norway': [8.4689, 60.4720],
+  'romania': [24.9668, 45.9432],
+  'bulgaria': [25.4858, 42.7339],
+  'turkey': [35.2433, 38.9637],
+  'ankara': [32.8541, 39.9334],
+  'istanbul': [28.9784, 41.0082],
+  'greece': [21.8243, 39.0742],
+  'serbia': [21.0059, 44.0165],
+  'belgrade': [20.4489, 44.7866],
+  'kosovo': [20.9020, 42.6026],
+  'bosnia': [17.6791, 43.9159],
+  'georgia': [43.3569, 42.3154],
+  'tbilisi': [44.7833, 41.7151],
+  'armenia': [45.0382, 40.0691],
+  'azerbaijan': [47.5769, 40.1431],
+  'nagorno-karabakh': [46.7517, 39.8366],
+
+  // ─── Cyrillic (Russian / Ukrainian) — top conflict-zone names ───
+  'украина': [31.1656, 48.3794],
+  'україна': [31.1656, 48.3794],
+  'киев': [30.5234, 50.4501],
+  'київ': [30.5234, 50.4501],
+  'харьков': [36.2304, 49.9935],
+  'харків': [36.2304, 49.9935],
+  'херсон': [32.6175, 46.6354],
+  'одесса': [30.7233, 46.4825],
+  'одеса': [30.7233, 46.4825],
+  'львов': [24.0297, 49.8397],
+  'львів': [24.0297, 49.8397],
+  'мариуполь': [37.5407, 47.0971],
+  'маріуполь': [37.5407, 47.0971],
+  'донецк': [37.8028, 48.0159],
+  'донецьк': [37.8028, 48.0159],
+  'луганск': [39.3344, 48.5740],
+  'луганськ': [39.3344, 48.5740],
+  'крым': [34.1024, 44.9521],
+  'крим': [34.1024, 44.9521],
+  'севастополь': [33.5256, 44.6166],
+  'запорожье': [35.1396, 47.8388],
+  'запоріжжя': [35.1396, 47.8388],
+  'бахмут': [38.0001, 48.5957],
+  'авдеевка': [37.7470, 48.1396],
+  'авдіївка': [37.7470, 48.1396],
+  'белгород': [36.5853, 50.5972],
+  'белгородская': [36.5853, 50.5972],
+  'белгородській': [36.5853, 50.5972],
+  'курск': [36.1947, 51.7373],
+  'россия': [37.6173, 55.7558],
+  'росія': [37.6173, 55.7558],
+  'москва': [37.6173, 55.7558],
+  'санкт-петербург': [30.3158, 59.9343],
+  'питер': [30.3158, 59.9343],
+  'беларусь': [27.9534, 53.7098],
+  'минск': [27.5615, 53.9006],
+  'мінськ': [27.5615, 53.9006],
+
+  // ─── Arabic — Middle-East conflict zones ───
+  'غزة': [34.4668, 31.5017],
+  'فلسطين': [35.2332, 31.9522],
+  'إسرائيل': [34.8516, 31.0461],
+  'القدس': [35.2137, 31.7683],
+  'بيروت': [35.5018, 33.8938],
+  'لبنان': [35.8623, 33.8547],
+  'دمشق': [36.2765, 33.5138],
+  'سوريا': [38.9968, 34.8021],
+  'بغداد': [44.3661, 33.3152],
+  'العراق': [43.6793, 33.2232],
+  'صنعاء': [44.2066, 15.3694],
+  'اليمن': [47.5868, 15.5527],
+  'طهران': [51.3890, 35.6892],
+  'إيران': [53.6880, 32.4279],
+  'القاهرة': [31.2357, 30.0444],
+  'مصر': [30.8025, 26.8206],
+  'الخرطوم': [32.5599, 15.5007],
+  'السودان': [30.2176, 12.8628],
+};
+
+// Pre-sort keys longest-first so multi-word labels match before substrings.
+const SORTED_KEYS = Object.keys(PLACES).sort((a, b) => b.length - a.length);
+
+export interface GeoMatch {
+  /** Place name as it appears in the dictionary. */
+  place: string;
+  /** `[lng, lat]` (GeoJSON order). */
+  coords: [number, number];
+}
+
+/**
+ * Returns the first place from the dictionary mentioned in `text`, or `null`
+ * when nothing matches. Whole-word, case-insensitive. Longer multi-word
+ * labels take precedence over shorter ones (e.g. "tel aviv" beats "israel"
+ * if both appear).
+ *
+ * Applies small random jitter (`±jitter` degrees, default 0) so multiple
+ * events that all map to the same capital don't stack into a single pixel.
+ */
+export function geoparse(text: string, jitter = 0): GeoMatch | null {
+  if (!text) return null;
+  const lower = text.toLowerCase();
+  for (const key of SORTED_KEYS) {
+    // Escape regex metacharacters in the key. ASCII `\b` doesn't work for
+    // Cyrillic/Arabic, so we use Unicode-aware lookarounds: the match must
+    // be preceded and followed by something that is *not* a letter in any
+    // script (the `u` flag makes `\p{L}` Unicode-aware).
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`(^|[^\\p{L}])${escaped}(?=[^\\p{L}]|$)`, 'iu');
+    if (re.test(lower)) {
+      const [lng, lat] = PLACES[key];
+      const jLng = jitter ? (Math.random() - 0.5) * 2 * jitter : 0;
+      const jLat = jitter ? (Math.random() - 0.5) * 2 * jitter : 0;
+      return { place: key, coords: [lng + jLng, lat + jLat] };
+    }
+  }
+  return null;
+}
+
+/**
+ * Conflict / OSINT-relevant keyword set. Used to filter raw feeds down to
+ * posts likely to be reporting on incidents rather than off-topic chatter.
+ */
+export const CONFLICT_KEYWORDS = [
+  // English
+  'attack', 'strike', 'missile', 'drone', 'war', 'troops', 'military',
+  'protest', 'riot', 'police', 'clash', 'bomb', 'killed', 'forces',
+  'shelling', 'artillery', 'airstrike', 'casualties', 'wounded', 'siege',
+  'invasion', 'offensive', 'frontline', 'ceasefire', 'sanctions', 'sanctioned',
+  // Cyrillic (RU/UA)
+  'удар', 'обстрел', 'обстріл', 'ракет', 'дрон', 'война', 'війна',
+  'погиб', 'загину', 'войск', 'військ', 'атак', 'наступ', 'фронт',
+  // Arabic
+  'هجوم', 'ضربة', 'صاروخ', 'حرب', 'قصف', 'قتل', 'جنود',
+];
+
+export function hasConflictKeyword(text: string): boolean {
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  return CONFLICT_KEYWORDS.some((kw) => lower.includes(kw));
+}

--- a/src/lib/telegram-scraper.ts
+++ b/src/lib/telegram-scraper.ts
@@ -1,0 +1,101 @@
+/**
+ * Telegram public-channel scraper.
+ *
+ * Fetches the public web preview at `https://t.me/s/<channel>` (no auth,
+ * no Bot API token, no MTProto) and extracts the most recent posts from
+ * the HTML. Only channels that have web preview enabled are reachable
+ * this way — most well-known OSINT channels do.
+ *
+ * The scraper parses with regex rather than a full DOM library to avoid
+ * pulling in `jsdom` / `cheerio` just for a handful of fields. The Telegram
+ * widget markup is stable and well-formed enough for this to be safe.
+ */
+
+export interface TelegramPost {
+  /** `<channel>/<post-id>` — unique across the scraper. */
+  id: string;
+  /** Channel username (without `@`). */
+  channel: string;
+  /** Plain-text body with HTML stripped and `<br>` converted to newlines. */
+  text: string;
+  /** Permalink to the post on t.me. */
+  url: string;
+  /** ISO-8601 timestamp from the `<time datetime=...>` attribute. */
+  datetime: string;
+  /** View counter as displayed (e.g. `"40.9K"`), or `undefined` if absent. */
+  views?: string;
+}
+
+const POST_WRAP_RE = /<div class="tgme_widget_message_wrap[^"]*"[\s\S]*?<\/div>\s*<\/div>/g;
+const TEXT_RE = /<div class="tgme_widget_message_text[^"]*"[^>]*>([\s\S]*?)<\/div>/;
+const DATE_HREF_RE = /<a class="tgme_widget_message_date"[^>]*href="(https:\/\/t\.me\/[^"]+)"/;
+const TIME_RE = /<time[^>]*datetime="([^"]+)"/;
+const VIEWS_RE = /<span class="tgme_widget_message_views">([^<]+)<\/span>/;
+const POST_DATA_RE = /data-post="([^"]+)"/;
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<a\s[^>]*>([\s\S]*?)<\/a>/gi, '$1')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * Fetches and parses a single channel. Returns up to `limit` of the most
+ * recent posts (Telegram's web preview returns them oldest-first, so we
+ * slice from the tail).
+ */
+export async function fetchChannel(
+  channel: string,
+  limit = 20
+): Promise<TelegramPost[]> {
+  const safe = channel.replace(/^@/, '').trim();
+  if (!/^[a-zA-Z][a-zA-Z0-9_]{2,31}$/.test(safe)) {
+    throw new Error(`Invalid Telegram channel name: ${channel}`);
+  }
+
+  const res = await fetch(`https://t.me/s/${safe}`, {
+    signal: AbortSignal.timeout(10_000),
+    headers: {
+      // Telegram serves the widget HTML to ordinary browser UAs. A bare
+      // `node-fetch` UA sometimes gets a stripped response.
+      'User-Agent': 'Mozilla/5.0 (compatible; OsirisOSINT/1.0; +https://osirisai.live)',
+      Accept: 'text/html,application/xhtml+xml',
+    },
+  });
+  if (!res.ok) throw new Error(`t.me/${safe} HTTP ${res.status}`);
+  const html = await res.text();
+
+  const posts: TelegramPost[] = [];
+  const wrappers = html.match(POST_WRAP_RE) || [];
+  for (const wrap of wrappers) {
+    const textMatch = wrap.match(TEXT_RE);
+    const timeMatch = wrap.match(TIME_RE);
+    const linkMatch = wrap.match(DATE_HREF_RE);
+    const dataMatch = wrap.match(POST_DATA_RE);
+    const viewsMatch = wrap.match(VIEWS_RE);
+
+    // Skip media-only posts (no text body) — geoparse needs words.
+    if (!textMatch || !timeMatch || !linkMatch || !dataMatch) continue;
+
+    posts.push({
+      id: dataMatch[1],
+      channel: safe,
+      text: stripHtml(textMatch[1]),
+      url: linkMatch[1],
+      datetime: timeMatch[1],
+      views: viewsMatch?.[1]?.trim(),
+    });
+  }
+
+  // Telegram returns oldest-first; the freshest posts are at the tail.
+  return posts.slice(-limit).reverse();
+}


### PR DESCRIPTION
## Summary
Adds a **Telegram OSINT** map layer that geoparses recent posts from a curated set of public Telegram channels (war reporting, fact-checking, geopolitics) and plots them on the map — fully keyless, scraped from the unauthenticated `t.me/s/<channel>` web preview.

## Why
- Telegram is where most modern war / conflict OSINT originates (Ukraine, Gaza, Sudan, Sahel). The platform previously had no Telegram surface area at all.
- War-reporting channels in Cyrillic and Arabic carry information the English RSS feeds we already aggregate routinely miss.
- All access goes through Telegram's *public* web preview — no Bot API token, no MTProto API ID, nothing that breaks the project's "works fully without any API keys" guarantee.

## Data sources (all keyless, open)
| Source | Notes |
|--------|-------|
| `t.me/s/<channel>` HTML | Public web preview, no auth, parsed with regex (no `jsdom`/`cheerio` dep) |
| Hand-curated EN + RU/UA + AR geo dictionary | In-repo, no external geocoder needed |

## What's in the PR
- `src/lib/geo-dict.ts` — shared `geoparse()` + `hasConflictKeyword()` with EN + Cyrillic + Arabic place names and Unicode-aware word-boundary regex so non-ASCII matches actually work.
- `src/lib/telegram-scraper.ts` — `fetchChannel(channel, limit)` returning typed `TelegramPost[]`. Parses post wrapper / text / `<time datetime=…>` / permalink / views with focused regexes.
- `src/app/api/telegram-feed/route.ts` — `GET /api/telegram-feed[?all=1]` aggregator across the default set of 5 channels, in-memory 5-minute single-flight cache per channel, stale-on-failure fallback.
- `src/components/OsirisMap.tsx` — new `telegram` GeoJSON source, `telegram-glow` + `telegram-dots` circle layers (cyan `#00BFFF`), click handler producing a styled popup with "OPEN POST" deep-link.
- `src/components/LayerPanel.tsx` — new toggle **Telegram OSINT** in the `SURVEILLANCE` group.
- `src/app/page.tsx` — initial state + `layerFetchedRef` hook so the layer is fetched on first toggle and cached client-side.

## Default channels
Balanced mix of English and Cyrillic OSINT, overridable via `OSIRIS_TELEGRAM_CHANNELS` (CSV).

| Channel | Lang | Role |
|---------|------|------|
| `osintdefender` | EN | Prominent OSINT aggregator |
| `insiderpaper` | EN | Breaking news wire |
| `aljazeeraenglish` | EN | Middle East coverage |
| `nexta_live` | RU/UA | Belarus / Ukraine OSINT |
| `war_monitor` | UA | Ukrainian war updates |

## Response shape
```json
{
  "events": [{
    "id": "telegram-osintdefender-12345",
    "lat": 31.5017,
    "lng": 34.4668,
    "name": "[@osintdefender] #Lebanon Hezbollah has successfully targeted...",
    "url": "https://t.me/osintdefender/12345",
    "html": "<b>@osintdefender</b><br/>... <a href=...>Open on Telegram</a>",
    "channel": "osintdefender",
    "datetime": "2026-05-23T18:04:00+00:00",
    "type": "telegram"
  }],
  "total": 16,
  "channels": ["osintdefender", "insiderpaper", "..."],
  "timestamp": "...",
  "source": "Telegram public channels (t.me/s)"
}
```

## Test plan
- [ ] Toggle **SURVEILLANCE → Telegram OSINT** in the layer panel — dots appear in cyan at geoparsed locations.
- [ ] Click a dot → popup shows channel handle, post text, timestamp, "OPEN POST" link to `t.me/<channel>/<id>`.
- [ ] Hit `GET /api/telegram-feed` directly — receives geolocated events from active channels, fresh timestamps.
- [ ] Hit `GET /api/telegram-feed?all=1` — disables conflict-keyword filter; returns more events.
- [ ] Set `OSIRIS_TELEGRAM_CHANNELS=foo,bar` — only those channels are scraped on next cache miss.
- [ ] Invalid channel name in env var → caught by `fetchChannel` regex, channel skipped, others still load.
- [ ] Channel temporarily 5xxs → stale cache served, no map gap.

## Known limitations / future work
- Geoparse uses a curated ~200-entry dictionary; events whose text mentions no recognized place name are dropped. A future enhancement could fall back to Nominatim (still keyless, but rate-limited and slower).
- Telegram orders posts oldest-first in the web preview; we tail-slice for the most recent. Channels with media-only posts contribute fewer plotted events because we need text for geoparsing.
- No polling interval set — the layer fetches once on first toggle (matches the existing GDELT pattern). Re-toggling forces a refresh; the API-level 5 min cache makes that cheap.
- No media (images / video) — only post text + deep link.

## Out of scope
- No new npm dependencies.
- No new env vars are *required*; only the optional `OSIRIS_TELEGRAM_CHANNELS` override.
- No changes to the existing `/api/gdelt` route (its own dictionary is left intact — the new shared `geo-dict.ts` is only consumed by the Telegram route).
