### PR TITLE
Fix dead WSDOT camera endpoint in CCTV aggregator

### DIFF
--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -51,17 +51,24 @@ async function fetchTfLCameras(): Promise<any[]> {
   } catch (e) { return []; }
 }
 
-// ── US-WEST: WSDOT Washington State (~500) ──
+// ── US-WEST: WSDOT Washington State (~1,700) ──
+// Backs https://wsdot.com/Travel/Real-time/Map/ — public ArcGIS FeatureServer, no key required.
 async function fetchWSDOTCameras(): Promise<any[]> {
   try {
-    const res = await stealthFetch('https://data.wsdot.wa.gov/log/public/cameras.json', { signal: AbortSignal.timeout(12000) });
+    const url = 'https://data.wsdot.wa.gov/arcgis/rest/services/TravelInformation/TravelInfoCamerasWeather/FeatureServer/0/query'
+      + '?where=1%3D1&outFields=CameraTitle,ImageURL,CompassDirection&f=geojson&outSR=4326';
+    const res = await stealthFetch(url, { signal: AbortSignal.timeout(15000) });
     if (!res.ok) return [];
     const data = await res.json();
-    return (data || []).map((cam: any) => ({
-      id: `wsdot-${cam.CameraID}`, lat: cam.CameraLocation?.Latitude, lng: cam.CameraLocation?.Longitude,
-      name: cam.Title || 'WSDOT Camera', city: 'Washington', country: 'US',
-      feed_url: cam.ImageURL || '', source: 'WSDOT',
-    })).filter((c: any) => c.lat && c.lng && c.feed_url);
+    return (data.features || []).map((f: any) => {
+      const [lng, lat] = f.geometry?.coordinates || [];
+      const p = f.properties || {};
+      return {
+        id: `wsdot-${f.id ?? p.OBJECTID}`, lat, lng,
+        name: p.CameraTitle || 'WSDOT Camera', city: 'Washington', country: 'US',
+        feed_url: p.ImageURL || '', source: 'WSDOT',
+      };
+    }).filter((c: any) => c.lat && c.lng && c.feed_url);
   } catch (e) { return []; }
 }
 


### PR DESCRIPTION
## Problem
`fetchWSDOTCameras()` in `src/app/api/cctv/route.ts` calls `https://data.wsdot.wa.gov/log/public/cameras.json`, which now returns 404. Because the fetcher wraps the call in a try/catch that silently returns `[]` on any failure, this has been quietly returning **zero** WSDOT cameras with no visible error.

## Fix
Point it at the public ArcGIS FeatureServer that actually backs [wsdot.com/Travel/Real-time/Map](https://wsdot.com/Travel/Real-time/Map/) (layer 0 = Cameras). No API key required — this is the same authoritative, always-in-sync source WSDOT's own map page uses (unlike the deprecated WSDOT Traveler Info REST API, which requires a free AccessCode).

```
https://data.wsdot.wa.gov/arcgis/rest/services/TravelInformation/TravelInfoCamerasWeather/FeatureServer/0/query?where=1%3D1&outFields=CameraTitle,ImageURL,CompassDirection&f=geojson&outSR=4326
```

## Verification
- Before: 0 WSDOT cameras returned
- After: 1,689 cameras returned, each with a valid `feed_url` image
- `npx tsc --noEmit` — no new type errors introduced (pre-existing unrelated error in `src/app/page.tsx` around `OsintPanelProps`/`theme` reproduces identically on a clean `master` checkout, confirmed not touched by this change)
- Live-tested against the dev server: `region=us-west` and `region=all` both now include populated `WSDOT` entries