### PR TITLE
feat(osint): add OFAC SDN sanctions search + cross-check

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -66,6 +66,13 @@ AIS_API_KEY=
 # Change this if 3000 is already taken on your host.
 OSIRIS_PORT=3000
 
+# Comma-separated list of public Telegram channel usernames (no @) to scrape
+# for the "Telegram OSINT" map layer. Overrides the curated default set.
+# Channels must have web preview enabled (most well-known OSINT channels do).
+# Default if unset:
+#   osintdefender,insiderpaper,aljazeeraenglish,nexta_live,war_monitor
+# OSIRIS_TELEGRAM_CHANNELS=
+
 # Set by the Docker image already — override only if needed.
 # NODE_ENV=production
 # PORT=3000

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -141,9 +141,19 @@ them only if you extend the relevant route or hit rate limits.
 > Keep `.env` out of version control — it is already in `.gitignore`. Only
 > `.env.template` (no secrets) is committed.
 
+### Optional runtime overrides
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `OSIRIS_TELEGRAM_CHANNELS` | Comma-separated list of public Telegram channel usernames (no `@`) to scrape for the **Telegram OSINT** map layer. Overrides the curated default set. | `osintdefender,insiderpaper,aljazeeraenglish,nexta_live,war_monitor` |
+| `OSIRIS_PORT` | Host port the compose file publishes (container itself always listens on 3000). | `3000` |
+
 ### Keyless sources (no configuration needed)
 
 Aviation → `adsb.lol` · Satellites → `celestrak.org` (TLE) · Fires →
 NASA FIRMS open-data CSV · Earthquakes → USGS · Weather → NASA EONET · Space
 weather → NOAA SWPC · CVEs → NVD · News → public RSS / HLS streams · CCTV →
-public traffic-authority feeds.
+public traffic-authority feeds · Crypto (BTC) → `blockstream.info` · Crypto
+(ETH) → `eth.blockscout.com` ([Blockscout](https://github.com/blockscout/blockscout)
+open-source explorer) · OFAC SDN sanctions → [OpenSanctions](https://www.opensanctions.org)
+mirror (CC-BY 4.0) · Telegram OSINT → public `t.me/s/<channel>` web preview.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Osiris is a production-grade OSINT platform that provides situational awareness 
 | **Space** | Solar Weather, Satellites | NOAA SWPC, N2YO |
 | **Cyber** | CVE Threats, Vulnerability Scanning | NVD, Custom Scanner |
 | **Conflict** | 13 Active Zones | Static OSINT Intel |
+| **Crypto** | BTC + ETH Wallet Tracing, OFAC SDN Match | blockstream.info, Blockscout, OpenSanctions |
+| **Sanctions** | Person / Org / Vessel SDN Search | OpenSanctions (US OFAC SDN mirror) |
+| **Telegram OSINT** | Geoparsed Posts from Public Channels | `t.me/s/<channel>` web preview |
 
 ---
 
@@ -52,14 +55,20 @@ Osiris is a production-grade OSINT platform that provides situational awareness 
 │  └──────────┘  └──────────┘  └───────────────┘ │
 ├─────────────────────────────────────────────────┤
 │               NEXT.JS API ROUTES                 │
-│  /api/flights  /api/earthquakes  /api/cctv      │
-│  /api/news     /api/fires        /api/maritime  │
-│  /api/gdelt    /api/satellites   /api/weather   │
-│  /api/scanner  /api/sentinel     /api/osint/*   │
+│  /api/flights         /api/earthquakes          │
+│  /api/cctv            /api/news                 │
+│  /api/fires           /api/maritime             │
+│  /api/gdelt           /api/satellites           │
+│  /api/weather         /api/scanner              │
+│  /api/sentinel        /api/telegram-feed        │
+│  /api/osint/*  (whois, dns, ip, cve, sanctions, │
+│                 crypto, sweep, threats, …)      │
 ├─────────────────────────────────────────────────┤
 │              EXTERNAL DATA SOURCES               │
 │  OpenSky · USGS · NASA · NOAA · TfL · NVD      │
 │  GDACS · EONET · FIRMS · N2YO · RSS Feeds      │
+│  blockstream.info · Blockscout · OpenSanctions  │
+│  t.me public previews                            │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -68,7 +77,7 @@ Osiris is a production-grade OSINT platform that provides situational awareness 
 ## Features
 
 ### Intelligence Layers
-- **15 toggleable data layers** with real-time entity counts
+- **16 toggleable data layers** with real-time entity counts
 - **GPU-accelerated rendering** — all map data rendered via WebGL, not DOM
 - **Progressive loading** — data fetched on-demand when layers are activated
 - **Viewport-aware** — only loads relevant data for the visible region
@@ -76,15 +85,34 @@ Osiris is a production-grade OSINT platform that provides situational awareness 
 ### RECON Toolkit
 - **Port Scanner** — TCP connect scan with service fingerprinting
 - **DNS Lookup** — Full record resolution (A, AAAA, MX, NS, TXT, CNAME)
-- **WHOIS** — Domain/IP registration data
+- **WHOIS** — Domain/IP registration data (auto-cross-checked against OFAC SDN)
 - **SSL/TLS Inspector** — Certificate chain analysis
-- **IP Intelligence** — Geolocation, ASN, and threat reputation
+- **IP Intelligence** — Geolocation, ASN, threat reputation (auto-cross-checked against OFAC SDN)
 - **Vulnerability Scanner** — CVE lookup against NVD database
+- **Crypto Wallet Trace** — BTC + ETH lookup (balance, tx history, OFAC SDN sanctions flag)
+- **OFAC Sanctions Search** — query persons, organizations, vessels and aircraft against the US OFAC SDN list
 
 ### Live Broadcast Network
 - **25+ live 24/7 news streams** from global broadcasters
 - Click any news dot on the map to open the live stream
 - Feeds from NBC, CBS, ABC, Sky News, Al Jazeera, France 24, NHK, WION, and more
+
+### Telegram OSINT Layer
+- **Public-channel feed** scraped from the unauthenticated `t.me/s/<channel>` web preview — no Bot API token, no MTProto
+- Default curated set of 5 channels (EN + RU/UA war reporting), overridable via `OSIRIS_TELEGRAM_CHANNELS`
+- Posts are geoparsed against a multilingual place dictionary (EN + Cyrillic + Arabic) and plotted on the map
+- Click any cyan dot to read the post and jump to the original on Telegram
+
+### Crypto Wallet Intelligence
+- **BTC** lookups via [blockstream.info](https://blockstream.info) (Esplora API, keyless)
+- **ETH** lookups via [Blockscout](https://github.com/blockscout/blockscout)'s public ETH instance (`eth.blockscout.com`, keyless)
+- Every lookup is cross-checked against the OFAC SDN sanctioned-address list (mirrored from [`0xB10C/ofac-sanctioned-digital-currency-addresses`](https://github.com/0xB10C/ofac-sanctioned-digital-currency-addresses))
+- Sanctioned wallets surface a red **SANCTIONED — OFAC SDN** badge in the RECON panel
+
+### OFAC SDN Cross-Check
+- Standalone `SANCTIONS` tab in the RECON toolkit — full-text search across persons, organisations, vessels and aircraft
+- WHOIS and IP-intel routes auto-cross-check registrant / ASN-owner names against the SDN list and surface an inline alert
+- Data sourced from [OpenSanctions](https://www.opensanctions.org) (CC-BY 4.0) — keyless, ~7 MB cached in-memory for 24h
 
 ### Conflict Zone Monitoring
 - **13 active conflict/tension zones** with severity-coded warning markers

--- a/src/app/api/osint/ip/route.ts
+++ b/src/app/api/osint/ip/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from 'next/server';
 import { isRateLimited, getClientIp } from '@/lib/ssrf-guard';
+import { matchExact, type SanctionEntry } from '@/lib/sanctions';
 
-// IP Geolocation + Reputation — combines multiple free sources
+// IP Geolocation + Reputation — combines multiple free sources.
+// Cross-checks the ASN owner / ISP / org strings against the OFAC SDN
+// list so an IP routed via a sanctioned operator surfaces a hit.
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const ip = searchParams.get('ip');
@@ -57,6 +60,22 @@ export async function GET(req: Request) {
       is_mobile: results.geo?.is_mobile || false,
       risk_level: results.geo?.is_proxy ? 'HIGH' : results.geo?.is_hosting ? 'MEDIUM' : 'LOW',
     };
+
+    // OFAC SDN cross-check on ASN / ISP / org strings.
+    try {
+      const candidates = new Set<string>();
+      if (results.geo?.org) candidates.add(results.geo.org);
+      if (results.geo?.isp) candidates.add(results.geo.isp);
+      if (results.geo?.as_name) candidates.add(results.geo.as_name);
+      const hits: Array<{ matched_value: string; entries: SanctionEntry[] }> = [];
+      for (const value of candidates) {
+        const entries = await matchExact(value);
+        if (entries.length) hits.push({ matched_value: value, entries });
+      }
+      results.sanctions_match = hits.length
+        ? { source: 'OFAC SDN', hits }
+        : null;
+    } catch (e) { console.warn('[OSIRIS] Sanctions cross-check failed:', e instanceof Error ? e.message : e); }
 
     return NextResponse.json(results);
   } catch {

--- a/src/app/api/osint/sanctions/route.ts
+++ b/src/app/api/osint/sanctions/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { isRateLimited, getClientIp } from '@/lib/ssrf-guard';
+import { search, type Schema } from '@/lib/sanctions';
+
+// Standalone OFAC SDN search (free, no key) backed by the OpenSanctions
+// `us_ofac_sdn` mirror. Substring + alias-aware match, schema-filterable.
+
+const ALLOWED_SCHEMAS: Schema[] = [
+  'Person',
+  'Organization',
+  'Company',
+  'Vessel',
+  'Airplane',
+  'LegalEntity',
+];
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const query = (searchParams.get('query') || '').trim();
+  const schemaParam = searchParams.get('schema');
+  const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '25', 10), 1), 100);
+
+  if (!query) {
+    return NextResponse.json({ error: 'Missing query parameter' }, { status: 400 });
+  }
+  if (query.length < 4) {
+    return NextResponse.json(
+      { error: 'Query must be at least 4 characters' },
+      { status: 400 }
+    );
+  }
+
+  const clientIp = getClientIp(req);
+  if (isRateLimited(clientIp, 20, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  let schema: Schema | undefined;
+  if (schemaParam) {
+    if (!ALLOWED_SCHEMAS.includes(schemaParam as Schema)) {
+      return NextResponse.json(
+        { error: `Invalid schema. Allowed: ${ALLOWED_SCHEMAS.join(', ')}` },
+        { status: 400 }
+      );
+    }
+    schema = schemaParam as Schema;
+  }
+
+  try {
+    const matches = await search(query, { schema, limit });
+    return NextResponse.json({
+      query,
+      schema: schema ?? null,
+      total: matches.length,
+      matches,
+      source: 'OpenSanctions / US OFAC SDN',
+      timestamp: new Date().toISOString(),
+    });
+  } catch (e) {
+    return NextResponse.json(
+      { error: 'Sanctions lookup failed', detail: e instanceof Error ? e.message : String(e) },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/api/osint/whois/route.ts
+++ b/src/app/api/osint/whois/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from 'next/server';
 import { safeFetch, isRateLimited, getClientIp } from '@/lib/ssrf-guard';
+import { matchExact, type SanctionEntry } from '@/lib/sanctions';
 
-// WHOIS + Domain Intelligence via RDAP (free, standardized)
+// WHOIS + Domain Intelligence via RDAP (free, standardized).
+// Cross-checks any registrant / org names returned by RDAP against the
+// OFAC SDN list so a sanctioned registrant surfaces alongside the WHOIS
+// metadata (still keyless — the SDN snapshot is sourced from the open
+// OpenSanctions mirror).
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const domain = searchParams.get('domain');
@@ -85,6 +90,23 @@ export async function GET(req: Request) {
       if (headers['referrer-policy']) score += 1;
       results.security_score = { score, max: 7, grade: score >= 5 ? 'A' : score >= 3 ? 'B' : score >= 1 ? 'C' : 'F' };
     } catch (e) { console.warn('[OSIRIS] Suppressed error:', e instanceof Error ? e.message : e); }
+
+    // OFAC SDN cross-check on RDAP entity names/orgs.
+    try {
+      const candidates = new Set<string>();
+      for (const ent of results.rdap?.entities ?? []) {
+        if (ent.name) candidates.add(ent.name);
+        if (ent.org) candidates.add(ent.org);
+      }
+      const hits: Array<{ matched_value: string; entries: SanctionEntry[] }> = [];
+      for (const value of candidates) {
+        const entries = await matchExact(value);
+        if (entries.length) hits.push({ matched_value: value, entries });
+      }
+      results.sanctions_match = hits.length
+        ? { source: 'OFAC SDN', hits }
+        : null;
+    } catch (e) { console.warn('[OSIRIS] Sanctions cross-check failed:', e instanceof Error ? e.message : e); }
 
     return NextResponse.json(results);
   } catch {

--- a/src/components/OsintPanel.tsx
+++ b/src/components/OsintPanel.tsx
@@ -7,7 +7,7 @@ import {
   ChevronDown, ChevronUp, Loader2, AlertTriangle, Server,
   Wifi, Lock, MapPin, Bug, Code, Layers, Network, Fingerprint,
   CheckCircle, XCircle, Clock, ExternalLink, Crosshair,
-  Maximize2, Minimize2
+  Maximize2, Minimize2, Gavel
 } from 'lucide-react';
 
 const TABS = [
@@ -22,6 +22,7 @@ const TABS = [
   { id: 'ssl', label: 'SSL/TLS', icon: Shield, placeholder: 'Domain name', color: '#76FF03' },
   { id: 'subdomains', label: 'SUBDOMAINS', icon: Layers, placeholder: 'Domain to enumerate', color: '#00BCD4' },
   { id: 'tech', label: 'TECH DETECT', icon: Fingerprint, placeholder: 'URL to fingerprint', color: '#9C27B0' },
+  { id: 'sanctions', label: 'SANCTIONS', icon: Gavel, placeholder: 'Person / org / vessel name', color: '#FF1744' },
   { id: 'sweep', label: 'IP SWEEP', icon: Crosshair, placeholder: 'Enter IP address (e.g. 8.8.8.8)', color: '#FF3D3D' },
 ];
 
@@ -106,6 +107,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
         case 'ssl': url = `/api/scanner?target=${encodeURIComponent(query)}&type=ssl`; break;
         case 'subdomains': url = `/api/scanner?target=${encodeURIComponent(query)}&type=subdomains`; break;
         case 'tech': url = `/api/scanner?target=${encodeURIComponent(query)}&type=tech`; break;
+        case 'sanctions': url = `/api/osint/sanctions?query=${encodeURIComponent(query)}`; break;
       }
       const res = await fetch(url);
       const data = await res.json();
@@ -114,7 +116,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
         setHistory(prev => [{ tab: activeTab, query, time: new Date().toLocaleTimeString() }, ...prev.slice(0, 9)]);
         
         // Geolocate the target in the background
-        if (activeTab !== 'sweep' && activeTab !== 'vuln') {
+        if (activeTab !== 'sweep' && activeTab !== 'vuln' && activeTab !== 'sanctions') {
           fetch(`/api/osint/ip?ip=${encodeURIComponent(query)}`)
             .then(r => r.json())
             .then(locData => {
@@ -154,6 +156,28 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
       {label}
     </span>
   );
+
+  // Surfaces an inline OFAC-SDN hit (used by the WHOIS and IP-intel routes
+  // when their cross-check finds a sanctioned registrant / ASN owner).
+  const SanctionsBadge = ({ match }: { match: any }) => {
+    if (!match || !Array.isArray(match.hits) || match.hits.length === 0) return null;
+    return (
+      <div className="mb-2 px-2 py-2 rounded border border-red-500/40 bg-red-500/15">
+        <div className="flex items-center gap-2 mb-1.5">
+          <AlertTriangle className="w-3.5 h-3.5 text-red-400" />
+          <span className="text-[10px] font-mono font-bold text-red-400 tracking-wider">
+            SANCTIONED — {match.source || 'OFAC SDN'}
+          </span>
+        </div>
+        {match.hits.slice(0, 5).map((h: any, i: number) => (
+          <div key={i} className="text-[9px] font-mono text-red-200 break-all leading-tight">
+            <span className="text-[var(--text-muted)]">↳ {h.matched_value}:</span>{' '}
+            {(h.entries || []).slice(0, 2).map((e: any) => e.name).join('; ')}
+          </div>
+        ))}
+      </div>
+    );
+  };
 
   const SectionHeader = ({ title, icon: Icon, color }: { title: string; icon: any; color: string }) => (
     <div className="flex items-center gap-2 mt-3 mb-1.5 first:mt-0">
@@ -278,6 +302,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
       return (
         <div>
           <SectionHeader title="WHOIS INTELLIGENCE" icon={FileText} color="#FFD700" />
+          <SanctionsBadge match={r.sanctions_match} />
           <ResultRow label="Domain" value={r.domain_name || r.domainName || query} color="#FFD700" />
           <ResultRow label="Registrar" value={r.registrar} />
           <ResultRow label="Created" value={r.creation_date || r.createdDate} />
@@ -285,7 +310,35 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           <ResultRow label="Updated" value={r.updated_date || r.updatedDate} />
           <ResultRow label="Status" value={Array.isArray(r.status) ? r.status.join(', ') : r.status} />
           <ResultRow label="Nameservers" value={Array.isArray(r.name_servers || r.nameServers) ? (r.name_servers || r.nameServers).join(', ') : r.name_servers} />
-          {renderFallbackExcluding(['domain_name','domainName','registrar','creation_date','createdDate','expiration_date','expiresDate','updated_date','updatedDate','status','name_servers','nameServers','timestamp','cached','raw'])}
+          {renderFallbackExcluding(['domain_name','domainName','registrar','creation_date','createdDate','expiration_date','expiresDate','updated_date','updatedDate','status','name_servers','nameServers','timestamp','cached','raw','sanctions_match'])}
+        </div>
+      );
+    }
+
+    // ── SANCTIONS ──
+    if (activeTab === 'sanctions') {
+      const matches = Array.isArray(r.matches) ? r.matches : [];
+      return (
+        <div>
+          <SectionHeader title="OFAC SDN SEARCH" icon={Gavel} color="#FF1744" />
+          <ResultRow label="Query" value={r.query || query} color="#FF1744" />
+          <ResultRow label="Source" value={r.source} />
+          <ResultRow label="Matches" value={r.total ?? matches.length} color={matches.length ? '#FF1744' : '#00E676'} />
+          {matches.slice(0, 20).map((m: any) => (
+            <div key={m.id} className="mt-2 p-2 rounded border border-red-500/30 bg-red-500/5">
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-[10px] font-mono font-bold text-red-400 break-all">{m.name}</span>
+                <span className="text-[8px] font-mono uppercase tracking-wider text-[var(--text-muted)] ml-2 flex-shrink-0">{m.schema}</span>
+              </div>
+              <ResultRow label="Aliases" value={Array.isArray(m.aliases) && m.aliases.length ? m.aliases.slice(0, 4).join(' • ') : undefined} />
+              <ResultRow label="Countries" value={Array.isArray(m.countries) && m.countries.length ? m.countries.join(', ').toUpperCase() : undefined} />
+              <ResultRow label="Programs" value={Array.isArray(m.programs) && m.programs.length ? m.programs.slice(0, 3).join(', ') : undefined} />
+              <ResultRow label="First Seen" value={m.first_seen ? m.first_seen.slice(0, 10) : undefined} />
+            </div>
+          ))}
+          {matches.length === 0 && (
+            <div className="mt-2 px-2 py-1.5 text-[10px] font-mono text-green-400">No OFAC SDN matches for that query.</div>
+          )}
         </div>
       );
     }

--- a/src/lib/sanctions.ts
+++ b/src/lib/sanctions.ts
@@ -1,0 +1,245 @@
+/**
+ * OFAC SDN sanctioned-entity lookup.
+ *
+ * Source: [OpenSanctions](https://www.opensanctions.org/) `us_ofac_sdn`
+ * dataset, distributed as a simple CSV under CC-BY 4.0. OpenSanctions
+ * normalises the upstream Treasury data into a flat schema with stable
+ * field names and an entity-type discriminator (`Person`, `Organization`,
+ * `Vessel`, `Aircraft`, …), which is far easier to consume than the raw
+ * SDN XML.
+ *
+ * The whole list (~7 MB, low-tens-of-thousands of entries) is downloaded
+ * once on first use, parsed into normalised lookup indices, and refreshed
+ * lazily every 24h. Concurrent requests that arrive while a fetch is in
+ * flight wait on the same promise (single-flight) so we never pull the
+ * file twice. If a refresh fails after the cache has gone stale we keep
+ * serving the previous snapshot rather than leaving the route blind.
+ */
+
+const SDN_CSV_URL =
+  'https://data.opensanctions.org/datasets/latest/us_ofac_sdn/targets.simple.csv';
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+export type Schema =
+  | 'Person'
+  | 'Organization'
+  | 'Company'
+  | 'Vessel'
+  | 'Airplane'
+  | 'LegalEntity'
+  | 'Security'
+  | string;
+
+export interface SanctionEntry {
+  id: string;
+  schema: Schema;
+  name: string;
+  aliases: string[];
+  countries: string[];
+  programs: string[];
+  sanctions: string;
+  first_seen?: string;
+  last_seen?: string;
+}
+
+interface LoadedList {
+  fetchedAt: number;
+  entries: SanctionEntry[];
+  /** Lower-cased, punctuation-stripped name/alias → entry. */
+  byNormName: Map<string, SanctionEntry[]>;
+}
+
+let cache: LoadedList | null = null;
+let inflight: Promise<LoadedList> | null = null;
+
+/**
+ * Lower-case, strip punctuation, collapse whitespace. Used for both index
+ * keys and incoming query normalisation so the same string yields the
+ * same key on both sides.
+ */
+export function normName(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Minimal CSV parser tolerant of double-quoted fields with embedded
+ * commas, newlines and `""` escapes. The OpenSanctions CSV is well-formed
+ * so we don't need a heavyweight parser — `papaparse` etc. would just
+ * pull a dependency for the same job.
+ */
+function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let field = '';
+  let row: string[] = [];
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ',') {
+      row.push(field);
+      field = '';
+    } else if (c === '\n') {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+    } else if (c === '\r') {
+      // ignore — handled by the \n branch
+    } else {
+      field += c;
+    }
+  }
+  if (field.length || row.length) {
+    row.push(field);
+    rows.push(row);
+  }
+  return rows;
+}
+
+async function loadList(): Promise<LoadedList> {
+  if (cache && Date.now() - cache.fetchedAt < TTL_MS) return cache;
+  if (inflight) return inflight;
+
+  inflight = (async () => {
+    try {
+      const res = await fetch(SDN_CSV_URL, {
+        signal: AbortSignal.timeout(30_000),
+        headers: { Accept: 'text/csv' },
+      });
+      if (!res.ok) throw new Error(`OpenSanctions HTTP ${res.status}`);
+      const text = await res.text();
+      const rows = parseCsv(text);
+      if (rows.length < 2) throw new Error('OpenSanctions CSV empty');
+
+      const headers = rows[0];
+      const idx = (col: string) => headers.indexOf(col);
+      const i = {
+        id: idx('id'),
+        schema: idx('schema'),
+        name: idx('name'),
+        aliases: idx('aliases'),
+        countries: idx('countries'),
+        programs: idx('program_ids'),
+        sanctions: idx('sanctions'),
+        first_seen: idx('first_seen'),
+        last_seen: idx('last_seen'),
+      };
+
+      const entries: SanctionEntry[] = [];
+      const byNormName = new Map<string, SanctionEntry[]>();
+
+      for (let r = 1; r < rows.length; r++) {
+        const row = rows[r];
+        if (!row[i.name]) continue;
+        const entry: SanctionEntry = {
+          id: row[i.id] || '',
+          schema: row[i.schema] || 'LegalEntity',
+          name: row[i.name],
+          aliases: (row[i.aliases] || '').split(';').map((s) => s.trim()).filter(Boolean),
+          countries: (row[i.countries] || '').split(';').map((s) => s.trim()).filter(Boolean),
+          programs: (row[i.programs] || '').split(';').map((s) => s.trim()).filter(Boolean),
+          sanctions: row[i.sanctions] || '',
+          first_seen: i.first_seen >= 0 ? row[i.first_seen] : undefined,
+          last_seen: i.last_seen >= 0 ? row[i.last_seen] : undefined,
+        };
+        entries.push(entry);
+
+        // Index every name + alias under its normalised form so an exact
+        // (post-normalisation) match is O(1).
+        const keys = new Set<string>([entry.name, ...entry.aliases].map(normName));
+        for (const key of keys) {
+          if (!key) continue;
+          const list = byNormName.get(key);
+          if (list) list.push(entry);
+          else byNormName.set(key, [entry]);
+        }
+      }
+
+      const loaded = { fetchedAt: Date.now(), entries, byNormName };
+      cache = loaded;
+      return loaded;
+    } catch (e) {
+      if (cache) return cache;
+      throw e;
+    } finally {
+      inflight = null;
+    }
+  })();
+
+  return inflight;
+}
+
+/**
+ * Strict exact-match lookup (used for inline cross-checks where false
+ * positives must be avoided — the registrant string `"Acme"` should NOT
+ * match `"Acme Holdings"` automatically).
+ */
+export async function matchExact(query: string): Promise<SanctionEntry[]> {
+  if (!query || query.length < 3) return [];
+  const list = await loadList();
+  return list.byNormName.get(normName(query)) ?? [];
+}
+
+/**
+ * Substring + contains search (used for the standalone SANCTIONS tab where
+ * the operator is explicitly probing for partial names).
+ *
+ * Returns up to `limit` matches, ranked: exact name match first, then
+ * exact alias match, then substring of name, then substring of alias.
+ */
+export async function search(
+  query: string,
+  opts: { schema?: Schema; limit?: number } = {}
+): Promise<SanctionEntry[]> {
+  if (!query || query.length < 4) return [];
+  const list = await loadList();
+  const q = normName(query);
+  const limit = opts.limit ?? 50;
+
+  const exactName: SanctionEntry[] = [];
+  const exactAlias: SanctionEntry[] = [];
+  const subName: SanctionEntry[] = [];
+  const subAlias: SanctionEntry[] = [];
+  const seen = new Set<string>();
+
+  const push = (bucket: SanctionEntry[], e: SanctionEntry) => {
+    if (seen.has(e.id)) return;
+    if (opts.schema && e.schema !== opts.schema) return;
+    seen.add(e.id);
+    bucket.push(e);
+  };
+
+  for (const entry of list.entries) {
+    const nameNorm = normName(entry.name);
+    if (nameNorm === q) push(exactName, entry);
+    else if (entry.aliases.some((a) => normName(a) === q)) push(exactAlias, entry);
+    else if (nameNorm.includes(q)) push(subName, entry);
+    else if (entry.aliases.some((a) => normName(a).includes(q))) push(subAlias, entry);
+    if (seen.size >= limit * 4) break; // hard cap on the scan
+  }
+
+  return [...exactName, ...exactAlias, ...subName, ...subAlias].slice(0, limit);
+}
+
+/** Number of indexed entries, for diagnostics / `/api/health`. */
+export async function indexSize(): Promise<number> {
+  const list = await loadList();
+  return list.entries.length;
+}


### PR DESCRIPTION
## Summary
Adds full **OFAC SDN entity intelligence** to the RECON toolkit — a standalone search tab plus automatic cross-checks wired into the existing WHOIS and IP-intel routes — and brings the README / DOCKER / `.env.template` docs back in sync with the new feature **and** the Crypto Wallet Trace + Telegram OSINT layers introduced in PRs #170 and #171.

All upstream sources remain keyless. No new npm dependencies.

## Why
- The crypto layer (#170) already cross-checks wallets against the OFAC SDN crypto sub-list; this PR generalises that capability to persons, organisations, vessels and aircraft so it covers the rest of the platform's pivot surface (domain registrants, ASN owners, vessels).
- WHOIS and IP-intel routes touch hostnames / ASNs that frequently belong to sanctioned operators (Russian banks, Iranian ISPs, etc.). Surfacing a SDN hit inline turns those existing tabs into compliance-aware tools without forcing the analyst to open another panel.
- The README / DOCKER docs had drifted: PRs #170 and #171 added three user-visible capabilities that were never mentioned anywhere in the repo. Folding the doc refresh into this PR keeps the operator-facing documentation coherent at merge time.

## Data source (keyless, open data)
| Source | Notes |
|--------|-------|
| [OpenSanctions](https://www.opensanctions.org) `us_ofac_sdn` simple CSV (~7 MB) | CC-BY 4.0, no key, refreshed daily upstream. Normalised flat schema (`Person` / `Organization` / `Vessel` / `Airplane` / `LegalEntity`) is much easier to consume than the raw Treasury XML. |

## What's in the PR

### Feature code
- `src/lib/sanctions.ts` — CSV loader with a tolerant inline parser (no `papaparse` dep added), in-memory index keyed by lower-cased + punctuation-stripped name **and** every alias, 24h TTL, single-flight refresh, stale-on-failure fallback.
- `src/app/api/osint/sanctions/route.ts` — `GET /api/osint/sanctions?query=&schema=&limit=` for free-text search. Requires ≥ 4-char query, ranks results exact-name → exact-alias → substring-name → substring-alias, schema-filterable to one of `Person`, `Organization`, `Company`, `Vessel`, `Airplane`, `LegalEntity`.
- `src/app/api/osint/whois/route.ts` — adds a `sanctions_match` field populated from a strict (exact normalised) lookup against every RDAP entity name / org. Strict matching is used here intentionally so a registrant called `"Acme"` does **not** auto-match `"Acme Holdings"` — false positives in a WHOIS popup are worse than a missed near-match.
- `src/app/api/osint/ip/route.ts` — same `sanctions_match` field, populated from the ASN owner / ISP / org strings returned by ip-api.
- `src/components/OsintPanel.tsx` — new **SANCTIONS** tab with its own result renderer; new `SanctionsBadge` component that surfaces inline hits at the top of the WHOIS and IP result panes.

### Documentation
- `README.md`
  - Key Capabilities table: **+3 rows** (Crypto, Sanctions, Telegram OSINT).
  - Architecture diagram: route list refreshed (adds `/api/osint/crypto`, `/api/osint/sanctions`, `/api/telegram-feed`); external data sources block updated (adds blockstream.info, Blockscout, OpenSanctions, `t.me` previews).
  - "15 toggleable data layers" → "16" (Telegram OSINT counted).
  - RECON Toolkit bullets: WHOIS / IP descriptions note the new auto-cross-check; **+2 new bullets** (Crypto Wallet Trace, OFAC Sanctions Search).
  - **+3 new feature sections**: Telegram OSINT Layer, Crypto Wallet Intelligence, OFAC SDN Cross-Check.
- `DOCKER.md`
  - New **Optional runtime overrides** table documenting `OSIRIS_TELEGRAM_CHANNELS` and re-stating `OSIRIS_PORT`.
  - Keyless-sources paragraph extended with blockstream.info, Blockscout, OpenSanctions and `t.me/s` previews.
- `.env.template`
  - New optional `OSIRIS_TELEGRAM_CHANNELS` entry with the default channel list documented in the comment.

## API response shapes

### Standalone search
```json
GET /api/osint/sanctions?query=putin
{
  "query": "putin",
  "schema": null,
  "total": 10,
  "matches": [
    {
      "id": "NK-...",
      "schema": "Person",
      "name": "Vladimir Vladimirovich Putin",
      "aliases": ["Putin, Vladimir", "..."],
      "countries": ["ru"],
      "programs": ["US-RUSHAR"],
      "sanctions": "Specially Designated Nationals (SDN) List",
      "first_seen": "...",
      "last_seen": "..."
    }
  ],
  "source": "OpenSanctions / US OFAC SDN",
  "timestamp": "..."
}
```

### Inline cross-check (added to WHOIS and IP responses)
```json
{
  "...existing fields...",
  "sanctions_match": {
    "source": "OFAC SDN",
    "hits": [
      { "matched_value": "Some Bank", "entries": [{ "id": "...", "name": "Some Bank", "programs": ["..."] }] }
    ]
  }
}
```
No match → `"sanctions_match": null`.

## Test plan
- [ ] `GET /api/osint/sanctions?query=putin` returns ≥ 1 match including `Vladimir Vladimirovich Putin` (Person).
- [ ] `GET /api/osint/sanctions?query=gazprom` returns multiple Organization matches.
- [ ] `GET /api/osint/sanctions?query=ship&schema=Vessel&limit=5` returns only Vessel rows.
- [ ] `GET /api/osint/sanctions?query=ab` returns 400 (`Query must be at least 4 characters`).
- [ ] First call is slower (CSV download + parse); subsequent calls in the same 24h window are sub-200 ms (cache hit).
- [ ] `GET /api/osint/whois?domain=google.com` and `GET /api/osint/ip?ip=8.8.8.8` keep returning their existing fields and add `"sanctions_match": null`.
- [ ] RECON panel: SANCTIONS tab renders matches with name, schema, aliases, countries, programs; "No matches" message renders green for queries with zero hits.
- [ ] WHOIS / IP panels: when `sanctions_match` is present, a red `SANCTIONED — OFAC SDN` badge appears above the existing fields.

## Known limitations / future work
- Strict (exact normalised) matching on the inline cross-check is conservative on purpose; a follow-up could add an opt-in fuzzy mode (Jaro-Winkler etc.) behind a query flag for analysts who want the wider net.
- Only the US OFAC SDN list is queried. Adding EU / UK / UN / Canada via OpenSanctions' multi-list datasets is a one-line URL change in `sanctions.ts` if there is appetite.
- Maritime vessels on the existing map layer are not yet cross-checked; the vessel data currently exposed by `/api/maritime` doesn't carry the vessel name fields that the SDN entries key on.

## Out of scope
- No new npm dependencies. No new required env vars. No schema changes.
- No changes to the existing `/api/gdelt` route or its dictionary.

## Note on the docs in this PR
The README mentions the **Crypto Wallet Trace** (#170) and **Telegram OSINT** (#171) features in addition to the sanctions feature added here. Both PRs are open against this repo at the time of writing; the docs assume they are merged. If you prefer to land the doc refresh after the other two PRs merge, the README/DOCKER/.env.template diffs in this PR can be cherry-picked separately.
