### PR TITLE
fix(security): allowlist host in /proxy/tiles to close open SSRF proxy

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,14 +13,17 @@ http {
 
     server {
         listen 8080;
-        
-        # Route 1: Proxy map tiles from CARTO
+
+        # Route 1: Proxy map tiles from CARTO.
         # Format: /proxy/tiles/<subdomain>/<path>
         # Example: /proxy/tiles/a.basemaps.cartocdn.com/gl/dark-matter/...
-        location ~ ^/proxy/tiles/([^/]+)/(.*)$ {
-            set $target_domain $1;
-            set $target_path $2;
-            
+        #
+        # The upstream host is allowlisted via the location regex itself —
+        # only basemaps.cartocdn.com and its [a-d] shard subdomains are
+        # accepted. Anything else falls through to the catch-all below and
+        # is rejected with 403. Without this constraint the dynamic
+        # proxy_pass host becomes an open egress / SSRF proxy.
+        location ~ ^/proxy/tiles/(?<target_domain>(?:[a-d]\.)?basemaps\.cartocdn\.com)/(?<target_path>.*)$ {
             # Reconstruct the upstream URL
             proxy_pass https://$target_domain/$target_path$is_args$args;
             
@@ -42,7 +45,15 @@ http {
             # Force browser caching
             add_header Cache-Control "public, max-age=31536000, immutable";
             add_header X-Cache-Status $upstream_cache_status;
-            
+
+        }
+
+        # Reject any other /proxy/tiles/* host. Must appear after the
+        # allowlist regex above — nginx checks regex locations in source
+        # order and uses the first match, so the explicit allowlist wins
+        # for cartocdn and everything else falls through to this 403.
+        location ~ ^/proxy/tiles/ {
+            return 403;
         }
 
         # Route 2: Pass everything else to OSIRIS

--- a/src/app/api/proxy-tiles/route.ts
+++ b/src/app/api/proxy-tiles/route.ts
@@ -8,9 +8,12 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    // Only allow cartocdn.com domains to prevent open proxy abuse
+    // Only allow cartocdn.com domains to prevent open proxy abuse.
+    // Match the full domain or any subdomain — a plain endsWith check
+    // would also accept e.g. evilcartocdn.com.
     const targetUrl = new URL(url);
-    if (!targetUrl.hostname.endsWith('cartocdn.com')) {
+    const host = targetUrl.hostname.toLowerCase();
+    if (host !== 'cartocdn.com' && !host.endsWith('.cartocdn.com')) {
       return NextResponse.json({ error: 'Forbidden domain' }, { status: 403 });
     }
 


### PR DESCRIPTION
## Summary

The nginx cache container (`osiris-cache`, published on port 8080 via `docker-compose.yml`) ships a `/proxy/tiles/<host>/<path>` route whose upstream host is captured verbatim from the URL:

```nginx
location ~ ^/proxy/tiles/([^/]+)/(.*)$ {
    set $target_domain $1;
    set $target_path $2;
    proxy_pass https://$target_domain/$target_path$is_args$args;
    …
}
```

Because the host capture (`[^/]+`) is unconstrained, the route accepts **any** HTTPS upstream. The OSIRIS frontend never actually calls this route (it goes through the Next.js `/api/proxy-tiles` endpoint), so the path is effectively orphan, but it is still reachable on port 8080 of every deployment.

## Impact

A network-adjacent attacker who can reach port 8080 of an osiris-cache deployment can use it as an open HTTPS egress proxy:

- Fetch arbitrary HTTPS endpoints (incl. internal services that happen to speak TLS) via the deployer's IP address.
- Poison the 365-day `tile_cache` with attacker-chosen responses (`proxy_cache_valid 200 304 365d;`).
- Hide outbound abuse behind the deployer's identity / CDN reputation.

The companion route at `src/app/api/proxy-tiles/route.ts` already documents this risk in a comment — _"Only allow cartocdn.com domains to prevent open proxy abuse"_ — and gates the host on `cartocdn.com`. The nginx route ships without that gate, so the same intent isn't enforced at the edge.

## Location

- `nginx/nginx.conf:20` — `location ~ ^/proxy/tiles/([^/]+)/(.*)$`
- `src/app/api/proxy-tiles/route.ts:13` — `endsWith('cartocdn.com')` (suffix-match also accepts e.g. `evilcartocdn.com`)

## Fix

**nginx/nginx.conf** — constrain the location regex to the actually-used CARTO basemap subdomains, and add a catch-all `^/proxy/tiles/` location that returns `403` for anything else:

```nginx
# Allowlist host inside the regex itself
location ~ ^/proxy/tiles/(?<target_domain>(?:[a-d]\.)?basemaps\.cartocdn\.com)/(?<target_path>.*)$ {
    proxy_pass https://$target_domain/$target_path$is_args$args;
    …
}

# Catch-all 403 — nginx checks regex locations in source order, so the
# allowlist above still wins for cartocdn requests.
location ~ ^/proxy/tiles/ {
    return 403;
}
```

This covers everything the README documents (`/proxy/tiles/a.basemaps.cartocdn.com/gl/dark-matter/…`) and rejects everything else with `403`. If you later need to widen to additional CARTO infrastructure, the regex is the one knob to tune.

**src/app/api/proxy-tiles/route.ts** — tighten the suffix match so it requires the bare domain or a real subdomain (a previous `endsWith('cartocdn.com')` would also accept `evilcartocdn.com`):

```ts
const host = targetUrl.hostname.toLowerCase();
if (host !== 'cartocdn.com' && !host.endsWith('.cartocdn.com')) {
  return NextResponse.json({ error: 'Forbidden domain' }, { status: 403 });
}
```

## Detected by

Aeon + semgrep — `generic.nginx.security.dynamic-proxy-host.dynamic-proxy-host` (CWE-441) and `generic.nginx.security.missing-internal.missing-internal` both fire on `nginx/nginx.conf:25`.

- Severity: high
- CWE-441 (Unintended Proxy / Confused Deputy)

## Verification

- `nginx -t` reports `syntax is ok` on the patched config (the `-t` run only fails the secondary mkdir/dns checks because the `osiris:3000` upstream is docker-only — pure syntax check passes).
- A regex-translation harness exercises the new nginx location regex against allowed CARTO subdomains (5 cases) and abuse attempts incl. metadata IPs, suffix-spoofs, and prefix-spoofs (9 cases) — 14/14 pass.
- The same harness checks the tightened Next.js suffix gate against `evilcartocdn.com`, `cartocdn.com.attacker.com`, etc. — 8/8 pass.

No application code path uses `/proxy/tiles/` directly (only nginx.conf references it), so legitimate map loading via `/api/proxy-tiles` is unaffected.

## Follow-ups (not in this PR)

- `osv-scanner` flags `postcss@8.4.31` ➜ GHSA-qx2v-qp2m-jg93 (XSS via unescaped `</style>`). Surfaced via transitive deps in `package-lock.json`; safe to bump independently and intentionally kept out of this security PR to keep the diff surgical.

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
