### PR TITLE
fix(conflicts): /api/conflicts times out and returns no data

### DIFF
--- a/src/app/api/conflicts/route.ts
+++ b/src/app/api/conflicts/route.ts
@@ -146,11 +146,12 @@ function parsePointDataCSV(csv: string): ConflictEvent[] {
 
 // Main comprehensive conflict query — fetches from GDELT DOC API (pointdata mode)
 async function fetchAllLiveConflictData(): Promise<{ events: ConflictEvent[]; eventsByRegion: Record<string, number> }> {
-  // Use fewer, broader queries with proper delays to avoid 429
+  // A single broad query keeps the whole route well under the client timeout.
+  // The previous 3-query loop spaced 6s apart (plus a 6s DOC-fallback delay)
+  // could run ~90s and time the endpoint out entirely, so the layer returned
+  // nothing. One combined GDELT query returns comparable coverage in ~10s.
   const conflictQueries = [
-    'airstrike OR missile OR shelling',
-    'military attack OR bombing OR frontline',
-    'drone strike OR war casualties',
+    'airstrike OR missile OR shelling OR bombing OR frontline OR drone strike OR war casualties',
   ];
 
   const allEvents: ConflictEvent[] = [];
@@ -208,8 +209,9 @@ async function fetchAllLiveConflictData(): Promise<{ events: ConflictEvent[]; ev
         }
       }
 
-      // Fallback: DOC API pointdata mode (CSV with lat/lng)
-      await new Promise(resolve => setTimeout(resolve, 6000)); // extra delay
+      // Fallback: DOC API pointdata mode (CSV with lat/lng). Short spacing so a
+      // single GEO miss doesn't push the route past the client timeout.
+      await new Promise(resolve => setTimeout(resolve, 1500));
       const docUrl = `https://api.gdeltproject.org/api/v2/doc/doc?query=${encodedQuery}&mode=pointdata&format=csv&timespan=72h&maxrecords=80`;
       const docRes = await stealthFetch(docUrl, { signal: AbortSignal.timeout(10000) });
       


### PR DESCRIPTION
## Summary

`/api/conflicts` returns nothing — the conflict layer is always empty.

The route fetches from GDELT with three queries run **sequentially**, each spaced 6s apart (GDELT rate-limits to ~1 query/5s), plus an extra 6s delay before the per-query DOC-API fallback. In the worst case that's roughly **90s**, which is well past the client/proxy timeout, so the endpoint times out and the frontend gets no data at all.

## Fix

- Collapse the three queries into a single combined query (`airstrike OR missile OR shelling OR bombing OR frontline OR drone strike OR war casualties`).
- Reduce the DOC-fallback spacing from 6s to 1.5s.

The route now completes in ~10–15s and actually returns conflict events. Coverage is comparable since GDELT scores the same corpus regardless of how the OR-terms are split.

## Test

Built and deployed; `GET /api/conflicts` went from a hard timeout (no response) to `200` with populated `zones`/events in ~14s. (I run this behind a short nginx cache so repeat loads are instant.)

## Note (separate issue)

`/api/air-quality` is also empty because it calls the **deprecated OpenAQ v2** API (`/v2/latest`). v2 has been sunset; v3 needs an API key and a different response shape. Happy to send a follow-up PR for that if you'd like the v3 migration.
