### PR TITLE
Add public rail operations and map layers

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,19 +3,19 @@
 #  Copy this file to `.env` (or `.env.local`) and fill in values as needed.
 #
 #  IMPORTANT — read before filling anything in:
-#  OSIRIS works fully WITHOUT any third-party API keys. Aviation, maritime,
-#  satellites, fires, earthquakes, weather, news, CVEs, etc. all use public
-#  keyless feeds (adsb.lol, celestrak.org, NASA FIRMS open CSV, USGS, …).
+#  OSIRIS works mostly WITHOUT third-party API keys. Aviation, maritime,
+#  satellites, fires, earthquakes, weather, news, CVEs, URLhaus, GLEIF,
+#  Overpass, GDACS, EPSS, etc. use public/keyless feeds where possible.
 #
-#  As of this revision the application code only actually reads SCANNER_URL
-#  and SCANNER_KEY. The other keys below are OPTIONAL and reserved for higher
-#  rate limits / future data sources — set them only if you extend the code or
-#  hit rate limits on the public feeds.
+#  Some public providers changed their access model: OpenAQ v3 now requires
+#  an API key, and ReliefWeb v2 requires an approved appname. Leave optional
+#  values empty; affected routes will report a disabled source instead of
+#  failing the app.
 # ═══════════════════════════════════════════════════════════════════════════
 
 
 # ─────────────────────────────────────────────────────────────────────────
-#  RECON SCANNER BACKEND  ── the ONLY keys the current code consumes ──
+#  RECON SCANNER BACKEND
 #  Powers the RECON toolkit (quick/ssl/headers/rdns/subdomains/tech/whois/
 #  geoloc/vuln scans). Requires running the separate OSIRIS scanner backend.
 #  SCANNER_KEY here MUST equal the backend's OSIRIS_KEY. Generate one with:
@@ -27,8 +27,20 @@ SCANNER_KEY=
 
 
 # ─────────────────────────────────────────────────────────────────────────
-#  OPTIONAL DATA-SOURCE KEYS  (not read by current code — future / upgrades)
+#  OPTIONAL DATA-SOURCE KEYS
 # ─────────────────────────────────────────────────────────────────────────
+
+# OpenAQ v3 — global air quality stations.
+# Required by OpenAQ v3. Without this, /api/air-quality returns enabled=false
+# with setup guidance, and the rest of OSIRIS continues to run.
+#   Docs: https://docs.openaq.org/using-the-api/quick-start
+OPENAQ_API_KEY=
+
+# ReliefWeb v2 — humanitarian reports and situation updates.
+# ReliefWeb requires an approved appname. Without this, /api/disasters uses
+# GDACS and marks ReliefWeb disabled.
+#   Request/Docs: https://apidoc.reliefweb.int/parameters#appname
+RELIEFWEB_APP_NAME=
 
 # NASA FIRMS — active wildfire hotspots.
 # Free, instant. Enter an email at the page below and the MAP_KEY is emailed

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,41 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - codex/**
+
+concurrency:
+  group: pr-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Test and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run integration tests
+        run: npm run test:integrations
+
+      - name: Type check
+        run: npx tsc --noEmit --incremental false
+
+      - name: Build
+        run: npm run build

--- a/docs/superpowers/plans/2026-06-04-osiris-public-data-phase-1-implementation.md
+++ b/docs/superpowers/plans/2026-06-04-osiris-public-data-phase-1-implementation.md
@@ -1,0 +1,225 @@
+# OSIRIS Public Data Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first public-data expansion wave: a safe connector foundation, OpenAQ v3 air-quality behavior, GDACS/ReliefWeb disaster intelligence and EPSS-based cyber prioritization.
+
+**Architecture:** Add focused connector modules under `src/lib/integrations/` and keep App Router route handlers thin. Preserve existing response contracts where routes already exist, and add explicit `enabled` / `partial` source status for integrations that now require credentials or approved app names.
+
+**Tech Stack:** Next.js 16 App Router route handlers, TypeScript, Node 25 built-in test runner with `--experimental-strip-types`, public HTTP JSON/RSS APIs.
+
+---
+
+## Files
+
+- Create: `src/lib/integrations/source-metadata.ts`
+- Create: `src/lib/integrations/openaq.ts`
+- Create: `src/lib/integrations/disasters.ts`
+- Create: `src/lib/integrations/cyber-priority.ts`
+- Modify: `src/app/api/air-quality/route.ts`
+- Create: `src/app/api/disasters/route.ts`
+- Create: `src/app/api/cyber-priority/route.ts`
+- Modify: `src/app/api/osint/cve/route.ts`
+- Modify: `src/app/api/cyber-threats/route.ts`
+- Create: `src/lib/integrations/*.test.ts`
+- Modify: `package.json`
+- Modify: `docs/superpowers/specs/2026-06-04-osiris-public-data-integrations-design.md`
+
+## Task 1: Connector Foundation and Tests
+
+**Files:**
+- Create: `src/lib/integrations/source-metadata.ts`
+- Create: `src/lib/integrations/openaq.ts`
+- Create: `src/lib/integrations/disasters.ts`
+- Create: `src/lib/integrations/cyber-priority.ts`
+- Create: `src/lib/integrations/openaq.test.ts`
+- Create: `src/lib/integrations/disasters.test.ts`
+- Create: `src/lib/integrations/cyber-priority.test.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Write failing tests**
+
+Create Node test files that import the TypeScript normalizer functions directly:
+
+```ts
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeOpenAqLatestResult } from './openaq.ts';
+
+test('normalizes OpenAQ v3 latest PM2.5 records into station output', () => {
+  const station = normalizeOpenAqLatestResult({
+    locationsId: 42,
+    location: 'Station A',
+    coordinates: { latitude: 48.1, longitude: 11.6 },
+    parameter: { name: 'pm25', units: 'µg/m³' },
+    value: 18.3,
+    datetime: { utc: '2026-06-04T08:00:00Z' },
+    country: { code: 'DE' },
+  });
+
+  assert.equal(station?.id, 'aq-42-pm25');
+  assert.equal(station?.pm25, 18.3);
+  assert.equal(station?.level, 'Good');
+});
+```
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+npm run test:integrations
+```
+
+Expected: fails because the test script or modules do not exist yet.
+
+- [ ] **Step 3: Implement connector modules**
+
+Add typed normalizers and small fetch helpers. Each connector must return source metadata and never throw for expected disabled states.
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+npm run test:integrations
+```
+
+Expected: all integration normalizer tests pass.
+
+## Task 2: Air Quality Route
+
+**Files:**
+- Modify: `src/app/api/air-quality/route.ts`
+- Test: `src/lib/integrations/openaq.test.ts`
+
+- [ ] **Step 1: Extend failing tests**
+
+Add tests for disabled OpenAQ behavior when no API key is configured and for unhealthy PM2.5 classification.
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+npm run test:integrations
+```
+
+Expected: fails until disabled-state helpers and classifications exist.
+
+- [ ] **Step 3: Implement route**
+
+Use `OPENAQ_API_KEY` in the `X-API-Key` header. If missing, return `200` with `stations: []`, `enabled: false`, source status and a setup message. If configured, call OpenAQ v3 `/v3/parameters/2/latest` and preserve the existing `stations`, `total`, `timestamp` contract.
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+npm run test:integrations
+curl -sS http://localhost:3001/api/air-quality
+```
+
+Expected without key: JSON response is non-failing and clearly disabled.
+
+## Task 3: Disaster Intelligence Route
+
+**Files:**
+- Create: `src/app/api/disasters/route.ts`
+- Test: `src/lib/integrations/disasters.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Test GDACS RSS and GDACS API feature normalization plus ReliefWeb disabled behavior without `RELIEFWEB_APP_NAME`.
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+npm run test:integrations
+```
+
+Expected: disaster tests fail until the normalizers are complete.
+
+- [ ] **Step 3: Implement route**
+
+Fetch GDACS GeoJSON API keylessly. If `RELIEFWEB_APP_NAME` exists, also POST to ReliefWeb v2 reports. If ReliefWeb is not configured or denied, return GDACS data and mark ReliefWeb disabled/error in `sources`.
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+curl -sS http://localhost:3001/api/disasters
+```
+
+Expected: a JSON response with `events`, `reports`, `sources`, `total`, and `timestamp`; GDACS should work without keys.
+
+## Task 4: Cyber Priority Route and CVE Enrichment
+
+**Files:**
+- Create: `src/app/api/cyber-priority/route.ts`
+- Modify: `src/app/api/osint/cve/route.ts`
+- Modify: `src/app/api/cyber-threats/route.ts`
+- Test: `src/lib/integrations/cyber-priority.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Test EPSS scoring thresholds and merged CVE priority calculation.
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+npm run test:integrations
+```
+
+Expected: cyber-priority tests fail until scoring helpers exist.
+
+- [ ] **Step 3: Implement route and enrichment**
+
+Add `/api/cyber-priority?cves=CVE-2024-3094,CVE-2023-...` for explicit CVEs and default to recent CISA KEV CVEs when no query is supplied. Add EPSS fields to `/api/osint/cve` responses. Keep `/api/cyber-threats` compatible, adding priority stats rather than replacing existing fields.
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+curl -sS 'http://localhost:3001/api/cyber-priority?cves=CVE-2024-3094'
+curl -sS 'http://localhost:3001/api/osint/cve?cve=CVE-2024-3094'
+```
+
+Expected: responses include EPSS probability/percentile and a clear priority label.
+
+## Task 5: Final Verification
+
+**Files:**
+- All changed implementation files.
+
+- [ ] **Step 1: Type/build check**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected: production build succeeds.
+
+- [ ] **Step 2: Targeted route smoke checks**
+
+Run:
+
+```bash
+curl -sS http://localhost:3001/api/air-quality
+curl -sS http://localhost:3001/api/disasters
+curl -sS 'http://localhost:3001/api/cyber-priority?cves=CVE-2024-3094'
+```
+
+Expected: all return JSON and no route crashes.
+
+- [ ] **Step 3: Browser smoke**
+
+Open `http://localhost:3001`, verify the dashboard still renders and no framework overlay appears.

--- a/docs/superpowers/specs/2026-06-04-osiris-public-data-integrations-design.md
+++ b/docs/superpowers/specs/2026-06-04-osiris-public-data-integrations-design.md
@@ -34,8 +34,8 @@ Implement or upgrade these integrations first:
 
 | Domain | Source | Intended product value |
 | --- | --- | --- |
-| Air quality | OpenAQ v3 | Replace old OpenAQ v2 usage and restore a global air-quality layer. |
-| Humanitarian/disaster impact | ReliefWeb | Add reports and situation updates tied to countries and incidents. |
+| Air quality | OpenAQ v3 | Replace old OpenAQ v2 usage and keep the route non-failing; OpenAQ v3 requires `OPENAQ_API_KEY`. |
+| Humanitarian/disaster impact | ReliefWeb v2 | Add reports and situation updates when `RELIEFWEB_APP_NAME` is configured with an approved app name. |
 | Disaster alerts | GDACS | Add authoritative disaster-alert context to existing hazards. |
 | Cyber prioritization | FIRST EPSS | Rank CVEs by exploitation probability. |
 | Malware and phishing indicators | URLhaus | Enrich RECON results with malicious URL and IOC context. |
@@ -54,6 +54,8 @@ Add connectors that require accounts or keys, but keep them disabled unless conf
 | Live maritime | AISStream | Server-side WebSocket or polling bridge. Disabled without `AISSTREAM_API_KEY`. |
 | Aviation fallback/enrichment | OpenSky OAuth | Used when `OPENSKY_CLIENT_ID` and `OPENSKY_CLIENT_SECRET` exist. |
 | Satellite enrichment | Existing N2YO-style key path or other configured source | Disabled without the matching environment variable. |
+| Air quality activation | OpenAQ v3 | Enabled only when `OPENAQ_API_KEY` exists. |
+| Humanitarian reports activation | ReliefWeb v2 | Enabled only when `RELIEFWEB_APP_NAME` exists and is approved by ReliefWeb. |
 
 ### Phase 3: Correlation Layer
 
@@ -124,8 +126,8 @@ Connectors that are not geospatial, such as EPSS or GLEIF, should still use sour
 
 Add or upgrade routes around product domains, not vendor names:
 
-- `/api/air-quality`: migrate to OpenAQ v3 and keep current consumer contract as stable as practical.
-- `/api/disasters`: compose GDACS and ReliefWeb summaries.
+- `/api/air-quality`: migrate to OpenAQ v3, keep current consumer contract as stable as practical and return a disabled setup state without `OPENAQ_API_KEY`.
+- `/api/disasters`: compose GDACS and ReliefWeb summaries; GDACS is keyless, ReliefWeb is optional through `RELIEFWEB_APP_NAME`.
 - `/api/cyber-priority`: compose EPSS, CISA KEV and NVD/CVE metadata.
 - `/api/infrastructure/context`: compose Overpass/OSM and HIFLD.
 - `/api/entities/resolve`: resolve entity identity from GLEIF and sanctions sources.

--- a/docs/superpowers/specs/2026-06-04-osiris-public-data-integrations-design.md
+++ b/docs/superpowers/specs/2026-06-04-osiris-public-data-integrations-design.md
@@ -1,0 +1,208 @@
+# OSIRIS Public Data Integrations Design
+
+Date: 2026-06-04
+Status: Design ready for user review
+
+## Goal
+
+Expand OSIRIS with a broad set of public data integrations while keeping the product reliable, attributable and useful for decision-making. The work should turn OSIRIS from a collection of live map feeds into a correlation cockpit that can answer questions such as:
+
+- Which active incidents affect infrastructure, suppliers, vessels, aircraft or public assets?
+- Which cyber findings are actually urgent because exploitation is likely or known?
+- Which environmental or humanitarian events change operational risk in the next 24-72 hours?
+- Which source produced the signal, how fresh is it and how much confidence should the user place in it?
+
+## Product Principles
+
+1. Keyless sources ship first.
+   Public feeds that work without new accounts create immediate user value and reduce rollout friction.
+
+2. API-key sources are optional connectors.
+   Sources such as AISStream and OpenSky OAuth are prepared behind server-side environment variables. Missing keys should disable only that connector, not the whole app.
+
+3. Correlation beats feed volume.
+   New data should not only add points to the map. Each integration should support cross-layer interpretation: event near infrastructure, supplier in risk zone, active CVE affecting a scanned host, vessel movement near a chokepoint, or forecast worsening an incident.
+
+4. Source trust must be visible.
+   Every normalized record carries source, timestamp, confidence, freshness and attribution metadata.
+
+## Scope
+
+### Phase 1: Keyless Core
+
+Implement or upgrade these integrations first:
+
+| Domain | Source | Intended product value |
+| --- | --- | --- |
+| Air quality | OpenAQ v3 | Replace old OpenAQ v2 usage and restore a global air-quality layer. |
+| Humanitarian/disaster impact | ReliefWeb | Add reports and situation updates tied to countries and incidents. |
+| Disaster alerts | GDACS | Add authoritative disaster-alert context to existing hazards. |
+| Cyber prioritization | FIRST EPSS | Rank CVEs by exploitation probability. |
+| Malware and phishing indicators | URLhaus | Enrich RECON results with malicious URL and IOC context. |
+| Forecast weather | Open-Meteo | Add forward-looking weather risk for selected locations. |
+| Infrastructure context | Overpass/OSM | Add global infrastructure points and lines for power, transport, ports and hospitals. |
+| US critical infrastructure | HIFLD | Add US-specific critical infrastructure context where available. |
+| Entity identity | GLEIF | Normalize legal entities and supplier/company identity. |
+| Sanctions/watchlists | OpenSanctions and OFAC | Extend existing sanctions workflows and entity cross-checks. |
+
+### Phase 2: Optional API-Key Connectors
+
+Add connectors that require accounts or keys, but keep them disabled unless configured:
+
+| Domain | Source | Runtime behavior |
+| --- | --- | --- |
+| Live maritime | AISStream | Server-side WebSocket or polling bridge. Disabled without `AISSTREAM_API_KEY`. |
+| Aviation fallback/enrichment | OpenSky OAuth | Used when `OPENSKY_CLIENT_ID` and `OPENSKY_CLIENT_SECRET` exist. |
+| Satellite enrichment | Existing N2YO-style key path or other configured source | Disabled without the matching environment variable. |
+
+### Phase 3: Correlation Layer
+
+Add derived findings on top of raw feeds:
+
+- `event_near_infrastructure`: hazard or conflict event within a configurable radius of critical infrastructure.
+- `supplier_in_risk_zone`: supplier/entity linked to a location with active risk.
+- `cve_priority`: CVE enriched with EPSS probability, CISA KEV status and NVD severity.
+- `chokepoint_pressure`: vessel or port risk combined with incidents, weather or market signals.
+- `environmental_exposure`: air-quality or weather risk affecting selected regions or assets.
+
+## Non-Goals
+
+- Do not scrape sources where an official public API or data file exists.
+- Do not add user-personal breach lookups beyond existing explicit RECON actions.
+- Do not require new API keys for the base app to boot.
+- Do not mix unrelated data-source cleanup into the initial connector commits unless required for correctness.
+
+## Architecture
+
+### Connector Boundary
+
+Each source gets a small connector module responsible for:
+
+- Fetching from the external source.
+- Applying timeout and retry policy.
+- Returning raw-but-typed source records.
+- Exposing source metadata, attribution and recommended cache TTL.
+
+API routes should not embed large source-specific parsing logic directly. Routes compose connector output into OSIRIS-normalized records.
+
+### Normalized Record Shape
+
+All new feeds should map into a shared shape where possible:
+
+```ts
+type OsirisSourceMeta = {
+  provider: string;
+  feed: string;
+  url?: string;
+  attribution?: string;
+  license?: string;
+  fetchedAt: string;
+  observedAt?: string;
+  cacheTtlSeconds: number;
+  confidence: number;
+};
+
+type OsirisGeoRecord = {
+  id: string;
+  domain: 'ENV' | 'HUMANITARIAN' | 'CYBER' | 'INFRA' | 'ENTITY' | 'MARITIME' | 'AIR' | 'SPACE';
+  type: string;
+  title: string;
+  severity?: 'low' | 'medium' | 'high' | 'critical';
+  lat?: number;
+  lng?: number;
+  geometry?: GeoJSON.Geometry;
+  countryCode?: string;
+  tags: string[];
+  source: OsirisSourceMeta;
+  raw?: unknown;
+};
+```
+
+Connectors that are not geospatial, such as EPSS or GLEIF, should still use source metadata and return records that can enrich map entities, RECON results or supplier graphs.
+
+### API Routes
+
+Add or upgrade routes around product domains, not vendor names:
+
+- `/api/air-quality`: migrate to OpenAQ v3 and keep current consumer contract as stable as practical.
+- `/api/disasters`: compose GDACS and ReliefWeb summaries.
+- `/api/cyber-priority`: compose EPSS, CISA KEV and NVD/CVE metadata.
+- `/api/infrastructure/context`: compose Overpass/OSM and HIFLD.
+- `/api/entities/resolve`: resolve entity identity from GLEIF and sanctions sources.
+- `/api/maritime/live`: optional AIS connector, disabled without key.
+
+Existing routes can call the new connectors internally where that avoids UI churn.
+
+## UX Design
+
+Phase 1 should add value without overwhelming the map:
+
+- Add one new "Impact" or "Disasters" layer for ReliefWeb/GDACS.
+- Fix/restore the existing air-quality route before adding new UI complexity.
+- Add cyber prioritization inside the existing RECON/CVE surface rather than creating a new panel.
+- Add infrastructure context as a layer with conservative default density and viewport-scoped queries.
+- Surface source freshness and attribution in popovers or detail panels.
+
+Correlation findings should appear as concise alerts, not as another dense layer by default.
+
+## Caching, Rate Limits and Failure Behavior
+
+- Every connector must define a cache TTL based on feed volatility.
+- Keyless public APIs should be protected with server-side caching and request de-duplication.
+- Large responses should not be cached through mechanisms that exceed Next.js data cache limits.
+- A failed connector returns a partial response with source-specific status instead of failing a composed endpoint.
+- Optional API-key connectors return a disabled state when the key is absent.
+
+Recommended initial TTLs:
+
+| Source type | TTL |
+| --- | --- |
+| EPSS, sanctions, entity identity | 12-24 hours |
+| ReliefWeb/GDACS | 15-60 minutes |
+| OpenAQ/Open-Meteo | 15-60 minutes |
+| Overpass/HIFLD | 24 hours or viewport cache |
+| AISStream/OpenSky | near real-time with throttling |
+
+## Security, Privacy and Compliance
+
+- Keep all API keys server-side.
+- Do not send sensitive user-entered identifiers to enrichment APIs unless the user intentionally triggers a RECON action.
+- Display attribution for feeds that require it.
+- Store only normalized operational data in memory/cache unless a source license allows broader persistence.
+- Avoid uncontrolled scraping of camera, social, breach or personal-data surfaces.
+
+## Testing Strategy
+
+Use tests proportional to each connector:
+
+- Unit tests for normalizers with fixture payloads.
+- Route tests for disabled API-key behavior and partial failures.
+- Smoke tests for keyless routes returning stable shapes.
+- Browser validation for new visible layers and RECON UI enrichment.
+- Build verification after each phase.
+
+Acceptance criteria for each source:
+
+- App boots without the source configured.
+- Route returns a clear success, partial or disabled state.
+- Records include source metadata and freshness.
+- UI does not render blank or blocking overlays when the source fails.
+- External calls are cached or throttled.
+
+## Rollout Plan
+
+1. Connector foundation and OpenAQ v3 migration.
+2. Disaster and humanitarian impact route.
+3. Cyber prioritization enrichment.
+4. Infrastructure context route and layer.
+5. Entity resolution and sanctions enrichment.
+6. Optional API-key connector framework.
+7. AISStream/OpenSky optional connectors.
+8. Correlation findings.
+9. UI polish and source freshness indicators.
+
+This order maximizes immediate user value while deferring streaming and account-dependent work until the app has a stable connector foundation.
+
+## Review Decision
+
+Proceed with the design as a phased implementation. The first implementation plan should cover steps 1-3 only, because they are mostly keyless, have limited UI blast radius and create the foundation for the later sources.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:integrations": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test src/lib/integrations/*.test.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/public/data/yameiko-project-intel.json
+++ b/public/data/yameiko-project-intel.json
@@ -1,0 +1,95 @@
+{
+  "caseId": "yameiko-project-intelligence",
+  "title": "Yameiko Project Intelligence",
+  "generatedFrom": "local development portfolio",
+  "generatedAt": "2026-06-04",
+  "summary": "A starter OSIRIS case that treats the local development portfolio as monitored digital assets.",
+  "projects": [
+    {
+      "name": "EntdeckerApp",
+      "type": "Capacitor mobile app",
+      "stack": ["React", "TypeScript", "Vite", "Firebase", "Tailwind", "Capacitor"],
+      "signals": ["Firebase deploy surface", "mobile release readiness", "test and admin workflows"],
+      "riskFocus": "Production app with auth, admin and deployment scripts needs release, credential and availability monitoring.",
+      "priority": "critical"
+    },
+    {
+      "name": "NatureCoach",
+      "type": "Capacitor mobile app",
+      "stack": ["React", "TypeScript", "Vite", "Firebase", "Tailwind", "Capacitor"],
+      "signals": ["Firebase deploy surface", "mobile release readiness", "user data flows"],
+      "riskFocus": "Similar app platform to EntdeckerApp, useful for shared release and security monitoring.",
+      "priority": "high"
+    },
+    {
+      "name": "evplanner",
+      "type": "EV charging and camping companion",
+      "stack": ["Vanilla JS", "Vite", "Capacitor", "Firebase"],
+      "signals": ["charging/camping data freshness", "Firebase deployment", "iOS verification scripts"],
+      "riskFocus": "Travel and charging decisions depend on data quality and mobile reliability.",
+      "priority": "critical"
+    },
+    {
+      "name": "ClarityAI",
+      "type": "iOS app",
+      "stack": ["Swift", "SwiftUI"],
+      "signals": ["App Store readiness", "simulator validation", "privacy posture"],
+      "riskFocus": "Native app should be monitored for release blockers and privacy-sensitive flows.",
+      "priority": "high"
+    },
+    {
+      "name": "Homeassistant",
+      "type": "Home automation",
+      "stack": ["Home Assistant", "YAML", "Python"],
+      "signals": ["automation availability", "IoT device dependencies", "local network exposure"],
+      "riskFocus": "Operational reliability and local network attack surface are the main concerns.",
+      "priority": "medium"
+    },
+    {
+      "name": "Webseite-efoil",
+      "type": "commerce website",
+      "stack": ["Firebase Hosting", "Firebase Functions", "PayPal", "Email"],
+      "signals": ["checkout uptime", "payment flow", "email delivery", "public domain posture"],
+      "riskFocus": "Revenue path depends on checkout, serverless API and email deliverability.",
+      "priority": "critical"
+    },
+    {
+      "name": "Webseite-yameiko",
+      "type": "website",
+      "stack": ["Vite", "React"],
+      "signals": ["public content", "SEO", "availability"],
+      "riskFocus": "Brand surface and portfolio visibility.",
+      "priority": "medium"
+    },
+    {
+      "name": "Webshop-CargoVault",
+      "type": "e-commerce prototype",
+      "stack": ["Vite", "React", "React Router", "Tailwind", "Framer Motion"],
+      "signals": ["conversion path", "public content", "frontend build health"],
+      "riskFocus": "Good candidate for market and product signal monitoring.",
+      "priority": "high"
+    },
+    {
+      "name": "Webshop-MainLakritz",
+      "type": "e-commerce prototype",
+      "stack": ["Vite"],
+      "signals": ["product page readiness", "frontend build health"],
+      "riskFocus": "Early-stage shop surface with simple technical footprint.",
+      "priority": "medium"
+    },
+    {
+      "name": "zigbee2mqtt-master",
+      "type": "IoT integration",
+      "stack": ["Zigbee2MQTT", "Node.js"],
+      "signals": ["device compatibility", "local network dependencies", "update cadence"],
+      "riskFocus": "Useful for device inventory and home automation dependency monitoring.",
+      "priority": "medium"
+    }
+  ],
+  "starterWorkflow": [
+    "Use OSIRIS live layers for external context around locations and infrastructure relevant to a project.",
+    "Use the RECON panel for public domains only: DNS, WHOIS, SSL and IP intelligence.",
+    "Track critical projects as assets with owner, deployment target, public URL and release status.",
+    "Convert repeated findings into a weekly operating review: critical changes, incidents, release blockers and next actions."
+  ]
+}

--- a/src/app/api/air-quality/route.ts
+++ b/src/app/api/air-quality/route.ts
@@ -1,70 +1,65 @@
 import { NextResponse } from 'next/server';
+import {
+  buildOpenAqDisabledResponse,
+  fetchOpenAqStations,
+} from '@/lib/integrations/openaq';
+import {
+  errorSourceStatus,
+  okSourceStatus,
+} from '@/lib/integrations/source-metadata';
+
+export const dynamic = 'force-dynamic';
 
 /**
  * OSIRIS — Air Quality Monitoring API
- * Fetches real-time global air quality data from OpenAQ
- * FREE — No API key required
- * Data: PM2.5, PM10, O3, NO2, SO2, CO measurements worldwide
+ *
+ * OpenAQ v1/v2 are retired and v3 requires an X-API-Key header. The route
+ * stays non-failing without credentials so the dashboard can still boot.
  */
-
 export async function GET() {
+  const apiKey = process.env.OPENAQ_API_KEY;
+
+  if (!apiKey) {
+    return NextResponse.json(buildOpenAqDisabledResponse(), {
+      headers: {
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+      },
+    });
+  }
+
   try {
-    // OpenAQ v2 — get latest measurements globally
-    // We request PM2.5 (most health-relevant) with coordinates
-    const urls = [
-      'https://api.openaq.org/v2/latest?limit=500&parameter=pm25&order_by=lastUpdated&sort=desc',
-    ];
-
-    const results = await Promise.allSettled(
-      urls.map(url =>
-        fetch(url, {
-          signal: AbortSignal.timeout(10000),
-          headers: { 'Accept': 'application/json' },
-        }).then(r => r.json())
-      )
-    );
-
-    const stations: any[] = [];
-    for (const result of results) {
-      if (result.status !== 'fulfilled') continue;
-      const data = result.value;
-      for (const loc of data.results || []) {
-        if (!loc.coordinates?.latitude || !loc.coordinates?.longitude) continue;
-        const pm25 = loc.measurements?.find((m: any) => m.parameter === 'pm25');
-        if (!pm25) continue;
-        
-        // AQI color coding based on PM2.5 (WHO/EPA scale)
-        const val = pm25.value;
-        let level = 'Good';
-        let color = '#00E676';
-        if (val > 150) { level = 'Hazardous'; color = '#8B0000'; }
-        else if (val > 100) { level = 'Unhealthy'; color = '#FF1744'; }
-        else if (val > 55) { level = 'Unhealthy (Sensitive)'; color = '#FF9500'; }
-        else if (val > 35) { level = 'Moderate'; color = '#FFD700'; }
-
-        stations.push({
-          id: `aq-${loc.location}`,
-          name: loc.location,
-          city: loc.city || 'Unknown',
-          country: loc.country,
-          lat: loc.coordinates.latitude,
-          lng: loc.coordinates.longitude,
-          pm25: val,
-          unit: pm25.unit,
-          level,
-          color,
-          lastUpdated: pm25.lastUpdated,
-        });
-      }
-    }
+    const stations = await fetchOpenAqStations(apiKey);
 
     return NextResponse.json({
+      enabled: true,
       stations,
       total: stations.length,
       timestamp: new Date().toISOString(),
+      sources: {
+        openaq: okSourceStatus('OpenAQ', 'https://api.openaq.org/v3/parameters/2/latest'),
+      },
+    }, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=1800, stale-while-revalidate=3600',
+      },
     });
   } catch (error) {
-    console.error('Air Quality API error:', error);
-    return NextResponse.json({ stations: [], error: 'Failed to fetch air quality data' }, { status: 500 });
+    const message = error instanceof Error ? error.message : 'Failed to fetch air quality data';
+
+    return NextResponse.json({
+      enabled: true,
+      stations: [],
+      total: 0,
+      timestamp: new Date().toISOString(),
+      sources: {
+        openaq: errorSourceStatus('OpenAQ', message, 'https://api.openaq.org/v3/parameters/2/latest'),
+      },
+      error: message,
+    }, {
+      status: 502,
+      headers: {
+        'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=300',
+      },
+    });
   }
 }

--- a/src/app/api/camping/route.ts
+++ b/src/app/api/camping/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import {
+  fallbackCampingSites,
   fetchCampingSites,
   type CampingBbox,
 } from '@/lib/integrations/camping-sites';
@@ -35,16 +36,21 @@ export async function GET(req: Request) {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Overpass camping lookup failed';
+    const fallbackSites = fallbackCampingSites(bbox);
     return NextResponse.json({
-      sites: [],
-      total: 0,
+      sites: fallbackSites,
+      total: fallbackSites.length,
       bbox,
       timestamp: new Date().toISOString(),
       sources: {
         overpass: errorSourceStatus('OpenStreetMap/Overpass', message, 'https://overpass-api.de/api/interpreter'),
+        fallback: fallbackSites.length > 0
+          ? okSourceStatus('OSIRIS fallback dataset')
+          : errorSourceStatus('OSIRIS fallback dataset', 'No fallback camping sites in bbox'),
       },
       error: message,
-    }, { status: message.includes('bbox') ? 400 : 502 });
+      partial: fallbackSites.length > 0,
+    }, { status: message.includes('bbox') ? 400 : 200 });
   }
 }
 

--- a/src/app/api/camping/route.ts
+++ b/src/app/api/camping/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import {
+  fetchCampingSites,
+  type CampingBbox,
+} from '@/lib/integrations/camping-sites';
+import {
+  errorSourceStatus,
+  okSourceStatus,
+} from '@/lib/integrations/source-metadata';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const bbox = parseBbox(searchParams);
+
+  if (!bbox) {
+    return NextResponse.json({
+      error: 'Missing bbox parameters. Use south,west,north,east or bbox=west,south,east,north.',
+    }, { status: 400 });
+  }
+
+  try {
+    const sites = await fetchCampingSites(bbox);
+    return NextResponse.json({
+      sites,
+      total: sites.length,
+      bbox,
+      timestamp: new Date().toISOString(),
+      sources: {
+        overpass: okSourceStatus('OpenStreetMap/Overpass', 'https://overpass-api.de/api/interpreter'),
+      },
+    }, {
+      headers: { 'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=86400' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Overpass camping lookup failed';
+    return NextResponse.json({
+      sites: [],
+      total: 0,
+      bbox,
+      timestamp: new Date().toISOString(),
+      sources: {
+        overpass: errorSourceStatus('OpenStreetMap/Overpass', message, 'https://overpass-api.de/api/interpreter'),
+      },
+      error: message,
+    }, { status: message.includes('bbox') ? 400 : 502 });
+  }
+}
+
+function parseBbox(searchParams: URLSearchParams): CampingBbox | null {
+  const rawBbox = searchParams.get('bbox');
+  if (rawBbox) {
+    const [west, south, east, north] = rawBbox.split(',').map(Number);
+    if ([south, west, north, east].every(Number.isFinite)) return { south, west, north, east };
+  }
+
+  const south = Number(searchParams.get('south'));
+  const west = Number(searchParams.get('west'));
+  const north = Number(searchParams.get('north'));
+  const east = Number(searchParams.get('east'));
+  if ([south, west, north, east].every(Number.isFinite)) return { south, west, north, east };
+
+  return null;
+}

--- a/src/app/api/cyber-priority/route.ts
+++ b/src/app/api/cyber-priority/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from 'next/server';
+import {
+  CISA_KEV_URL,
+  EPSS_URL,
+  fetchEpss,
+  fetchKevCatalog,
+  mergeCvePriority,
+  type KevRecord,
+} from '@/lib/integrations/cyber-priority';
+import {
+  errorSourceStatus,
+  okSourceStatus,
+} from '@/lib/integrations/source-metadata';
+
+export const dynamic = 'force-dynamic';
+
+const CVE_PATTERN = /^CVE-\d{4}-\d{4,}$/i;
+
+function parseCves(req: Request): string[] {
+  const { searchParams } = new URL(req.url);
+  const raw = searchParams.get('cves') || searchParams.get('cve') || '';
+  return raw
+    .split(',')
+    .map(item => item.trim().toUpperCase())
+    .filter(item => CVE_PATTERN.test(item))
+    .slice(0, 50);
+}
+
+function newestKevCves(catalog: KevRecord[], limit = 20): string[] {
+  return [...catalog]
+    .sort((a, b) => new Date(b.dateAdded || 0).getTime() - new Date(a.dateAdded || 0).getTime())
+    .map(item => item.cveID?.toUpperCase())
+    .filter((item): item is string => Boolean(item && CVE_PATTERN.test(item)))
+    .slice(0, limit);
+}
+
+export async function GET(req: Request) {
+  const explicitCves = parseCves(req);
+  const sourceStatuses = {
+    epss: okSourceStatus('FIRST EPSS', EPSS_URL),
+    cisa_kev: okSourceStatus('CISA KEV', CISA_KEV_URL),
+  };
+
+  let kevCatalog: KevRecord[] = [];
+  try {
+    kevCatalog = await fetchKevCatalog();
+  } catch (error) {
+    sourceStatuses.cisa_kev = errorSourceStatus(
+      'CISA KEV',
+      error instanceof Error ? error.message : 'CISA KEV fetch failed',
+      CISA_KEV_URL,
+    );
+  }
+
+  const cves = explicitCves.length > 0 ? explicitCves : newestKevCves(kevCatalog);
+  const kevByCve = new Map(kevCatalog.map(item => [item.cveID?.toUpperCase(), item] as const));
+
+  let epssByCve = new Map();
+  try {
+    epssByCve = await fetchEpss(cves);
+  } catch (error) {
+    sourceStatuses.epss = errorSourceStatus(
+      'FIRST EPSS',
+      error instanceof Error ? error.message : 'EPSS fetch failed',
+      EPSS_URL,
+    );
+  }
+
+  const priorities = cves.map(cve => mergeCvePriority({
+    cve,
+    epss: epssByCve.get(cve),
+    kev: kevByCve.get(cve),
+  }));
+
+  const stats = {
+    total: priorities.length,
+    critical: priorities.filter(item => item.priority === 'critical').length,
+    high: priorities.filter(item => item.priority === 'high').length,
+    medium: priorities.filter(item => item.priority === 'medium').length,
+    low: priorities.filter(item => item.priority === 'low').length,
+  };
+
+  return NextResponse.json({
+    priorities,
+    stats,
+    total: priorities.length,
+    partial: Object.values(sourceStatuses).some(source => source.status !== 'ok'),
+    timestamp: new Date().toISOString(),
+    sources: sourceStatuses,
+  }, {
+    headers: {
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/src/app/api/cyber-threats/route.ts
+++ b/src/app/api/cyber-threats/route.ts
@@ -1,27 +1,57 @@
 import { NextResponse } from 'next/server';
+import {
+  type EpssRecord,
+  fetchEpss,
+  mergeCvePriority,
+  type KevRecord,
+} from '@/lib/integrations/cyber-priority';
 
 // Cyber threat intelligence from public feeds
 // Inspired by WorldMonitor's infrastructure tracking
 
 export async function GET() {
   try {
-    const results: any = { threats: [], stats: {}, timestamp: new Date().toISOString() };
+    const results: {
+      threats: {
+        id?: string;
+        name?: string;
+        vendor?: string;
+        product?: string;
+        severity: string;
+        date?: string;
+        due?: string;
+        source: string;
+        priority?: string;
+        epss?: { probability: number; percentile: number; date?: string };
+      }[];
+      stats: Record<string, number | string>;
+      timestamp: string;
+    } = { threats: [], stats: {}, timestamp: new Date().toISOString() };
 
     // 1. CISA Known Exploited Vulnerabilities (authoritative US govt source)
     try {
       const res = await fetch('https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json', {
-        
+        headers: { Accept: 'application/json' },
       });
       if (res.ok) {
-        const data = await res.json();
-        const recent = (data.vulnerabilities || [])
-          .filter((v: any) => {
-            const added = new Date(v.dateAdded);
+        const data = (await res.json()) as { vulnerabilities?: KevRecord[] };
+        const recentKev = (data.vulnerabilities || [])
+          .filter((v) => {
+            const added = new Date(v.dateAdded || 0);
             const daysAgo = (Date.now() - added.getTime()) / (1000 * 60 * 60 * 24);
             return daysAgo <= 30;
           })
-          .slice(0, 10)
-          .map((v: any) => ({
+          .slice(0, 10);
+        const recentCves = recentKev.map(v => v.cveID).filter((cve): cve is string => Boolean(cve));
+        const epssByCve = await fetchEpss(recentCves).catch(() => new Map<string, EpssRecord>());
+        const recent = recentKev.map((v) => {
+          const priority = mergeCvePriority({
+            cve: v.cveID || 'UNKNOWN',
+            epss: v.cveID ? epssByCve.get(v.cveID.toUpperCase()) : null,
+            kev: v,
+          });
+
+          return {
             id: v.cveID,
             name: v.vulnerabilityName,
             vendor: v.vendorProject,
@@ -30,17 +60,23 @@ export async function GET() {
             date: v.dateAdded,
             due: v.dueDate,
             source: 'CISA KEV',
-          }));
+            priority: priority.priority,
+            epss: priority.epss,
+          };
+        });
         results.threats.push(...recent);
         results.stats.cisa_total = data.vulnerabilities?.length || 0;
+        results.stats.priority_critical = recent.filter(threat => threat.priority === 'critical').length;
+        results.stats.priority_high = recent.filter(threat => threat.priority === 'high').length;
       }
-    } catch (e) { console.warn('[OSIRIS] Suppressed error:', e instanceof Error ? e.message : e); }
+    } catch (e) {
+      console.warn('[OSIRIS] Suppressed error:', e instanceof Error ? e.message : e);
+    }
 
     // 2. Shadowserver honeypot stats (global attack surface)
     try {
       const res = await fetch('https://dashboard.shadowserver.org/statistics/combined/map/', {
-        
-        headers: { 'Accept': 'application/json' },
+        headers: { Accept: 'application/json' },
       });
       if (res.ok) {
         results.stats.shadowserver = 'active';

--- a/src/app/api/disasters/route.ts
+++ b/src/app/api/disasters/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import {
+  buildReliefWebDisabledStatus,
+  fetchGdacsEvents,
+  fetchReliefWebReports,
+} from '@/lib/integrations/disasters';
+import {
+  errorSourceStatus,
+  okSourceStatus,
+} from '@/lib/integrations/source-metadata';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const reliefWebAppName = process.env.RELIEFWEB_APP_NAME;
+
+  const [gdacsResult, reliefWebResult] = await Promise.allSettled([
+    fetchGdacsEvents(),
+    reliefWebAppName ? fetchReliefWebReports(reliefWebAppName) : Promise.resolve(null),
+  ]);
+
+  const events = gdacsResult.status === 'fulfilled' ? gdacsResult.value : [];
+  const reports = reliefWebResult.status === 'fulfilled' && reliefWebResult.value ? reliefWebResult.value : [];
+
+  const gdacsSource = gdacsResult.status === 'fulfilled'
+    ? okSourceStatus('GDACS', 'https://www.gdacs.org/gdacsapi/api/events/geteventlist/SEARCH')
+    : errorSourceStatus(
+        'GDACS',
+        gdacsResult.reason instanceof Error ? gdacsResult.reason.message : 'GDACS fetch failed',
+        'https://www.gdacs.org/gdacsapi/api/events/geteventlist/SEARCH',
+      );
+
+  const reliefWebSource = reliefWebAppName
+    ? (reliefWebResult.status === 'fulfilled'
+        ? okSourceStatus('ReliefWeb', 'https://api.reliefweb.int/v2/reports')
+        : errorSourceStatus(
+            'ReliefWeb',
+            reliefWebResult.reason instanceof Error ? reliefWebResult.reason.message : 'ReliefWeb fetch failed',
+            'https://api.reliefweb.int/v2/reports',
+          ))
+    : buildReliefWebDisabledStatus();
+
+  const sourceValues = [gdacsSource, reliefWebSource];
+  const partial = sourceValues.some(source => source.status !== 'ok');
+
+  return NextResponse.json({
+    events,
+    reports,
+    total: events.length + reports.length,
+    partial,
+    timestamp: new Date().toISOString(),
+    sources: {
+      gdacs: gdacsSource,
+      reliefweb: reliefWebSource,
+    },
+  }, {
+    headers: {
+      'Cache-Control': 'public, s-maxage=900, stale-while-revalidate=1800',
+    },
+  });
+}

--- a/src/app/api/entities/resolve/route.ts
+++ b/src/app/api/entities/resolve/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { fetchGleifEntities } from '@/lib/integrations/entities';
+import {
+  errorSourceStatus,
+  okSourceStatus,
+} from '@/lib/integrations/source-metadata';
+import { search as searchSanctions } from '@/lib/sanctions';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const query = (searchParams.get('query') || searchParams.get('q') || '').trim();
+
+  if (query.length < 3) {
+    return NextResponse.json({ error: 'Missing query parameter with at least 3 characters' }, { status: 400 });
+  }
+
+  const [gleifResult, sanctionsResult] = await Promise.allSettled([
+    fetchGleifEntities(query),
+    searchSanctions(query, { limit: 10 }),
+  ]);
+
+  const entities = gleifResult.status === 'fulfilled' ? gleifResult.value : [];
+  const sanctions = sanctionsResult.status === 'fulfilled' ? sanctionsResult.value : [];
+
+  return NextResponse.json({
+    query,
+    entities,
+    sanctions,
+    total: entities.length,
+    sanctions_total: sanctions.length,
+    partial: gleifResult.status === 'rejected' || sanctionsResult.status === 'rejected',
+    timestamp: new Date().toISOString(),
+    sources: {
+      gleif: gleifResult.status === 'fulfilled'
+        ? okSourceStatus('GLEIF', 'https://api.gleif.org/api/v1/lei-records')
+        : errorSourceStatus('GLEIF', gleifResult.reason instanceof Error ? gleifResult.reason.message : 'GLEIF lookup failed', 'https://api.gleif.org/api/v1/lei-records'),
+      sanctions: sanctionsResult.status === 'fulfilled'
+        ? okSourceStatus('OpenSanctions', 'https://data.opensanctions.org/datasets/latest/us_ofac_sdn/targets.simple.csv')
+        : errorSourceStatus('OpenSanctions', sanctionsResult.reason instanceof Error ? sanctionsResult.reason.message : 'Sanctions lookup failed', 'https://data.opensanctions.org/datasets/latest/us_ofac_sdn/targets.simple.csv'),
+    },
+  }, {
+    headers: { 'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=86400' },
+  });
+}

--- a/src/app/api/infrastructure/context/route.ts
+++ b/src/app/api/infrastructure/context/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import {
+  fetchOverpassInfrastructure,
+  type InfrastructureBbox,
+} from '@/lib/integrations/infrastructure-context';
+import {
+  errorSourceStatus,
+  okSourceStatus,
+} from '@/lib/integrations/source-metadata';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const bbox = parseBbox(searchParams);
+
+  if (!bbox) {
+    return NextResponse.json({
+      error: 'Missing bbox parameters. Use south,west,north,east or bbox=west,south,east,north.',
+    }, { status: 400 });
+  }
+
+  try {
+    const infrastructure = await fetchOverpassInfrastructure(bbox);
+    return NextResponse.json({
+      infrastructure,
+      total: infrastructure.length,
+      bbox,
+      timestamp: new Date().toISOString(),
+      sources: {
+        overpass: okSourceStatus('OpenStreetMap/Overpass', 'https://overpass-api.de/api/interpreter'),
+      },
+    }, {
+      headers: { 'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=86400' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Overpass infrastructure lookup failed';
+    return NextResponse.json({
+      infrastructure: [],
+      total: 0,
+      bbox,
+      timestamp: new Date().toISOString(),
+      sources: {
+        overpass: errorSourceStatus('OpenStreetMap/Overpass', message, 'https://overpass-api.de/api/interpreter'),
+      },
+      error: message,
+    }, { status: message.includes('bbox') ? 400 : 502 });
+  }
+}
+
+function parseBbox(searchParams: URLSearchParams): InfrastructureBbox | null {
+  const rawBbox = searchParams.get('bbox');
+  if (rawBbox) {
+    const [west, south, east, north] = rawBbox.split(',').map(Number);
+    if ([south, west, north, east].every(Number.isFinite)) return { south, west, north, east };
+  }
+
+  const south = Number(searchParams.get('south'));
+  const west = Number(searchParams.get('west'));
+  const north = Number(searchParams.get('north'));
+  const east = Number(searchParams.get('east'));
+  if ([south, west, north, east].every(Number.isFinite)) return { south, west, north, east };
+
+  return null;
+}

--- a/src/app/api/osint/cve/route.ts
+++ b/src/app/api/osint/cve/route.ts
@@ -1,11 +1,67 @@
 import { NextResponse } from 'next/server';
+import {
+  fetchEpss,
+  fetchKevCatalog,
+  mergeCvePriority,
+  type CvePriorityRecord,
+} from '@/lib/integrations/cyber-priority';
 import { isRateLimited, getClientIp } from '@/lib/ssrf-guard';
+
+type MitreCveDescription = {
+  lang?: string;
+  value?: string;
+};
+
+type MitreCvssMetric = {
+  cvssV3_1?: { baseScore?: number; vectorString?: string; baseSeverity?: string };
+  cvssV3_0?: { baseScore?: number; vectorString?: string; baseSeverity?: string };
+  cvssV31?: { baseScore?: number; vectorString?: string; baseSeverity?: string };
+  cvssV2_0?: { baseScore?: number; vectorString?: string };
+  cvssV2?: { baseScore?: number; vectorString?: string };
+};
+
+type MitreCveReference = {
+  url?: string;
+};
+
+type MitreAffectedVersion = {
+  version?: string;
+};
+
+type MitreAffectedProduct = {
+  vendor?: string;
+  product?: string;
+  versions?: MitreAffectedVersion[];
+};
+
+type MitreCveApiResponse = {
+  cveMetadata?: {
+    cveId?: string;
+    datePublished?: string;
+    dateUpdated?: string;
+  };
+  containers?: {
+    cna?: {
+      descriptions?: MitreCveDescription[];
+      metrics?: MitreCvssMetric[];
+      problemTypes?: Array<{
+        descriptions?: Array<{
+          cweId?: string;
+          description?: string;
+        }>;
+      }>;
+      references?: MitreCveReference[];
+      affected?: MitreAffectedProduct[];
+    };
+  };
+};
 
 // CVE Intelligence — fetches vulnerability details from CIRCL CVE API (free, no key)
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const cve = searchParams.get('cve');
   if (!cve) return NextResponse.json({ error: 'Missing cve parameter' }, { status: 400 });
+  const normalizedCve = cve.toUpperCase();
 
   const clientIp = getClientIp(req);
   if (isRateLimited(clientIp, 30, 60_000)) {
@@ -18,7 +74,7 @@ export async function GET(req: Request) {
   }
 
   try {
-    const res = await fetch(`https://cveawg.mitre.org/api/cve/${encodeURIComponent(cve.toUpperCase())}`, {
+    const res = await fetch(`https://cveawg.mitre.org/api/cve/${encodeURIComponent(normalizedCve)}`, {
       signal: AbortSignal.timeout(8000),
       headers: { 'Accept': 'application/json' },
     });
@@ -26,14 +82,15 @@ export async function GET(req: Request) {
     if (!res.ok) {
       // Fallback to CIRCL
       try {
-        const circlRes = await fetch(`https://cve.circl.lu/api/cve/${encodeURIComponent(cve.toUpperCase())}`, {
+        const circlRes = await fetch(`https://cve.circl.lu/api/cve/${encodeURIComponent(normalizedCve)}`, {
           signal: AbortSignal.timeout(8000),
           headers: { 'Accept': 'application/json' },
         });
         if (circlRes.ok) {
           const data = await circlRes.json();
+          const priority = await resolveCvePriority(normalizedCve, data.cvss ?? null);
           return NextResponse.json({
-            id: data.id || cve.toUpperCase(),
+            id: data.id || normalizedCve,
             description: data.summary || 'No description available.',
             cvss: data.cvss ?? null,
             cvss_vector: data.cvss_vector || null,
@@ -42,24 +99,27 @@ export async function GET(req: Request) {
             modified: data.Modified || null,
             cwe: data.cwe || null,
             source: 'circl',
+            priority,
           });
         }
       } catch { /* fall through */ }
 
+      const priority = await resolveCvePriority(normalizedCve, null);
       return NextResponse.json({
-        id: cve.toUpperCase(),
+        id: normalizedCve,
         description: 'CVE details could not be retrieved at this time.',
         cvss: null,
         references: [],
         source: 'unavailable',
+        priority,
       });
     }
 
-    const data = await res.json();
+    const data = (await res.json()) as MitreCveApiResponse;
 
     // Parse the CVE 5.0 JSON format from MITRE
     const cna = data.containers?.cna;
-    const description = cna?.descriptions?.find((d: any) => d.lang === 'en')?.value
+    const description = cna?.descriptions?.find(d => d.lang === 'en')?.value
       || cna?.descriptions?.[0]?.value
       || 'No description available.';
 
@@ -95,17 +155,20 @@ export async function GET(req: Request) {
     }
 
     // Extract references
-    const references = (cna?.references || []).slice(0, 5).map((r: any) => r.url);
+    const references = (cna?.references || []).slice(0, 5).map(r => r.url);
 
     // Extract affected products
-    const affected = (cna?.affected || []).slice(0, 5).map((a: any) => ({
+    const affected = (cna?.affected || []).slice(0, 5).map(a => ({
       vendor: a.vendor || 'Unknown',
       product: a.product || 'Unknown',
-      versions: (a.versions || []).slice(0, 3).map((v: any) => v.version).filter(Boolean),
+      versions: (a.versions || []).slice(0, 3).map(v => v.version).filter(Boolean),
     }));
 
+    const responseCve = data.cveMetadata?.cveId || normalizedCve;
+    const priority = await resolveCvePriority(responseCve, cvss);
+
     return NextResponse.json({
-      id: data.cveMetadata?.cveId || cve.toUpperCase(),
+      id: responseCve,
       description,
       cvss,
       cvss_vector,
@@ -116,8 +179,23 @@ export async function GET(req: Request) {
       published: data.cveMetadata?.datePublished || null,
       modified: data.cveMetadata?.dateUpdated || null,
       source: 'mitre',
+      priority,
     });
   } catch {
     return NextResponse.json({ error: 'CVE lookup failed' }, { status: 500 });
   }
+}
+
+async function resolveCvePriority(cve: string, cvss: number | null): Promise<CvePriorityRecord> {
+  const [epssResult, kevResult] = await Promise.allSettled([
+    fetchEpss([cve]),
+    fetchKevCatalog(),
+  ]);
+
+  const epss = epssResult.status === 'fulfilled' ? epssResult.value.get(cve.toUpperCase()) : null;
+  const kev = kevResult.status === 'fulfilled'
+    ? kevResult.value.find(item => item.cveID?.toUpperCase() === cve.toUpperCase()) || null
+    : null;
+
+  return mergeCvePriority({ cve, epss, kev, cvss });
 }

--- a/src/app/api/osint/urlhaus/route.ts
+++ b/src/app/api/osint/urlhaus/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { fetchUrlhausRecent } from '@/lib/integrations/threat-intel';
+import {
+  errorSourceStatus,
+  okSourceStatus,
+} from '@/lib/integrations/source-metadata';
+import { getClientIp, isRateLimited } from '@/lib/ssrf-guard';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const clientIp = getClientIp(req);
+  if (isRateLimited(clientIp, 20, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const query = searchParams.get('query') || searchParams.get('host') || searchParams.get('url') || undefined;
+
+  try {
+    const matches = await fetchUrlhausRecent(query);
+    return NextResponse.json({
+      query: query || null,
+      matches,
+      total: matches.length,
+      timestamp: new Date().toISOString(),
+      sources: {
+        urlhaus: okSourceStatus('URLhaus', 'https://urlhaus.abuse.ch/downloads/csv_recent/'),
+      },
+    }, {
+      headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'URLhaus lookup failed';
+    return NextResponse.json({
+      query: query || null,
+      matches: [],
+      total: 0,
+      timestamp: new Date().toISOString(),
+      sources: {
+        urlhaus: errorSourceStatus('URLhaus', message, 'https://urlhaus.abuse.ch/downloads/csv_recent/'),
+      },
+      error: message,
+    }, { status: 502 });
+  }
+}

--- a/src/app/api/rail/germany/route.ts
+++ b/src/app/api/rail/germany/route.ts
@@ -1,49 +1,92 @@
 import { NextResponse } from 'next/server';
 import {
+  DB_TRANSPORT_REST_URL,
   fetchGermanyRailInfrastructure,
+  fetchGermanyRailOperations,
   OVERPASS_INTERPRETER_URL,
   staticGermanyRailInfrastructure,
+  GERMANY_RAIL_HUBS,
+  type RailStationOperationStatus,
 } from '@/lib/integrations/rail-germany';
-import { errorSourceStatus, okSourceStatus } from '@/lib/integrations/source-metadata';
+import { disabledSourceStatus, errorSourceStatus, okSourceStatus } from '@/lib/integrations/source-metadata';
 
-export const revalidate = 86400;
+export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const limit = clampNumber(Number(searchParams.get('limit') || 160), 1, 500);
+  const includeOverpass = searchParams.get('overpass') === 'true';
+  const includeOperations = searchParams.get('operations') !== 'false';
+  const operationHubLimit = clampNumber(Number(searchParams.get('operationHubs') || 4), 1, GERMANY_RAIL_HUBS.length);
+  const departuresPerHub = clampNumber(Number(searchParams.get('departures') || 8), 1, 20);
 
   let infrastructure = staticGermanyRailInfrastructure();
   let overpassError: string | null = null;
+  let operationStatuses: RailStationOperationStatus[] = [];
+  let operationErrors: string[] = [];
 
-  try {
-    const overpassInfrastructure = await fetchGermanyRailInfrastructure(limit);
-    if (overpassInfrastructure.length > 0) {
-      infrastructure = mergeInfrastructure(overpassInfrastructure, infrastructure);
+  if (includeOverpass) {
+    try {
+      const overpassInfrastructure = await fetchGermanyRailInfrastructure(limit);
+      if (overpassInfrastructure.length > 0) {
+        infrastructure = mergeInfrastructure(overpassInfrastructure, infrastructure);
+      }
+    } catch (error) {
+      overpassError = error instanceof Error ? error.message : String(error);
     }
-  } catch (error) {
-    overpassError = error instanceof Error ? error.message : String(error);
   }
 
   const stations = infrastructure.filter(item => item.kind !== 'line' && typeof item.lat === 'number' && typeof item.lng === 'number');
   const lines = infrastructure.filter(item => item.kind === 'line' && item.geometry);
+  if (includeOperations) {
+    const operations = await fetchGermanyRailOperations(GERMANY_RAIL_HUBS.slice(0, operationHubLimit), departuresPerHub);
+    operationStatuses = operations.statuses;
+    operationErrors = operations.errors;
+  }
 
   return NextResponse.json({
     infrastructure,
     stations,
     lines,
+    operations: {
+      enabled: includeOperations,
+      stationStatus: operationStatuses,
+      stats: {
+        monitored_hubs: operationHubLimit,
+        loaded_hubs: operationStatuses.length,
+        delayed_hubs: operationStatuses.filter(station => station.status === 'delayed' || station.status === 'severe').length,
+        delayed_departures: operationStatuses.reduce((sum, station) => sum + station.delayedDepartures + station.severeDepartures, 0),
+        cancelled_departures: operationStatuses.reduce((sum, station) => sum + station.cancelledDepartures, 0),
+        platform_changes: operationStatuses.reduce((sum, station) => sum + station.platformChanges, 0),
+      },
+    },
     stats: {
       total: infrastructure.length,
       facilities: stations.length,
       lines: lines.length,
-      infrastructure_only: true,
+      infrastructure_only: false,
+      operations_enabled: includeOperations,
     },
-    partial: Boolean(overpassError),
+    partial: Boolean(overpassError) || operationErrors.length > 0,
     sources: {
       overpass: overpassError
         ? errorSourceStatus('OpenStreetMap/Overpass', `${overpassError}; returned static German rail hubs`, OVERPASS_INTERPRETER_URL)
-        : okSourceStatus('OpenStreetMap/Overpass', OVERPASS_INTERPRETER_URL),
+        : includeOverpass
+          ? okSourceStatus('OpenStreetMap/Overpass', OVERPASS_INTERPRETER_URL)
+          : disabledSourceStatus('OpenStreetMap/Overpass', 'Using fast static German rail infrastructure fallback; pass overpass=true for live OSM enrichment.', OVERPASS_INTERPRETER_URL),
+      dbTransportRest: !includeOperations
+        ? okSourceStatus('db.transport.rest', DB_TRANSPORT_REST_URL)
+        : operationErrors.length > 0
+          ? errorSourceStatus('db.transport.rest', `${operationStatuses.length}/${operationHubLimit} hubs loaded`, DB_TRANSPORT_REST_URL)
+          : okSourceStatus('db.transport.rest', DB_TRANSPORT_REST_URL),
     },
     timestamp: new Date().toISOString(),
+  }, {
+    headers: {
+      'Cache-Control': includeOperations
+        ? 'public, s-maxage=120, stale-while-revalidate=300'
+        : 'public, s-maxage=86400, stale-while-revalidate=86400',
+    },
   });
 }
 

--- a/src/app/api/rail/germany/route.ts
+++ b/src/app/api/rail/germany/route.ts
@@ -64,7 +64,7 @@ export async function GET(req: Request) {
       total: infrastructure.length,
       facilities: stations.length,
       lines: lines.length,
-      infrastructure_only: false,
+      infrastructure_only: !includeOperations,
       operations_enabled: includeOperations,
     },
     partial: Boolean(overpassError) || operationErrors.length > 0,
@@ -75,7 +75,7 @@ export async function GET(req: Request) {
           ? okSourceStatus('OpenStreetMap/Overpass', OVERPASS_INTERPRETER_URL)
           : disabledSourceStatus('OpenStreetMap/Overpass', 'Using fast static German rail infrastructure fallback; pass overpass=true for live OSM enrichment.', OVERPASS_INTERPRETER_URL),
       dbTransportRest: !includeOperations
-        ? okSourceStatus('db.transport.rest', DB_TRANSPORT_REST_URL)
+        ? disabledSourceStatus('db.transport.rest', 'Live rail operations disabled for infrastructure-only response; omit operations=false to monitor departures.', DB_TRANSPORT_REST_URL)
         : operationErrors.length > 0
           ? errorSourceStatus('db.transport.rest', `${operationStatuses.length}/${operationHubLimit} hubs loaded`, DB_TRANSPORT_REST_URL)
           : okSourceStatus('db.transport.rest', DB_TRANSPORT_REST_URL),

--- a/src/app/api/rail/germany/route.ts
+++ b/src/app/api/rail/germany/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import {
+  fetchGermanyRailInfrastructure,
+  OVERPASS_INTERPRETER_URL,
+  staticGermanyRailInfrastructure,
+} from '@/lib/integrations/rail-germany';
+import { errorSourceStatus, okSourceStatus } from '@/lib/integrations/source-metadata';
+
+export const revalidate = 86400;
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const limit = clampNumber(Number(searchParams.get('limit') || 160), 1, 500);
+
+  let infrastructure = staticGermanyRailInfrastructure();
+  let overpassError: string | null = null;
+
+  try {
+    const overpassInfrastructure = await fetchGermanyRailInfrastructure(limit);
+    if (overpassInfrastructure.length > 0) {
+      infrastructure = mergeInfrastructure(overpassInfrastructure, infrastructure);
+    }
+  } catch (error) {
+    overpassError = error instanceof Error ? error.message : String(error);
+  }
+
+  const stations = infrastructure.filter(item => item.kind !== 'line' && typeof item.lat === 'number' && typeof item.lng === 'number');
+  const lines = infrastructure.filter(item => item.kind === 'line' && item.geometry);
+
+  return NextResponse.json({
+    infrastructure,
+    stations,
+    lines,
+    stats: {
+      total: infrastructure.length,
+      facilities: stations.length,
+      lines: lines.length,
+      infrastructure_only: true,
+    },
+    partial: Boolean(overpassError),
+    sources: {
+      overpass: overpassError
+        ? errorSourceStatus('OpenStreetMap/Overpass', `${overpassError}; returned static German rail hubs`, OVERPASS_INTERPRETER_URL)
+        : okSourceStatus('OpenStreetMap/Overpass', OVERPASS_INTERPRETER_URL),
+    },
+    timestamp: new Date().toISOString(),
+  });
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function mergeInfrastructure<T extends { id: string }>(primary: T[], fallback: T[]): T[] {
+  const ids = new Set(primary.map(item => item.id));
+  return [...primary, ...fallback.filter(item => !ids.has(item.id))];
+}

--- a/src/app/api/weather/forecast/route.ts
+++ b/src/app/api/weather/forecast/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { fetchOpenMeteoForecast } from '@/lib/integrations/forecast';
+import {
+  errorSourceStatus,
+  okSourceStatus,
+} from '@/lib/integrations/source-metadata';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const lat = Number(searchParams.get('lat'));
+  const lng = Number(searchParams.get('lng') ?? searchParams.get('lon'));
+
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    return NextResponse.json({ error: 'Missing or invalid lat/lng parameters' }, { status: 400 });
+  }
+
+  try {
+    const forecast = await fetchOpenMeteoForecast(lat, lng);
+    return NextResponse.json({
+      forecast,
+      timestamp: new Date().toISOString(),
+      sources: {
+        open_meteo: okSourceStatus('Open-Meteo', 'https://api.open-meteo.com/v1/forecast'),
+      },
+    }, {
+      headers: { 'Cache-Control': 'public, s-maxage=1800, stale-while-revalidate=3600' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Open-Meteo forecast failed';
+    return NextResponse.json({
+      forecast: null,
+      timestamp: new Date().toISOString(),
+      sources: {
+        open_meteo: errorSourceStatus('Open-Meteo', message, 'https://api.open-meteo.com/v1/forecast'),
+      },
+      error: message,
+    }, { status: 502 });
+  }
+}

--- a/src/app/cases/yameiko/page.tsx
+++ b/src/app/cases/yameiko/page.tsx
@@ -1,0 +1,135 @@
+import Link from "next/link";
+import caseData from "../../../../public/data/yameiko-project-intel.json";
+
+const priorityStyles: Record<string, string> = {
+  critical: "border-red-400/40 bg-red-500/10 text-red-200",
+  high: "border-orange-300/40 bg-orange-400/10 text-orange-100",
+  medium: "border-cyan-300/30 bg-cyan-400/10 text-cyan-100",
+};
+
+export const metadata = {
+  title: "Yameiko Project Intelligence Case",
+  description: "Local OSIRIS starter case for the Yameiko development portfolio.",
+};
+
+export default function YameikoCasePage() {
+  const priorityCounts = caseData.projects.reduce<Record<string, number>>((acc, project) => {
+    acc[project.priority] = (acc[project.priority] || 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <main className="min-h-screen overflow-y-auto bg-[var(--bg-void)] text-[var(--text-primary)]">
+      <section className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-5 py-8 md:px-8 lg:px-10">
+        <header className="flex flex-col gap-5 border-b border-[var(--border-primary)] pb-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="max-w-3xl">
+            <p className="hud-label mb-3">LOCAL CASE / DEVELOPMENT PORTFOLIO</p>
+            <h1 className="text-3xl font-semibold tracking-normal text-[var(--text-heading)] md:text-5xl">
+              {caseData.title}
+            </h1>
+            <p className="mt-4 max-w-2xl text-sm leading-6 text-[var(--text-secondary)] md:text-base">
+              {caseData.summary} The case turns your local projects into an
+              asset map for monitoring, release readiness and public-surface review.
+            </p>
+          </div>
+          <Link
+            href="/"
+            className="inline-flex h-10 items-center justify-center rounded border border-[var(--border-active)] px-4 font-mono text-xs uppercase tracking-[0.12em] text-[var(--gold-primary)] transition hover:bg-[var(--hover-accent)]"
+          >
+            Open OSIRIS Dashboard
+          </Link>
+        </header>
+
+        <section className="grid gap-3 md:grid-cols-4">
+          <Metric label="Projects" value={caseData.projects.length.toString()} />
+          <Metric label="Critical" value={(priorityCounts.critical || 0).toString()} tone="risk-critical" />
+          <Metric label="High" value={(priorityCounts.high || 0).toString()} tone="risk-high" />
+          <Metric label="Medium" value={(priorityCounts.medium || 0).toString()} tone="text-[var(--cyan-primary)]" />
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-2">
+          {caseData.projects.map((project) => (
+            <article
+              key={project.name}
+              className="glass-panel rounded-lg p-5"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="hud-label">{project.type}</p>
+                  <h2 className="mt-2 text-xl font-semibold tracking-normal text-[var(--text-heading)]">
+                    {project.name}
+                  </h2>
+                </div>
+                <span className={`w-fit rounded border px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] ${priorityStyles[project.priority]}`}>
+                  {project.priority}
+                </span>
+              </div>
+
+              <p className="mt-4 text-sm leading-6 text-[var(--text-secondary)]">
+                {project.riskFocus}
+              </p>
+
+              <div className="mt-5 grid gap-4 md:grid-cols-2">
+                <div>
+                  <p className="hud-label mb-2">Stack</p>
+                  <div className="flex flex-wrap gap-2">
+                    {project.stack.map((item) => (
+                      <span key={item} className="rounded border border-[var(--border-secondary)] px-2 py-1 text-xs text-[var(--text-secondary)]">
+                        {item}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <p className="hud-label mb-2">Signals</p>
+                  <ul className="space-y-2 text-xs leading-5 text-[var(--text-secondary)]">
+                    {project.signals.map((signal) => (
+                      <li key={signal} className="border-l border-[var(--border-cyan)] pl-3">
+                        {signal}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </article>
+          ))}
+        </section>
+
+        <section className="glass-panel rounded-lg p-5">
+          <p className="hud-label mb-3">Starter Workflow</p>
+          <ol className="grid gap-3 md:grid-cols-2">
+            {caseData.starterWorkflow.map((step, index) => (
+              <li key={step} className="flex gap-3 text-sm leading-6 text-[var(--text-secondary)]">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[var(--border-active)] font-mono text-xs text-[var(--gold-primary)]">
+                  {index + 1}
+                </span>
+                <span>{step}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <footer className="pb-8 text-xs text-[var(--text-muted)]">
+          Data source: {caseData.generatedFrom}. Generated locally on {caseData.generatedAt}.
+        </footer>
+      </section>
+    </main>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  tone = "text-[var(--gold-primary)]",
+}: {
+  label: string;
+  value: string;
+  tone?: string;
+}) {
+  return (
+    <div className="glass-panel-sm rounded-lg p-4">
+      <p className="hud-label">{label}</p>
+      <p className={`mt-2 font-mono text-3xl font-semibold ${tone}`}>{value}</p>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -298,6 +298,33 @@ export default function Dashboard() {
     fetchEndpoint('/api/earthquakes');
     fetchEndpoint('/api/news');
     const marketTimer = setTimeout(() => fetchEndpoint('/api/markets', d => ({ markets: d })), 800);
+    const publicIntelTimers = [
+      setTimeout(() => fetchEndpoint('/api/disasters', d => ({
+        disaster_events: d.events || [],
+        relief_reports: d.reports || [],
+        disaster_sources: d.sources || {},
+      })), 1600),
+      setTimeout(() => fetchEndpoint('/api/cyber-priority', d => ({
+        cyber_priorities: d.priorities || [],
+        cyber_priority_stats: d.stats || null,
+      })), 2200),
+      setTimeout(() => fetchEndpoint('/api/osint/urlhaus', d => ({
+        urlhaus_indicators: d.results || [],
+        urlhaus_source: d.sources?.urlhaus || null,
+      })), 2800),
+      setTimeout(() => fetchEndpoint('/api/weather/forecast?lat=52.52&lng=13.41', d => ({
+        local_forecast: d.forecast || null,
+        forecast_source: d.sources?.openMeteo || null,
+      })), 3400),
+      setTimeout(() => fetchEndpoint('/api/air-quality', d => ({
+        air_quality_stations: d.stations || [],
+        air_quality_source: d.sources?.openaq || null,
+      })), 4200),
+      setTimeout(() => fetchEndpoint('/api/infrastructure/context?south=52.45&west=13.30&north=52.60&east=13.55', d => ({
+        infrastructure_context: d.infrastructure || [],
+        infrastructure_context_source: d.sources?.overpass || null,
+      })), 5200),
+    ];
 
     // Priority 2: Space Weather (needed for MarketsPanel)
     const spaceTimer = setTimeout(async () => {
@@ -315,6 +342,7 @@ export default function Dashboard() {
     ];
     return () => {
       clearTimeout(marketTimer);
+      publicIntelTimers.forEach(clearTimeout);
       clearTimeout(spaceTimer);
       intervals.forEach(clearInterval);
     };
@@ -825,7 +853,7 @@ export default function Dashboard() {
       {/* ── RIGHT TOOL STRIP (desktop only — mobile uses bottom nav) ── */}
       {!isMobile && <div className="absolute right-2 top-1/2 -translate-y-1/2 flex flex-col gap-2 z-[250] pointer-events-auto bg-black/40 backdrop-blur-sm p-1 rounded-full border border-white/5">
         <div className="relative group">
-          <button onClick={() => { setShowIntel(!showIntel); setShowMarkets(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showIntel ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`}>
+          <button aria-label="Open OSINT recon panel" onClick={() => { setShowIntel(!showIntel); setShowMarkets(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showIntel ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`}>
             <Radar className={`w-4 h-4 ${showIntel ? 'text-[var(--cyan-primary)]' : 'text-white/60'}`} />
           </button>
           {/* OSINT / Recon Panel Slideout */}
@@ -845,7 +873,7 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`}>
+          <button aria-label="Open markets and public intel panel" onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`}>
             <BarChart3 className={`w-4 h-4 ${showMarkets ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
           {/* Markets Panel Slideout */}
@@ -859,7 +887,7 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowAlerts(!showAlerts); setShowIntel(false); setShowMarkets(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showAlerts ? 'bg-[#FF3D3D]/20' : 'hover:bg-white/10'}`}>
+          <button aria-label="Open live alerts panel" onClick={() => { setShowAlerts(!showAlerts); setShowIntel(false); setShowMarkets(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showAlerts ? 'bg-[#FF3D3D]/20' : 'hover:bg-white/10'}`}>
             <AlertTriangle className={`w-4 h-4 ${showAlerts ? 'text-[#FF3D3D]' : 'text-white/60'}`} />
           </button>
           {/* Alerts Panel Slideout */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,8 +56,9 @@ function useIsMobile() {
 }
 const UptimeClock = () => {
   const [uptime, setUptime] = useState('00:00:00');
-  const startTime = useRef(Date.now());
+  const startTime = useRef(0);
   useEffect(() => {
+    startTime.current = Date.now();
     const iv = setInterval(() => {
       const e = Math.floor((Date.now() - startTime.current) / 1000);
       setUptime(`${String(Math.floor(e/3600)).padStart(2,'0')}:${String(Math.floor((e%3600)/60)).padStart(2,'0')}:${String(e%60).padStart(2,'0')}`);
@@ -146,7 +147,6 @@ export default function Dashboard() {
   const [demoMode, setDemoMode] = useState(false);
 
   const isMobile = useIsMobile();
-  const startTime = useRef(Date.now());
   const geocodeCache = useRef<Map<string, string>>(new Map());
   const geocodeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastGeocodedPos = useRef<{ lat: number; lng: number } | null>(null);
@@ -435,6 +435,8 @@ export default function Dashboard() {
       fetchEndpoint('/api/rail/germany', d => ({
         rail_germany: d.stations || [],
         rail_germany_lines: d.lines || [],
+        rail_germany_operations: d.operations?.stationStatus || [],
+        rail_germany_operation_stats: d.operations?.stats || null,
         rail_germany_stats: d.stats,
         rail_germany_sources: d.sources,
       }));

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,20 @@ const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
 const CameraViewer = dynamic(() => import('@/components/CameraViewer'));
 const OsintPanel = dynamic(() => import('@/components/OsintPanel'));
 
+type MapBbox = {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+};
+
+type MapViewState = {
+  zoom: number;
+  latitude: number;
+  longitude: number;
+  bbox?: MapBbox;
+};
+
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(false);
   useEffect(() => {
@@ -81,13 +95,33 @@ function getYouTubeWatchUrl(url: string): string {
   return url;
 }
 
+function getCampingBbox(view: MapViewState): string | null {
+  const centerLng = Number.isFinite(view.longitude) ? view.longitude : 25.48;
+  const centerLat = Number.isFinite(view.latitude) ? view.latitude : 42.7;
+  const maxSpan = view.zoom >= 9 ? 1.2 : 2.4;
+  const rawWest = view.bbox?.west ?? centerLng - maxSpan / 2;
+  const rawEast = view.bbox?.east ?? centerLng + maxSpan / 2;
+  const rawSouth = view.bbox?.south ?? centerLat - maxSpan / 2;
+  const rawNorth = view.bbox?.north ?? centerLat + maxSpan / 2;
+
+  if (![rawWest, rawEast, rawSouth, rawNorth].every(Number.isFinite)) return null;
+
+  const west = Math.max(-180, Math.max(rawWest, centerLng - maxSpan / 2));
+  const east = Math.min(180, Math.min(rawEast, centerLng + maxSpan / 2));
+  const south = Math.max(-85, Math.max(rawSouth, centerLat - maxSpan / 2));
+  const north = Math.min(85, Math.min(rawNorth, centerLat + maxSpan / 2));
+
+  if (east <= west || north <= south) return null;
+  return [west, south, east, north].map(value => value.toFixed(3)).join(',');
+}
+
 export default function Dashboard() {
   const dataRef = useRef<any>({});
   const [dataVersion, setDataVersion] = useState(0);
   const data = dataRef.current;
 
   const [backendStatus, setBackendStatus] = useState<'connecting' | 'connected' | 'error'>('connecting');
-  const [mapView, setMapView] = useState({ zoom: 2.5, latitude: 20 });
+  const [mapView, setMapView] = useState<MapViewState>({ zoom: 6.5, latitude: 42.7, longitude: 25.48 });
   const [flyToLocation, setFlyToLocation] = useState<{ lat: number; lng: number; ts: number } | null>(null);
   const [globalStats, setGlobalStats] = useState<any>(null);
   const mouseCoordsRef = useRef<{ lat: number; lng: number } | null>(null);
@@ -118,7 +152,7 @@ export default function Dashboard() {
   const lastGeocodedPos = useRef<{ lat: number; lng: number } | null>(null);
 
   // ── DEFAULT: Most layers OFF — fast initial load ──
-  const [activeLayers, setActiveLayers] = useState({
+  const [activeLayers, setActiveLayers] = useState<Record<string, boolean>>({
     flights: false,
     private: false,
     jets: false,
@@ -127,8 +161,10 @@ export default function Dashboard() {
     satellites: false,
     balloons: false,
     cctv: true,
+    camping: false,
     live_news: true,
     news_intel: true,
+    rail_germany: false,
     earthquakes: true,
     fires: false,
     weather: false,
@@ -185,7 +221,7 @@ export default function Dashboard() {
     urlTimer.current = setTimeout(() => {
       const p = new URLSearchParams();
       p.set('lat', (mapView.latitude ?? 20).toFixed(4));
-      p.set('lon', '0');
+      p.set('lon', (mapView.longitude ?? 0).toFixed(4));
       p.set('zoom', mapView.zoom.toFixed(2));
       const active = Object.entries(activeLayers).filter(([,v]) => v).map(([k]) => k).join(',');
       p.set('layers', active);
@@ -394,6 +430,30 @@ export default function Dashboard() {
       fetchEndpoint('/api/live-news', d => ({ live_feeds: d.feeds }));
       layerFetchedRef.current.add('live_news');
     }
+    // Germany rail network
+    if (activeLayers.rail_germany && !layerFetchedRef.current.has('rail_germany')) {
+      fetchEndpoint('/api/rail/germany', d => ({
+        rail_germany: d.stations || [],
+        rail_germany_lines: d.lines || [],
+        rail_germany_stats: d.stats,
+        rail_germany_sources: d.sources,
+      }));
+      layerFetchedRef.current.add('rail_germany');
+    }
+    // Camping sites
+    if (activeLayers.camping) {
+      const bbox = getCampingBbox(mapView);
+      if (bbox) {
+        const key = `camping:${bbox}`;
+        if (!layerFetchedRef.current.has(key)) {
+          fetchEndpoint(`/api/camping?bbox=${bbox}`, d => ({
+            camping_sites: d.sites || [],
+            camping_sources: d.sources,
+          }));
+          layerFetchedRef.current.add(key);
+        }
+      }
+    }
     // Weather
     if (activeLayers.weather && !layerFetchedRef.current.has('weather')) {
       fetchEndpoint('/api/weather', d => ({ weather_events: d.events }));
@@ -438,7 +498,7 @@ export default function Dashboard() {
     }
 
 
-  }, [activeLayers]);
+  }, [activeLayers, mapView, fetchEndpoint]);
 
   // ── LAYER-AWARE POLLING — only poll data for active layers ──
   useEffect(() => {

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -70,7 +70,7 @@ const LAYER_GROUPS: LayerGroup[] = [
     layers: [
       { key: 'cctv', label: 'CCTV Cameras', icon: Camera, color: '#39FF14', dataKey: 'cameras' },
       { key: 'live_news', label: 'Live News Feeds', icon: Tv, color: '#FF4081', dataKey: 'live_feeds' },
-      { key: 'rail_germany', label: 'DE Rail Infra', icon: Train, color: '#FFD54F', dataKey: 'rail_germany,rail_germany_lines' },
+      { key: 'rail_germany', label: 'DE Rail Data', icon: Train, color: '#FFD54F', dataKey: 'rail_germany,rail_germany_lines,rail_germany_operations' },
       { key: 'camping', label: 'Campingplaetze', icon: MapPinned, color: '#9CCC65', dataKey: 'camping_sites' },
     ],
   },

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -4,7 +4,7 @@ import { memo, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Plane, Satellite, Activity, Sun, AlertTriangle, Camera, Flame,
-  CloudLightning, Radiation, Tv, Anchor, Ship,
+  CloudLightning, Radiation, Tv, Anchor, Ship, Network,
   Share2, Radio, Train, Shield, MapPinned
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -3,19 +3,36 @@
 import { memo, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  Plane, Satellite, Activity, Sun, AlertTriangle, Camera, Flame, Target,
-  CloudLightning, Radiation, Tv, Anchor, Ship, Newspaper,
-  Network, Share2, Radio
+  Plane, Satellite, Activity, Sun, AlertTriangle, Camera, Flame,
+  CloudLightning, Radiation, Tv, Anchor, Ship,
+  Share2, Radio, Train, Shield, MapPinned
 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+type LayerState = Record<string, boolean>;
+type LayerData = Record<string, unknown>;
+type LayerConfig = {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  color: string;
+  dataKey: string;
+};
+type LayerGroup = {
+  label: string;
+  fullLabel: string;
+  color: string;
+  layers: LayerConfig[];
+};
 
 interface LayerPanelProps {
-  data: any;
-  activeLayers: any;
-  setActiveLayers: React.Dispatch<React.SetStateAction<any>>;
+  data: LayerData;
+  activeLayers: LayerState;
+  setActiveLayers: React.Dispatch<React.SetStateAction<LayerState>>;
   isMobile?: boolean;
 }
 
-const LAYER_GROUPS = [
+const LAYER_GROUPS: LayerGroup[] = [
   {
     label: 'SDK',
     fullLabel: 'OSIRIS SDK',
@@ -53,6 +70,8 @@ const LAYER_GROUPS = [
     layers: [
       { key: 'cctv', label: 'CCTV Cameras', icon: Camera, color: '#39FF14', dataKey: 'cameras' },
       { key: 'live_news', label: 'Live News Feeds', icon: Tv, color: '#FF4081', dataKey: 'live_feeds' },
+      { key: 'rail_germany', label: 'DE Rail Infra', icon: Train, color: '#FFD54F', dataKey: 'rail_germany,rail_germany_lines' },
+      { key: 'camping', label: 'Campingplaetze', icon: MapPinned, color: '#9CCC65', dataKey: 'camping_sites' },
     ],
   },
   {
@@ -94,29 +113,19 @@ const LAYER_GROUPS = [
   },
 ];
 
-const ALL_LAYERS = LAYER_GROUPS.flatMap(g => g.layers);
-
-// SVG component for Shield which was missing in the imports above
-function Shield(props: any) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
-      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-    </svg>
-  );
-}
-
 function LayerPanel({ data, activeLayers, setActiveLayers, isMobile }: LayerPanelProps) {
   const [hoveredGroup, setHoveredGroup] = useState<string | null>(null);
 
-  const toggle = (key: string) => setActiveLayers((prev: any) => ({ ...prev, [key]: !prev[key] }));
+  const toggle = (key: string) => setActiveLayers((prev) => ({ ...prev, [key]: !prev[key] }));
   
   const getCount = (dk: string): number | null => {
     if (!dk) return null;
     let total = 0;
     let found = false;
     for (const k of dk.split(',')) {
-      if (data[k] && Array.isArray(data[k])) {
-        total += data[k].length;
+      const value = data[k];
+      if (Array.isArray(value)) {
+        total += value.length;
         found = true;
       }
     }
@@ -236,8 +245,6 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile }: LayerPane
                       {group.layers.map((layer) => {
                         const isLayerActive = activeLayers[layer.key];
                         const count = getCount(layer.dataKey);
-                        const Icon = layer.icon || Shield;
-                        
                         return (
                           <button
                             key={layer.key}

--- a/src/components/MarketsPanel.tsx
+++ b/src/components/MarketsPanel.tsx
@@ -1,16 +1,66 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   TrendingUp, TrendingDown, ChevronDown, ChevronUp, BarChart3,
-  Zap, Shield, Droplets, Gem, Bitcoin, LineChart, Maximize2, Minimize2
+  Zap, Shield, Droplets, Gem, Bitcoin, LineChart, Maximize2, Minimize2,
+  Globe2, AlertTriangle, Bug, CloudLightning, Building2, Wind
 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
-interface MarketsPanelProps { data: any; spaceWeather?: any; }
+type MarketTicker = {
+  price?: number;
+  up?: boolean;
+  change_percent?: number;
+};
+
+type MarketsData = Record<string, Record<string, MarketTicker> | string[] | undefined> & {
+  scm_alerts?: string[];
+};
+
+type SpaceWeather = {
+  storm_color?: string;
+  kp_index?: number;
+  storm_level?: string;
+  solar_flares?: Array<{ class?: string }>;
+};
+
+type CyberPriorityItem = {
+  id?: string;
+  priority?: string;
+};
+
+type DisasterEvent = {
+  id?: string;
+  title?: string;
+  type?: string;
+};
+
+type UrlhausIndicator = {
+  id?: string | number;
+  host?: string;
+  url?: string;
+  threat?: string;
+};
+
+type DashboardData = {
+  markets?: MarketsData;
+  cyber_priority_stats?: { critical?: number; total?: number };
+  cyber_priorities?: CyberPriorityItem[];
+  disaster_events?: DisasterEvent[];
+  urlhaus_indicators?: UrlhausIndicator[];
+  infrastructure_context?: unknown[];
+  local_forecast?: { risk?: { level?: string } };
+  air_quality_source?: { status?: string };
+  air_quality_stations?: unknown[];
+};
+
+interface MarketsPanelProps { data: DashboardData; spaceWeather?: SpaceWeather | null; }
 
 const SECTIONS = [
+  { key: 'public', label: 'PUBLIC', icon: Globe2 },
   { key: 'indices', label: 'INDICES', icon: LineChart },
   { key: 'stocks', label: 'DEFENSE', icon: Shield },
   { key: 'oil', label: 'ENERGY', icon: Droplets },
@@ -18,19 +68,130 @@ const SECTIONS = [
   { key: 'crypto', label: 'CRYPTO', icon: Bitcoin },
 ];
 
-function Ticker({ name, data: d }: { name: string; data: any }) {
+function Ticker({ name, data: d }: { name: string; data: MarketTicker }) {
   if (!d) return null;
+  const price = d.price ?? 0;
+  const changePercent = d.change_percent ?? 0;
   return (
     <div className="flex items-center justify-between py-1.5 px-2 rounded hover:bg-[var(--hover-accent)] transition-colors">
       <span className="text-[10px] font-mono text-[var(--text-secondary)] tracking-wide">{name}</span>
       <div className="flex items-center gap-2">
         <span className="text-[11px] font-mono font-bold text-[var(--text-primary)] tabular-nums">
-          {d.price >= 1000 ? `${(d.price / 1000).toFixed(1)}K` : d.price?.toFixed(2)}
+          {price >= 1000 ? `${(price / 1000).toFixed(1)}K` : price.toFixed(2)}
         </span>
         <span className={`text-[9px] font-mono font-bold flex items-center gap-0.5 ${d.up ? 'text-[var(--alert-green)]' : 'text-[var(--alert-red)]'}`}>
           {d.up ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
-          {d.change_percent > 0 ? '+' : ''}{d.change_percent?.toFixed(2)}%
+          {changePercent > 0 ? '+' : ''}{changePercent.toFixed(2)}%
         </span>
+      </div>
+    </div>
+  );
+}
+
+const severityClass: Record<string, string> = {
+  critical: 'text-[var(--alert-red)] border-[var(--alert-red)]/30 bg-[var(--alert-red)]/10',
+  high: 'text-[#FF9500] border-[#FF9500]/30 bg-[#FF9500]/10',
+  medium: 'text-[#FFD54F] border-[#FFD54F]/30 bg-[#FFD54F]/10',
+  low: 'text-[var(--alert-green)] border-[var(--alert-green)]/30 bg-[var(--alert-green)]/10',
+  disabled: 'text-[var(--text-muted)] border-white/10 bg-white/5',
+};
+
+function PublicStat({
+  icon: Icon,
+  label,
+  value,
+  tone = 'low',
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string | number;
+  tone?: string;
+}) {
+  return (
+    <div className={`rounded-lg border px-2 py-2 ${severityClass[tone] || severityClass.low}`}>
+      <div className="flex items-center gap-1.5">
+        <Icon className="w-3 h-3 flex-shrink-0" />
+        <span className="text-[8px] font-mono tracking-widest text-[var(--text-muted)] uppercase truncate">{label}</span>
+      </div>
+      <div className="mt-1 text-[13px] font-mono font-bold tabular-nums text-[var(--text-primary)]">{value}</div>
+    </div>
+  );
+}
+
+function PublicIntelSection({ data }: { data: DashboardData }) {
+  const cyberStats = data.cyber_priority_stats || {};
+  const cyberPriorities = Array.isArray(data.cyber_priorities) ? data.cyber_priorities : [];
+  const disasters = Array.isArray(data.disaster_events) ? data.disaster_events : [];
+  const urlhaus = Array.isArray(data.urlhaus_indicators) ? data.urlhaus_indicators : [];
+  const infra = Array.isArray(data.infrastructure_context) ? data.infrastructure_context : [];
+  const forecast = data.local_forecast;
+  const airQualityStatus = data.air_quality_source?.status || 'disabled';
+  const forecastRisk = forecast?.risk?.level || 'pending';
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-2">
+        <PublicStat icon={Bug} label="Cyber priority" value={`${cyberStats.critical || 0}/${cyberStats.total || 0}`} tone={(cyberStats.critical || 0) > 0 ? 'critical' : 'low'} />
+        <PublicStat icon={AlertTriangle} label="Disasters" value={disasters.length} tone={disasters.length > 0 ? 'high' : 'low'} />
+        <PublicStat icon={CloudLightning} label="Forecast risk" value={forecastRisk.toUpperCase()} tone={forecastRisk} />
+        <PublicStat icon={Building2} label="Infra context" value={infra.length} tone={infra.length > 0 ? 'medium' : 'disabled'} />
+      </div>
+
+      <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2">
+        <div className="mb-1.5 flex items-center justify-between">
+          <span className="text-[9px] font-mono tracking-widest text-[var(--text-muted)]">TOP CVE PRIORITY</span>
+          <span className="text-[8px] font-mono text-[var(--text-muted)]">EPSS / KEV</span>
+        </div>
+        <div className="space-y-1">
+          {cyberPriorities.slice(0, 3).map((item) => (
+            <div key={item.id} className="flex items-center justify-between gap-2 text-[9px] font-mono">
+              <span className="truncate text-[var(--text-secondary)]">{item.id}</span>
+              <span className={`rounded border px-1.5 py-0.5 uppercase ${severityClass[item.priority || 'low'] || severityClass.low}`}>{item.priority || 'low'}</span>
+            </div>
+          ))}
+          {cyberPriorities.length === 0 && <div className="py-2 text-center text-[9px] font-mono text-[var(--text-muted)]">Loading cyber priorities...</div>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2">
+          <div className="mb-1 flex items-center gap-1.5 text-[9px] font-mono tracking-widest text-[var(--text-muted)]">
+            <Globe2 className="w-3 h-3" />
+            GDACS
+          </div>
+          <div className="space-y-1">
+            {disasters.slice(0, 2).map((event) => (
+              <div key={event.id || event.title} className="truncate text-[9px] font-mono text-[var(--text-secondary)]">{event.title || event.type}</div>
+            ))}
+            {disasters.length === 0 && <div className="text-[9px] font-mono text-[var(--text-muted)]">No active events</div>}
+          </div>
+        </div>
+        <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2">
+          <div className="mb-1 flex items-center gap-1.5 text-[9px] font-mono tracking-widest text-[var(--text-muted)]">
+            <Wind className="w-3 h-3" />
+            OPENAQ
+          </div>
+          <div className="text-[9px] font-mono text-[var(--text-secondary)]">
+            {data.air_quality_stations?.length || 0} stations
+            <span className="ml-1 text-[var(--text-muted)]">({airQualityStatus})</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2">
+        <div className="mb-1.5 flex items-center justify-between">
+          <span className="text-[9px] font-mono tracking-widest text-[var(--text-muted)]">URLHAUS RECENT</span>
+          <span className="text-[8px] font-mono text-[var(--text-muted)]">{urlhaus.length} indicators</span>
+        </div>
+        <div className="space-y-1">
+          {urlhaus.slice(0, 3).map((indicator) => (
+            <div key={indicator.id || indicator.url} className="flex items-center justify-between gap-2 text-[9px] font-mono">
+              <span className="truncate text-[var(--text-secondary)]">{indicator.host || indicator.url}</span>
+              <span className="text-[var(--text-muted)] uppercase">{indicator.threat || 'malware'}</span>
+            </div>
+          ))}
+          {urlhaus.length === 0 && <div className="py-2 text-center text-[9px] font-mono text-[var(--text-muted)]">Loading malware indicators...</div>}
+        </div>
       </div>
     </div>
   );
@@ -39,29 +200,28 @@ function Ticker({ name, data: d }: { name: string; data: any }) {
 export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) {
   const [expanded, setExpanded] = useState(true);
   const [maximized, setMaximized] = useState(false);
-  const [activeSection, setActiveSection] = useState('stocks');
+  const [activeSection, setActiveSection] = useState('public');
   const markets = data.markets || {};
-
-  // Ensure portal only renders on client
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  const latestFlare = spaceWeather?.solar_flares?.[0];
 
   const content = (
     <motion.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} transition={{ delay: 0.6, duration: 0.6 }} className={`glass-panel p-3 pointer-events-auto transition-all duration-300 flex flex-col ${maximized ? 'fixed inset-4 z-[9999] bg-[#0a0a09]/95 backdrop-blur-3xl' : ''}`}>
-      <button onClick={() => setExpanded(!expanded)} className="flex items-center justify-between w-full mb-2">
-        <div className="flex items-center gap-2">
+      <div className="flex items-center justify-between w-full mb-2">
+        <button aria-label={expanded ? "Collapse markets and intel panel" : "Expand markets and intel panel"} onClick={() => setExpanded(!expanded)} className="flex min-w-0 flex-1 items-center gap-2 text-left">
           <BarChart3 className="w-3.5 h-3.5 text-[var(--gold-primary)]" />
           <span className="hud-text text-[12px] text-[var(--text-primary)]">MARKETS & INTEL</span>
           <span className="gotham-tag gotham-tag--low" style={{ fontSize: '7px', padding: '1px 4px' }}>LIVE</span>
-        </div>
+        </button>
         <div className="flex items-center gap-2">
           <div className="w-1.5 h-1.5 rounded-full bg-[var(--alert-green)] animate-osiris-pulse" />
-          <button onClick={(e) => { e.stopPropagation(); setMaximized(!maximized); if (!expanded && !maximized) setExpanded(true); }} className="hover:text-white transition-colors" title={maximized ? "Restore" : "Maximize"}>
+          <button aria-label={maximized ? "Restore markets and intel panel" : "Maximize markets and intel panel"} onClick={(e) => { e.stopPropagation(); setMaximized(!maximized); if (!expanded && !maximized) setExpanded(true); }} className="hover:text-white transition-colors" title={maximized ? "Restore" : "Maximize"}>
             {maximized ? <Minimize2 className="w-3.5 h-3.5 text-[var(--text-muted)]" /> : <Maximize2 className="w-3.5 h-3.5 text-[var(--text-muted)]" />}
           </button>
-          {expanded ? <ChevronUp className="w-3.5 h-3.5 text-[var(--text-muted)]" /> : <ChevronDown className="w-3.5 h-3.5 text-[var(--text-muted)]" />}
+          <button aria-label={expanded ? "Collapse markets and intel panel" : "Expand markets and intel panel"} onClick={() => setExpanded(!expanded)} className="hover:text-white transition-colors" title={expanded ? "Collapse" : "Expand"}>
+            {expanded ? <ChevronUp className="w-3.5 h-3.5 text-[var(--text-muted)]" /> : <ChevronDown className="w-3.5 h-3.5 text-[var(--text-muted)]" />}
+          </button>
         </div>
-      </button>
+      </div>
 
       <AnimatePresence>
         {expanded && (
@@ -78,9 +238,9 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
                     Kp {spaceWeather.kp_index} — {spaceWeather.storm_level}
                   </span>
                 </div>
-                {spaceWeather.solar_flares?.length > 0 && (
+                {latestFlare && (
                   <div className="mt-1 text-[8px] font-mono text-[var(--text-muted)]">
-                    Latest flare: {spaceWeather.solar_flares[0].class}
+                    Latest flare: {latestFlare.class}
                   </div>
                 )}
               </div>
@@ -91,7 +251,7 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
               {SECTIONS.map(s => {
                 const Icon = s.icon;
                 return (
-                  <button key={s.key} onClick={() => setActiveSection(s.key)}
+                  <button key={s.key} aria-label={`Show ${s.label.toLowerCase()} intelligence`} onClick={() => setActiveSection(s.key)}
                     className={`flex items-center gap-1 px-2.5 py-1.5 rounded text-[9px] font-mono tracking-wider whitespace-nowrap transition-all ${activeSection === s.key ? 'bg-[var(--hover-accent)] text-[var(--gold-primary)] border border-[var(--border-primary)]' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)] border border-transparent'}`}>
                     <Icon className="w-3 h-3" />
                     {s.label}
@@ -111,24 +271,31 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
               </div>
             )}
 
-            {/* Ticker List */}
-            <div className="space-y-0.5 overflow-y-auto styled-scrollbar mt-2">
-              {markets[activeSection] && Object.entries(markets[activeSection]).map(([name, d]) => (
-                <Ticker key={name} name={name} data={d} />
-              ))}
-              {(!markets[activeSection] || Object.keys(markets[activeSection]).length === 0) && (
-                <div className="text-center py-3 text-[10px] font-mono text-[var(--text-muted)]">Loading {activeSection}...</div>
-              )}
-            </div>
+            {activeSection === 'public' ? (
+              <PublicIntelSection data={data} />
+            ) : (
+              <div className="space-y-0.5 overflow-y-auto styled-scrollbar mt-2">
+                {isTickerSection(markets[activeSection]) && Object.entries(markets[activeSection]).map(([name, d]) => (
+                  <Ticker key={name} name={name} data={d} />
+                ))}
+                {(!isTickerSection(markets[activeSection]) || Object.keys(markets[activeSection]).length === 0) && (
+                  <div className="text-center py-3 text-[10px] font-mono text-[var(--text-muted)]">Loading {activeSection}...</div>
+                )}
+              </div>
+            )}
           </motion.div>
         )}
       </AnimatePresence>
     </motion.div>
   );
 
-  if (maximized && mounted && typeof document !== 'undefined') {
+  if (maximized && typeof document !== 'undefined') {
     return createPortal(content, document.body);
   }
 
   return content;
+}
+
+function isTickerSection(value: MarketsData[string]): value is Record<string, MarketTicker> {
+  return Boolean(value) && !Array.isArray(value) && typeof value === 'object';
 }

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -618,6 +618,32 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       popupRef.current?.remove();
       popupRef.current = new maplibregl.Popup({ closeButton: true, maxWidth: '420px', offset: 14 }).setLngLat(coords).setHTML(html).addTo(map);
     };
+    const escapeHtml = (value: unknown) => String(value ?? '').replace(/[&<>"']/g, char => ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+    }[char] || char));
+    const safeExternalUrl = (value: unknown) => {
+      if (typeof value !== 'string') return '';
+      try {
+        const url = new URL(value);
+        return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : '';
+      } catch {
+        return '';
+      }
+    };
+    const safeJsonArray = (value: unknown) => {
+      if (Array.isArray(value)) return value;
+      if (typeof value !== 'string') return [];
+      try {
+        const parsed = JSON.parse(value);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    };
     const pStyle = `background:rgba(12,14,26,0.95);backdrop-filter:blur(16px);border-radius:10px;padding:16px;font-family:'JetBrains Mono',monospace;`;
     const linkStyle = `display:inline-block;margin-top:8px;padding:5px 12px;font-size:10px;letter-spacing:0.12em;text-decoration:none;border-radius:5px;font-family:'JetBrains Mono',monospace;`;
 
@@ -684,18 +710,21 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       const coords = (e.features[0].geometry as any).coordinates;
       const color = p.kind === 'caravan_site' ? '#FFB74D' : '#9CCC65';
       const typeLabel = p.kind === 'caravan_site' ? 'CARAVAN SITE' : 'CAMP SITE';
+      const website = safeExternalUrl(p.website);
+      const osmType = ['node', 'way', 'relation'].includes(p.osmType) ? p.osmType : 'node';
+      const osmId = /^\d+$/.test(String(p.osmId || '')) ? p.osmId : '';
       popup(coords, `<div style="${pStyle}border:1px solid ${color}40;">
-        <div style="color:${color};font-size:13px;font-weight:700;margin-bottom:4px;">${p.name || 'Camping site'}</div>
+        <div style="color:${color};font-size:13px;font-weight:700;margin-bottom:4px;">${escapeHtml(p.name || 'Camping site')}</div>
         <div style="font-size:9px;color:#8A8880;margin-bottom:8px;">${typeLabel} / OpenStreetMap</div>
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;margin-bottom:8px;">
-          <div><span style="color:#5C5A54;">OPERATOR</span><br/><span style="color:#E8E6E0;">${p.operator || '-'}</span></div>
-          <div><span style="color:#5C5A54;">CAPACITY</span><br/><span style="color:#E8E6E0;">${p.capacity || '-'}</span></div>
-          <div><span style="color:#5C5A54;">PHONE</span><br/><span style="color:#E8E6E0;">${p.phone || '-'}</span></div>
+          <div><span style="color:#5C5A54;">OPERATOR</span><br/><span style="color:#E8E6E0;">${escapeHtml(p.operator || '-')}</span></div>
+          <div><span style="color:#5C5A54;">CAPACITY</span><br/><span style="color:#E8E6E0;">${escapeHtml(p.capacity || '-')}</span></div>
+          <div><span style="color:#5C5A54;">PHONE</span><br/><span style="color:#E8E6E0;">${escapeHtml(p.phone || '-')}</span></div>
           <div><span style="color:#5C5A54;">COORDS</span><br/><span style="color:#E8E6E0;">${coords[1].toFixed(3)}, ${coords[0].toFixed(3)}</span></div>
         </div>
         <div style="display:flex;gap:6px;flex-wrap:wrap;">
-          ${p.website ? `<a href="${p.website}" target="_blank" style="${linkStyle}color:${color};border:1px solid ${color}66;background:${color}18;">WEBSITE</a>` : ''}
-          <a href="https://www.openstreetmap.org/${p.osmType || 'node'}/${p.osmId || ''}" target="_blank" style="${linkStyle}color:#C5E1A5;border:1px solid rgba(197,225,165,0.4);background:rgba(197,225,165,0.1);">OSM</a>
+          ${website ? `<a href="${website}" target="_blank" rel="noopener noreferrer" style="${linkStyle}color:${color};border:1px solid ${color}66;background:${color}18;">WEBSITE</a>` : ''}
+          ${osmId ? `<a href="https://www.openstreetmap.org/${osmType}/${osmId}" target="_blank" rel="noopener noreferrer" style="${linkStyle}color:#C5E1A5;border:1px solid rgba(197,225,165,0.4);background:rgba(197,225,165,0.1);">OSM</a>` : ''}
           <a href="https://www.google.com/maps/@${coords[1]},${coords[0]},15z" target="_blank" style="${linkStyle}color:#448AFF;border:1px solid rgba(68,138,255,0.4);background:rgba(68,138,255,0.1);">MAP</a>
         </div>
       </div>`);
@@ -815,7 +844,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     });
 
     // ── Generic hover for clickables ──
-    ['conflict-icons','cctv-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','rail-dots','rail-lines','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo'].forEach(layer => {
+    ['conflict-icons','cctv-dots','camping-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','rail-dots','rail-lines','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo'].forEach(layer => {
       map.on('mouseenter', layer, () => { map.getCanvas().style.cursor = 'pointer'; });
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
     });
@@ -1037,12 +1066,12 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       const coords = e.lngLat;
       popup([coords.lng, coords.lat], `<div style="${pStyle}border:1px solid rgba(255,213,79,0.35);">
         <div style="color:#FFD54F;font-size:13px;font-weight:700;margin-bottom:4px;">GERMAN RAIL LINE</div>
-        <div style="font-size:12px;color:#E8E6E0;margin-bottom:8px;">${p.name || p.ref || 'Rail line'}</div>
+        <div style="font-size:12px;color:#E8E6E0;margin-bottom:8px;">${escapeHtml(p.name || p.ref || 'Rail line')}</div>
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;">
-          <div><span style="color:#5C5A54;">USAGE</span><br/><span style="color:#E8E6E0;">${p.usage || '—'}</span></div>
-          <div><span style="color:#5C5A54;">ELECTRIFIED</span><br/><span style="color:#E8E6E0;">${p.electrified || '—'}</span></div>
-          <div><span style="color:#5C5A54;">OPERATOR</span><br/><span style="color:#E8E6E0;">${p.operator || '—'}</span></div>
-          <div><span style="color:#5C5A54;">GAUGE</span><br/><span style="color:#E8E6E0;">${p.gauge || '—'}</span></div>
+          <div><span style="color:#5C5A54;">USAGE</span><br/><span style="color:#E8E6E0;">${escapeHtml(p.usage || '—')}</span></div>
+          <div><span style="color:#5C5A54;">ELECTRIFIED</span><br/><span style="color:#E8E6E0;">${escapeHtml(p.electrified || '—')}</span></div>
+          <div><span style="color:#5C5A54;">OPERATOR</span><br/><span style="color:#E8E6E0;">${escapeHtml(p.operator || '—')}</span></div>
+          <div><span style="color:#5C5A54;">GAUGE</span><br/><span style="color:#E8E6E0;">${escapeHtml(p.gauge || '—')}</span></div>
         </div>
       </div>`);
     });
@@ -1052,16 +1081,35 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       const p = e.features[0].properties as any;
       const coords = (e.features[0].geometry as any).coordinates;
       const kindColor = p.kind === 'yard' ? '#FF9500' : p.kind === 'depot' ? '#00BCD4' : p.kind === 'junction' ? '#76FF03' : p.kind === 'halt' ? '#D4AF37' : '#FFD54F';
+      const operationColor = p.operationStatus === 'severe' || p.operationStatus === 'cancelled' ? '#FF1744' : p.operationStatus === 'delayed' ? '#FF9500' : p.operationStatus === 'on_time' ? '#76FF03' : '#8A8880';
+      const departures = safeJsonArray(p.departures).slice(0, 4);
+      const operationsHtml = p.operationStatus
+        ? `<div style="margin-top:10px;padding-top:8px;border-top:1px solid rgba(255,255,255,0.1);">
+            <div style="color:${operationColor};font-size:10px;font-weight:700;letter-spacing:0.1em;margin-bottom:6px;">LIVE OPS</div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;margin-bottom:6px;">
+              <div><span style="color:#5C5A54;">STATUS</span><br/><span style="color:${operationColor};">${escapeHtml(String(p.operationStatus).toUpperCase())}</span></div>
+              <div><span style="color:#5C5A54;">DELAYS</span><br/><span style="color:#E8E6E0;">${Number(p.delayedDepartures || 0) + Number(p.severeDepartures || 0)}</span></div>
+              <div><span style="color:#5C5A54;">CANCELLED</span><br/><span style="color:#FF1744;">${p.cancelledDepartures || 0}</span></div>
+              <div><span style="color:#5C5A54;">PLATFORM CHG</span><br/><span style="color:#FFD54F;">${p.platformChanges || 0}</span></div>
+            </div>
+            ${departures.map((departure: any) => `<div style="display:flex;justify-content:space-between;gap:8px;border-top:1px solid rgba(255,255,255,0.06);padding-top:5px;margin-top:5px;font-size:9px;">
+              <span style="color:#E8E6E0;">${escapeHtml(departure.line || 'TRAIN')}</span>
+              <span style="color:#8A8880;max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(departure.direction || '')}</span>
+              <span style="color:${departure.status === 'severe' ? '#FF1744' : departure.status === 'delayed' ? '#FF9500' : '#76FF03'};">${departure.delayMinutes ? `+${escapeHtml(departure.delayMinutes)}` : 'OK'}</span>
+            </div>`).join('')}
+          </div>`
+        : '<div style="margin-top:10px;padding-top:8px;border-top:1px solid rgba(255,255,255,0.1);color:#8A8880;font-size:9px;">LIVE OPS not loaded for this station.</div>';
       popup(coords, `<div style="${pStyle}border:1px solid ${kindColor}40;">
         <div style="color:${kindColor};font-size:13px;font-weight:700;margin-bottom:4px;">GERMAN RAIL INFRA</div>
-        <div style="font-size:12px;color:#E8E6E0;margin-bottom:8px;">${p.name || 'Rail infrastructure'}</div>
+        <div style="font-size:12px;color:#E8E6E0;margin-bottom:8px;">${escapeHtml(p.name || 'Rail infrastructure')}</div>
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;margin-bottom:8px;">
-          <div><span style="color:#5C5A54;">TYPE</span><br/><span style="color:${kindColor};">${(p.kind || 'station').toUpperCase()}</span></div>
-          <div><span style="color:#5C5A54;">NETWORK</span><br/><span style="color:#E8E6E0;">${p.network || '—'}</span></div>
-          <div><span style="color:#5C5A54;">OPERATOR</span><br/><span style="color:#E8E6E0;">${p.operator || '—'}</span></div>
-          <div><span style="color:#5C5A54;">UIC / REF</span><br/><span style="color:#E8E6E0;">${p.uicRef || p.ref || '—'}</span></div>
+          <div><span style="color:#5C5A54;">TYPE</span><br/><span style="color:${kindColor};">${escapeHtml(String(p.kind || 'station').toUpperCase())}</span></div>
+          <div><span style="color:#5C5A54;">NETWORK</span><br/><span style="color:#E8E6E0;">${escapeHtml(p.network || '—')}</span></div>
+          <div><span style="color:#5C5A54;">OPERATOR</span><br/><span style="color:#E8E6E0;">${escapeHtml(p.operator || '—')}</span></div>
+          <div><span style="color:#5C5A54;">UIC / REF</span><br/><span style="color:#E8E6E0;">${escapeHtml(p.uicRef || p.ref || '—')}</span></div>
           <div><span style="color:#5C5A54;">COORDS</span><br/><span style="color:#E8E6E0;">${coords[1].toFixed(3)}°, ${coords[0].toFixed(3)}°</span></div>
         </div>
+        ${operationsHtml}
       </div>`);
     });
 
@@ -1234,20 +1282,52 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
 
   useEffect(() => {
     if (!mapReady) return;
+    setGeo('camping', activeLayers.camping && data.camping_sites ? data.camping_sites
+      .filter((site: any) => typeof site.lng === 'number' && typeof site.lat === 'number')
+      .map((site: any) => ({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [site.lng, site.lat] },
+        properties: {
+          name: site.name,
+          kind: site.kind,
+          operator: site.operator,
+          website: site.website,
+          phone: site.phone,
+          capacity: site.capacity,
+          osmType: site.id?.split('-')[1],
+          osmId: site.id?.split('-')[2],
+        },
+      })) : []);
+  }, [mapReady, data.camping_sites, activeLayers.camping, setGeo]);
+
+  useEffect(() => {
+    if (!mapReady) return;
+    const operationsByStation = new Map<string, any>(
+      (data.rail_germany_operations || []).map((operation: any) => [operation.stationId, operation]),
+    );
     setGeo('rail-germany', activeLayers.rail_germany && data.rail_germany ? data.rail_germany
       .filter((item: any) => typeof item.lng === 'number' && typeof item.lat === 'number')
-      .map((item: any) => ({
-      type: 'Feature',
-      geometry: { type: 'Point', coordinates: [item.lng, item.lat] },
-      properties: {
-        name: item.name,
-        kind: item.kind,
-        operator: item.operator,
-        network: item.network,
-        uicRef: item.uicRef,
-        ref: item.ref,
-      },
-    })) : []);
+      .map((item: any) => {
+        const operation = operationsByStation.get(item.uicRef) || operationsByStation.get(item.id);
+        return {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [item.lng, item.lat] },
+          properties: {
+            name: item.name,
+            kind: item.kind,
+            operator: item.operator,
+            network: item.network,
+            uicRef: item.uicRef,
+            ref: item.ref,
+            operationStatus: operation?.status,
+            delayedDepartures: operation?.delayedDepartures || 0,
+            severeDepartures: operation?.severeDepartures || 0,
+            cancelledDepartures: operation?.cancelledDepartures || 0,
+            platformChanges: operation?.platformChanges || 0,
+            departures: JSON.stringify(operation?.departures || []),
+          },
+        };
+      }) : []);
     setGeo('rail-germany-lines', activeLayers.rail_germany && data.rail_germany_lines ? data.rail_germany_lines
       .filter((item: any) => item.geometry?.type === 'LineString')
       .map((item: any) => ({
@@ -1264,7 +1344,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
           gauge: item.gauge,
         },
       })) : []);
-  }, [mapReady, data.rail_germany, data.rail_germany_lines, activeLayers.rail_germany, setGeo]);
+  }, [mapReady, data.rail_germany, data.rail_germany_lines, data.rail_germany_operations, activeLayers.rail_germany, setGeo]);
 
   useEffect(() => {
     if (!mapReady) return;
@@ -1320,6 +1400,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     setVis(['fl-jets'], activeLayers.jets);
     setVis(['fl-military'], activeLayers.military);
     setVis(['cctv-glow','cctv-dots','cctv-label'], activeLayers.cctv);
+    setVis(['camping-glow','camping-dots','camping-label'], activeLayers.camping);
     setVis(['fires-heat'], activeLayers.fires);
     setVis(['weather-glow','weather-dots','weather-label'], activeLayers.weather);
     setVis(['infra-glow','infra-dots','infra-label'], activeLayers.infrastructure);

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -10,7 +10,12 @@ interface OsirisMapProps {
   onEntityClick?: (entity: any) => void;
   onMouseCoords?: (coords: { lat: number; lng: number }) => void;
   onRightClick?: (coords: { lat: number; lng: number }) => void;
-  onViewStateChange?: (vs: { zoom: number; latitude: number }) => void;
+  onViewStateChange?: (vs: {
+    zoom: number;
+    latitude: number;
+    longitude: number;
+    bbox: { west: number; south: number; east: number; north: number };
+  }) => void;
   flyToLocation?: { lat: number; lng: number; ts: number } | null;
   projection?: 'mercator' | 'globe';
   mapStyle?: string;
@@ -166,7 +171,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       createDot(map, 'dot-cctv', '#39FF14', 10);
 
       // Sources
-      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'ioda-outages', 'malware-nodes'];
+      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','gps-jamming','day-night','cctv','camping','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','rail-germany','rail-germany-lines','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'ioda-outages', 'malware-nodes'];
       sources.forEach(s => map.addSource(s, { type: 'geojson', data: EMPTY_FC }));
 
       // Warning icon generator (parameterized — eliminates 3x copy-paste)
@@ -242,6 +247,22 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         'text-field': ['get','name'], 'text-size': 9, 'text-font': ['Open Sans Regular'],
         'text-offset': [0, 1.8], 'text-max-width': 12, 'text-allow-overlap': false,
       }, paint: { 'text-color': '#39FF14', 'text-halo-color': '#000', 'text-halo-width': 1, 'text-opacity': 0.7 }});
+
+      // Camping sites
+      map.addLayer({ id: 'camping-glow', type: 'circle', source: 'camping', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 5,6, 9,12, 13,20],
+        'circle-color': '#9CCC65', 'circle-opacity': 0.12, 'circle-blur': 1,
+      }});
+      map.addLayer({ id: 'camping-dots', type: 'circle', source: 'camping', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 5,3, 9,6, 13,10],
+        'circle-color': ['match', ['get','kind'], 'caravan_site','#FFB74D', '#9CCC65'],
+        'circle-opacity': 0.88,
+        'circle-stroke-width': 1.5, 'circle-stroke-color': '#E8F5E9', 'circle-stroke-opacity': 0.55,
+      }});
+      map.addLayer({ id: 'camping-label', type: 'symbol', source: 'camping', minzoom: 10, layout: {
+        'text-field': ['get','name'], 'text-size': 9, 'text-font': ['Open Sans Regular'],
+        'text-offset': [0, 1.7], 'text-max-width': 12, 'text-allow-overlap': false,
+      }, paint: { 'text-color': '#C5E1A5', 'text-halo-color': '#000', 'text-halo-width': 1, 'text-opacity': 0.8 }});
 
       // GDELT
       // ══ NETWORK INTEL — IODA Internet Outages ══
@@ -379,6 +400,28 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         'text-field': ['get','name'], 'text-size': 9, 'text-font': ['Open Sans Regular'],
         'text-offset': [0, 1.8], 'text-max-width': 12, 'text-allow-overlap': false,
       }, paint: { 'text-color': '#FF4081', 'text-halo-color': '#000', 'text-halo-width': 1, 'text-opacity': 0.8 }});
+
+      // Germany rail infrastructure
+      map.addLayer({ id: 'rail-lines', type: 'line', source: 'rail-germany-lines', paint: {
+        'line-color': '#FFD54F',
+        'line-width': ['interpolate',['linear'],['zoom'], 4,0.6, 7,1.2, 11,2.4],
+        'line-opacity': 0.45,
+      }});
+      map.addLayer({ id: 'rail-glow', type: 'circle', source: 'rail-germany', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 4,5, 7,10, 11,18],
+        'circle-color': ['match', ['get','kind'], 'yard','#FF9500', 'depot','#00BCD4', 'junction','#76FF03', 'halt','#D4AF37', '#FFD54F'],
+        'circle-opacity': 0.12, 'circle-blur': 1,
+      }});
+      map.addLayer({ id: 'rail-dots', type: 'circle', source: 'rail-germany', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 4,3, 7,5, 11,9],
+        'circle-color': ['match', ['get','kind'], 'yard','#FF9500', 'depot','#00BCD4', 'junction','#76FF03', 'halt','#D4AF37', '#FFD54F'],
+        'circle-opacity': 0.9,
+        'circle-stroke-width': 1.5, 'circle-stroke-color': '#FFF8DC', 'circle-stroke-opacity': 0.5,
+      }});
+      map.addLayer({ id: 'rail-label', type: 'symbol', source: 'rail-germany', minzoom: 6, layout: {
+        'text-field': ['get','name'], 'text-size': 9, 'text-font': ['Open Sans Regular'],
+        'text-offset': [0, 1.7], 'text-max-width': 12, 'text-allow-overlap': false,
+      }, paint: { 'text-color': '#FFD54F', 'text-halo-color': '#000', 'text-halo-width': 1, 'text-opacity': 0.8 }});
 
       // SIGINT RSS news - gold markers
       map.addLayer({ id: 'sigint-news-glow', type: 'circle', source: 'sigint-news', paint: {
@@ -551,8 +594,24 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         onMouseCoords?.({ lat: e.lngLat.lat, lng: e.lngLat.lng });
       }
     });
+    const emitViewState = () => {
+      const c = map.getCenter();
+      const b = map.getBounds();
+      onViewStateChange?.({
+        zoom: map.getZoom(),
+        latitude: c.lat,
+        longitude: c.lng,
+        bbox: {
+          west: b.getWest(),
+          south: b.getSouth(),
+          east: b.getEast(),
+          north: b.getNorth(),
+        },
+      });
+    };
+    emitViewState();
     map.on('contextmenu', e => { e.preventDefault(); onRightClick?.({ lat: e.lngLat.lat, lng: e.lngLat.lng }); });
-    map.on('moveend', () => { const c = map.getCenter(); onViewStateChange?.({ zoom: map.getZoom(), latitude: c.lat }); });
+    map.on('moveend', emitViewState);
 
     // ── POPUP HELPER ──
     const popup = (coords: any, html: string) => {
@@ -616,6 +675,30 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       });
       // Also fly to the camera
       map.flyTo({ center: coords, zoom: Math.max(map.getZoom(), 13), duration: 1000 });
+    });
+
+    // ── Camping sites ──
+    map.on('click', 'camping-dots', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      const color = p.kind === 'caravan_site' ? '#FFB74D' : '#9CCC65';
+      const typeLabel = p.kind === 'caravan_site' ? 'CARAVAN SITE' : 'CAMP SITE';
+      popup(coords, `<div style="${pStyle}border:1px solid ${color}40;">
+        <div style="color:${color};font-size:13px;font-weight:700;margin-bottom:4px;">${p.name || 'Camping site'}</div>
+        <div style="font-size:9px;color:#8A8880;margin-bottom:8px;">${typeLabel} / OpenStreetMap</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;margin-bottom:8px;">
+          <div><span style="color:#5C5A54;">OPERATOR</span><br/><span style="color:#E8E6E0;">${p.operator || '-'}</span></div>
+          <div><span style="color:#5C5A54;">CAPACITY</span><br/><span style="color:#E8E6E0;">${p.capacity || '-'}</span></div>
+          <div><span style="color:#5C5A54;">PHONE</span><br/><span style="color:#E8E6E0;">${p.phone || '-'}</span></div>
+          <div><span style="color:#5C5A54;">COORDS</span><br/><span style="color:#E8E6E0;">${coords[1].toFixed(3)}, ${coords[0].toFixed(3)}</span></div>
+        </div>
+        <div style="display:flex;gap:6px;flex-wrap:wrap;">
+          ${p.website ? `<a href="${p.website}" target="_blank" style="${linkStyle}color:${color};border:1px solid ${color}66;background:${color}18;">WEBSITE</a>` : ''}
+          <a href="https://www.openstreetmap.org/${p.osmType || 'node'}/${p.osmId || ''}" target="_blank" style="${linkStyle}color:#C5E1A5;border:1px solid rgba(197,225,165,0.4);background:rgba(197,225,165,0.1);">OSM</a>
+          <a href="https://www.google.com/maps/@${coords[1]},${coords[0]},15z" target="_blank" style="${linkStyle}color:#448AFF;border:1px solid rgba(68,138,255,0.4);background:rgba(68,138,255,0.1);">MAP</a>
+        </div>
+      </div>`);
     });
 
     // ── Earthquakes (with USGS link) ──
@@ -732,7 +815,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     });
 
     // ── Generic hover for clickables ──
-    ['conflict-icons','cctv-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo'].forEach(layer => {
+    ['conflict-icons','cctv-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','rail-dots','rail-lines','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo'].forEach(layer => {
       map.on('mouseenter', layer, () => { map.getCanvas().style.cursor = 'pointer'; });
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
     });
@@ -947,6 +1030,41 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       });
     });
 
+    // ── Germany Rail ──
+    map.on('click', 'rail-lines', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = e.lngLat;
+      popup([coords.lng, coords.lat], `<div style="${pStyle}border:1px solid rgba(255,213,79,0.35);">
+        <div style="color:#FFD54F;font-size:13px;font-weight:700;margin-bottom:4px;">GERMAN RAIL LINE</div>
+        <div style="font-size:12px;color:#E8E6E0;margin-bottom:8px;">${p.name || p.ref || 'Rail line'}</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;">
+          <div><span style="color:#5C5A54;">USAGE</span><br/><span style="color:#E8E6E0;">${p.usage || '—'}</span></div>
+          <div><span style="color:#5C5A54;">ELECTRIFIED</span><br/><span style="color:#E8E6E0;">${p.electrified || '—'}</span></div>
+          <div><span style="color:#5C5A54;">OPERATOR</span><br/><span style="color:#E8E6E0;">${p.operator || '—'}</span></div>
+          <div><span style="color:#5C5A54;">GAUGE</span><br/><span style="color:#E8E6E0;">${p.gauge || '—'}</span></div>
+        </div>
+      </div>`);
+    });
+
+    map.on('click', 'rail-dots', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      const kindColor = p.kind === 'yard' ? '#FF9500' : p.kind === 'depot' ? '#00BCD4' : p.kind === 'junction' ? '#76FF03' : p.kind === 'halt' ? '#D4AF37' : '#FFD54F';
+      popup(coords, `<div style="${pStyle}border:1px solid ${kindColor}40;">
+        <div style="color:${kindColor};font-size:13px;font-weight:700;margin-bottom:4px;">GERMAN RAIL INFRA</div>
+        <div style="font-size:12px;color:#E8E6E0;margin-bottom:8px;">${p.name || 'Rail infrastructure'}</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;margin-bottom:8px;">
+          <div><span style="color:#5C5A54;">TYPE</span><br/><span style="color:${kindColor};">${(p.kind || 'station').toUpperCase()}</span></div>
+          <div><span style="color:#5C5A54;">NETWORK</span><br/><span style="color:#E8E6E0;">${p.network || '—'}</span></div>
+          <div><span style="color:#5C5A54;">OPERATOR</span><br/><span style="color:#E8E6E0;">${p.operator || '—'}</span></div>
+          <div><span style="color:#5C5A54;">UIC / REF</span><br/><span style="color:#E8E6E0;">${p.uicRef || p.ref || '—'}</span></div>
+          <div><span style="color:#5C5A54;">COORDS</span><br/><span style="color:#E8E6E0;">${coords[1].toFixed(3)}°, ${coords[0].toFixed(3)}°</span></div>
+        </div>
+      </div>`);
+    });
+
     return () => { map.remove(); mapRef.current = null; };
   }, []);
 
@@ -1116,6 +1234,40 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
 
   useEffect(() => {
     if (!mapReady) return;
+    setGeo('rail-germany', activeLayers.rail_germany && data.rail_germany ? data.rail_germany
+      .filter((item: any) => typeof item.lng === 'number' && typeof item.lat === 'number')
+      .map((item: any) => ({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [item.lng, item.lat] },
+      properties: {
+        name: item.name,
+        kind: item.kind,
+        operator: item.operator,
+        network: item.network,
+        uicRef: item.uicRef,
+        ref: item.ref,
+      },
+    })) : []);
+    setGeo('rail-germany-lines', activeLayers.rail_germany && data.rail_germany_lines ? data.rail_germany_lines
+      .filter((item: any) => item.geometry?.type === 'LineString')
+      .map((item: any) => ({
+        type: 'Feature',
+        geometry: item.geometry,
+        properties: {
+          name: item.name,
+          kind: item.kind,
+          operator: item.operator,
+          network: item.network,
+          ref: item.ref,
+          electrified: item.electrified,
+          usage: item.usage,
+          gauge: item.gauge,
+        },
+      })) : []);
+  }, [mapReady, data.rail_germany, data.rail_germany_lines, activeLayers.rail_germany, setGeo]);
+
+  useEffect(() => {
+    if (!mapReady) return;
     const items = data.news || [];
     setGeo('sigint-news', activeLayers.news_intel && items.length > 0
       ? items.filter((n: any) => n.coords?.length === 2).map((n: any) => ({
@@ -1176,6 +1328,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     setVis(['ship-dots','ship-label'], activeLayers.maritime);
     setVis(['news-glow','news-dots','news-label'], activeLayers.live_news);
     setVis(['sigint-news-glow','sigint-news-dots','sigint-news-label'], activeLayers.news_intel);
+    setVis(['rail-lines','rail-glow','rail-dots','rail-label'], activeLayers.rail_germany);
     setVis(['conflict-icons'], activeLayers.conflict_zones !== false);
 
     setVis(['balloon-dots','balloon-label'], activeLayers.balloons);

--- a/src/lib/integrations/camping-sites.test.ts
+++ b/src/lib/integrations/camping-sites.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildOverpassCampingQuery,
+  fallbackCampingSites,
   normalizeCampingElement,
 } from './camping-sites.ts';
 
@@ -38,4 +39,16 @@ test('normalizes Overpass camping element', () => {
   assert.equal(item?.website, 'https://example.com');
   assert.equal(item?.capacity, '40');
   assert.equal(item?.source.provider, 'OpenStreetMap/Overpass');
+});
+
+test('returns fallback camping sites inside bbox when Overpass is unavailable', () => {
+  const sites = fallbackCampingSites({
+    south: 42.4,
+    west: 25.0,
+    north: 43.3,
+    east: 26.0,
+  });
+
+  assert.ok(sites.some(site => site.name === 'Camping Veliko Tarnovo'));
+  assert.equal(sites[0].source.provider, 'OSIRIS fallback dataset');
 });

--- a/src/lib/integrations/camping-sites.test.ts
+++ b/src/lib/integrations/camping-sites.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildOverpassCampingQuery,
+  normalizeCampingElement,
+} from './camping-sites.ts';
+
+test('builds bounded Overpass camping query', () => {
+  const query = buildOverpassCampingQuery({
+    south: 42.2,
+    west: 24.4,
+    north: 43.4,
+    east: 26.0,
+  });
+
+  assert.match(query, /tourism"="camp_site/);
+  assert.match(query, /tourism"="caravan_site/);
+  assert.match(query, /out center 300/);
+});
+
+test('normalizes Overpass camping element', () => {
+  const item = normalizeCampingElement({
+    type: 'node',
+    id: 123,
+    lat: 42.7,
+    lon: 25.4,
+    tags: {
+      tourism: 'camp_site',
+      name: 'Camping A',
+      website: 'https://example.com',
+      capacity: '40',
+    },
+  });
+
+  assert.equal(item?.id, 'osm-node-123');
+  assert.equal(item?.kind, 'camp_site');
+  assert.equal(item?.name, 'Camping A');
+  assert.equal(item?.website, 'https://example.com');
+  assert.equal(item?.capacity, '40');
+  assert.equal(item?.source.provider, 'OpenStreetMap/Overpass');
+});

--- a/src/lib/integrations/camping-sites.ts
+++ b/src/lib/integrations/camping-sites.ts
@@ -32,6 +32,106 @@ export type CampingSite = {
   source: ReturnType<typeof sourceMeta>;
 };
 
+type CampingSeed = Omit<CampingSite, 'source' | 'tags'> & {
+  tags?: Record<string, string>;
+};
+
+const FALLBACK_CAMPING_SITES: CampingSeed[] = [
+  {
+    id: 'fallback-camping-berlin-kladow',
+    name: 'Campingplatz Berlin Kladow',
+    kind: 'camp_site',
+    lat: 52.4581,
+    lng: 13.1433,
+    website: 'https://www.campingplatz-kladow.de/',
+  },
+  {
+    id: 'fallback-camping-muenchen-thalkirchen',
+    name: 'Campingplatz Muenchen-Thalkirchen',
+    kind: 'camp_site',
+    lat: 48.0879,
+    lng: 11.5459,
+    website: 'https://www.campingplatz-thalkirchen.de/',
+  },
+  {
+    id: 'fallback-camping-hamburg-stover-strand',
+    name: 'Camping Stover Strand',
+    kind: 'camp_site',
+    lat: 53.4144,
+    lng: 10.2805,
+    website: 'https://www.stover-strand.de/',
+  },
+  {
+    id: 'fallback-camping-nuremberg-knaus',
+    name: 'KNAUS Campingpark Nuernberg',
+    kind: 'camp_site',
+    lat: 49.4264,
+    lng: 11.1289,
+    website: 'https://www.knauscamp.de/nuernberg',
+  },
+  {
+    id: 'fallback-caravan-duesseldorf-rheinblick',
+    name: 'Reisemobilstellplatz Rheinblick',
+    kind: 'caravan_site',
+    lat: 51.2165,
+    lng: 6.7277,
+  },
+  {
+    id: 'fallback-camping-wien-neue-donau',
+    name: 'Camping Neue Donau',
+    kind: 'camp_site',
+    lat: 48.2089,
+    lng: 16.4487,
+    website: 'https://www.campingwien.at/',
+  },
+  {
+    id: 'fallback-camping-salzburg-nord-sam',
+    name: 'Camping Nord-Sam Salzburg',
+    kind: 'camp_site',
+    lat: 47.8297,
+    lng: 13.0583,
+    website: 'https://www.camping-nord-sam.com/',
+  },
+  {
+    id: 'fallback-camping-zurich-fischers-fritz',
+    name: 'Fischers Fritz Camping',
+    kind: 'camp_site',
+    lat: 47.3435,
+    lng: 8.5359,
+    website: 'https://www.fischers-fritz.ch/',
+  },
+  {
+    id: 'fallback-camping-prague-dzban',
+    name: 'Camp Dzban Praha',
+    kind: 'camp_site',
+    lat: 50.0946,
+    lng: 14.3247,
+    website: 'https://www.campdzban.eu/',
+  },
+  {
+    id: 'fallback-camping-sofia-vrana',
+    name: 'Camping Vrana',
+    kind: 'camp_site',
+    lat: 42.6396,
+    lng: 23.4209,
+  },
+  {
+    id: 'fallback-camping-veliko-tarnovo',
+    name: 'Camping Veliko Tarnovo',
+    kind: 'camp_site',
+    lat: 43.0476,
+    lng: 25.7311,
+    website: 'https://campingvelikotarnovo.com/',
+  },
+  {
+    id: 'fallback-camping-istanbul-mocamp',
+    name: 'Istanbul Mocamp',
+    kind: 'camp_site',
+    lat: 41.0172,
+    lng: 28.5944,
+  },
+];
+
 export function buildOverpassCampingQuery(bbox: CampingBbox): string {
   assertCampingBbox(bbox);
   const box = `${bbox.south},${bbox.west},${bbox.north},${bbox.east}`;
@@ -92,6 +192,23 @@ export async function fetchCampingSites(bbox: CampingBbox): Promise<CampingSite[
 
   const data = (await res.json()) as { elements?: OverpassCampingElement[] };
   return (data.elements || []).map(normalizeCampingElement).filter((item): item is CampingSite => Boolean(item));
+}
+
+export function fallbackCampingSites(bbox: CampingBbox): CampingSite[] {
+  assertCampingBbox(bbox);
+  return FALLBACK_CAMPING_SITES
+    .filter(site => site.lat >= bbox.south && site.lat <= bbox.north && site.lng >= bbox.west && site.lng <= bbox.east)
+    .map(site => ({
+      ...site,
+      tags: site.tags || {},
+      source: sourceMeta({
+        provider: 'OSIRIS fallback dataset',
+        feed: 'camping-sites-fallback',
+        attribution: 'Curated public camping location seed',
+        cacheTtlSeconds: 86400,
+        confidence: 0.45,
+      }),
+    }));
 }
 
 function assertCampingBbox(bbox: CampingBbox) {

--- a/src/lib/integrations/camping-sites.ts
+++ b/src/lib/integrations/camping-sites.ts
@@ -1,0 +1,106 @@
+import { sourceMeta } from './source-metadata.ts';
+
+export const OVERPASS_CAMPING_URL = 'https://overpass-api.de/api/interpreter';
+
+export type CampingBbox = {
+  south: number;
+  west: number;
+  north: number;
+  east: number;
+};
+
+type OverpassCampingElement = {
+  type?: string;
+  id?: number;
+  lat?: number;
+  lon?: number;
+  center?: { lat?: number; lon?: number };
+  tags?: Record<string, string>;
+};
+
+export type CampingSite = {
+  id: string;
+  name: string;
+  kind: 'camp_site' | 'caravan_site';
+  lat: number;
+  lng: number;
+  operator?: string;
+  website?: string;
+  phone?: string;
+  capacity?: string;
+  tags: Record<string, string>;
+  source: ReturnType<typeof sourceMeta>;
+};
+
+export function buildOverpassCampingQuery(bbox: CampingBbox): string {
+  assertCampingBbox(bbox);
+  const box = `${bbox.south},${bbox.west},${bbox.north},${bbox.east}`;
+  return `[out:json][timeout:10];(
+node["tourism"="camp_site"](${box});
+way["tourism"="camp_site"](${box});
+relation["tourism"="camp_site"](${box});
+node["tourism"="caravan_site"](${box});
+way["tourism"="caravan_site"](${box});
+relation["tourism"="caravan_site"](${box});
+);out center 300;`;
+}
+
+export function normalizeCampingElement(element: OverpassCampingElement): CampingSite | null {
+  const lat = typeof element.lat === 'number' ? element.lat : element.center?.lat;
+  const lng = typeof element.lon === 'number' ? element.lon : element.center?.lon;
+  if (!element.type || typeof element.id !== 'number' || typeof lat !== 'number' || typeof lng !== 'number') return null;
+
+  const tags = element.tags || {};
+  const tourism = tags.tourism === 'caravan_site' ? 'caravan_site' : 'camp_site';
+
+  return {
+    id: `osm-${element.type}-${element.id}`,
+    name: tags.name || tags.operator || (tourism === 'caravan_site' ? 'Unnamed caravan site' : 'Unnamed camp site'),
+    kind: tourism,
+    lat,
+    lng,
+    operator: tags.operator,
+    website: tags.website || tags['contact:website'],
+    phone: tags.phone || tags['contact:phone'],
+    capacity: tags.capacity || tags['capacity:caravans'] || tags['capacity:tents'],
+    tags,
+    source: sourceMeta({
+      provider: 'OpenStreetMap/Overpass',
+      feed: 'camping-sites',
+      url: OVERPASS_CAMPING_URL,
+      attribution: 'OpenStreetMap contributors',
+      license: 'ODbL',
+      cacheTtlSeconds: 86400,
+      confidence: 0.72,
+    }),
+  };
+}
+
+export async function fetchCampingSites(bbox: CampingBbox): Promise<CampingSite[]> {
+  const query = buildOverpassCampingQuery(bbox);
+  const res = await fetch(OVERPASS_CAMPING_URL, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': 'OSIRIS/0.1 camping sites',
+    },
+    body: new URLSearchParams({ data: query }),
+    signal: AbortSignal.timeout(12000),
+  });
+  if (!res.ok) throw new Error(`Overpass HTTP ${res.status}`);
+
+  const data = (await res.json()) as { elements?: OverpassCampingElement[] };
+  return (data.elements || []).map(normalizeCampingElement).filter((item): item is CampingSite => Boolean(item));
+}
+
+function assertCampingBbox(bbox: CampingBbox) {
+  const width = bbox.east - bbox.west;
+  const height = bbox.north - bbox.south;
+  if (![bbox.south, bbox.west, bbox.north, bbox.east].every(Number.isFinite)) {
+    throw new Error('Invalid bbox coordinates');
+  }
+  if (width <= 0 || height <= 0 || width > 3 || height > 3) {
+    throw new Error('Camping bbox must be positive and no larger than 3 degrees per axis');
+  }
+}

--- a/src/lib/integrations/cyber-priority.test.ts
+++ b/src/lib/integrations/cyber-priority.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mergeCvePriority,
+  normalizeEpssRecord,
+  scoreCyberPriority,
+} from './cyber-priority.ts';
+
+test('normalizes EPSS score strings into numbers', () => {
+  const record = normalizeEpssRecord({
+    cve: 'CVE-2024-3094',
+    epss: '0.850580000',
+    percentile: '0.993660000',
+    date: '2026-06-03',
+  });
+
+  assert.equal(record?.cve, 'CVE-2024-3094');
+  assert.equal(record?.epss, 0.85058);
+  assert.equal(record?.percentile, 0.99366);
+});
+
+test('scores CVE priority from EPSS, KEV and CVSS signals', () => {
+  assert.equal(scoreCyberPriority({ epss: 0.85, percentile: 0.99, isKnownExploited: true, cvss: 9.8 }), 'critical');
+  assert.equal(scoreCyberPriority({ epss: 0.3, percentile: 0.8, isKnownExploited: false, cvss: 7.2 }), 'high');
+  assert.equal(scoreCyberPriority({ epss: 0.05, percentile: 0.4, isKnownExploited: false, cvss: 5.1 }), 'medium');
+});
+
+test('merges CVE priority metadata', () => {
+  const merged = mergeCvePriority({
+    cve: 'CVE-2024-3094',
+    epss: { cve: 'CVE-2024-3094', epss: 0.85, percentile: 0.99, date: '2026-06-03' },
+    kev: { cveID: 'CVE-2024-3094', vulnerabilityName: 'XZ Utils backdoor', dateAdded: '2024-03-29' },
+    cvss: 9.8,
+  });
+
+  assert.equal(merged.id, 'CVE-2024-3094');
+  assert.equal(merged.priority, 'critical');
+  assert.equal(merged.epss?.probability, 0.85);
+  assert.equal(merged.kev?.known_exploited, true);
+});

--- a/src/lib/integrations/cyber-priority.ts
+++ b/src/lib/integrations/cyber-priority.ts
@@ -1,0 +1,155 @@
+import { sourceMeta, type OsirisSeverity } from './source-metadata.ts';
+
+export const EPSS_URL = 'https://api.first.org/data/v1/epss';
+export const CISA_KEV_URL = 'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json';
+
+export type EpssApiRecord = {
+  cve?: string;
+  epss?: string | number;
+  percentile?: string | number;
+  date?: string;
+};
+
+export type EpssRecord = {
+  cve: string;
+  epss: number;
+  percentile: number;
+  date?: string;
+};
+
+export type KevRecord = {
+  cveID?: string;
+  vulnerabilityName?: string;
+  vendorProject?: string;
+  product?: string;
+  dateAdded?: string;
+  dueDate?: string;
+};
+
+export type CyberPriority = OsirisSeverity;
+
+export type CvePriorityRecord = {
+  id: string;
+  priority: CyberPriority;
+  epss?: {
+    probability: number;
+    percentile: number;
+    date?: string;
+  };
+  kev?: {
+    known_exploited: boolean;
+    name?: string;
+    date_added?: string;
+    due_date?: string;
+    vendor?: string;
+    product?: string;
+  };
+  cvss?: number | null;
+  source: ReturnType<typeof sourceMeta>;
+};
+
+export function normalizeEpssRecord(record: EpssApiRecord): EpssRecord | null {
+  if (!record.cve) return null;
+  const epss = Number(record.epss);
+  const percentile = Number(record.percentile);
+  if (!Number.isFinite(epss) || !Number.isFinite(percentile)) return null;
+
+  return {
+    cve: record.cve.toUpperCase(),
+    epss,
+    percentile,
+    date: record.date,
+  };
+}
+
+export function scoreCyberPriority(input: {
+  epss?: number;
+  percentile?: number;
+  isKnownExploited?: boolean;
+  cvss?: number | null;
+}): CyberPriority {
+  const epss = input.epss ?? 0;
+  const percentile = input.percentile ?? 0;
+  const cvss = input.cvss ?? 0;
+
+  if (input.isKnownExploited && (epss >= 0.5 || cvss >= 9)) return 'critical';
+  if (epss >= 0.7 || percentile >= 0.97 || (input.isKnownExploited && cvss >= 7)) return 'critical';
+  if (epss >= 0.2 || percentile >= 0.75 || cvss >= 7) return 'high';
+  if (epss >= 0.03 || percentile >= 0.35 || cvss >= 4) return 'medium';
+  return 'low';
+}
+
+export function mergeCvePriority(input: {
+  cve: string;
+  epss?: EpssRecord | null;
+  kev?: KevRecord | null;
+  cvss?: number | null;
+}): CvePriorityRecord {
+  const cve = input.cve.toUpperCase();
+  const knownExploited = Boolean(input.kev);
+
+  return {
+    id: cve,
+    priority: scoreCyberPriority({
+      epss: input.epss?.epss,
+      percentile: input.epss?.percentile,
+      isKnownExploited: knownExploited,
+      cvss: input.cvss,
+    }),
+    epss: input.epss
+      ? {
+          probability: input.epss.epss,
+          percentile: input.epss.percentile,
+          date: input.epss.date,
+        }
+      : undefined,
+    kev: input.kev
+      ? {
+          known_exploited: true,
+          name: input.kev.vulnerabilityName,
+          date_added: input.kev.dateAdded,
+          due_date: input.kev.dueDate,
+          vendor: input.kev.vendorProject,
+          product: input.kev.product,
+        }
+      : undefined,
+    cvss: input.cvss ?? null,
+    source: sourceMeta({
+      provider: 'FIRST EPSS / CISA KEV',
+      feed: 'cyber-priority',
+      url: EPSS_URL,
+      attribution: 'FIRST EPSS and CISA KEV',
+      cacheTtlSeconds: 86400,
+      confidence: knownExploited ? 0.95 : 0.85,
+    }),
+  };
+}
+
+export async function fetchEpss(cves: string[]): Promise<Map<string, EpssRecord>> {
+  if (cves.length === 0) return new Map();
+  const params = new URLSearchParams({ cve: cves.map(cve => cve.toUpperCase()).join(',') });
+  const res = await fetch(`${EPSS_URL}?${params.toString()}`, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!res.ok) throw new Error(`EPSS HTTP ${res.status}`);
+
+  const data = (await res.json()) as { data?: EpssApiRecord[] };
+  return new Map(
+    (data.data || [])
+      .map(normalizeEpssRecord)
+      .filter((record): record is EpssRecord => Boolean(record))
+      .map(record => [record.cve, record]),
+  );
+}
+
+export async function fetchKevCatalog(): Promise<KevRecord[]> {
+  const res = await fetch(CISA_KEV_URL, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!res.ok) throw new Error(`CISA KEV HTTP ${res.status}`);
+
+  const data = (await res.json()) as { vulnerabilities?: KevRecord[] };
+  return data.vulnerabilities || [];
+}

--- a/src/lib/integrations/disasters.test.ts
+++ b/src/lib/integrations/disasters.test.ts
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildReliefWebDisabledStatus,
+  normalizeGdacsFeature,
+  normalizeGdacsRssItem,
+  normalizeReliefWebReport,
+} from './disasters.ts';
+
+test('normalizes a GDACS GeoJSON feature into a disaster event', () => {
+  const event = normalizeGdacsFeature({
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [46.567, -20.506] },
+    properties: {
+      eventtype: 'DR',
+      eventid: 1018431,
+      episodeid: 5,
+      eventname: 'Madagascar-2026',
+      alertlevel: 'Orange',
+      description: 'Drought in Madagascar',
+      fromdate: '2025-11-21T00:00:00',
+      url: { report: 'https://www.gdacs.org/report.aspx' },
+    },
+  });
+
+  assert.equal(event?.id, 'gdacs-DR-1018431-5');
+  assert.equal(event?.title, 'Drought in Madagascar');
+  assert.equal(event?.severity, 'high');
+  assert.equal(event?.lat, -20.506);
+  assert.equal(event?.lng, 46.567);
+});
+
+test('normalizes ReliefWeb v2 report fields', () => {
+  const report = normalizeReliefWebReport({
+    id: '123',
+    fields: {
+      title: 'Flood response update',
+      url: 'https://reliefweb.int/report/example',
+      date: { created: '2026-06-04T08:00:00Z' },
+      country: [{ name: 'Germany', iso3: 'DEU' }],
+      disaster: [{ name: 'Flood' }],
+      source: [{ name: 'OCHA' }],
+    },
+  });
+
+  assert.equal(report.id, 'reliefweb-123');
+  assert.equal(report.country, 'Germany');
+  assert.equal(report.source.provider, 'ReliefWeb');
+});
+
+test('normalizes a GDACS RSS item into a disaster event', () => {
+  const event = normalizeGdacsRssItem(`
+    <item>
+      <title>Green flood alert in Türkiye</title>
+      <link>https://www.gdacs.org/report.aspx?eventtype=FL&amp;eventid=1103920</link>
+      <pubDate>Tue, 02 Jun 2026 05:45:56 GMT</pubDate>
+      <geo:lat>37.2401223</geo:lat>
+      <geo:long>36.4534072</geo:long>
+      <gdacs:eventtype>FL</gdacs:eventtype>
+      <gdacs:alertlevel>Green</gdacs:alertlevel>
+      <gdacs:eventid>1103920</gdacs:eventid>
+      <gdacs:episodeid>1</gdacs:episodeid>
+    </item>
+  `);
+
+  assert.equal(event?.id, 'gdacs-rss-FL-1103920-1');
+  assert.equal(event?.severity, 'low');
+  assert.equal(event?.lat, 37.2401223);
+  assert.equal(event?.lng, 36.4534072);
+});
+
+test('marks ReliefWeb disabled without approved app name', () => {
+  const status = buildReliefWebDisabledStatus();
+
+  assert.equal(status.enabled, false);
+  assert.equal(status.status, 'disabled');
+});

--- a/src/lib/integrations/disasters.ts
+++ b/src/lib/integrations/disasters.ts
@@ -1,0 +1,252 @@
+import {
+  disabledSourceStatus,
+  type IntegrationSourceStatus,
+  type OsirisSeverity,
+  sourceMeta,
+} from './source-metadata.ts';
+
+export const GDACS_EVENTS_URL = 'https://www.gdacs.org/gdacsapi/api/events/geteventlist/SEARCH';
+export const GDACS_RSS_URL = 'https://www.gdacs.org/xml/rss.xml';
+export const RELIEFWEB_REPORTS_URL = 'https://api.reliefweb.int/v2/reports';
+
+type GdacsFeature = {
+  type?: string;
+  geometry?: {
+    type?: string;
+    coordinates?: number[];
+  };
+  properties?: {
+    eventtype?: string;
+    eventid?: number | string;
+    episodeid?: number | string;
+    eventname?: string;
+    name?: string;
+    description?: string;
+    htmldescription?: string;
+    alertlevel?: string;
+    alertLevel?: string;
+    fromdate?: string;
+    todate?: string;
+    url?: string | { report?: string; details?: string; geometry?: string };
+  };
+};
+
+export type DisasterEvent = {
+  id: string;
+  title: string;
+  type: string;
+  severity: OsirisSeverity;
+  lat: number;
+  lng: number;
+  startedAt?: string;
+  endedAt?: string;
+  url?: string;
+  source: ReturnType<typeof sourceMeta>;
+};
+
+type ReliefWebReportInput = {
+  id?: string;
+  fields?: {
+    title?: string;
+    url?: string;
+    date?: { created?: string; original?: string };
+    country?: { name?: string; iso3?: string }[];
+    disaster?: { name?: string }[];
+    source?: { name?: string }[];
+  };
+};
+
+export type ReliefWebReport = {
+  id: string;
+  title: string;
+  url?: string;
+  published?: string;
+  country?: string;
+  countryCode?: string;
+  disaster?: string;
+  reportingSource?: string;
+  source: ReturnType<typeof sourceMeta>;
+};
+
+export function normalizeGdacsSeverity(alertLevel?: string): OsirisSeverity {
+  const normalized = (alertLevel || '').toLowerCase();
+  if (normalized === 'red') return 'critical';
+  if (normalized === 'orange') return 'high';
+  if (normalized === 'green') return 'low';
+  return 'medium';
+}
+
+export function normalizeGdacsFeature(feature: GdacsFeature): DisasterEvent | null {
+  const coords = feature.geometry?.coordinates;
+  const props = feature.properties || {};
+  if (!coords || coords.length < 2 || typeof coords[0] !== 'number' || typeof coords[1] !== 'number') return null;
+
+  const eventType = props.eventtype || 'event';
+  const eventId = props.eventid || 'unknown';
+  const episodeId = props.episodeid || 'latest';
+  const url = typeof props.url === 'string' ? props.url : props.url?.report || props.url?.details;
+
+  return {
+    id: `gdacs-${eventType}-${eventId}-${episodeId}`,
+    title: props.description || props.name || props.eventname || 'GDACS disaster event',
+    type: eventType,
+    severity: normalizeGdacsSeverity(props.alertlevel || props.alertLevel),
+    lat: coords[1],
+    lng: coords[0],
+    startedAt: props.fromdate,
+    endedAt: props.todate,
+    url,
+    source: sourceMeta({
+      provider: 'GDACS',
+      feed: 'event-list',
+      url: GDACS_EVENTS_URL,
+      attribution: 'Global Disaster Alert and Coordination System',
+      license: 'GDACS public feed',
+      observedAt: props.fromdate,
+      cacheTtlSeconds: 900,
+      confidence: 0.9,
+    }),
+  };
+}
+
+export function normalizeGdacsRssItem(itemXml: string): DisasterEvent | null {
+  const lat = Number(readXmlTag(itemXml, 'geo:lat'));
+  const lng = Number(readXmlTag(itemXml, 'geo:long'));
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+
+  const eventType = readXmlTag(itemXml, 'gdacs:eventtype') || 'event';
+  const eventId = readXmlTag(itemXml, 'gdacs:eventid') || 'unknown';
+  const episodeId = readXmlTag(itemXml, 'gdacs:episodeid') || 'latest';
+  const pubDate = readXmlTag(itemXml, 'pubDate');
+
+  return {
+    id: `gdacs-rss-${eventType}-${eventId}-${episodeId}`,
+    title: readXmlTag(itemXml, 'title') || 'GDACS disaster event',
+    type: eventType,
+    severity: normalizeGdacsSeverity(readXmlTag(itemXml, 'gdacs:alertlevel')),
+    lat,
+    lng,
+    startedAt: readXmlTag(itemXml, 'gdacs:fromdate') || pubDate,
+    endedAt: readXmlTag(itemXml, 'gdacs:todate'),
+    url: readXmlTag(itemXml, 'link'),
+    source: sourceMeta({
+      provider: 'GDACS',
+      feed: 'rss',
+      url: GDACS_RSS_URL,
+      attribution: 'Global Disaster Alert and Coordination System',
+      license: 'GDACS public feed',
+      observedAt: pubDate,
+      cacheTtlSeconds: 900,
+      confidence: 0.85,
+    }),
+  };
+}
+
+export function normalizeReliefWebReport(report: ReliefWebReportInput): ReliefWebReport {
+  const fields = report.fields || {};
+  const country = fields.country?.[0];
+
+  return {
+    id: `reliefweb-${report.id || encodeURIComponent(fields.url || fields.title || 'report')}`,
+    title: fields.title || 'ReliefWeb report',
+    url: fields.url,
+    published: fields.date?.created || fields.date?.original,
+    country: country?.name,
+    countryCode: country?.iso3,
+    disaster: fields.disaster?.[0]?.name,
+    reportingSource: fields.source?.[0]?.name,
+    source: sourceMeta({
+      provider: 'ReliefWeb',
+      feed: 'v2-reports',
+      url: RELIEFWEB_REPORTS_URL,
+      attribution: 'ReliefWeb / OCHA',
+      license: 'ReliefWeb terms and source-specific rights',
+      observedAt: fields.date?.created || fields.date?.original,
+      cacheTtlSeconds: 1800,
+      confidence: 0.85,
+    }),
+  };
+}
+
+export function buildReliefWebDisabledStatus(): IntegrationSourceStatus {
+  return disabledSourceStatus(
+    'ReliefWeb',
+    'ReliefWeb v2 requires a pre-approved appname in RELIEFWEB_APP_NAME.',
+    'https://apidoc.reliefweb.int/parameters#appname',
+  );
+}
+
+export async function fetchGdacsEvents(): Promise<DisasterEvent[]> {
+  const to = new Date();
+  const from = new Date(to.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const params = new URLSearchParams({
+    eventtypes: 'EQ,TC,FL,VO',
+    fromdate: from.toISOString().slice(0, 10),
+    todate: to.toISOString().slice(0, 10),
+  });
+
+  try {
+    const res = await fetch(`${GDACS_EVENTS_URL}?${params.toString()}`, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!res.ok) throw new Error(`GDACS HTTP ${res.status}`);
+    const data = (await res.json()) as { features?: GdacsFeature[] };
+    return (data.features || []).map(normalizeGdacsFeature).filter((event): event is DisasterEvent => Boolean(event));
+  } catch {
+    return fetchGdacsRssEvents();
+  }
+}
+
+export async function fetchGdacsRssEvents(): Promise<DisasterEvent[]> {
+  const res = await fetch(GDACS_RSS_URL, {
+    headers: { Accept: 'application/rss+xml, application/xml, text/xml' },
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!res.ok) throw new Error(`GDACS RSS HTTP ${res.status}`);
+
+  const xml = await res.text();
+  const items = xml.match(/<item>[\s\S]*?<\/item>/gi) || [];
+  return items
+    .map(normalizeGdacsRssItem)
+    .filter((event): event is DisasterEvent => Boolean(event));
+}
+
+export async function fetchReliefWebReports(appName: string): Promise<ReliefWebReport[]> {
+  const res = await fetch(`${RELIEFWEB_REPORTS_URL}?appname=${encodeURIComponent(appName)}`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      limit: 10,
+      sort: ['date:desc'],
+      fields: {
+        include: ['title', 'url', 'date.created', 'date.original', 'country', 'disaster', 'source'],
+      },
+    }),
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (!res.ok) throw new Error(`ReliefWeb HTTP ${res.status}`);
+  const data = (await res.json()) as { data?: ReliefWebReportInput[] };
+  return (data.data || []).map(normalizeReliefWebReport);
+}
+
+function readXmlTag(xml: string, tag: string): string {
+  const match = xml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i'));
+  return decodeXml((match?.[1] || '').trim());
+}
+
+function decodeXml(value: string): string {
+  return value
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}

--- a/src/lib/integrations/entities.test.ts
+++ b/src/lib/integrations/entities.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeGleifLeiRecord } from './entities.ts';
+
+test('normalizes GLEIF LEI records into entity results', () => {
+  const entity = normalizeGleifLeiRecord({
+    id: '5493001KJTIIGC8Y1R12',
+    attributes: {
+      lei: '5493001KJTIIGC8Y1R12',
+      entity: {
+        legalName: { name: 'OPENAI OPCO, LLC' },
+        legalAddress: { country: 'US', city: 'San Francisco' },
+        status: 'ACTIVE',
+      },
+      registration: { status: 'ISSUED', initialRegistrationDate: '2024-01-01T00:00:00Z' },
+    },
+  });
+
+  assert.equal(entity.id, 'gleif-5493001KJTIIGC8Y1R12');
+  assert.equal(entity.name, 'OPENAI OPCO, LLC');
+  assert.equal(entity.countryCode, 'US');
+  assert.equal(entity.source.provider, 'GLEIF');
+});

--- a/src/lib/integrations/entities.ts
+++ b/src/lib/integrations/entities.ts
@@ -1,0 +1,90 @@
+import { sourceMeta } from './source-metadata.ts';
+
+export const GLEIF_LEI_RECORDS_URL = 'https://api.gleif.org/api/v1/lei-records';
+
+type GleifLeiRecordInput = {
+  id?: string;
+  attributes?: {
+    lei?: string;
+    entity?: {
+      legalName?: { name?: string };
+      legalAddress?: {
+        country?: string;
+        city?: string;
+      };
+      headquartersAddress?: {
+        country?: string;
+        city?: string;
+      };
+      status?: string;
+      legalForm?: {
+        id?: string;
+        other?: string;
+      };
+    };
+    registration?: {
+      status?: string;
+      initialRegistrationDate?: string;
+      lastUpdateDate?: string;
+    };
+  };
+};
+
+export type EntityResolutionResult = {
+  id: string;
+  lei?: string;
+  name: string;
+  status?: string;
+  registrationStatus?: string;
+  countryCode?: string;
+  city?: string;
+  legalForm?: string;
+  registeredAt?: string;
+  updatedAt?: string;
+  source: ReturnType<typeof sourceMeta>;
+};
+
+export function normalizeGleifLeiRecord(record: GleifLeiRecordInput): EntityResolutionResult {
+  const entity = record.attributes?.entity;
+  const lei = record.attributes?.lei || record.id;
+  const address = entity?.legalAddress || entity?.headquartersAddress;
+
+  return {
+    id: `gleif-${lei || record.id || 'entity'}`,
+    lei,
+    name: entity?.legalName?.name || 'Unknown legal entity',
+    status: entity?.status,
+    registrationStatus: record.attributes?.registration?.status,
+    countryCode: address?.country,
+    city: address?.city,
+    legalForm: entity?.legalForm?.id || entity?.legalForm?.other,
+    registeredAt: record.attributes?.registration?.initialRegistrationDate,
+    updatedAt: record.attributes?.registration?.lastUpdateDate,
+    source: sourceMeta({
+      provider: 'GLEIF',
+      feed: 'lei-records',
+      url: GLEIF_LEI_RECORDS_URL,
+      attribution: 'Global Legal Entity Identifier Foundation',
+      license: 'GLEIF API Terms',
+      observedAt: record.attributes?.registration?.lastUpdateDate,
+      cacheTtlSeconds: 86400,
+      confidence: 0.9,
+    }),
+  };
+}
+
+export async function fetchGleifEntities(query: string): Promise<EntityResolutionResult[]> {
+  const params = new URLSearchParams({
+    'filter[entity.legalName]': query,
+    'page[size]': '10',
+    sort: '-registration.initialRegistrationDate',
+  });
+  const res = await fetch(`${GLEIF_LEI_RECORDS_URL}?${params.toString()}`, {
+    headers: { Accept: 'application/vnd.api+json' },
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!res.ok) throw new Error(`GLEIF HTTP ${res.status}`);
+
+  const data = (await res.json()) as { data?: GleifLeiRecordInput[] };
+  return (data.data || []).map(normalizeGleifLeiRecord);
+}

--- a/src/lib/integrations/forecast.test.ts
+++ b/src/lib/integrations/forecast.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeOpenMeteoForecast } from './forecast.ts';
+
+test('normalizes Open-Meteo current and hourly forecast into risk summary', () => {
+  const result = normalizeOpenMeteoForecast({
+    latitude: 52.52,
+    longitude: 13.42,
+    current: {
+      time: '2026-06-04T08:45',
+      temperature_2m: 19.9,
+      wind_speed_10m: 11.8,
+      precipitation: 0,
+      rain: 0,
+      weather_code: 80,
+    },
+    hourly: {
+      time: ['2026-06-04T09:00', '2026-06-04T10:00'],
+      precipitation_probability: [20, 90],
+      wind_speed_10m: [10, 45],
+      wind_gusts_10m: [20, 80],
+    },
+  });
+
+  assert.equal(result.lat, 52.52);
+  assert.equal(result.lng, 13.42);
+  assert.equal(result.risk.level, 'high');
+  assert.equal(result.risk.maxPrecipitationProbability, 90);
+  assert.equal(result.source.provider, 'Open-Meteo');
+});

--- a/src/lib/integrations/forecast.ts
+++ b/src/lib/integrations/forecast.ts
@@ -1,0 +1,134 @@
+import { sourceMeta, type OsirisSeverity } from './source-metadata.ts';
+
+export const OPEN_METEO_FORECAST_URL = 'https://api.open-meteo.com/v1/forecast';
+
+type OpenMeteoForecastInput = {
+  latitude?: number;
+  longitude?: number;
+  timezone?: string;
+  current?: {
+    time?: string;
+    temperature_2m?: number;
+    wind_speed_10m?: number;
+    precipitation?: number;
+    rain?: number;
+    weather_code?: number;
+  };
+  hourly?: {
+    time?: string[];
+    precipitation_probability?: number[];
+    wind_speed_10m?: number[];
+    wind_gusts_10m?: number[];
+  };
+};
+
+export type ForecastRiskLevel = OsirisSeverity;
+
+export type OpenMeteoForecastSummary = {
+  lat: number;
+  lng: number;
+  current: {
+    time?: string;
+    temperatureC?: number;
+    windSpeedKmh?: number;
+    precipitationMm?: number;
+    rainMm?: number;
+    weatherCode?: number;
+  };
+  risk: {
+    level: ForecastRiskLevel;
+    maxPrecipitationProbability: number;
+    maxWindSpeedKmh: number;
+    maxWindGustKmh: number;
+    reasons: string[];
+  };
+  source: ReturnType<typeof sourceMeta>;
+};
+
+export function normalizeOpenMeteoForecast(input: OpenMeteoForecastInput): OpenMeteoForecastSummary {
+  const lat = typeof input.latitude === 'number' ? input.latitude : 0;
+  const lng = typeof input.longitude === 'number' ? input.longitude : 0;
+  const maxPrecip = maxNumber(input.hourly?.precipitation_probability);
+  const maxWind = maxNumber(input.hourly?.wind_speed_10m);
+  const maxGust = maxNumber(input.hourly?.wind_gusts_10m);
+  const risk = classifyForecastRisk({ maxPrecip, maxWind, maxGust });
+
+  return {
+    lat,
+    lng,
+    current: {
+      time: input.current?.time,
+      temperatureC: input.current?.temperature_2m,
+      windSpeedKmh: input.current?.wind_speed_10m,
+      precipitationMm: input.current?.precipitation,
+      rainMm: input.current?.rain,
+      weatherCode: input.current?.weather_code,
+    },
+    risk,
+    source: sourceMeta({
+      provider: 'Open-Meteo',
+      feed: 'forecast',
+      url: OPEN_METEO_FORECAST_URL,
+      attribution: 'Open-Meteo.com',
+      license: 'CC BY 4.0',
+      observedAt: input.current?.time,
+      cacheTtlSeconds: 1800,
+      confidence: 0.85,
+    }),
+  };
+}
+
+export function classifyForecastRisk(input: {
+  maxPrecip: number;
+  maxWind: number;
+  maxGust: number;
+}): OpenMeteoForecastSummary['risk'] {
+  const reasons: string[] = [];
+  let level: ForecastRiskLevel = 'low';
+
+  if (input.maxPrecip >= 80) {
+    level = 'high';
+    reasons.push('high_precipitation_probability');
+  } else if (input.maxPrecip >= 50) {
+    level = 'medium';
+    reasons.push('elevated_precipitation_probability');
+  }
+
+  if (input.maxGust >= 75 || input.maxWind >= 50) {
+    level = 'high';
+    reasons.push('strong_wind');
+  } else if ((input.maxGust >= 50 || input.maxWind >= 35) && level === 'low') {
+    level = 'medium';
+    reasons.push('elevated_wind');
+  }
+
+  return {
+    level,
+    maxPrecipitationProbability: input.maxPrecip,
+    maxWindSpeedKmh: input.maxWind,
+    maxWindGustKmh: input.maxGust,
+    reasons,
+  };
+}
+
+export async function fetchOpenMeteoForecast(lat: number, lng: number): Promise<OpenMeteoForecastSummary> {
+  const params = new URLSearchParams({
+    latitude: String(lat),
+    longitude: String(lng),
+    current: 'temperature_2m,wind_speed_10m,precipitation,rain,weather_code',
+    hourly: 'precipitation_probability,wind_speed_10m,wind_gusts_10m',
+    forecast_days: '2',
+    timezone: 'auto',
+  });
+  const res = await fetch(`${OPEN_METEO_FORECAST_URL}?${params.toString()}`, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(8000),
+  });
+  if (!res.ok) throw new Error(`Open-Meteo HTTP ${res.status}`);
+  return normalizeOpenMeteoForecast(await res.json());
+}
+
+function maxNumber(values?: number[]): number {
+  if (!values || values.length === 0) return 0;
+  return values.reduce((max, value) => Number.isFinite(value) ? Math.max(max, value) : max, 0);
+}

--- a/src/lib/integrations/infrastructure-context.test.ts
+++ b/src/lib/integrations/infrastructure-context.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildOverpassInfrastructureQuery,
+  normalizeOverpassElement,
+} from './infrastructure-context.ts';
+
+test('builds bounded Overpass infrastructure query', () => {
+  const query = buildOverpassInfrastructureQuery({
+    south: 52.45,
+    west: 13.3,
+    north: 52.6,
+    east: 13.55,
+  });
+
+  assert.match(query, /power/);
+  assert.match(query, /out center 50/);
+});
+
+test('normalizes Overpass node infrastructure element', () => {
+  const item = normalizeOverpassElement({
+    type: 'node',
+    id: 123,
+    lat: 52.5,
+    lon: 13.4,
+    tags: { power: 'plant', name: 'Plant A' },
+  });
+
+  assert.equal(item?.id, 'osm-node-123');
+  assert.equal(item?.type, 'power_plant');
+  assert.equal(item?.name, 'Plant A');
+  assert.equal(item?.source.provider, 'OpenStreetMap/Overpass');
+});

--- a/src/lib/integrations/infrastructure-context.ts
+++ b/src/lib/integrations/infrastructure-context.ts
@@ -1,0 +1,114 @@
+import { sourceMeta } from './source-metadata.ts';
+
+export const OVERPASS_INTERPRETER_URL = 'https://overpass-api.de/api/interpreter';
+
+export type InfrastructureBbox = {
+  south: number;
+  west: number;
+  north: number;
+  east: number;
+};
+
+type OverpassElement = {
+  type?: string;
+  id?: number;
+  lat?: number;
+  lon?: number;
+  center?: { lat?: number; lon?: number };
+  tags?: Record<string, string>;
+};
+
+export type InfrastructureContextItem = {
+  id: string;
+  type: string;
+  name: string;
+  lat: number;
+  lng: number;
+  operator?: string;
+  tags: Record<string, string>;
+  source: ReturnType<typeof sourceMeta>;
+};
+
+export function buildOverpassInfrastructureQuery(bbox: InfrastructureBbox): string {
+  assertBbox(bbox);
+  const box = `${bbox.south},${bbox.west},${bbox.north},${bbox.east}`;
+  return `[out:json][timeout:10];(
+node["power"="plant"](${box});
+way["power"="plant"](${box});
+node["amenity"="hospital"](${box});
+way["amenity"="hospital"](${box});
+node["man_made"="pipeline"](${box});
+way["man_made"="pipeline"](${box});
+node["railway"="station"](${box});
+way["railway"="station"](${box});
+node["aeroway"="aerodrome"](${box});
+way["aeroway"="aerodrome"](${box});
+node["harbour"](${box});
+way["harbour"](${box});
+);out center 50;`;
+}
+
+export function normalizeOverpassElement(element: OverpassElement): InfrastructureContextItem | null {
+  const lat = typeof element.lat === 'number' ? element.lat : element.center?.lat;
+  const lng = typeof element.lon === 'number' ? element.lon : element.center?.lon;
+  if (!element.type || typeof element.id !== 'number' || typeof lat !== 'number' || typeof lng !== 'number') return null;
+  const tags = element.tags || {};
+
+  return {
+    id: `osm-${element.type}-${element.id}`,
+    type: classifyInfrastructure(tags),
+    name: tags.name || tags.operator || 'Unnamed infrastructure',
+    lat,
+    lng,
+    operator: tags.operator,
+    tags,
+    source: sourceMeta({
+      provider: 'OpenStreetMap/Overpass',
+      feed: 'infrastructure-context',
+      url: OVERPASS_INTERPRETER_URL,
+      attribution: 'OpenStreetMap contributors',
+      license: 'ODbL',
+      cacheTtlSeconds: 86400,
+      confidence: 0.75,
+    }),
+  };
+}
+
+export async function fetchOverpassInfrastructure(bbox: InfrastructureBbox): Promise<InfrastructureContextItem[]> {
+  const query = buildOverpassInfrastructureQuery(bbox);
+  const res = await fetch(OVERPASS_INTERPRETER_URL, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': 'OSIRIS/0.1 infrastructure context',
+    },
+    body: new URLSearchParams({ data: query }),
+    signal: AbortSignal.timeout(12000),
+  });
+  if (!res.ok) throw new Error(`Overpass HTTP ${res.status}`);
+
+  const data = (await res.json()) as { elements?: OverpassElement[] };
+  return (data.elements || []).map(normalizeOverpassElement).filter((item): item is InfrastructureContextItem => Boolean(item));
+}
+
+function classifyInfrastructure(tags: Record<string, string>): string {
+  if (tags.power === 'plant') return 'power_plant';
+  if (tags.amenity === 'hospital') return 'hospital';
+  if (tags.man_made === 'pipeline') return 'pipeline';
+  if (tags.railway === 'station') return 'rail_station';
+  if (tags.aeroway === 'aerodrome') return 'airport';
+  if (tags.harbour !== undefined) return 'harbour';
+  return 'infrastructure';
+}
+
+function assertBbox(bbox: InfrastructureBbox) {
+  const width = bbox.east - bbox.west;
+  const height = bbox.north - bbox.south;
+  if (![bbox.south, bbox.west, bbox.north, bbox.east].every(Number.isFinite)) {
+    throw new Error('Invalid bbox coordinates');
+  }
+  if (width <= 0 || height <= 0 || width > 2 || height > 2) {
+    throw new Error('Overpass bbox must be positive and no larger than 2 degrees per axis');
+  }
+}

--- a/src/lib/integrations/openaq.test.ts
+++ b/src/lib/integrations/openaq.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildOpenAqDisabledResponse,
+  classifyPm25,
+  normalizeOpenAqLatestResult,
+} from './openaq.ts';
+
+test('normalizes OpenAQ v3 latest PM2.5 records into station output', () => {
+  const station = normalizeOpenAqLatestResult({
+    locationsId: 42,
+    location: 'Station A',
+    coordinates: { latitude: 48.1, longitude: 11.6 },
+    parameter: { name: 'pm25', units: 'µg/m3' },
+    value: 18.3,
+    datetime: { utc: '2026-06-04T08:00:00Z' },
+    country: { code: 'DE' },
+  });
+
+  assert.equal(station?.id, 'aq-42-pm25');
+  assert.equal(station?.name, 'Station A');
+  assert.equal(station?.pm25, 18.3);
+  assert.equal(station?.level, 'Good');
+  assert.equal(station?.source.provider, 'OpenAQ');
+});
+
+test('classifies unhealthy PM2.5 values', () => {
+  assert.deepEqual(classifyPm25(42), {
+    level: 'Moderate',
+    color: '#FFD700',
+    severity: 'medium',
+  });
+  assert.deepEqual(classifyPm25(180), {
+    level: 'Hazardous',
+    color: '#8B0000',
+    severity: 'critical',
+  });
+});
+
+test('builds a non-failing disabled response when OpenAQ key is missing', () => {
+  const response = buildOpenAqDisabledResponse();
+
+  assert.equal(response.enabled, false);
+  assert.equal(response.stations.length, 0);
+  assert.equal(response.sources.openaq.status, 'disabled');
+});

--- a/src/lib/integrations/openaq.ts
+++ b/src/lib/integrations/openaq.ts
@@ -1,0 +1,155 @@
+import {
+  disabledSourceStatus,
+  type IntegrationSourceStatus,
+  type OsirisSeverity,
+  sourceMeta,
+} from './source-metadata.ts';
+
+const OPENAQ_PM25_LATEST_URL = 'https://api.openaq.org/v3/parameters/2/latest';
+
+type OpenAqCoordinates = {
+  latitude?: number;
+  longitude?: number;
+};
+
+type OpenAqParameter = {
+  name?: string;
+  units?: string;
+  displayName?: string;
+};
+
+type OpenAqDateTime = {
+  utc?: string;
+  local?: string;
+};
+
+export type OpenAqLatestResult = {
+  id?: number | string;
+  locationsId?: number | string;
+  location?: string;
+  name?: string;
+  locality?: string;
+  city?: string;
+  country?: string | { code?: string; name?: string };
+  coordinates?: OpenAqCoordinates;
+  parameter?: string | OpenAqParameter;
+  value?: number;
+  unit?: string;
+  datetime?: OpenAqDateTime;
+};
+
+export type OpenAqStation = {
+  id: string;
+  name: string;
+  city: string;
+  country?: string;
+  lat: number;
+  lng: number;
+  pm25: number;
+  unit: string;
+  level: string;
+  color: string;
+  severity: OsirisSeverity;
+  lastUpdated?: string;
+  source: ReturnType<typeof sourceMeta>;
+};
+
+export type OpenAqResponse = {
+  enabled: boolean;
+  stations: OpenAqStation[];
+  total: number;
+  timestamp: string;
+  sources: {
+    openaq: IntegrationSourceStatus;
+  };
+  setup?: {
+    env: string;
+    docs: string;
+  };
+  error?: string;
+};
+
+export function classifyPm25(value: number): { level: string; color: string; severity: OsirisSeverity } {
+  if (value > 150) return { level: 'Hazardous', color: '#8B0000', severity: 'critical' };
+  if (value > 100) return { level: 'Unhealthy', color: '#FF1744', severity: 'high' };
+  if (value > 55) return { level: 'Unhealthy (Sensitive)', color: '#FF9500', severity: 'high' };
+  if (value > 35) return { level: 'Moderate', color: '#FFD700', severity: 'medium' };
+  return { level: 'Good', color: '#00E676', severity: 'low' };
+}
+
+export function normalizeOpenAqLatestResult(result: OpenAqLatestResult): OpenAqStation | null {
+  const lat = result.coordinates?.latitude;
+  const lng = result.coordinates?.longitude;
+  const value = result.value;
+  if (typeof lat !== 'number' || typeof lng !== 'number' || typeof value !== 'number') return null;
+
+  const parameterName = typeof result.parameter === 'string' ? result.parameter : result.parameter?.name;
+  if (parameterName && parameterName.toLowerCase() !== 'pm25') return null;
+
+  const locationId = result.locationsId || result.id || `${lat.toFixed(4)}-${lng.toFixed(4)}`;
+  const classification = classifyPm25(value);
+  const observedAt = result.datetime?.utc || result.datetime?.local;
+  const country = typeof result.country === 'string' ? result.country : result.country?.code || result.country?.name;
+
+  return {
+    id: `aq-${locationId}-pm25`,
+    name: result.location || result.name || 'OpenAQ station',
+    city: result.city || result.locality || 'Unknown',
+    country,
+    lat,
+    lng,
+    pm25: value,
+    unit: result.unit || (typeof result.parameter === 'object' ? result.parameter.units : undefined) || 'µg/m3',
+    level: classification.level,
+    color: classification.color,
+    severity: classification.severity,
+    lastUpdated: observedAt,
+    source: sourceMeta({
+      provider: 'OpenAQ',
+      feed: 'v3-parameters-2-latest',
+      url: OPENAQ_PM25_LATEST_URL,
+      attribution: 'OpenAQ',
+      license: 'OpenAQ Terms of Use',
+      observedAt,
+      cacheTtlSeconds: 1800,
+      confidence: 0.85,
+    }),
+  };
+}
+
+export function buildOpenAqDisabledResponse(): OpenAqResponse {
+  return {
+    enabled: false,
+    stations: [],
+    total: 0,
+    timestamp: new Date().toISOString(),
+    sources: {
+      openaq: disabledSourceStatus(
+        'OpenAQ',
+        'OpenAQ v3 requires an API key in OPENAQ_API_KEY.',
+        'https://docs.openaq.org/using-the-api/quick-start',
+      ),
+    },
+    setup: {
+      env: 'OPENAQ_API_KEY',
+      docs: 'https://docs.openaq.org/using-the-api/quick-start',
+    },
+  };
+}
+
+export async function fetchOpenAqStations(apiKey: string): Promise<OpenAqStation[]> {
+  const res = await fetch(`${OPENAQ_PM25_LATEST_URL}?limit=500`, {
+    headers: {
+      Accept: 'application/json',
+      'X-API-Key': apiKey,
+    },
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`OpenAQ HTTP ${res.status}`);
+  }
+
+  const data = (await res.json()) as { results?: OpenAqLatestResult[] };
+  return (data.results || []).map(normalizeOpenAqLatestResult).filter((station): station is OpenAqStation => Boolean(station));
+}

--- a/src/lib/integrations/rail-germany.test.ts
+++ b/src/lib/integrations/rail-germany.test.ts
@@ -2,7 +2,12 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildGermanyRailInfrastructureQuery,
+  buildStationOperationStatus,
+  classifyRailOperationStatus,
+  fetchStationDepartures,
   GERMANY_RAIL_HUBS,
+  staticGermanyRailInfrastructure,
+  normalizeDbDeparture,
   normalizeOverpassRailElement,
   normalizeStaticRailHub,
 } from './rail-germany.ts';
@@ -25,6 +30,16 @@ test('normalizes German static rail hubs as infrastructure facilities', () => {
   assert.equal(hub.lat, 52.525592);
   assert.equal(hub.lng, 13.369545);
   assert.equal(hub.source.feed, 'rail-germany-infrastructure');
+});
+
+test('includes static German trunk rail corridors when Overpass is unavailable', () => {
+  const infrastructure = staticGermanyRailInfrastructure();
+  const lines = infrastructure.filter(item => item.kind === 'line');
+
+  assert.ok(lines.length >= 5);
+  assert.equal(lines[0].geometry?.type, 'LineString');
+  assert.ok((lines[0].geometry?.coordinates.length || 0) >= 2);
+  assert.equal(lines[0].source.feed, 'rail-germany-infrastructure');
 });
 
 test('normalizes Overpass rail stations with operator and UIC metadata', () => {
@@ -100,4 +115,102 @@ test('normalizes Overpass railway ways as line infrastructure geometry', () => {
 test('drops non-rail or coordinate-less rail elements', () => {
   assert.equal(normalizeOverpassRailElement({ type: 'node', id: 1, tags: { amenity: 'cafe' } }), null);
   assert.equal(normalizeOverpassRailElement({ type: 'way', id: 2, tags: { railway: 'rail' }, geometry: [{ lat: 1 }] }), null);
+});
+
+test('classifies live German rail operational status from delay and cancellation signals', () => {
+  assert.equal(classifyRailOperationStatus({ plannedWhen: '2026-06-04T10:00:00+02:00', when: '2026-06-04T10:01:00+02:00' }), 'on_time');
+  assert.equal(classifyRailOperationStatus({ plannedWhen: '2026-06-04T10:00:00+02:00', when: '2026-06-04T10:08:00+02:00' }), 'delayed');
+  assert.equal(classifyRailOperationStatus({ plannedWhen: '2026-06-04T10:00:00+02:00', when: '2026-06-04T10:18:00+02:00' }), 'severe');
+  assert.equal(classifyRailOperationStatus({ plannedWhen: '2026-06-04T10:00:00+02:00', when: '2026-06-04T10:00:00+02:00', cancelled: true }), 'cancelled');
+});
+
+test('normalizes db.transport.rest departures as separate live operations', () => {
+  const departure = normalizeDbDeparture({
+    tripId: '1|123|0|80|4062026',
+    line: { name: 'ICE 100', productName: 'ICE' },
+    direction: 'Hamburg-Altona',
+    when: '2026-06-04T10:12:00+02:00',
+    plannedWhen: '2026-06-04T10:00:00+02:00',
+    platform: '7',
+    plannedPlatform: '8',
+    cancelled: false,
+  });
+
+  assert.deepEqual(departure, {
+    id: '1|123|0|80|4062026',
+    line: 'ICE 100',
+    product: 'ICE',
+    direction: 'Hamburg-Altona',
+    when: '2026-06-04T10:12:00+02:00',
+    plannedWhen: '2026-06-04T10:00:00+02:00',
+    delayMinutes: 12,
+    status: 'delayed',
+    platform: '7',
+    plannedPlatform: '8',
+    platformChanged: true,
+  });
+});
+
+test('uses db.transport.rest delay seconds when normalizing departures', () => {
+  const departure = normalizeDbDeparture({
+    tripId: 'delay-field',
+    line: { name: 'RE 1', product: 'regional' },
+    direction: 'Magdeburg Hbf',
+    plannedWhen: '2026-06-04T10:00:00+02:00',
+    when: '2026-06-04T10:00:00+02:00',
+    delay: 900,
+  });
+
+  assert.equal(departure?.delayMinutes, 15);
+  assert.equal(departure?.status, 'severe');
+});
+
+test('parses db.transport.rest departure arrays', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify([
+    {
+      tripId: 'array-response',
+      line: { name: 'ICE 100', productName: 'ICE' },
+      direction: 'Hamburg-Altona',
+      delay: 300,
+      cancelled: false,
+    },
+  ]), { status: 200, headers: { 'content-type': 'application/json' } });
+
+  try {
+    const departures = await fetchStationDepartures('8011160', 1);
+    assert.equal(departures.length, 1);
+    assert.equal(departures[0].id, 'array-response');
+    assert.equal(departures[0].status, 'delayed');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('builds station-level live operations without mutating infrastructure records', () => {
+  const station = GERMANY_RAIL_HUBS[0];
+  const status = buildStationOperationStatus(station, [
+    {
+      id: 'ice-1',
+      line: 'ICE 1',
+      delayMinutes: 0,
+      status: 'on_time',
+      platformChanged: false,
+    },
+    {
+      id: 'ice-2',
+      line: 'ICE 2',
+      delayMinutes: 22,
+      status: 'severe',
+      platformChanged: true,
+    },
+  ]);
+
+  assert.equal(status.stationId, '8011160');
+  assert.equal(status.stationName, 'Berlin Hbf');
+  assert.equal(status.status, 'severe');
+  assert.equal(status.delayedDepartures, 0);
+  assert.equal(status.severeDepartures, 1);
+  assert.equal(status.platformChanges, 1);
+  assert.equal(status.source.feed, 'rail-germany-operations');
 });

--- a/src/lib/integrations/rail-germany.test.ts
+++ b/src/lib/integrations/rail-germany.test.ts
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildGermanyRailInfrastructureQuery,
+  GERMANY_RAIL_HUBS,
+  normalizeOverpassRailElement,
+  normalizeStaticRailHub,
+} from './rail-germany.ts';
+
+test('builds a Germany-only rail infrastructure query without operational departures', () => {
+  const query = buildGermanyRailInfrastructureQuery(80);
+
+  assert.match(query, /ISO3166-1"="DE/);
+  assert.match(query, /railway"="rail/);
+  assert.match(query, /station\|halt\|yard\|depot\|junction/);
+  assert.doesNotMatch(query, /departures|delay|trip|journey/i);
+});
+
+test('normalizes German static rail hubs as infrastructure facilities', () => {
+  const hub = normalizeStaticRailHub(GERMANY_RAIL_HUBS[0]);
+
+  assert.equal(hub.id, 'rail-de-hub-8011160');
+  assert.equal(hub.kind, 'station');
+  assert.equal(hub.name, 'Berlin Hbf');
+  assert.equal(hub.lat, 52.525592);
+  assert.equal(hub.lng, 13.369545);
+  assert.equal(hub.source.feed, 'rail-germany-infrastructure');
+});
+
+test('normalizes Overpass rail stations with operator and UIC metadata', () => {
+  const facility = normalizeOverpassRailElement({
+    type: 'node',
+    id: 123,
+    lat: 52.525592,
+    lon: 13.369545,
+    tags: {
+      railway: 'station',
+      name: 'Berlin Hauptbahnhof',
+      operator: 'DB InfraGO',
+      uic_ref: '8011160',
+      network: 'DB',
+    },
+  });
+
+  assert.deepEqual(facility && {
+    id: facility.id,
+    kind: facility.kind,
+    name: facility.name,
+    operator: facility.operator,
+    uicRef: facility.uicRef,
+    network: facility.network,
+    lat: facility.lat,
+    lng: facility.lng,
+  }, {
+    id: 'rail-de-uic-8011160',
+    kind: 'station',
+    name: 'Berlin Hauptbahnhof',
+    operator: 'DB InfraGO',
+    uicRef: '8011160',
+    network: 'DB',
+    lat: 52.525592,
+    lng: 13.369545,
+  });
+});
+
+test('normalizes Overpass railway ways as line infrastructure geometry', () => {
+  const line = normalizeOverpassRailElement({
+    type: 'way',
+    id: 987,
+    tags: {
+      railway: 'rail',
+      name: 'Berlin-Hamburg railway',
+      operator: 'DB Netz',
+      electrified: 'contact_line',
+      usage: 'main',
+      gauge: '1435',
+    },
+    geometry: [
+      { lat: 52.52, lon: 13.36 },
+      { lat: 52.6, lon: 13.2 },
+      { lat: 52.8, lon: 12.9 },
+    ],
+  });
+
+  assert.equal(line?.id, 'rail-de-way-987');
+  assert.equal(line?.kind, 'line');
+  assert.equal(line?.operator, 'DB Netz');
+  assert.equal(line?.electrified, 'contact_line');
+  assert.equal(line?.usage, 'main');
+  assert.deepEqual(line?.geometry, {
+    type: 'LineString',
+    coordinates: [
+      [13.36, 52.52],
+      [13.2, 52.6],
+      [12.9, 52.8],
+    ],
+  });
+});
+
+test('drops non-rail or coordinate-less rail elements', () => {
+  assert.equal(normalizeOverpassRailElement({ type: 'node', id: 1, tags: { amenity: 'cafe' } }), null);
+  assert.equal(normalizeOverpassRailElement({ type: 'way', id: 2, tags: { railway: 'rail' }, geometry: [{ lat: 1 }] }), null);
+});

--- a/src/lib/integrations/rail-germany.ts
+++ b/src/lib/integrations/rail-germany.ts
@@ -1,14 +1,28 @@
 import { sourceMeta } from './source-metadata.ts';
 
 export const OVERPASS_INTERPRETER_URL = 'https://overpass-api.de/api/interpreter';
+export const DB_TRANSPORT_REST_URL = 'https://v6.db.transport.rest';
 
 export type GermanyRailKind = 'station' | 'halt' | 'yard' | 'depot' | 'junction' | 'line';
+export type RailOperationStatus = 'on_time' | 'delayed' | 'severe' | 'cancelled' | 'unknown';
 
 export type StaticRailHub = {
   id: string;
   name: string;
   lat: number;
   lng: number;
+  operator?: string;
+  network?: string;
+};
+
+export type StaticRailCorridor = {
+  id: string;
+  name: string;
+  from: string;
+  to: string;
+  usage?: string;
+  electrified?: string;
+  gauge?: string;
   operator?: string;
   network?: string;
 };
@@ -32,6 +46,58 @@ export type GermanyRailInfrastructure = {
   };
   tags: Record<string, string>;
   source: ReturnType<typeof sourceMeta>;
+};
+
+export type RailDepartureOperation = {
+  id: string;
+  line: string;
+  product?: string;
+  direction?: string;
+  when?: string;
+  plannedWhen?: string;
+  delayMinutes: number;
+  status: RailOperationStatus;
+  platform?: string;
+  plannedPlatform?: string;
+  platformChanged: boolean;
+};
+
+export type RailStationOperationStatus = {
+  stationId: string;
+  stationName: string;
+  lat: number;
+  lng: number;
+  status: RailOperationStatus;
+  departures: RailDepartureOperation[];
+  delayedDepartures: number;
+  severeDepartures: number;
+  cancelledDepartures: number;
+  platformChanges: number;
+  source: ReturnType<typeof sourceMeta>;
+};
+
+type DbDeparture = {
+  tripId?: string;
+  id?: string;
+  line?: {
+    name?: string;
+    productName?: string;
+    product?: string;
+  };
+  direction?: string;
+  when?: string | null;
+  plannedWhen?: string | null;
+  delay?: number | null;
+  platform?: string | null;
+  plannedPlatform?: string | null;
+  cancelled?: boolean;
+};
+
+type RailOperationInput = {
+  plannedWhen?: string | null;
+  when?: string | null;
+  delayMinutes?: number;
+  cancelled?: boolean;
 };
 
 type OverpassGeometryPoint = {
@@ -64,6 +130,19 @@ export const GERMANY_RAIL_HUBS: StaticRailHub[] = [
   { id: '8000090', name: 'Stuttgart Hbf', lat: 48.78395, lng: 9.181635, operator: 'DB InfraGO', network: 'DB' },
 ];
 
+export const GERMANY_RAIL_CORRIDORS: StaticRailCorridor[] = [
+  { id: 'berlin-hamburg', name: 'Berlin-Hamburg corridor', from: '8011160', to: '8002549', usage: 'main', electrified: 'contact_line', gauge: '1435', operator: 'DB InfraGO', network: 'DB' },
+  { id: 'berlin-leipzig', name: 'Berlin-Leipzig corridor', from: '8011160', to: '8010205', usage: 'main', electrified: 'contact_line', gauge: '1435', operator: 'DB InfraGO', network: 'DB' },
+  { id: 'leipzig-munich', name: 'Leipzig-Munich corridor', from: '8010205', to: '8000261', usage: 'main', electrified: 'contact_line', gauge: '1435', operator: 'DB InfraGO', network: 'DB' },
+  { id: 'cologne-frankfurt', name: 'Cologne-Frankfurt corridor', from: '8000207', to: '8000105', usage: 'main', electrified: 'contact_line', gauge: '1435', operator: 'DB InfraGO', network: 'DB' },
+  { id: 'frankfurt-stuttgart', name: 'Frankfurt-Stuttgart corridor', from: '8000105', to: '8000090', usage: 'main', electrified: 'contact_line', gauge: '1435', operator: 'DB InfraGO', network: 'DB' },
+  { id: 'stuttgart-munich', name: 'Stuttgart-Munich corridor', from: '8000090', to: '8000261', usage: 'main', electrified: 'contact_line', gauge: '1435', operator: 'DB InfraGO', network: 'DB' },
+  { id: 'dortmund-dusseldorf-cologne', name: 'Ruhr-Rhine corridor', from: '8000096', to: '8000207', usage: 'main', electrified: 'contact_line', gauge: '1435', operator: 'DB InfraGO', network: 'DB' },
+  { id: 'hannover-berlin', name: 'Hannover-Berlin corridor', from: '8000091', to: '8011160', usage: 'main', electrified: 'contact_line', gauge: '1435', operator: 'DB InfraGO', network: 'DB' },
+  { id: 'hannover-hamburg', name: 'Hannover-Hamburg corridor', from: '8000091', to: '8002549', usage: 'main', electrified: 'contact_line', gauge: '1435', operator: 'DB InfraGO', network: 'DB' },
+  { id: 'dresden-leipzig', name: 'Dresden-Leipzig corridor', from: '8000098', to: '8010205', usage: 'main', electrified: 'contact_line', gauge: '1435', operator: 'DB InfraGO', network: 'DB' },
+];
+
 export function buildGermanyRailInfrastructureQuery(limit = 160): string {
   const boundedLimit = Math.min(500, Math.max(1, Math.round(limit)));
   return `[out:json][timeout:18];area["ISO3166-1"="DE"][admin_level=2]->.de;(
@@ -90,6 +169,43 @@ export function normalizeStaticRailHub(hub: StaticRailHub): GermanyRailInfrastru
       network: hub.network || '',
     },
     source: railSourceMeta('rail-germany-infrastructure', 86400, 0.65),
+  };
+}
+
+export function normalizeStaticRailCorridor(
+  corridor: StaticRailCorridor,
+  hubs: StaticRailHub[] = GERMANY_RAIL_HUBS,
+): GermanyRailInfrastructure | null {
+  const byId = new Map(hubs.map(hub => [hub.id, hub]));
+  const from = byId.get(corridor.from);
+  const to = byId.get(corridor.to);
+  if (!from || !to) return null;
+
+  return {
+    id: `rail-de-corridor-${corridor.id}`,
+    kind: 'line',
+    name: corridor.name,
+    operator: corridor.operator,
+    network: corridor.network,
+    electrified: corridor.electrified,
+    usage: corridor.usage,
+    gauge: corridor.gauge,
+    geometry: {
+      type: 'LineString',
+      coordinates: [
+        [from.lng, from.lat],
+        [to.lng, to.lat],
+      ],
+    },
+    tags: {
+      railway: 'rail',
+      usage: corridor.usage || '',
+      electrified: corridor.electrified || '',
+      gauge: corridor.gauge || '',
+      operator: corridor.operator || '',
+      network: corridor.network || '',
+    },
+    source: railSourceMeta('rail-germany-infrastructure', 86400, 0.55),
   };
 }
 
@@ -146,7 +262,122 @@ export async function fetchGermanyRailInfrastructure(limit = 160): Promise<Germa
 }
 
 export function staticGermanyRailInfrastructure(): GermanyRailInfrastructure[] {
-  return GERMANY_RAIL_HUBS.map(normalizeStaticRailHub);
+  return [
+    ...GERMANY_RAIL_HUBS.map(normalizeStaticRailHub),
+    ...GERMANY_RAIL_CORRIDORS
+      .map(corridor => normalizeStaticRailCorridor(corridor))
+      .filter((item): item is GermanyRailInfrastructure => Boolean(item)),
+  ];
+}
+
+export function classifyRailOperationStatus(input: RailOperationInput): RailOperationStatus {
+  if (input.cancelled) return 'cancelled';
+  const delayMinutes = typeof input.delayMinutes === 'number'
+    ? input.delayMinutes
+    : calculateDelayMinutes(input.plannedWhen, input.when);
+  if (delayMinutes >= 15) return 'severe';
+  if (delayMinutes >= 5) return 'delayed';
+  if (input.plannedWhen || input.when) return 'on_time';
+  return 'unknown';
+}
+
+export function normalizeDbDeparture(departure: DbDeparture): RailDepartureOperation | null {
+  const line = departure.line?.name;
+  const id = departure.tripId || departure.id;
+  if (!id || !line) return null;
+  const platform = departure.platform || undefined;
+  const plannedPlatform = departure.plannedPlatform || undefined;
+  const delayMinutes = typeof departure.delay === 'number'
+    ? Math.max(0, Math.round(departure.delay / 60))
+    : calculateDelayMinutes(departure.plannedWhen, departure.when);
+
+  return {
+    id,
+    line,
+    product: departure.line?.productName || departure.line?.product,
+    direction: departure.direction,
+    when: departure.when || undefined,
+    plannedWhen: departure.plannedWhen || undefined,
+    delayMinutes,
+    status: classifyRailOperationStatus({
+      plannedWhen: departure.plannedWhen,
+      when: departure.when,
+      cancelled: departure.cancelled,
+      delayMinutes,
+    }),
+    platform,
+    plannedPlatform,
+    platformChanged: Boolean(platform && plannedPlatform && platform !== plannedPlatform),
+  };
+}
+
+export function buildStationOperationStatus(
+  station: StaticRailHub,
+  departures: RailDepartureOperation[],
+): RailStationOperationStatus {
+  const delayedDepartures = departures.filter(departure => departure.status === 'delayed').length;
+  const severeDepartures = departures.filter(departure => departure.status === 'severe').length;
+  const cancelledDepartures = departures.filter(departure => departure.status === 'cancelled').length;
+  const platformChanges = departures.filter(departure => departure.platformChanged).length;
+  const status: RailOperationStatus = cancelledDepartures > 0 || severeDepartures > 0
+    ? 'severe'
+    : delayedDepartures > 0
+      ? 'delayed'
+      : departures.length > 0
+        ? 'on_time'
+        : 'unknown';
+
+  return {
+    stationId: station.id,
+    stationName: station.name,
+    lat: station.lat,
+    lng: station.lng,
+    status,
+    departures,
+    delayedDepartures,
+    severeDepartures,
+    cancelledDepartures,
+    platformChanges,
+    source: operationsSourceMeta(120, departures.length > 0 ? 0.72 : 0.45),
+  };
+}
+
+export async function fetchStationDepartures(stationId: string, results = 8): Promise<RailDepartureOperation[]> {
+  const params = new URLSearchParams({
+    duration: '120',
+    results: String(Math.min(20, Math.max(1, Math.round(results)))),
+    remarks: 'true',
+    stopovers: 'false',
+    language: 'en',
+  });
+  const res = await fetch(`${DB_TRANSPORT_REST_URL}/stops/${encodeURIComponent(stationId)}/departures?${params.toString()}`, {
+    headers: { Accept: 'application/json', 'User-Agent': 'OSIRIS/0.1 germany rail operations' },
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) throw new Error(`db.transport.rest HTTP ${res.status}`);
+
+  const data = (await res.json()) as DbDeparture[] | { departures?: DbDeparture[] };
+  const departures = Array.isArray(data) ? data : data.departures || [];
+  return departures
+    .map(normalizeDbDeparture)
+    .filter((item): item is RailDepartureOperation => Boolean(item));
+}
+
+export async function fetchGermanyRailOperations(
+  hubs: StaticRailHub[] = GERMANY_RAIL_HUBS,
+  departuresPerHub = 8,
+): Promise<{ statuses: RailStationOperationStatus[]; errors: string[] }> {
+  const settled = await Promise.allSettled(
+    hubs.map(async hub => buildStationOperationStatus(hub, await fetchStationDepartures(hub.id, departuresPerHub))),
+  );
+  return {
+    statuses: settled
+      .filter((result): result is PromiseFulfilledResult<RailStationOperationStatus> => result.status === 'fulfilled')
+      .map(result => result.value),
+    errors: settled
+      .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+      .map(result => result.reason instanceof Error ? result.reason.message : String(result.reason)),
+  };
 }
 
 function classifyRailKind(tags: Record<string, string>): GermanyRailKind | null {
@@ -195,6 +426,26 @@ function railSourceMeta(feed: string, cacheTtlSeconds: number, confidence: numbe
     cacheTtlSeconds,
     confidence,
   });
+}
+
+function operationsSourceMeta(cacheTtlSeconds: number, confidence: number) {
+  return sourceMeta({
+    provider: 'db.transport.rest',
+    feed: 'rail-germany-operations',
+    url: DB_TRANSPORT_REST_URL,
+    attribution: 'db.transport.rest public API',
+    license: 'upstream terms',
+    cacheTtlSeconds,
+    confidence,
+  });
+}
+
+function calculateDelayMinutes(plannedWhen?: string | null, actualWhen?: string | null): number {
+  if (!plannedWhen || !actualWhen) return 0;
+  const planned = Date.parse(plannedWhen);
+  const actual = Date.parse(actualWhen);
+  if (!Number.isFinite(planned) || !Number.isFinite(actual)) return 0;
+  return Math.max(0, Math.round((actual - planned) / 60000));
 }
 
 function dedupeRailInfrastructure(items: GermanyRailInfrastructure[]): GermanyRailInfrastructure[] {

--- a/src/lib/integrations/rail-germany.ts
+++ b/src/lib/integrations/rail-germany.ts
@@ -1,0 +1,209 @@
+import { sourceMeta } from './source-metadata.ts';
+
+export const OVERPASS_INTERPRETER_URL = 'https://overpass-api.de/api/interpreter';
+
+export type GermanyRailKind = 'station' | 'halt' | 'yard' | 'depot' | 'junction' | 'line';
+
+export type StaticRailHub = {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  operator?: string;
+  network?: string;
+};
+
+export type GermanyRailInfrastructure = {
+  id: string;
+  kind: GermanyRailKind;
+  name: string;
+  lat?: number;
+  lng?: number;
+  operator?: string;
+  network?: string;
+  uicRef?: string;
+  ref?: string;
+  electrified?: string;
+  usage?: string;
+  gauge?: string;
+  geometry?: {
+    type: 'LineString';
+    coordinates: [number, number][];
+  };
+  tags: Record<string, string>;
+  source: ReturnType<typeof sourceMeta>;
+};
+
+type OverpassGeometryPoint = {
+  lat?: number;
+  lon?: number;
+};
+
+type OverpassElement = {
+  type?: string;
+  id?: number;
+  lat?: number;
+  lon?: number;
+  center?: { lat?: number; lon?: number };
+  geometry?: OverpassGeometryPoint[];
+  tags?: Record<string, string>;
+};
+
+export const GERMANY_RAIL_HUBS: StaticRailHub[] = [
+  { id: '8011160', name: 'Berlin Hbf', lat: 52.525592, lng: 13.369545, operator: 'DB InfraGO', network: 'DB' },
+  { id: '8000105', name: 'Frankfurt(Main)Hbf', lat: 50.107149, lng: 8.663785, operator: 'DB InfraGO', network: 'DB' },
+  { id: '8000261', name: 'München Hbf', lat: 48.140232, lng: 11.558335, operator: 'DB InfraGO', network: 'DB' },
+  { id: '8002549', name: 'Hamburg Hbf', lat: 53.552733, lng: 10.006909, operator: 'DB InfraGO', network: 'DB' },
+  { id: '8000207', name: 'Köln Hbf', lat: 50.943029, lng: 6.958729, operator: 'DB InfraGO', network: 'DB' },
+  { id: '8000080', name: 'Düsseldorf Hbf', lat: 51.219961, lng: 6.794138, operator: 'DB InfraGO', network: 'DB' },
+  { id: '8000096', name: 'Dortmund Hbf', lat: 51.517899, lng: 7.459294, operator: 'DB InfraGO', network: 'DB' },
+  { id: '8000098', name: 'Dresden Hbf', lat: 51.040562, lng: 13.732035, operator: 'DB InfraGO', network: 'DB' },
+  { id: '8010205', name: 'Leipzig Hbf', lat: 51.345477, lng: 12.382128, operator: 'DB InfraGO', network: 'DB' },
+  { id: '8000290', name: 'Nürnberg Hbf', lat: 49.445435, lng: 11.082276, operator: 'DB InfraGO', network: 'DB' },
+  { id: '8000091', name: 'Hannover Hbf', lat: 52.377689, lng: 9.741859, operator: 'DB InfraGO', network: 'DB' },
+  { id: '8000090', name: 'Stuttgart Hbf', lat: 48.78395, lng: 9.181635, operator: 'DB InfraGO', network: 'DB' },
+];
+
+export function buildGermanyRailInfrastructureQuery(limit = 160): string {
+  const boundedLimit = Math.min(500, Math.max(1, Math.round(limit)));
+  return `[out:json][timeout:18];area["ISO3166-1"="DE"][admin_level=2]->.de;(
+node["railway"~"station|halt|yard|depot|junction"](area.de);
+way["railway"~"station|halt|yard|depot"](area.de);
+way["railway"="rail"](area.de);
+);out center geom ${boundedLimit};`;
+}
+
+export function normalizeStaticRailHub(hub: StaticRailHub): GermanyRailInfrastructure {
+  return {
+    id: `rail-de-hub-${hub.id}`,
+    kind: 'station',
+    name: hub.name,
+    lat: hub.lat,
+    lng: hub.lng,
+    operator: hub.operator,
+    network: hub.network,
+    uicRef: hub.id,
+    tags: {
+      railway: 'station',
+      uic_ref: hub.id,
+      operator: hub.operator || '',
+      network: hub.network || '',
+    },
+    source: railSourceMeta('rail-germany-infrastructure', 86400, 0.65),
+  };
+}
+
+export function normalizeOverpassRailElement(element: OverpassElement): GermanyRailInfrastructure | null {
+  if (!element.type || typeof element.id !== 'number') return null;
+  const tags = element.tags || {};
+  const kind = classifyRailKind(tags);
+  if (!kind) return null;
+
+  const geometry = kind === 'line' ? normalizeLineGeometry(element.geometry) : undefined;
+  const lat = typeof element.lat === 'number' ? element.lat : element.center?.lat;
+  const lng = typeof element.lon === 'number' ? element.lon : element.center?.lon;
+  if (!geometry && (typeof lat !== 'number' || typeof lng !== 'number')) return null;
+
+  return {
+    id: buildRailId(element, tags),
+    kind,
+    name: tags.name || tags.ref || railKindLabel(kind),
+    lat,
+    lng,
+    operator: tags.operator,
+    network: tags.network,
+    uicRef: tags.uic_ref,
+    ref: tags.ref,
+    electrified: tags.electrified,
+    usage: tags.usage,
+    gauge: tags.gauge,
+    geometry,
+    tags,
+    source: railSourceMeta('rail-germany-infrastructure', 86400, 0.78),
+  };
+}
+
+export async function fetchGermanyRailInfrastructure(limit = 160): Promise<GermanyRailInfrastructure[]> {
+  const query = buildGermanyRailInfrastructureQuery(limit);
+  const res = await fetch(OVERPASS_INTERPRETER_URL, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': 'OSIRIS/0.1 germany rail infrastructure',
+    },
+    body: new URLSearchParams({ data: query }),
+    signal: AbortSignal.timeout(18000),
+  });
+  if (!res.ok) throw new Error(`Overpass HTTP ${res.status}`);
+
+  const data = (await res.json()) as { elements?: OverpassElement[] };
+  return dedupeRailInfrastructure(
+    (data.elements || [])
+      .map(normalizeOverpassRailElement)
+      .filter((item): item is GermanyRailInfrastructure => Boolean(item)),
+  );
+}
+
+export function staticGermanyRailInfrastructure(): GermanyRailInfrastructure[] {
+  return GERMANY_RAIL_HUBS.map(normalizeStaticRailHub);
+}
+
+function classifyRailKind(tags: Record<string, string>): GermanyRailKind | null {
+  const railway = tags.railway;
+  if (railway === 'rail') return 'line';
+  if (railway === 'station') return 'station';
+  if (railway === 'halt') return 'halt';
+  if (railway === 'yard') return 'yard';
+  if (railway === 'depot') return 'depot';
+  if (railway === 'junction') return 'junction';
+  return null;
+}
+
+function normalizeLineGeometry(points?: OverpassGeometryPoint[]): GermanyRailInfrastructure['geometry'] | undefined {
+  const coordinates = (points || [])
+    .map((point): [number, number] | null => (
+      typeof point.lon === 'number' && typeof point.lat === 'number' ? [point.lon, point.lat] : null
+    ))
+    .filter((point): point is [number, number] => Boolean(point));
+
+  if (coordinates.length < 2) return undefined;
+  return { type: 'LineString', coordinates };
+}
+
+function buildRailId(element: OverpassElement, tags: Record<string, string>): string {
+  if (tags.uic_ref) return `rail-de-uic-${tags.uic_ref}`;
+  return `rail-de-${element.type}-${element.id}`;
+}
+
+function railKindLabel(kind: GermanyRailKind): string {
+  if (kind === 'line') return 'Rail line';
+  if (kind === 'yard') return 'Rail yard';
+  if (kind === 'depot') return 'Rail depot';
+  if (kind === 'junction') return 'Rail junction';
+  if (kind === 'halt') return 'Rail halt';
+  return 'Rail station';
+}
+
+function railSourceMeta(feed: string, cacheTtlSeconds: number, confidence: number) {
+  return sourceMeta({
+    provider: 'OpenStreetMap/Overpass',
+    feed,
+    url: OVERPASS_INTERPRETER_URL,
+    attribution: 'OpenStreetMap contributors',
+    license: 'ODbL',
+    cacheTtlSeconds,
+    confidence,
+  });
+}
+
+function dedupeRailInfrastructure(items: GermanyRailInfrastructure[]): GermanyRailInfrastructure[] {
+  const seen = new Set<string>();
+  const deduped: GermanyRailInfrastructure[] = [];
+  for (const item of items) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    deduped.push(item);
+  }
+  return deduped;
+}

--- a/src/lib/integrations/source-metadata.ts
+++ b/src/lib/integrations/source-metadata.ts
@@ -1,0 +1,63 @@
+export type OsirisSeverity = 'low' | 'medium' | 'high' | 'critical';
+
+export type SourceStatus = 'ok' | 'partial' | 'disabled' | 'error';
+
+export type OsirisSourceMeta = {
+  provider: string;
+  feed: string;
+  url?: string;
+  attribution?: string;
+  license?: string;
+  fetchedAt: string;
+  observedAt?: string;
+  cacheTtlSeconds: number;
+  confidence: number;
+};
+
+export type IntegrationSourceStatus = {
+  enabled: boolean;
+  status: SourceStatus;
+  provider: string;
+  message?: string;
+  url?: string;
+  fetchedAt: string;
+};
+
+export function sourceMeta(input: Omit<OsirisSourceMeta, 'fetchedAt'> & { fetchedAt?: string }): OsirisSourceMeta {
+  return {
+    ...input,
+    fetchedAt: input.fetchedAt || new Date().toISOString(),
+  };
+}
+
+export function disabledSourceStatus(provider: string, message: string, url?: string): IntegrationSourceStatus {
+  return {
+    enabled: false,
+    status: 'disabled',
+    provider,
+    message,
+    url,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+export function okSourceStatus(provider: string, url?: string): IntegrationSourceStatus {
+  return {
+    enabled: true,
+    status: 'ok',
+    provider,
+    url,
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+export function errorSourceStatus(provider: string, message: string, url?: string): IntegrationSourceStatus {
+  return {
+    enabled: true,
+    status: 'error',
+    provider,
+    message,
+    url,
+    fetchedAt: new Date().toISOString(),
+  };
+}

--- a/src/lib/integrations/threat-intel.test.ts
+++ b/src/lib/integrations/threat-intel.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeUrlhausCsvLine } from './threat-intel.ts';
+
+test('normalizes URLhaus recent CSV rows', () => {
+  const item = normalizeUrlhausCsvLine(
+    '"3858443","2026-06-04 08:41:14","http://125.40.94.54:57173/i","online","2026-06-04 08:41:14","malware_download","32-bit,elf,mips,Mozi","https://urlhaus.abuse.ch/url/3858443/","abuse_ch"',
+  );
+
+  assert.equal(item?.id, 'urlhaus-3858443');
+  assert.equal(item?.host, '125.40.94.54');
+  assert.equal(item?.status, 'online');
+  assert.equal(item?.threat, 'malware_download');
+  assert.equal(item?.source.provider, 'URLhaus');
+});

--- a/src/lib/integrations/threat-intel.ts
+++ b/src/lib/integrations/threat-intel.ts
@@ -1,0 +1,102 @@
+import { sourceMeta } from './source-metadata.ts';
+
+export const URLHAUS_RECENT_CSV_URL = 'https://urlhaus.abuse.ch/downloads/csv_recent/';
+
+export type UrlhausRecentItem = {
+  id: string;
+  dateAdded?: string;
+  url: string;
+  host: string;
+  status: string;
+  lastOnline?: string;
+  threat: string;
+  tags: string[];
+  urlhausLink?: string;
+  reporter?: string;
+  source: ReturnType<typeof sourceMeta>;
+};
+
+export function normalizeUrlhausCsvLine(line: string): UrlhausRecentItem | null {
+  const fields = parseCsvLine(line);
+  if (fields.length < 9 || fields[0].startsWith('#')) return null;
+
+  const url = fields[2];
+  let host = '';
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return null;
+  }
+
+  return {
+    id: `urlhaus-${fields[0]}`,
+    dateAdded: fields[1],
+    url,
+    host,
+    status: fields[3],
+    lastOnline: fields[4],
+    threat: fields[5],
+    tags: fields[6] ? fields[6].split(',').map(tag => tag.trim()).filter(Boolean) : [],
+    urlhausLink: fields[7],
+    reporter: fields[8],
+    source: sourceMeta({
+      provider: 'URLhaus',
+      feed: 'recent-csv',
+      url: URLHAUS_RECENT_CSV_URL,
+      attribution: 'abuse.ch URLhaus',
+      license: 'URLhaus Terms of Use',
+      observedAt: fields[1],
+      cacheTtlSeconds: 300,
+      confidence: 0.85,
+    }),
+  };
+}
+
+export async function fetchUrlhausRecent(query?: string): Promise<UrlhausRecentItem[]> {
+  const res = await fetch(URLHAUS_RECENT_CSV_URL, {
+    headers: { Accept: 'text/csv' },
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!res.ok) throw new Error(`URLhaus CSV HTTP ${res.status}`);
+
+  const normalizedQuery = query?.toLowerCase();
+  const items = (await res.text())
+    .split('\n')
+    .map(normalizeUrlhausCsvLine)
+    .filter((item): item is UrlhausRecentItem => Boolean(item));
+
+  return (normalizedQuery
+    ? items.filter(item => item.url.toLowerCase().includes(normalizedQuery) || item.host.toLowerCase().includes(normalizedQuery))
+    : items).slice(0, 100);
+}
+
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (line[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += char;
+      }
+    } else if (char === '"') {
+      inQuotes = true;
+    } else if (char === ',') {
+      fields.push(field);
+      field = '';
+    } else {
+      field += char;
+    }
+  }
+  fields.push(field);
+  return fields;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Kurzfazit
Adds public map layers for German rail data and camping sites, including station-level rail operations from db.transport.rest when available.

## Produktwirkung
- Users can enable DE Rail Data to inspect German rail stations, corridors, and operational station status.
- Rail popups show Live Ops for monitored hubs: delays, cancellations, platform changes, and next departures.
- Camping sites can be visualized from OpenStreetMap/Overpass with a curated fallback when Overpass is unavailable.

## Geprüft
- Integration tests: 29/29 pass
- TypeScript: pass
- Targeted ESLint: pass
- Production build: pass
- Local browser smoke on localhost:3001 Rail layer: pass

## Hinweise
- This is station-level live operations, not live moving train positions.
- db.transport.rest can currently return 503/timeouts; the API marks partial results and keeps infrastructure usable.
