### PR TITLE
Threat Fusion engine, real-time maritime tracker, and scale/reliability fixes

### DIFF
--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -519,8 +519,17 @@ export async function GET(request: Request) {
       regionsToFetch = Object.keys(REGION_FETCHERS);
     }
 
+    // Bound each region so a single hung upstream (a dead traffic-cam server)
+    // can't stall the whole batch — return whatever loaded within the budget.
+    const REGION_BUDGET_MS = 15000;
+    const withBudget = (p: Promise<any[]>): Promise<any[]> =>
+      Promise.race([
+        p.catch(() => []),
+        new Promise<any[]>(resolve => setTimeout(() => resolve([]), REGION_BUDGET_MS)),
+      ]);
+
     const results = await Promise.allSettled(
-      regionsToFetch.map(r => REGION_FETCHERS[r]())
+      regionsToFetch.map(r => withBudget(REGION_FETCHERS[r]()))
     );
 
     const allCameras: any[] = [];

--- a/src/app/api/fusion/route.ts
+++ b/src/app/api/fusion/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { computeFusion, type Fusion } from '@/lib/fusion';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+/**
+ * OSIRIS — Global Threat Fusion (server-side, edge-cacheable)
+ *
+ * SCALE DESIGN (≈333K visitors/month behind Cloudflare):
+ * The fusion is computed ONCE here and served as a ~2 KB JSON. Clients make a
+ * single tiny request instead of pulling six heavy feeds each and recomputing —
+ * that's the difference between hammering the origin (and every upstream's
+ * per-IP rate limit) 333K× and serving almost entirely from cache.
+ *
+ *   • module cache (60s) + single-flight coalescing → the six sub-feeds are
+ *     read at most once per minute regardless of traffic
+ *   • the sub-feeds have their own caches, so this rarely does real work
+ *   • Cache-Control s-maxage lets Cloudflare's edge answer most requests
+ *     without ever touching the origin
+ */
+
+const CACHE_TTL = 60_000;
+const MIN_FEEDS = 2; // below this the read is degenerate — don't overwrite good cache
+const CC = 'public, s-maxage=60, stale-while-revalidate=300';
+let cached: Fusion | null = null;
+let cachedAt = 0;
+let inflight: Promise<Fusion> | null = null;
+let lastOverall = 0;
+
+async function grab(origin: string, path: string, revalidate: number): Promise<any> {
+  try {
+    const res = await fetch(`${origin}${path}`, { next: { revalidate } });
+    return res.ok ? await res.json() : null;
+  } catch {
+    return null;
+  }
+}
+
+async function build(origin: string): Promise<Fusion> {
+  const results = await Promise.all([
+    grab(origin, '/api/malware', 300),
+    grab(origin, '/api/earthquakes', 300),
+    grab(origin, '/api/weather', 300),
+    grab(origin, '/api/conflicts', 300),
+    grab(origin, '/api/flights', 45),
+    grab(origin, '/api/news', 120),
+  ]);
+  const online = results.filter(Boolean).length;
+  const [malware, quakes, weather, conflicts, flights, news] = results;
+  const f = computeFusion({ malware, quakes, weather, conflicts, flights, news }, lastOverall);
+
+  // Only commit a read backed by enough feeds — a transient failure of several
+  // upstreams must not overwrite a good cache with a bogus "all clear".
+  if (online >= MIN_FEEDS) {
+    lastOverall = f.overall;
+    cached = f;
+    cachedAt = Date.now();
+  }
+  return f;
+}
+
+function kickRebuild(origin: string) {
+  if (inflight) return;
+  inflight = build(origin).finally(() => { inflight = null; });
+  // Swallow background errors — stale cache remains valid.
+  inflight.catch(() => {});
+}
+
+export async function GET(request: NextRequest) {
+  const origin = new URL(request.url).origin;
+  const age = Date.now() - cachedAt;
+
+  // Fresh → serve instantly.
+  if (cached && age < CACHE_TTL) {
+    return NextResponse.json(cached, { headers: { 'Cache-Control': CC } });
+  }
+
+  // Stale-while-revalidate: serve stale NOW, refresh in the background (never block).
+  if (cached) {
+    kickRebuild(origin);
+    return NextResponse.json(cached, { headers: { 'Cache-Control': CC } });
+  }
+
+  // Cold start (no cache yet) → must build once.
+  kickRebuild(origin);
+  try {
+    const fresh = await inflight!;
+    return NextResponse.json(fresh, { headers: { 'Cache-Control': CC } });
+  } catch {
+    return NextResponse.json({ error: 'fusion unavailable' }, { status: 503 });
+  }
+}

--- a/src/app/api/geo/route.ts
+++ b/src/app/api/geo/route.ts
@@ -1,95 +1,72 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-// Server-side proxy for IP geolocation — avoids mixed-content block on HTTPS pages
-// Three providers with cascading fallback for maximum reliability
+/**
+ * Server-side IP geolocation proxy (avoids mixed-content block on HTTPS pages).
+ *
+ * SCALE DESIGN (≈333K visitors/month): a visitor's location is stable, so each
+ * IP is resolved at most once per hour and cached in-process — repeat page loads
+ * cost nothing and never re-hit the providers' per-IP daily limits. The three
+ * providers race in PARALLEL (first success wins) so a slow/dead provider can't
+ * add latency, and failures are negative-cached briefly to stop retry storms.
+ */
+
+type Geo = Record<string, unknown>;
+const cache = new Map<string, { data: Geo; expiry: number }>();
+const OK_TTL = 60 * 60 * 1000;   // 1h — geo is stable
+const FAIL_TTL = 30 * 1000;      // 30s — don't hammer on failure
+const FAIL = { __fail: true } as Geo;
+
+async function ipapiCo(ip: string): Promise<Geo | null> {
+  const url = ip ? `https://ipapi.co/${ip}/json/` : 'https://ipapi.co/json/';
+  const res = await fetch(url, { signal: AbortSignal.timeout(5000), cache: 'no-store', headers: { 'User-Agent': 'OSIRIS/5.0' } });
+  if (!res.ok) throw new Error('ipapi.co');
+  const d = await res.json();
+  if (d.error || !d.latitude) throw new Error('ipapi.co empty');
+  return { status: 'success', query: d.ip, lat: d.latitude, lon: d.longitude, city: d.city, regionName: d.region, country: d.country_name, isp: d.org || 'Unknown', org: d.org || 'Unknown', as: d.asn ? `AS${d.asn} ${d.org}` : 'Unknown' };
+}
+async function freeIpApi(ip: string): Promise<Geo | null> {
+  const url = ip ? `https://freeipapi.com/api/json/${ip}` : 'https://freeipapi.com/api/json';
+  const res = await fetch(url, { signal: AbortSignal.timeout(5000), cache: 'no-store' });
+  if (!res.ok) throw new Error('freeipapi');
+  const d = await res.json();
+  if (!d.latitude) throw new Error('freeipapi empty');
+  return { status: 'success', query: d.ipAddress || ip || 'auto', lat: d.latitude, lon: d.longitude, city: d.cityName || 'Unknown', regionName: d.regionName || 'Unknown', country: d.countryName || 'Unknown', isp: d.isp || 'Unknown', org: d.isp || 'Unknown', as: 'Unknown' };
+}
+async function ipApiCom(ip: string): Promise<Geo | null> {
+  const q = 'fields=status,lat,lon,city,regionName,country,query,isp,org,as';
+  const url = ip ? `http://ip-api.com/json/${ip}?${q}` : `http://ip-api.com/json/?${q}`;
+  const res = await fetch(url, { signal: AbortSignal.timeout(5000), cache: 'no-store' });
+  if (!res.ok) throw new Error('ip-api');
+  const d = await res.json();
+  if (d.status !== 'success') throw new Error('ip-api empty');
+  return d;
+}
+
 export async function GET(request: NextRequest) {
+  const clientIp =
+    request.headers.get('cf-connecting-ip') ||
+    request.headers.get('x-real-ip') ||
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    '';
+  const isPrivate = !clientIp || clientIp === '::1' || clientIp === '127.0.0.1' || clientIp.startsWith('192.168.') || clientIp.startsWith('10.') || clientIp.startsWith('172.');
+  const ip = isPrivate ? '' : clientIp;
+  const key = ip || 'auto';
+
+  const hit = cache.get(key);
+  if (hit && Date.now() < hit.expiry) {
+    if ((hit.data as any).__fail) {
+      return NextResponse.json({ error: 'All geolocation providers failed (cached)' }, { status: 502, headers: { 'Cache-Control': 'no-store' } });
+    }
+    return NextResponse.json(hit.data, { headers: { 'Cache-Control': 'private, max-age=3600' } });
+  }
+
   try {
-    // Extract the real client IP from standard proxy headers
-    const clientIp =
-      request.headers.get('cf-connecting-ip') ||        // Cloudflare
-      request.headers.get('x-real-ip') ||                // Nginx / generic
-      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-      '';
-
-    // Skip private/loopback IPs — let the API auto-detect
-    const isPrivate = !clientIp || clientIp === '::1' || clientIp === '127.0.0.1' || clientIp.startsWith('192.168.') || clientIp.startsWith('10.') || clientIp.startsWith('172.');
-    const ip = isPrivate ? '' : clientIp;
-
-    // ── Provider 1: ipapi.co (HTTPS, free tier 1000/day) ──
-    try {
-      const url = ip ? `https://ipapi.co/${ip}/json/` : 'https://ipapi.co/json/';
-      const res = await fetch(url, {
-        signal: AbortSignal.timeout(5000),
-        cache: 'no-store',
-        headers: { 'User-Agent': 'OSIRIS/4.2' },
-      });
-      if (res.ok) {
-        const d = await res.json();
-        if (!d.error && d.latitude) {
-          return NextResponse.json({
-            status: 'success',
-            query: d.ip,
-            lat: d.latitude,
-            lon: d.longitude,
-            city: d.city,
-            regionName: d.region,
-            country: d.country_name,
-            isp: d.org || 'Unknown',
-            org: d.org || 'Unknown',
-            as: d.asn ? `AS${d.asn} ${d.org}` : 'Unknown',
-          });
-        }
-      }
-    } catch { /* fall through */ }
-
-    // ── Provider 2: freeipapi.com (HTTPS, no key needed) ──
-    try {
-      const url = ip ? `https://freeipapi.com/api/json/${ip}` : 'https://freeipapi.com/api/json';
-      const res = await fetch(url, {
-        signal: AbortSignal.timeout(5000),
-        cache: 'no-store',
-      });
-      if (res.ok) {
-        const d = await res.json();
-        if (d.latitude) {
-          return NextResponse.json({
-            status: 'success',
-            query: d.ipAddress || ip || 'auto',
-            lat: d.latitude,
-            lon: d.longitude,
-            city: d.cityName || 'Unknown',
-            regionName: d.regionName || 'Unknown',
-            country: d.countryName || 'Unknown',
-            isp: d.isp || 'Unknown',
-            org: d.isp || 'Unknown',
-            as: 'Unknown',
-          });
-        }
-      }
-    } catch { /* fall through */ }
-
-    // ── Provider 3: ip-api.com (HTTP — safe here because this is server-to-server) ──
-    try {
-      const url = ip
-        ? `http://ip-api.com/json/${ip}?fields=status,lat,lon,city,regionName,country,query,isp,org,as`
-        : 'http://ip-api.com/json/?fields=status,lat,lon,city,regionName,country,query,isp,org,as';
-      const res = await fetch(url, {
-        signal: AbortSignal.timeout(5000),
-        cache: 'no-store',
-      });
-      if (res.ok) {
-        const data = await res.json();
-        if (data.status === 'success') {
-          return NextResponse.json(data);
-        }
-      }
-    } catch { /* fall through */ }
-
-    return NextResponse.json({ error: 'All geolocation providers failed' }, { status: 502 });
-  } catch (e) {
-    return NextResponse.json(
-      { error: 'Failed to reach geolocation service', detail: e instanceof Error ? e.message : String(e) },
-      { status: 503 }
-    );
+    // Race all providers — first valid answer wins, dead providers can't add latency.
+    const data = await Promise.any([ipapiCo(ip), freeIpApi(ip), ipApiCom(ip)]);
+    cache.set(key, { data: data!, expiry: Date.now() + OK_TTL });
+    return NextResponse.json(data, { headers: { 'Cache-Control': 'private, max-age=3600' } });
+  } catch {
+    cache.set(key, { data: FAIL, expiry: Date.now() + FAIL_TTL });
+    return NextResponse.json({ error: 'All geolocation providers failed' }, { status: 502, headers: { 'Cache-Control': 'no-store' } });
   }
 }

--- a/src/app/api/malware/route.ts
+++ b/src/app/api/malware/route.ts
@@ -3,11 +3,45 @@ import { NextResponse } from 'next/server';
 export const dynamic = 'force-dynamic';
 
 /**
- * OSIRIS — Live Malware Feed (abuse.ch Feodo Tracker + URLhaus)
- * Source: abuse.ch — completely free, no auth for public feeds
- * Fetches botnet C2 servers & malware distribution URLs with geo-mapping.
+ * OSIRIS — Live Malware Infrastructure Feed
+ *
+ * Aggregates active malware/botnet infrastructure from abuse.ch (free, keyless):
+ *   • Feodo Tracker  — live botnet C2 servers (Emotet, Dridex, QakBot, …)
+ *   • URLhaus        — live malware distribution URLs (payload delivery)
+ *
+ * IPs are geolocated to precise coordinates via ip-api.com (free batch API,
+ * city-level lat/lon + ISP + ASN). Country centroids are only a last-resort
+ * fallback. Threats are deduped by IP across feeds, scored by severity, and
+ * enriched with hosting-provider (ASN) attribution.
+ *
+ * NOTE: abuse.ch's ThreatFox now requires an Auth-Key, so it is intentionally
+ * not used here — this feed is 100% keyless.
  */
 
+type Severity = 'critical' | 'high' | 'medium';
+type ThreatType = 'botnet_c2' | 'malware_download' | 'payload_delivery' | 'malware';
+
+interface Threat {
+  id: string;
+  lat: number;
+  lng: number;
+  ip: string;
+  port: number;
+  malware: string;        // family, e.g. "Emotet", "mirai"
+  threat_type: ThreatType;
+  severity: Severity;
+  status: string;
+  country: string;        // ISO-2
+  city?: string;
+  isp?: string;
+  asn?: string;           // e.g. "AS14061 DigitalOcean"
+  first_seen?: string;
+  last_online?: string;
+  reference?: string;     // link back to the abuse.ch record
+  geolocated: boolean;
+}
+
+// Last-resort fallback only (ip-api geo is preferred).
 const COUNTRY_CENTROIDS: Record<string, [number, number]> = {
   AF:[65,33],AL:[20,41],DZ:[3,28],AO:[18.5,-12.5],AR:[-64,-34],AM:[45,40],AU:[134,-25],AT:[14,47.5],AZ:[50,40.5],
   BD:[90,24],BY:[28,53],BE:[4,50.8],BR:[-51,-10],BG:[25.5,42.7],CA:[-96,62],CL:[-71,-30],
@@ -21,124 +55,243 @@ const COUNTRY_CENTROIDS: Record<string, [number, number]> = {
   US:[-97,38],VN:[106,16],
 };
 
-export async function GET() {
+const MAX_URLHAUS_IPS = 300; // caps ip-api usage to ≤3 batches
+const IP_API_BATCH = 100;
+
+// ── Server-side cache. ip-api free tier is 15 req/min; a 10-min TTL keeps us
+//    far under that even with many dashboard loads, and coalesces bursts. ──
+let cache: any = null;
+let cacheTime = 0;
+const CACHE_TTL = 10 * 60 * 1000;
+let inflight: Promise<any> | null = null;
+
+const IPV4_RE = /^https?:\/\/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})(?::(\d+))?/;
+
+interface RawSource {
+  ip: string;
+  port: number;
+  malware: string;
+  threat_type: ThreatType;
+  severity: Severity;
+  status: string;
+  country?: string;
+  first_seen?: string;
+  last_online?: string;
+  reference?: string;
+}
+
+async function fetchFeodo(): Promise<RawSource[]> {
   try {
-    // Fetch Feodo Tracker botnet C2 servers (has country field)
-    const feodoRes = await fetch('https://feodotracker.abuse.ch/downloads/ipblocklist.json', {
+    const res = await fetch('https://feodotracker.abuse.ch/downloads/ipblocklist.json', {
       signal: AbortSignal.timeout(10000),
       cache: 'no-store',
-      headers: { 'User-Agent': 'OSIRIS/4.2', 'Accept': 'application/json' },
+      headers: { 'User-Agent': 'OSIRIS/5.0', Accept: 'application/json' },
     });
+    if (!res.ok) return [];
+    const data = await res.json();
+    if (!Array.isArray(data)) return [];
+    return data.map((e: any) => ({
+      ip: e.ip_address,
+      port: Number(e.port) || 0,
+      malware: e.malware || 'Unknown C2',
+      threat_type: 'botnet_c2' as const,
+      severity: 'critical' as const, // live command & control is the top tier
+      status: e.status || 'unknown',
+      country: e.country,
+      first_seen: e.first_seen,
+      last_online: e.last_online,
+      reference: 'https://feodotracker.abuse.ch/browse/',
+    })).filter((e: RawSource) => e.ip);
+  } catch {
+    return [];
+  }
+}
 
-    console.log('[OSIRIS] Feodo response status:', feodoRes.status);
+function unquote(s: string): string {
+  return (s || '').replace(/^"+|"+$/g, '').trim();
+}
 
-    const threats: any[] = [];
-    let id = 0;
+// URLhaus "tags" mix the real family (mirai, Mozi, gafgyt…) with architecture/
+// format/tooling noise. Strip the noise and surface the cleanest family label.
+const TAG_NOISE = new Set([
+  '32-bit', '64-bit', 'elf', 'exe', 'arm', 'arm7', 'mips', 'mipsel', 'x86', 'x86-64',
+  'sh', 'dll', 'js', 'php', 'apk', 'bin', 'sparc', 'ppc', 'm68k', 'renesas', 'motorola',
+]);
+function cleanFamily(tags: string): string {
+  if (!tags || tags.toLowerCase() === 'none') return 'Unclassified';
+  const parts = tags.split(',').map(t => t.trim()).filter(Boolean);
+  const families = parts.filter(t => !TAG_NOISE.has(t.toLowerCase()) && !t.toLowerCase().startsWith('ua-'));
+  if (!families.length) return 'Generic payload';
+  // Prefer a recognisable named family (has an uppercase letter) over lowercase tooling tags.
+  const named = families.find(f => /[A-Z]/.test(f));
+  return named || families[0];
+}
 
-    if (feodoRes.ok) {
-      const feodoData = await feodoRes.json();
-      const entries = Array.isArray(feodoData) ? feodoData : [];
+async function fetchUrlhaus(): Promise<RawSource[]> {
+  try {
+    const res = await fetch('https://urlhaus.abuse.ch/downloads/csv_online/', {
+      signal: AbortSignal.timeout(12000),
+      cache: 'no-store',
+    });
+    if (!res.ok) return [];
+    const text = await res.text();
+    const out: RawSource[] = [];
+    const seen = new Set<string>();
 
-      for (const entry of entries.slice(0, 200)) {
-        const cc = entry.country;
-        if (!cc || !COUNTRY_CENTROIDS[cc]) continue;
-        const [lng, lat] = COUNTRY_CENTROIDS[cc];
-        // Jitter within country
-        const jLng = ((id * 173.7) % 200 - 100) / 100 * 4;
-        const jLat = ((id * 293.1) % 200 - 100) / 100 * 4;
-        threats.push({
-          id: `feodo-${id++}`,
-          lat: lat + jLat,
-          lng: lng + jLng,
-          ip: entry.ip_address || 'unknown',
-          port: entry.dst_port || 0,
-          malware: entry.malware || 'unknown',
-          status: entry.status || 'active',
-          first_seen: entry.first_seen,
-          last_online: entry.last_online,
-          country: cc,
-          threat_type: 'botnet_c2',
-        });
+    for (const line of text.split('\n')) {
+      if (!line || line.startsWith('#')) continue;
+      const m = IPV4_RE.exec(unquote(line.split('","')[2] || ''));
+      if (!m) continue;
+      const ip = m[1];
+      if (seen.has(ip)) continue;
+
+      const cols = line.split('","');
+      const threatType = unquote(cols[5] || 'malware') as ThreatType;
+      const family = cleanFamily(unquote(cols[6] || ''));
+      seen.add(ip);
+      out.push({
+        ip,
+        port: m[2] ? Number(m[2]) : (unquote(cols[2]).startsWith('https') ? 443 : 80),
+        malware: family,
+        threat_type: threatType === 'malware_download' ? 'malware_download' : 'payload_delivery',
+        severity: 'high',
+        status: unquote(cols[3]) || 'online',
+        first_seen: unquote(cols[1]).split(' ')[0],
+        last_online: unquote(cols[4]).split(' ')[0] || undefined,
+        reference: unquote(cols[7]) || 'https://urlhaus.abuse.ch/',
+      });
+      if (out.length >= MAX_URLHAUS_IPS) break;
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+// Batch-geolocate IPs via ip-api. Returns ip -> geo record.
+async function geolocate(ips: string[]): Promise<Map<string, any>> {
+  const result = new Map<string, any>();
+  for (let i = 0; i < ips.length; i += IP_API_BATCH) {
+    const batch = ips.slice(i, i + IP_API_BATCH);
+    try {
+      const res = await fetch('http://ip-api.com/batch?fields=status,countryCode,city,lat,lon,isp,org,as,query', {
+        method: 'POST',
+        body: JSON.stringify(batch),
+        headers: { 'Content-Type': 'application/json' },
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!res.ok) continue;
+      const data = await res.json();
+      for (const g of data) {
+        if (g.status === 'success') result.set(g.query, g);
       }
+    } catch {
+      // partial geo is fine — fallback handles the rest
+    }
+  }
+  return result;
+}
+
+const SEVERITY_RANK: Record<Severity, number> = { critical: 3, high: 2, medium: 1 };
+
+async function build() {
+  const [feodo, urlhaus] = await Promise.all([fetchFeodo(), fetchUrlhaus()]);
+
+  // Dedup across feeds by IP, keeping the highest-severity classification.
+  const byIp = new Map<string, RawSource>();
+  for (const s of [...feodo, ...urlhaus]) {
+    const existing = byIp.get(s.ip);
+    if (!existing || SEVERITY_RANK[s.severity] > SEVERITY_RANK[existing.severity]) {
+      byIp.set(s.ip, existing ? { ...s, ...(existing.threat_type === 'botnet_c2' ? existing : {}) } : s);
+    }
+  }
+
+  const geo = await geolocate([...byIp.keys()]);
+
+  const threats: Threat[] = [];
+  let id = 0;
+  let jitter = 0;
+  for (const s of byIp.values()) {
+    const g = geo.get(s.ip);
+    let lat: number, lng: number, geolocated = false;
+    if (g && typeof g.lat === 'number' && typeof g.lon === 'number') {
+      lat = g.lat; lng = g.lon; geolocated = true;
+    } else {
+      const cc = s.country && COUNTRY_CENTROIDS[s.country];
+      if (!cc) continue; // no geo and no known centroid → skip rather than fake it
+      lat = cc[1] + (((jitter * 293.1) % 200 - 100) / 100) * 3;
+      lng = cc[0] + (((jitter * 173.7) % 200 - 100) / 100) * 3;
+      jitter++;
     }
 
-    // 2. Fetch URLhaus active malware (CSV is free and open)
-    try {
-      const urlhausRes = await fetch('https://urlhaus.abuse.ch/downloads/csv_online/', {
-        signal: AbortSignal.timeout(10000),
-        cache: 'no-store'
-      });
-      if (urlhausRes.ok) {
-        const text = await urlhausRes.text();
-        const lines = text.split('\n').filter(l => !l.startsWith('#') && l.trim().length > 0);
-        
-        // Extract up to 100 unique IPv4 addresses
-        const ipMap = new Map<string, any>();
-        for (const line of lines) {
-          const cols = line.split('","'); // Simple CSV split since URLhaus uses "val","val"
-          if (cols.length > 3) {
-            const dateAdded = cols[1];
-            const url = cols[2];
-            const threat = cols[5] || 'malware';
-            
-            // Extract IPv4 from URL
-            const ipMatch = url.match(/https?:\/\/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})/);
-            if (ipMatch && ipMatch[1]) {
-              const ip = ipMatch[1];
-              if (!ipMap.has(ip)) {
-                ipMap.set(ip, { url, dateAdded, threat, ip });
-                if (ipMap.size >= 100) break; // limit to 100 for ip-api batch limit
-              }
-            }
-          }
-        }
-
-        // Batch Geolocate via ip-api.com (15 req/min free tier, max 100 per batch)
-        if (ipMap.size > 0) {
-          const ipsToGeo = Array.from(ipMap.keys());
-          const geoRes = await fetch('http://ip-api.com/batch', {
-            method: 'POST',
-            body: JSON.stringify(ipsToGeo),
-            headers: { 'Content-Type': 'application/json' },
-            signal: AbortSignal.timeout(10000)
-          });
-          
-          if (geoRes.ok) {
-            const geoData = await geoRes.json();
-            for (const geo of geoData) {
-              if (geo.status === 'success' && geo.lat && geo.lon) {
-                const info = ipMap.get(geo.query);
-                if (info) {
-                  threats.push({
-                    id: `urlhaus-${id++}`,
-                    lat: geo.lat,
-                    lng: geo.lon,
-                    ip: info.ip,
-                    port: info.url.includes('https') ? 443 : 80,
-                    malware: info.threat.replace(/"/g, ''),
-                    status: 'online',
-                    first_seen: info.dateAdded.replace(/"/g, '').split(' ')[0] || new Date().toISOString().split('T')[0],
-                    last_online: new Date().toISOString().split('T')[0],
-                    country: geo.countryCode || 'Unknown',
-                    threat_type: 'malware_url',
-                  });
-                }
-              }
-            }
-          }
-        }
-      }
-    } catch (e) { console.error('URLHaus CSV Fetch Error', e); }
-
-    return NextResponse.json({
-      threats,
-      total: threats.length,
-      timestamp: new Date().toISOString(),
-      source: threats[0]?.id?.includes('sim-') ? 'OSIRIS Simulated Threat Engine' : 'abuse.ch Feodo Tracker + URLhaus + ThreatFox',
-    }, {
-      headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+    threats.push({
+      id: `${s.threat_type}-${id++}`,
+      lat, lng,
+      ip: s.ip,
+      port: s.port,
+      malware: s.malware,
+      threat_type: s.threat_type,
+      severity: s.severity,
+      status: s.status,
+      country: g?.countryCode || s.country || 'Unknown',
+      city: g?.city || undefined,
+      isp: g?.isp || undefined,
+      asn: g?.as || undefined,
+      first_seen: s.first_seen,
+      last_online: s.last_online,
+      reference: s.reference,
+      geolocated,
     });
+  }
+
+  // Aggregate stats for the UI.
+  const byType: Record<string, number> = {};
+  const byFamily: Record<string, number> = {};
+  const byCountry: Record<string, number> = {};
+  for (const t of threats) {
+    byType[t.threat_type] = (byType[t.threat_type] || 0) + 1;
+    byFamily[t.malware] = (byFamily[t.malware] || 0) + 1;
+    byCountry[t.country] = (byCountry[t.country] || 0) + 1;
+  }
+  const topFamilies = Object.entries(byFamily).sort((a, b) => b[1] - a[1]).slice(0, 8).map(([name, count]) => ({ name, count }));
+
+  return {
+    threats,
+    total: threats.length,
+    stats: {
+      by_type: byType,
+      top_families: topFamilies,
+      countries: Object.keys(byCountry).length,
+      geolocated: threats.filter(t => t.geolocated).length,
+    },
+    source: 'abuse.ch Feodo Tracker + URLhaus · geo: ip-api.com',
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export async function GET() {
+  const now = Date.now();
+  if (cache && now - cacheTime < CACHE_TTL) {
+    return NextResponse.json(cache, { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' } });
+  }
+  if (inflight) {
+    try { return NextResponse.json(await inflight); } catch { /* fall through */ }
+  }
+
+  inflight = build();
+  try {
+    const data = await inflight;
+    inflight = null;
+    // Never cache an empty result — that means the upstreams (abuse.ch / ip-api)
+    // failed transiently, and we don't want to serve 0 threats for the full TTL.
+    if (data.total > 0) {
+      cache = data;
+      cacheTime = Date.now();
+    }
+    const cacheControl = data.total > 0 ? 'public, s-maxage=300, stale-while-revalidate=600' : 'no-store, max-age=0';
+    return NextResponse.json(data, { headers: { 'Cache-Control': cacheControl } });
   } catch (error) {
+    inflight = null;
     console.error('[OSIRIS] Malware feed error:', error);
     return NextResponse.json({ threats: [], total: 0, error: 'Malware feed unavailable' }, { status: 500 });
   }

--- a/src/app/api/maritime/route.ts
+++ b/src/app/api/maritime/route.ts
@@ -41,6 +41,35 @@ const PORTS = [
   { name: 'Felixstowe', country: 'GB', lat: 51.96, lng: 1.35, type: 'container', volume: '3.8M TEU', rank: 25 },
   { name: 'Santos', country: 'BR', lat: -23.95, lng: -46.31, type: 'container', volume: '4.2M TEU', rank: 22 },
   { name: 'Colombo', country: 'LK', lat: 6.94, lng: 79.84, type: 'container', volume: '7.2M TEU', rank: 17 },
+  { name: 'Tianjin', country: 'CN', lat: 39.00, lng: 117.72, type: 'container', volume: '20.3M TEU', rank: 8 },
+  { name: 'Hong Kong', country: 'HK', lat: 22.30, lng: 114.13, type: 'container', volume: '14.3M TEU', rank: 10 },
+  { name: 'Kaohsiung', country: 'TW', lat: 22.55, lng: 120.30, type: 'container', volume: '9.8M TEU', rank: 18 },
+  { name: 'New York / NJ', country: 'US', lat: 40.66, lng: -74.09, type: 'container', volume: '9.5M TEU', rank: 19 },
+  { name: 'Tanger Med', country: 'MA', lat: 35.88, lng: -5.50, type: 'container', volume: '7.6M TEU', rank: 21 },
+  { name: 'Laem Chabang', country: 'TH', lat: 13.08, lng: 100.88, type: 'container', volume: '8.7M TEU', rank: 23 },
+  { name: 'Ho Chi Minh (Cat Lai)', country: 'VN', lat: 10.75, lng: 106.79, type: 'container', volume: '7.9M TEU', rank: 24 },
+  { name: 'Mundra', country: 'IN', lat: 22.74, lng: 69.70, type: 'container', volume: '6.6M TEU', rank: 26 },
+  { name: 'Jakarta (Tanjung Priok)', country: 'ID', lat: -6.10, lng: 106.88, type: 'container', volume: '6.5M TEU', rank: 27 },
+  { name: 'Jawaharlal Nehru', country: 'IN', lat: 18.95, lng: 72.95, type: 'container', volume: '6.4M TEU', rank: 28 },
+  { name: 'Valencia', country: 'ES', lat: 39.44, lng: -0.32, type: 'container', volume: '5.6M TEU', rank: 29 },
+  { name: 'Piraeus', country: 'GR', lat: 37.94, lng: 23.63, type: 'container', volume: '5.4M TEU', rank: 30 },
+  { name: 'Manila', country: 'PH', lat: 14.60, lng: 120.96, type: 'container', volume: '5.3M TEU' },
+  { name: 'Algeciras', country: 'ES', lat: 36.13, lng: -5.44, type: 'container', volume: '5.1M TEU' },
+  { name: 'Salalah', country: 'OM', lat: 16.95, lng: 54.01, type: 'container', volume: '4.5M TEU' },
+  { name: 'Colon', country: 'PA', lat: 9.36, lng: -79.90, type: 'container', volume: '4.3M TEU' },
+  { name: 'Port Said', country: 'EG', lat: 31.25, lng: 32.30, type: 'container', volume: '4.0M TEU' },
+  { name: 'Bremerhaven', country: 'DE', lat: 53.55, lng: 8.57, type: 'container', volume: '4.6M TEU' },
+  { name: 'Vancouver', country: 'CA', lat: 49.29, lng: -123.11, type: 'container', volume: '3.5M TEU' },
+  { name: 'Seattle-Tacoma', country: 'US', lat: 47.27, lng: -122.41, type: 'container', volume: '3.4M TEU' },
+  { name: 'Manzanillo', country: 'MX', lat: 19.05, lng: -104.31, type: 'container', volume: '3.4M TEU' },
+  { name: 'Le Havre', country: 'FR', lat: 49.48, lng: 0.12, type: 'container', volume: '3.0M TEU' },
+  { name: 'Barcelona', country: 'ES', lat: 41.35, lng: 2.16, type: 'container', volume: '3.5M TEU' },
+  { name: 'Gioia Tauro', country: 'IT', lat: 38.43, lng: 15.90, type: 'container', volume: '3.5M TEU' },
+  { name: 'Melbourne', country: 'AU', lat: -37.83, lng: 144.92, type: 'container', volume: '3.3M TEU' },
+  { name: 'Durban', country: 'ZA', lat: -29.87, lng: 31.03, type: 'container', volume: '2.9M TEU' },
+  { name: 'Gdansk', country: 'PL', lat: 54.40, lng: 18.68, type: 'container', volume: '2.1M TEU' },
+  { name: 'Cartagena', country: 'CO', lat: 10.40, lng: -75.52, type: 'container', volume: '3.0M TEU' },
+  { name: 'Sydney (Botany)', country: 'AU', lat: -33.97, lng: 151.23, type: 'container', volume: '2.6M TEU' },
 
   // ── Energy/Oil Ports ──
   { name: 'Ras Tanura', country: 'SA', lat: 26.64, lng: 50.16, type: 'energy', volume: '6.5M bpd' },
@@ -94,6 +123,72 @@ if (!globalForAis.shipsCache) {
 }
 
 const shipsCache = globalForAis.shipsCache;
+
+// ── KEYLESS real-time ship source: Digitraffic marine AIS (Finnish Transport
+//    Agency). ~18K live vessels across the Baltic/North-Sea approaches, no API
+//    key — so the maritime layer is populated even without AIS_API_KEY. The
+//    keyed aisstream feed (when configured) adds global chokepoint coverage on
+//    top. Both merge by MMSI. ──
+function aisTypeToCategory(t: number): string {
+  if (t === 35) return 'military';
+  if (t >= 80 && t <= 89) return 'tanker';
+  if (t >= 70 && t <= 79) return 'cargo';
+  if (t >= 60 && t <= 69) return 'passenger';
+  if (t >= 40 && t <= 49) return 'hsc';
+  if (t >= 30 && t <= 39) return 'fishing';
+  return 'other';
+}
+
+let dtCache: any[] = [];
+let dtCacheAt = 0;
+let dtInflight: Promise<any[]> | null = null;
+const DT_TTL = 45000;
+const DT_HEADERS = { 'Digitraffic-User': 'OSIRIS-OSINT', 'Accept-Encoding': 'gzip' };
+
+async function fetchDigitraffic(): Promise<any[]> {
+  if (Date.now() - dtCacheAt < DT_TTL) return dtCache;
+  if (dtInflight) return dtInflight;
+  dtInflight = (async () => {
+    try {
+      const [locRes, vesRes] = await Promise.all([
+        fetch('https://meri.digitraffic.fi/api/ais/v1/locations', { headers: DT_HEADERS, signal: AbortSignal.timeout(12000) }),
+        fetch('https://meri.digitraffic.fi/api/ais/v1/vessels', { headers: DT_HEADERS, signal: AbortSignal.timeout(12000) }),
+      ]);
+      if (!locRes.ok) return dtCache;
+      const loc = await locRes.json();
+      const meta = new Map<number, any>();
+      if (vesRes.ok) {
+        const vs = await vesRes.json();
+        if (Array.isArray(vs)) for (const v of vs) meta.set(v.mmsi, v);
+      }
+      const ships: any[] = [];
+      for (const f of (loc.features || [])) {
+        const p = f.properties || {};
+        const c = f.geometry?.coordinates;
+        if (!c || c.length < 2) continue;
+        const m = meta.get(p.mmsi) || {};
+        ships.push({
+          id: p.mmsi, mmsi: p.mmsi,
+          lat: c[1], lng: c[0],
+          speed: typeof p.sog === 'number' ? p.sog : 0,
+          heading: (p.heading != null && p.heading < 360) ? p.heading : (p.cog ?? 0),
+          name: (m.name && m.name.trim()) || `MMSI ${p.mmsi}`,
+          destination: (m.destination && m.destination.trim()) || '',
+          type: aisTypeToCategory(m.shipType || 0),
+          source: 'digitraffic',
+          timestamp: Date.now(),
+        });
+      }
+      if (ships.length > 0) { dtCache = ships; dtCacheAt = Date.now(); }
+      return dtCache;
+    } catch {
+      return dtCache;
+    } finally {
+      dtInflight = null;
+    }
+  })();
+  return dtInflight;
+}
 
 function connectAisStream() {
   if (globalForAis.isAisConnecting) return;
@@ -215,11 +310,23 @@ async function fetchVesselApiFallback() {
   // Mock data removed per user request. We only rely on real live stream data.
 }
 
-export async function GET() {
-  // Trigger Hybrid Fallback
-  await fetchVesselApiFallback();
+// Response cache — merging + congestion math over thousands of ships is O(ports×ships);
+// caching keeps it cheap at scale and lets Cloudflare's edge serve most requests.
+let respCache: any = null;
+let respCacheAt = 0;
+const RESP_TTL = 30000;
+const SHIP_CAP = 8000; // keep the map (and payload) performant
+const EDGE_CC = 'public, s-maxage=30, stale-while-revalidate=60';
 
-  // Clean up stale ships (older than 10 minutes)
+export async function GET() {
+  if (respCache && Date.now() - respCacheAt < RESP_TTL) {
+    return NextResponse.json(respCache, { headers: { 'Cache-Control': EDGE_CC } });
+  }
+
+  // Keyless Digitraffic feed (always) + keyed aisstream cache (if configured), merged by MMSI.
+  const dtShips = await fetchDigitraffic();
+
+  // Clean up stale aisstream ships (older than 10 minutes)
   const now = Date.now();
   for (const [mmsi, ship] of shipsCache.entries()) {
     if (now - ship.timestamp > 10 * 60 * 1000) {
@@ -227,7 +334,11 @@ export async function GET() {
     }
   }
 
-  const ships = Array.from(shipsCache.values());
+  const byMmsi = new Map<number, any>();
+  for (const s of dtShips) byMmsi.set(s.mmsi, s);
+  for (const s of shipsCache.values()) byMmsi.set(s.mmsi, s); // aisstream (global) overrides
+  let ships = Array.from(byMmsi.values());
+  if (ships.length > SHIP_CAP) ships = ships.slice(0, SHIP_CAP);
 
   // Dynamically calculate live traffic (Fast approximation of Haversine)
   const getDistanceKm = (lat1: number, lng1: number, lat2: number, lng2: number) => {
@@ -290,18 +401,18 @@ export async function GET() {
     };
   });
 
-  return NextResponse.json({
+  const payload = {
     ports: dynamicPorts,
     chokepoints: dynamicChokepoints,
-    ships: ships,
+    ships,
     total_ports: dynamicPorts.length,
     total_chokepoints: dynamicChokepoints.length,
     total_ships: ships.length,
+    sources: (process.env.AIS_API_KEY ? ['aisstream.io'] : []).concat(['Digitraffic marine AIS']),
     timestamp: new Date().toISOString(),
-  }, {
-    headers: { 
-      'Cache-Control': 'no-store, no-cache, must-revalidate',
-      'Pragma': 'no-cache'
-    },
-  });
+  };
+  respCache = payload;
+  respCacheAt = Date.now();
+
+  return NextResponse.json(payload, { headers: { 'Cache-Control': EDGE_CC } });
 }

--- a/src/app/api/proxy-tiles/route.ts
+++ b/src/app/api/proxy-tiles/route.ts
@@ -20,7 +20,10 @@ export async function GET(request: NextRequest) {
         'Accept': '*/*',
         'User-Agent': 'Osiris-Tile-Proxy/1.0',
       },
-      // Using Next.js fetch cache options to heavily cache tiles locally
+      // Bound the upstream fetch so a slow/unreachable CDN can't hang the request
+      // and leak connections into the shared pool (the tile proxy is now bypassed
+      // by the map, but this stays as a hard safety net).
+      signal: AbortSignal.timeout(6000),
       next: {
         revalidate: 31536000, // Cache for 1 year
       }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2247,3 +2247,79 @@ html, body {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   UI/UX LEVEL-UP — cohesive polish (theme-aware via tokens)
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Branded text selection (was default browser blue) ── */
+::selection {
+  background: rgba(var(--gold-rgb), 0.28);
+  color: var(--text-heading);
+  text-shadow: none;
+}
+
+/* ── Accessible keyboard focus ring — visible only for keyboard nav,
+      never on mouse click. Uses box-shadow so it never shifts layout. ── */
+:focus { outline: none; }
+:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--bg-void),
+    0 0 0 3px rgba(var(--gold-rgb), 0.75),
+    0 0 12px rgba(var(--gold-rgb), 0.35);
+  border-radius: 6px;
+}
+
+/* ── Snappier interactive feedback ──
+      The global `* { transition: 0.6s }` is tuned for the theme cross-fade,
+      but it makes hovers feel sluggish. Interactive elements get a fast,
+      responsive curve instead (theme change on them is still smooth enough). */
+button, a, [role="button"], .layer-toggle, .mobile-nav-btn, summary, select, input {
+  transition:
+    background-color 0.18s ease,
+    border-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease,
+    transform 0.12s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* ── Tactile press micro-interaction ── */
+button:active:not(:disabled),
+[role="button"]:active,
+.layer-toggle:active {
+  transform: scale(0.97);
+}
+
+/* ── Premium glass depth: brighter top sheen + hover lift ── */
+.glass-panel {
+  box-shadow:
+    0 4px 30px rgba(0, 0, 0, 0.55),
+    0 1px 0 rgba(var(--gold-rgb), 0.10) inset,
+    0 12px 40px -12px rgba(0, 0, 0, 0.6),
+    0 -1px 0 rgba(0, 0, 0, 0.3) inset;
+}
+.glass-panel:hover {
+  border-color: rgba(var(--gold-rgb), 0.28);
+  box-shadow:
+    0 6px 34px rgba(0, 0, 0, 0.6),
+    0 1px 0 rgba(var(--gold-rgb), 0.14) inset,
+    0 16px 48px -14px rgba(0, 0, 0, 0.65),
+    0 0 24px -6px rgba(var(--gold-rgb), 0.12);
+}
+
+/* ── Interactive rows get a smooth accent wash on hover ── */
+.osiris-row {
+  border-radius: 8px;
+  transition: background-color 0.18s ease, transform 0.12s ease;
+}
+.osiris-row:hover {
+  background: var(--hover-accent);
+}
+
+/* ── Respect reduced-motion for the new micro-interactions too ── */
+@media (prefers-reduced-motion: reduce) {
+  button:active:not(:disabled),
+  [role="button"]:active,
+  .layer-toggle:active { transform: none; }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,8 @@ import ViewPresets from '@/components/ViewPresets';
 import KeyboardShortcuts from '@/components/KeyboardShortcuts';
 import GlobalStatusBar from '@/components/GlobalStatusBar';
 import LiveAlerts from '@/components/LiveAlerts';
+import CommandPalette, { type PaletteCommand } from '@/components/CommandPalette';
+import ThreatFusionHUD from '@/components/ThreatFusionHUD';
 
 const OsirisMap = dynamic(() => import('@/components/OsirisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
@@ -107,6 +109,7 @@ export default function Dashboard() {
   const [showIntel, setShowIntel] = useState(false);
   const [showEntityGraph, setShowEntityGraph] = useState(false);
   const [showDesktopSearch, setShowDesktopSearch] = useState(false);
+  const [showFusion, setShowFusion] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [mobilePanel, setMobilePanel] = useState<'layers'|'markets'|'intel'|'search'|'recon'|null>(null);
   const [mapProjection, setMapProjection] = useState<'globe'|'mercator'>('globe');
@@ -115,7 +118,7 @@ export default function Dashboard() {
   const [scanTargets, setScanTargets] = useState<any[]>([]);
   const [entityGraphTarget, setEntityGraphTarget] = useState<{ type: string; id: string; label?: string; properties?: Record<string, any> } | null>(null);
   const [demoMode, setDemoMode] = useState(false);
-  const [osirisTheme, setOsirisTheme] = useState<'core'|'ghost'>('ghost');
+  const [osirisTheme, setOsirisTheme] = useState<'core'|'ghost'>('core');
 
   useEffect(() => {
     document.body.className = osirisTheme === 'core' ? '' : `theme-${osirisTheme}`;
@@ -561,6 +564,130 @@ export default function Dashboard() {
     (data.commercial_flights?.length||0)+(data.private_flights?.length||0)+(data.private_jets?.length||0)+(data.military_flights?.length||0)
   ), [data.commercial_flights, data.private_flights, data.private_jets, data.military_flights]);
 
+  // ── COMMAND PALETTE (⌘K) — unified launcher for layers, navigation, panels & display ──
+  const flyTo = useCallback((lat: number, lng: number, zoom: number) => {
+    setFlyToLocation({ lat, lng, ts: Date.now() });
+    setMapView(v => ({ ...v, zoom }));
+  }, []);
+  const closeRightPanels = useCallback(() => {
+    setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowEntityGraph(false); setShowDesktopSearch(false); setShowFusion(false);
+  }, []);
+  const toggleFullscreen = useCallback(() => {
+    if (typeof document === 'undefined') return;
+    if (document.fullscreenElement) document.exitFullscreen();
+    else document.documentElement.requestFullscreen().catch(() => {});
+  }, []);
+
+  const paletteCommands = useMemo<PaletteCommand[]>(() => {
+    const LAYER_DEFS: { key: keyof typeof activeLayers; label: string; hint: string }[] = [
+      { key: 'flights', label: 'Commercial Flights', hint: 'ADS-B / OpenSky' },
+      { key: 'private', label: 'Private Aircraft', hint: 'ADS-B' },
+      { key: 'jets', label: 'Private Jets', hint: 'ADS-B' },
+      { key: 'military', label: 'Military Aircraft', hint: 'ADS-B' },
+      { key: 'maritime', label: 'Maritime / Naval', hint: 'Ports · Chokepoints · Ships' },
+      { key: 'satellites', label: 'Satellites', hint: 'Orbital tracking' },
+      { key: 'sat_military', label: 'Military Satellites', hint: 'Intel constellations' },
+      { key: 'balloons', label: 'High-Altitude Balloons', hint: 'Stratospheric' },
+      { key: 'cctv', label: 'CCTV Cameras', hint: 'Public traffic cams' },
+      { key: 'live_news', label: 'Live News Feeds', hint: '24/7 broadcasters' },
+      { key: 'news_intel', label: 'SIGINT News', hint: 'Geoparsed RSS' },
+      { key: 'earthquakes', label: 'Earthquakes', hint: 'USGS M2.5+' },
+      { key: 'fires', label: 'Active Fires', hint: 'NASA FIRMS' },
+      { key: 'weather', label: 'Severe Weather', hint: 'EONET + NWS + GDACS' },
+      { key: 'radiation', label: 'Radiation Monitors', hint: 'Geiger network' },
+      { key: 'infrastructure', label: 'Nuclear Facilities', hint: 'Critical infra' },
+      { key: 'global_incidents', label: 'Global Incidents', hint: 'GDELT events' },
+      { key: 'gps_jamming', label: 'GPS Jamming', hint: 'Interference zones' },
+      { key: 'malware', label: 'Live Malware', hint: 'abuse.ch threat feed' },
+      { key: 'cables', label: 'Submarine Cables', hint: 'Undersea backbone' },
+      { key: 'day_night', label: 'Day / Night Terminator', hint: 'Solar overlay' },
+      { key: 'terrain_3d', label: '3D Terrain & Buildings', hint: 'Elevation mesh' },
+    ];
+    const layerCount = (k: string): string => {
+      const map: Record<string, string> = {
+        flights: 'commercial_flights', private: 'private_flights', jets: 'private_jets', military: 'military_flights',
+        maritime: 'maritime_ships', satellites: 'satellites', earthquakes: 'earthquakes', fires: 'fires',
+        cctv: 'cameras', live_news: 'live_feeds', global_incidents: 'gdelt', malware: 'malware_threats',
+      };
+      const dk = map[k];
+      const arr = dk ? (data as Record<string, unknown>)[dk] : undefined;
+      return Array.isArray(arr) && arr.length ? String(arr.length) : '';
+    };
+
+    const NAV: { label: string; hint: string; lat: number; lng: number; zoom: number }[] = [
+      { label: 'Global View', hint: 'Whole earth', lat: 20, lng: 0, zoom: 2.5 },
+      { label: 'Ukraine', hint: 'Active conflict', lat: 49, lng: 32, zoom: 6 },
+      { label: 'Middle East', hint: 'Regional theatre', lat: 30, lng: 45, zoom: 4.5 },
+      { label: 'Gaza / Israel', hint: 'Conflict zone', lat: 31.5, lng: 34.7, zoom: 8 },
+      { label: 'Taiwan Strait', hint: 'Flashpoint', lat: 24.5, lng: 120, zoom: 6.5 },
+      { label: 'South China Sea', hint: 'Disputed waters', lat: 14, lng: 114, zoom: 5 },
+      { label: 'Strait of Hormuz', hint: 'Oil chokepoint', lat: 26.6, lng: 56.3, zoom: 7.5 },
+      { label: 'Suez Canal', hint: 'Maritime chokepoint', lat: 30.5, lng: 32.35, zoom: 8 },
+      { label: 'Panama Canal', hint: 'Maritime chokepoint', lat: 9.1, lng: -79.7, zoom: 8 },
+      { label: 'Bab-el-Mandeb', hint: 'Red Sea gate', lat: 12.6, lng: 43.3, zoom: 7.5 },
+      { label: 'Washington DC', hint: 'Capital', lat: 38.9, lng: -77.04, zoom: 9 },
+      { label: 'Moscow', hint: 'Capital', lat: 55.75, lng: 37.62, zoom: 9 },
+      { label: 'Beijing', hint: 'Capital', lat: 39.9, lng: 116.4, zoom: 9 },
+      { label: 'London', hint: 'Capital', lat: 51.5, lng: -0.12, zoom: 9 },
+      { label: 'Kyiv', hint: 'Capital', lat: 50.45, lng: 30.52, zoom: 9 },
+      { label: 'Tehran', hint: 'Capital', lat: 35.7, lng: 51.4, zoom: 9 },
+      { label: 'Pyongyang', hint: 'Capital', lat: 39.04, lng: 125.76, zoom: 9 },
+    ];
+
+    const cmds: PaletteCommand[] = [];
+
+    // Layers
+    for (const l of LAYER_DEFS) {
+      const on = !!activeLayers[l.key];
+      const cnt = on ? layerCount(l.key as string) : '';
+      cmds.push({
+        id: `layer:${String(l.key)}`,
+        group: 'LAYERS',
+        title: `${on ? 'Hide' : 'Show'} ${l.label}`,
+        subtitle: l.hint,
+        keywords: `layer toggle ${l.label} ${l.hint}`,
+        icon: <Layers className="w-4 h-4" />,
+        badge: on ? (cnt || 'ON') : 'OFF',
+        active: on,
+        keepOpen: true,
+        run: () => setActiveLayers(prev => ({ ...prev, [l.key]: !prev[l.key] })),
+      });
+    }
+
+    // Navigation
+    for (const n of NAV) {
+      cmds.push({
+        id: `nav:${n.label}`,
+        group: 'NAVIGATE',
+        title: `Fly to ${n.label}`,
+        subtitle: n.hint,
+        keywords: `go navigate location ${n.label} ${n.hint}`,
+        icon: <Crosshair className="w-4 h-4" />,
+        run: () => flyTo(n.lat, n.lng, n.zoom),
+      });
+    }
+
+    // Panels & tools
+    cmds.push(
+      { id: 'panel:recon', group: 'TOOLS', title: 'Open RECON / OSINT Toolkit', subtitle: 'Scanner · WHOIS · DNS · Crypto · Sanctions', keywords: 'recon osint scanner whois dns vuln crypto sanctions', icon: <Radar className="w-4 h-4" />, run: () => { closeRightPanels(); setShowIntel(true); } },
+      { id: 'panel:markets', group: 'TOOLS', title: 'Open Markets & Intel', subtitle: 'Indices · commodities · space weather', keywords: 'markets stocks commodities finance', icon: <BarChart3 className="w-4 h-4" />, run: () => { closeRightPanels(); setShowMarkets(true); } },
+      { id: 'panel:alerts', group: 'TOOLS', title: 'Open Live Alerts', subtitle: 'Real-time event stream', keywords: 'alerts warnings events', icon: <AlertTriangle className="w-4 h-4" />, run: () => { closeRightPanels(); setShowAlerts(true); } },
+      { id: 'panel:graph', group: 'TOOLS', title: 'Open Entity Graph', subtitle: 'Link analysis & fusion', keywords: 'entity graph network link analysis', icon: <Network className="w-4 h-4" />, run: () => { closeRightPanels(); setShowEntityGraph(true); } },
+      { id: 'panel:search', group: 'TOOLS', title: 'Open Search', subtitle: 'Find places & entities', keywords: 'search find place', icon: <Search className="w-4 h-4" />, run: () => { closeRightPanels(); setShowDesktopSearch(true); } },
+      { id: 'panel:layers', group: 'TOOLS', title: 'Toggle Layer Sidebar', subtitle: 'Show / hide layer rail', keywords: 'layers panel sidebar', icon: <Layers className="w-4 h-4" />, keepOpen: true, run: () => setShowLayers(p => !p) },
+    );
+
+    // Display
+    cmds.push(
+      { id: 'disp:proj', group: 'DISPLAY', title: mapProjection === 'globe' ? 'Switch to 2D Map' : 'Switch to 3D Globe', subtitle: 'Map projection', keywords: 'globe mercator 2d 3d projection', icon: <Globe className="w-4 h-4" />, badge: mapProjection === 'globe' ? 'GLOBE' : 'FLAT', active: mapProjection === 'globe', keepOpen: true, run: () => setMapProjection(p => p === 'globe' ? 'mercator' : 'globe') },
+      { id: 'disp:style', group: 'DISPLAY', title: mapStyle === 'dark' ? 'Satellite Imagery' : 'Night / Dark Basemap', subtitle: 'Basemap style', keywords: 'satellite imagery dark night basemap style', icon: <Satellite className="w-4 h-4" />, badge: mapStyle === 'satellite' ? 'SAT' : 'DARK', active: mapStyle === 'satellite', keepOpen: true, run: () => setMapStyle(s => s === 'dark' ? 'satellite' : 'dark') },
+      { id: 'disp:theme', group: 'DISPLAY', title: osirisTheme === 'ghost' ? 'Core Protocol (Gold)' : 'Ghost Protocol (Violet)', subtitle: 'Interface theme', keywords: 'theme ghost core gold violet colour', icon: <Moon className="w-4 h-4" />, badge: osirisTheme === 'ghost' ? 'GHOST' : 'CORE', active: osirisTheme === 'ghost', keepOpen: true, run: () => setOsirisTheme(t => t === 'core' ? 'ghost' : 'core') },
+      { id: 'disp:fs', group: 'DISPLAY', title: 'Toggle Fullscreen', subtitle: 'Immersive mode', keywords: 'fullscreen immersive', icon: <MapPinned className="w-4 h-4" />, run: toggleFullscreen },
+    );
+
+    return cmds;
+  }, [activeLayers, mapProjection, mapStyle, osirisTheme, data, flyTo, closeRightPanels, toggleFullscreen]);
+
 
   return (
     <main className="fixed inset-0 w-full h-full bg-[var(--bg-void)] overflow-hidden">
@@ -780,44 +907,51 @@ export default function Dashboard() {
       </ErrorBoundary>
 
 
-      {/* ── MAP VIEW CONTROLS (3D/2D + SATELLITE TOGGLE) ── */}
+      {/* ── MAP VIEW CONTROLS (3D/2D + SATELLITE TOGGLE) — unified glass control ── */}
       <motion.div
         initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 3.5 }}
-        className="absolute bottom-[75px] md:bottom-[100px] z-[200] flex items-center gap-2 pointer-events-none"
+        className="absolute bottom-[75px] md:bottom-[100px] z-[200] flex items-center pointer-events-none"
         style={{ left: isMobile ? '12px' : '120px' }}
       >
-        {/* 3D/2D Toggle */}
-        <button
-          onClick={() => setMapProjection(p => p === 'globe' ? 'mercator' : 'globe')}
-          className="glass-panel p-3.5 pointer-events-auto hover:border-[var(--gold-primary)]/40 transition-colors group relative"
-          title={mapProjection === 'globe' ? 'Switch to 2D Map' : 'Switch to 3D Globe'}
-        >
-          {mapProjection === 'globe' ? (
-            <MapPinned className="w-5 h-5 text-[var(--gold-primary)] group-hover:scale-110 transition-transform" />
-          ) : (
-            <Globe className="w-5 h-5 text-[var(--cyan-primary)] group-hover:scale-110 transition-transform" />
-          )}
-          <span className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 text-[9px] font-mono text-[var(--text-muted)] whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity glass-panel px-2 py-1 z-[300]">
-            {mapProjection === 'globe' ? '2D MAP' : '3D GLOBE'}
-          </span>
-        </button>
+        <div className="glass-panel flex items-center gap-1 p-1 pointer-events-auto">
+          {/* 3D/2D Toggle */}
+          <button
+            onClick={() => setMapProjection(p => p === 'globe' ? 'mercator' : 'globe')}
+            className="group relative flex items-center justify-center w-10 h-10 rounded-[10px] transition-colors"
+            style={{
+              background: mapProjection === 'globe' ? 'rgba(0,229,255,0.12)' : 'transparent',
+              boxShadow: mapProjection === 'globe' ? 'inset 0 0 0 1px rgba(0,229,255,0.35)' : 'none',
+            }}
+            title={mapProjection === 'globe' ? 'Switch to 2D Map' : 'Switch to 3D Globe'}
+          >
+            {mapProjection === 'globe'
+              ? <Globe className="w-[18px] h-[18px] text-[var(--cyan-primary)] group-hover:scale-110 transition-transform" />
+              : <MapPinned className="w-[18px] h-[18px] text-[var(--text-secondary)] group-hover:text-[var(--gold-primary)] group-hover:scale-110 transition-all" />}
+            <span className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 text-[8px] font-mono tracking-widest text-[var(--text-secondary)] whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity glass-panel px-2 py-1 z-[300]">
+              {mapProjection === 'globe' ? '3D GLOBE' : '2D MAP'}
+            </span>
+          </button>
 
-        {/* Map Style Toggle */}
-        <button
-          onClick={() => setMapStyle(s => s === 'dark' ? 'satellite' : 'dark')}
-          className="glass-panel p-3.5 pointer-events-auto hover:border-[var(--gold-primary)]/40 transition-colors group relative"
-          title={mapStyle === 'dark' ? 'Satellite View' : 'Night View'}
-        >
-          {mapStyle === 'dark' ? (
-            <Satellite className="w-5 h-5 text-[var(--alert-green)] group-hover:scale-110 transition-transform" />
-          ) : (
-            <Moon className="w-5 h-5 text-[var(--cyan-primary)] group-hover:scale-110 transition-transform" />
-          )}
-          <span className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 text-[9px] font-mono text-[var(--text-muted)] whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity glass-panel px-2 py-1 z-[300]">
-            {mapStyle === 'dark' ? 'SATELLITE' : 'NIGHT MODE'}
-          </span>
-        </button>
+          <div className="w-px h-6 bg-white/10" />
 
+          {/* Map Style Toggle */}
+          <button
+            onClick={() => setMapStyle(s => s === 'dark' ? 'satellite' : 'dark')}
+            className="group relative flex items-center justify-center w-10 h-10 rounded-[10px] transition-colors"
+            style={{
+              background: mapStyle === 'satellite' ? 'rgba(0,230,118,0.12)' : 'transparent',
+              boxShadow: mapStyle === 'satellite' ? 'inset 0 0 0 1px rgba(0,230,118,0.35)' : 'none',
+            }}
+            title={mapStyle === 'dark' ? 'Switch to Satellite' : 'Switch to Night'}
+          >
+            {mapStyle === 'satellite'
+              ? <Satellite className="w-[18px] h-[18px] text-[var(--alert-green)] group-hover:scale-110 transition-transform" />
+              : <Moon className="w-[18px] h-[18px] text-[var(--text-secondary)] group-hover:text-[var(--cyan-primary)] group-hover:scale-110 transition-all" />}
+            <span className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 text-[8px] font-mono tracking-widest text-[var(--text-secondary)] whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity glass-panel px-2 py-1 z-[300]">
+              {mapStyle === 'satellite' ? 'SATELLITE' : 'NIGHT'}
+            </span>
+          </button>
+        </div>
       </motion.div>
 
       {/* ── HEADER ── */}
@@ -897,14 +1031,28 @@ export default function Dashboard() {
       {/* ── RIGHT TOOL STRIP (desktop only — mobile uses bottom nav) ── */}
       {!isMobile && <div className="absolute right-2 top-1/2 -translate-y-1/2 flex flex-col gap-2 z-[250] pointer-events-auto bg-black/40 backdrop-blur-sm p-1 rounded-full border border-white/5">
         <div className="relative group">
-          <button onClick={() => { setShowIntel(!showIntel); setShowMarkets(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showIntel ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`}>
+          <button onClick={() => { setShowFusion(!showFusion); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showFusion ? 'bg-[#FF1744]/20' : 'hover:bg-white/10'}`} title="Global Threat Fusion">
+            <Activity className={`w-4 h-4 ${showFusion ? 'text-[#FF1744]' : 'text-white/60'}`} />
+          </button>
+          {/* Threat Fusion HUD Slideout */}
+          <AnimatePresence>
+            {showFusion && (
+              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2">
+                <ThreatFusionHUD onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMapView(v => ({ ...v, zoom: Math.max(v.zoom, 5) })); }} />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
+        <div className="relative group">
+          <button onClick={() => { setShowIntel(!showIntel); setShowMarkets(false); setShowAlerts(false); setShowFusion(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showIntel ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`}>
             <Radar className={`w-4 h-4 ${showIntel ? 'text-[var(--cyan-primary)]' : 'text-white/60'}`} />
           </button>
           {/* OSINT / Recon Panel Slideout */}
           <AnimatePresence>
             {showIntel && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
-                <OsintPanel theme={osirisTheme} setTheme={setOsirisTheme} onSweepVisualize={setSweepData} onScanGeolocate={(target, data) => {
+                <OsintPanel onSweepVisualize={setSweepData} onScanGeolocate={(target, data) => {
                   setScanTargets(prev => {
                     const existing = prev.filter(t => t.id !== target);
                     return [{ id: target, timestamp: Date.now(), ...data }, ...existing].slice(0, 10);
@@ -917,7 +1065,7 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`}>
+          <button onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); setShowFusion(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`}>
             <BarChart3 className={`w-4 h-4 ${showMarkets ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
           {/* Markets Panel Slideout */}
@@ -931,7 +1079,7 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowAlerts(!showAlerts); setShowIntel(false); setShowMarkets(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showAlerts ? 'bg-[#FF3D3D]/20' : 'hover:bg-white/10'}`}>
+          <button onClick={() => { setShowAlerts(!showAlerts); setShowIntel(false); setShowMarkets(false); setShowEntityGraph(false); setShowFusion(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showAlerts ? 'bg-[#FF3D3D]/20' : 'hover:bg-white/10'}`}>
             <AlertTriangle className={`w-4 h-4 ${showAlerts ? 'text-[#FF3D3D]' : 'text-white/60'}`} />
           </button>
           {/* Alerts Panel Slideout */}
@@ -1229,15 +1377,18 @@ export default function Dashboard() {
         </div>
       ))}
 
+      {/* Command Palette (⌘K / Ctrl+K) */}
+      <CommandPalette commands={paletteCommands} />
+
       {/* Keyboard Shortcuts Overlay */}
       <KeyboardShortcuts />
 
       {/* ── GLOBAL STATUS TICKER (bottom) ── */}
-      <GlobalStatusBar />
+      <GlobalStatusBar onThreatClick={() => { closeRightPanels(); setShowFusion(true); }} />
 
       {/* Shortcut hint */}
       <div className="desktop-only absolute bottom-[26px] right-5 z-[200] pointer-events-none text-[6px] font-mono text-[var(--text-muted)]/40 tracking-widest">
-        [?] SHORTCUTS · [F] FULLSCREEN · [S] SHARE · [R] RESET VIEW
+        [⌘K] COMMAND · [?] SHORTCUTS · [F] FULLSCREEN · [S] SHARE · [R] RESET VIEW
       </div>
 
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useState, useEffect, useMemo, useRef, useCallback, type ReactNode } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Search, CornerDownLeft, ArrowUp, ArrowDown, Command as CommandIcon } from 'lucide-react';
+
+export interface PaletteCommand {
+  id: string;
+  title: string;
+  subtitle?: string;
+  group: string;
+  keywords?: string;
+  icon?: ReactNode;
+  /** Right-aligned status pill, e.g. a live count or "ON" */
+  badge?: string;
+  /** Renders the badge in the active/accent colour */
+  active?: boolean;
+  run: () => void;
+  /** Keep palette open after running (for toggles) */
+  keepOpen?: boolean;
+}
+
+interface CommandPaletteProps {
+  commands: PaletteCommand[];
+}
+
+/** Subsequence fuzzy match — returns a score (higher = better) or -1 for no match. */
+function fuzzyScore(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  const h = haystack.toLowerCase();
+  const n = needle.toLowerCase();
+  const idx = h.indexOf(n);
+  if (idx !== -1) return 1000 - idx; // contiguous substring — strongly preferred
+  // fall back to subsequence
+  let hi = 0;
+  let score = 0;
+  let streak = 0;
+  for (let ni = 0; ni < n.length; ni++) {
+    const c = n[ni];
+    let found = -1;
+    for (; hi < h.length; hi++) {
+      if (h[hi] === c) { found = hi; break; }
+    }
+    if (found === -1) return -1;
+    streak = hi > 0 && h[hi - 1] === n[ni - 1] ? streak + 1 : 0;
+    score += 1 + streak;
+    hi++;
+  }
+  return score;
+}
+
+export default function CommandPalette({ commands }: CommandPaletteProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => { setOpen(false); setQuery(''); setSelected(0); }, []);
+
+  // ── Global open shortcut: ⌘K / Ctrl+K ──
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault();
+        setOpen(prev => {
+          if (!prev) { setQuery(''); setSelected(0); } // reset on open
+          return !prev;
+        });
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  // Focus the input whenever the palette opens (no state writes — lint-safe).
+  useEffect(() => {
+    if (!open) return;
+    const t = setTimeout(() => inputRef.current?.focus(), 20);
+    return () => clearTimeout(t);
+  }, [open]);
+
+  const results = useMemo(() => {
+    if (!query.trim()) return commands;
+    return commands
+      .map(c => ({ c, s: fuzzyScore(`${c.title} ${c.subtitle ?? ''} ${c.keywords ?? ''} ${c.group}`, query.trim()) }))
+      .filter(x => x.s >= 0)
+      .sort((a, b) => b.s - a.s)
+      .map(x => x.c);
+  }, [commands, query]);
+
+  // Group results while preserving the sorted order of first appearance.
+  const groups = useMemo(() => {
+    const order: string[] = [];
+    const map = new Map<string, PaletteCommand[]>();
+    for (const c of results) {
+      if (!map.has(c.group)) { map.set(c.group, []); order.push(c.group); }
+      map.get(c.group)!.push(c);
+    }
+    // Flat index lookup for keyboard navigation
+    const flat: PaletteCommand[] = [];
+    for (const g of order) flat.push(...map.get(g)!);
+    return { order, map, flat };
+  }, [results]);
+
+  const runAt = useCallback((i: number) => {
+    const cmd = groups.flat[i];
+    if (!cmd) return;
+    cmd.run();
+    if (!cmd.keepOpen) close();
+  }, [groups, close]);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') { e.preventDefault(); close(); return; }
+    if (e.key === 'ArrowDown') { e.preventDefault(); setSelected(s => Math.min(s + 1, groups.flat.length - 1)); }
+    if (e.key === 'ArrowUp') { e.preventDefault(); setSelected(s => Math.max(s - 1, 0)); }
+    if (e.key === 'Enter') { e.preventDefault(); runAt(selected); }
+  };
+
+  // Keep the selected row in view.
+  useEffect(() => {
+    const el = listRef.current?.querySelector<HTMLElement>(`[data-idx="${selected}"]`);
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [selected]);
+
+  let flatIndex = -1;
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+          className="fixed inset-0 z-[900] flex items-start justify-center pointer-events-auto"
+          onClick={close}
+          style={{ paddingTop: 'clamp(56px, 14vh, 160px)' }}
+        >
+          <div className="absolute inset-0 bg-[var(--bg-void)]/75 backdrop-blur-[3px]" />
+
+          <motion.div
+            initial={{ opacity: 0, y: -14, scale: 0.985 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -8, scale: 0.99 }}
+            transition={{ type: 'spring', damping: 26, stiffness: 320 }}
+            onClick={e => e.stopPropagation()}
+            className="relative w-[92vw] max-w-[620px] rounded-2xl overflow-hidden osiris-glow"
+            style={{
+              background: 'rgba(6,8,16,0.86)',
+              backdropFilter: 'blur(40px) saturate(1.4)',
+              WebkitBackdropFilter: 'blur(40px) saturate(1.4)',
+              border: '1px solid var(--border-active)',
+              boxShadow: '0 24px 80px rgba(0,0,0,0.65), 0 0 40px var(--gold-glow)',
+            }}
+          >
+            {/* ── Search header ── */}
+            <div className="flex items-center gap-3 px-4 py-3.5 border-b border-[var(--border-primary)]">
+              <Search className="w-4 h-4 text-[var(--gold-primary)] shrink-0" />
+              <input
+                ref={inputRef}
+                value={query}
+                onChange={e => { setQuery(e.target.value); setSelected(0); }}
+                onKeyDown={onKeyDown}
+                placeholder="Search layers, regions, tools, display…"
+                spellCheck={false}
+                autoComplete="off"
+                className="flex-1 bg-transparent outline-none text-[14px] font-mono text-[var(--text-primary)] placeholder:text-[var(--text-muted)] tracking-wide"
+              />
+              <kbd className="hidden sm:flex items-center gap-1 px-1.5 py-0.5 rounded text-[8px] font-mono text-[var(--text-muted)] border border-[var(--border-primary)]">
+                <CommandIcon className="w-2.5 h-2.5" />K
+              </kbd>
+            </div>
+
+            {/* ── Results ── */}
+            <div ref={listRef} className="max-h-[52vh] overflow-y-auto py-2 styled-scrollbar">
+              {groups.flat.length === 0 && (
+                <div className="px-4 py-10 text-center text-[11px] font-mono text-[var(--text-muted)] tracking-widest">
+                  NO MATCHING COMMANDS
+                </div>
+              )}
+              {groups.order.map(group => (
+                <div key={group} className="mb-1">
+                  <div className="px-4 pt-2 pb-1 text-[8px] font-mono tracking-[0.25em] uppercase text-[var(--text-muted)]/70">
+                    {group}
+                  </div>
+                  {groups.map.get(group)!.map(cmd => {
+                    flatIndex++;
+                    const idx = flatIndex;
+                    const isSel = idx === selected;
+                    return (
+                      <button
+                        key={cmd.id}
+                        data-idx={idx}
+                        onMouseMove={() => setSelected(idx)}
+                        onClick={() => runAt(idx)}
+                        className="w-full flex items-center gap-3 px-4 py-2 text-left transition-colors"
+                        style={{
+                          background: isSel ? 'var(--hover-accent)' : 'transparent',
+                          borderLeft: isSel ? '2px solid var(--gold-primary)' : '2px solid transparent',
+                        }}
+                      >
+                        <span
+                          className="w-4 h-4 shrink-0 flex items-center justify-center"
+                          style={{ color: isSel ? 'var(--gold-primary)' : 'var(--text-secondary)' }}
+                        >
+                          {cmd.icon}
+                        </span>
+                        <span className="flex-1 min-w-0">
+                          <span className={`block text-[12.5px] font-mono tracking-wide truncate ${isSel ? 'text-[var(--text-heading)]' : 'text-[var(--text-primary)]'}`}>
+                            {cmd.title}
+                          </span>
+                          {cmd.subtitle && (
+                            <span className="block text-[9px] font-mono text-[var(--text-muted)] truncate">{cmd.subtitle}</span>
+                          )}
+                        </span>
+                        {cmd.badge && (
+                          <span
+                            className="shrink-0 px-1.5 py-0.5 rounded text-[8px] font-mono font-bold tabular-nums tracking-wider"
+                            style={{
+                              color: cmd.active ? 'var(--gold-primary)' : 'var(--text-muted)',
+                              background: cmd.active ? 'var(--gold-glow)' : 'rgba(255,255,255,0.03)',
+                              border: `1px solid ${cmd.active ? 'var(--border-active)' : 'var(--border-secondary)'}`,
+                            }}
+                          >
+                            {cmd.badge}
+                          </span>
+                        )}
+                        {isSel && <CornerDownLeft className="w-3 h-3 text-[var(--gold-primary)] shrink-0" />}
+                      </button>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+
+            {/* ── Footer hint ── */}
+            <div className="flex items-center justify-between px-4 py-2 border-t border-[var(--border-primary)] text-[8px] font-mono text-[var(--text-muted)] tracking-widest">
+              <span className="flex items-center gap-2">
+                <span className="flex items-center gap-1"><ArrowUp className="w-2.5 h-2.5" /><ArrowDown className="w-2.5 h-2.5" /> NAVIGATE</span>
+                <span className="flex items-center gap-1"><CornerDownLeft className="w-2.5 h-2.5" /> RUN</span>
+                <span>ESC CLOSE</span>
+              </span>
+              <span className="text-[var(--gold-primary)]/60">{groups.flat.length} CMD</span>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/GlobalStatusBar.tsx
+++ b/src/components/GlobalStatusBar.tsx
@@ -42,11 +42,27 @@ const formatPrice = (price: number) => {
   return `$${price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 };
 
-export default function GlobalStatusBar() {
+interface ThreatState { threatcon: number; level_label: string; level_color: string; overall: number; dominant_domain?: string; }
+
+export default function GlobalStatusBar({ onThreatClick }: { onThreatClick?: () => void }) {
   const [crypto, setCrypto] = useState<CryptoPrice[]>([]);
   const [quakes, setQuakes] = useState<Earthquake[]>([]);
+  const [threat, setThreat] = useState<ThreatState | null>(null);
 
   const [hoveredQuake, setHoveredQuake] = useState<Earthquake | null>(null);
+
+  // Live THREATCON from the server-computed fusion (tiny, edge-cached payload).
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const r = await fetch('/api/fusion', { signal: AbortSignal.timeout(30000) });
+        if (r.ok) setThreat(await r.json());
+      } catch { /* keep last */ }
+    };
+    load();
+    const iv = setInterval(load, 60000);
+    return () => clearInterval(iv);
+  }, []);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -103,7 +119,7 @@ export default function GlobalStatusBar() {
     return () => clearInterval(iv);
   }, []);
 
-  if (crypto.length === 0 && quakes.length === 0) return null;
+  if (crypto.length === 0 && quakes.length === 0 && !threat) return null;
 
   const cryptoContent = crypto.length > 0 ? (
     <>
@@ -159,6 +175,21 @@ export default function GlobalStatusBar() {
         <div className="flex-shrink-0 px-3 h-full flex items-center gap-1 border-r border-[var(--cyan-primary)]/30 bg-black pointer-events-auto relative z-10 shadow-[4px_0_10px_rgba(0,0,0,0.5)]">
           <span className="text-[var(--cyan-primary)] font-bold">LIVE</span>
         </div>
+
+        {/* THREATCON badge — live fusion read, click to open the Threat Fusion panel */}
+        {threat && (
+          <button
+            onClick={onThreatClick}
+            title={`Global threat: ${threat.overall}/100 · dominant ${threat.dominant_domain || '—'} — open Threat Fusion`}
+            className="flex-shrink-0 px-3 h-full flex items-center gap-1.5 border-r bg-black pointer-events-auto relative z-10 hover:bg-white/5 transition-colors"
+            style={{ borderColor: `${threat.level_color}40` }}
+          >
+            <span className="w-1.5 h-1.5 rounded-full animate-osiris-pulse" style={{ background: threat.level_color, boxShadow: `0 0 6px ${threat.level_color}` }} />
+            <span className="font-bold" style={{ color: threat.level_color }}>THREATCON {threat.threatcon}</span>
+            <span className="text-[var(--text-muted)]">{threat.level_label}</span>
+            <span className="tabular-nums" style={{ color: threat.level_color }}>{threat.overall}</span>
+          </button>
+        )}
 
         {/* CSS-animated ticker */}
         <div className="flex-1 overflow-hidden relative" style={{ maskImage: 'linear-gradient(to right, transparent, black 5%, black 95%, transparent)' }}>

--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Keyboard, X } from 'lucide-react';
 
 const SHORTCUTS = [
+  { key: '⌘K', desc: 'Command palette' },
   { key: 'F', desc: 'Toggle fullscreen' },
   { key: 'S', desc: 'Share current view' },
   { key: 'L', desc: 'Toggle layer panel' },

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -145,14 +145,14 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       center: [25.48, 42.70], zoom: 6.5, minZoom: 1.5, maxZoom: 18,
       attributionControl: false,
       maxPitch: 85,
-      transformRequest: (url: string) => {
-        // Route all CARTO CDN requests through the internal Next.js proxy API
-        if (url.includes('cartocdn.com')) {
-          const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
-          return { url: `${baseUrl}/api/proxy-tiles?url=${encodeURIComponent(url)}` };
-        }
-        return { url };
-      },
+      // Load CARTO basemap tiles DIRECTLY in the browser. Previously every tile
+      // was routed through /api/proxy-tiles, so the map fired dozens of server-side
+      // tile fetches per pan/zoom — when CARTO was momentarily slow these hung and
+      // poisoned the Next server's shared outbound connection pool, which silently
+      // broke the data feeds (CCTV, earthquakes, malware, …). CARTO's public tiles
+      // are CORS-enabled (Access-Control-Allow-Origin: *), so direct loading is
+      // correct, faster, and keeps the server's fetch pool healthy for real data.
+      transformRequest: (url: string) => ({ url }),
     });
 
     map.on('load', () => {
@@ -262,39 +262,49 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
 
 
 
-      // ══ NETWORK INTEL — Live Malware (abuse.ch) — crimson threat ══
+      // ══ NETWORK INTEL — Live Malware (abuse.ch) — colour-coded by severity ══
+      // critical = live botnet C2 (crimson), high = malware distribution (amber).
+      const malwareColor = ['match', ['get', 'severity'],
+        'critical', '#FF1744',
+        'high', '#FF9500',
+        '#FFD54F' /* medium / default */] as any;
       map.addLayer({ id: 'malware-glow', type: 'circle', source: 'malware-nodes', paint: {
-        'circle-radius': ['interpolate',['linear'],['zoom'], 1,6, 5,12, 10,20],
-        'circle-color': '#D32F2F', 'circle-opacity': 0.06, 'circle-blur': 0.5,
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,6, 5,12, 10,22],
+        'circle-color': malwareColor, 'circle-opacity': 0.07, 'circle-blur': 0.5,
       }});
       map.addLayer({ id: 'malware-dots', type: 'circle', source: 'malware-nodes', paint: {
-        'circle-radius': ['interpolate',['linear'],['zoom'], 1,2, 5,4, 10,6],
-        'circle-color': '#D32F2F',
+        // Critical C2 nodes render larger than distribution hosts.
+        'circle-radius': ['interpolate',['linear'],['zoom'],
+          1, ['case', ['==', ['get','severity'], 'critical'], 3.5, 2],
+          5, ['case', ['==', ['get','severity'], 'critical'], 6, 4],
+          10, ['case', ['==', ['get','severity'], 'critical'], 9, 6]],
+        'circle-color': malwareColor,
         'circle-opacity': 0.9,
-        'circle-stroke-width': 1, 'circle-stroke-color': '#000000', 'circle-stroke-opacity': 0.8,
+        'circle-stroke-width': ['case', ['==', ['get','severity'], 'critical'], 1.5, 1],
+        'circle-stroke-color': '#000000', 'circle-stroke-opacity': 0.8,
       }});
       map.addLayer({ id: 'malware-label', type: 'symbol', source: 'malware-nodes', minzoom: 5, layout: {
         'text-field': ['get','malware'], 'text-size': 8, 'text-font': ['JetBrains Mono Bold', 'Open Sans Bold'],
         'text-offset': [0, 1.5], 'text-max-width': 10, 'text-allow-overlap': false,
-      }, paint: { 'text-color': '#D32F2F', 'text-halo-color': '#111', 'text-halo-width': 1.5, 'text-opacity': 0.85 }});
+      }, paint: { 'text-color': malwareColor, 'text-halo-color': '#111', 'text-halo-width': 1.5, 'text-opacity': 0.85 }});
 
-      // ── NETWORK INTEL MESH (SDK STYLE) ──
+      // ── NETWORK INTEL MESH — Live Malware botnet web (always red) ──
       map.addLayer({ id: 'network-mesh-atmo', type: 'line', source: 'network-mesh', paint: {
-
+        'line-color': '#FF1744',
         'line-width': ['interpolate',['linear'],['zoom'], 1, 2, 5, 4, 10, 8],
         'line-opacity': 0.08,
         'line-blur': 4,
       }});
       map.addLayer({ id: 'network-mesh-glow', type: 'line', source: 'network-mesh', paint: {
-
+        'line-color': '#FF1744',
         'line-width': ['interpolate',['linear'],['zoom'], 1, 1, 5, 2, 10, 4],
         'line-opacity': 0.2,
         'line-blur': 1.5,
       }});
       map.addLayer({ id: 'network-mesh-core', type: 'line', source: 'network-mesh', paint: {
-
+        'line-color': '#FF3D3D',
         'line-width': ['interpolate',['linear'],['zoom'], 1, 0.2, 5, 0.5, 10, 1.5],
-        'line-opacity': 0.4,
+        'line-opacity': 0.45,
       }});
 
 
@@ -551,15 +561,19 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       }});
 
       // Maritime Ships (moving entities) — ocean teal family
+      const shipColor = ['match', ['get','type'],
+        'military','#D32F2F', 'tanker','#E65100', 'cargo','#26C6DA',
+        'passenger','#66BB6A', 'fishing','#AB47BC', 'hsc','#FFD54F',
+        '#B0BEC5'] as any;
       map.addLayer({ id: 'ship-dots', type: 'circle', source: 'maritime-ships', paint: {
         'circle-radius': ['interpolate',['linear'],['zoom'], 1,2, 5,4, 10,6],
-        'circle-color': ['match', ['get','type'], 'military','#D32F2F', 'tanker','#E65100', 'cargo','#26C6DA', '#B0BEC5'],
+        'circle-color': shipColor,
         'circle-opacity': 0.75,
       }});
-      map.addLayer({ id: 'ship-label', type: 'symbol', source: 'maritime-ships', minzoom: 5, layout: {
+      map.addLayer({ id: 'ship-label', type: 'symbol', source: 'maritime-ships', minzoom: 7, layout: {
         'text-field': ['get','name'], 'text-size': 9, 'text-font': ['Open Sans Regular'],
         'text-offset': [0, 1.2], 'text-allow-overlap': false,
-      }, paint: { 'text-color': ['match', ['get','type'], 'military','#D32F2F', 'tanker','#E65100', 'cargo','#26C6DA', '#B0BEC5'], 'text-halo-color': '#000', 'text-halo-width': 1 }});
+      }, paint: { 'text-color': shipColor, 'text-halo-color': '#000', 'text-halo-width': 1 }});
 
       setMapReady(true);
     });
@@ -693,28 +707,36 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       </div>`);
     });
 
-    // ── Malware Threats (Abuse.ch) ──
+    // ── Malware Threats (abuse.ch — Feodo C2 + URLhaus distribution) ──
     map.on('click', 'malware-dots', e => {
       if (!e.features?.length) return;
       const p = e.features[0].properties as any;
       const coords = (e.features[0].geometry as any).coordinates;
-      const tType = (p.threat_type || 'MALWARE').toUpperCase();
-      const statusColor = p.status === 'online' ? '#39FF14' : '#FF1744';
-      
-      popup(coords, `<div style="${pStyle}border:1px solid rgba(255,23,68,0.4);box-shadow:inset 0 0 12px rgba(255,23,68,0.1);">
-        <div style="display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid rgba(255,23,68,0.3);padding-bottom:6px;margin-bottom:8px;">
-          <div style="color:#FF1744;font-size:12px;font-weight:700;letter-spacing:0.1em;text-shadow:0 0 4px rgba(255,23,68,0.5);">[ ${htmlEsc(tType)} ]</div>
-          <div style="color:#5C5A54;font-size:9px;">${htmlEsc(p.country || 'UNKNOWN')}</div>
+      const sev = (p.severity || 'high') as string;
+      const accent = sev === 'critical' ? '#FF1744' : sev === 'high' ? '#FF9500' : '#FFD54F';
+      const typeLabel = ({ botnet_c2: 'BOTNET C2', malware_download: 'MALWARE DOWNLOAD', payload_delivery: 'PAYLOAD DELIVERY', malware: 'MALWARE' } as Record<string,string>)[p.threat_type] || 'MALWARE';
+      const statusColor = (p.status || '').toLowerCase() === 'online' ? '#39FF14' : (p.status || '').toLowerCase() === 'offline' ? '#8A8880' : '#FF9500';
+      const ref = p.reference || 'https://urlhaus.abuse.ch/';
+      const locus = [p.city, p.country].filter(Boolean).map(htmlEsc).join(', ') || 'UNKNOWN';
+
+      popup(coords, `<div style="${pStyle}border:1px solid ${accent}66;box-shadow:inset 0 0 12px ${accent}1a;">
+        <div style="display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid ${accent}4d;padding-bottom:6px;margin-bottom:8px;">
+          <div style="color:${accent};font-size:12px;font-weight:700;letter-spacing:0.1em;text-shadow:0 0 4px ${accent}80;">[ ${typeLabel} ]</div>
+          <div style="color:${accent};font-size:8px;font-weight:700;border:1px solid ${accent}66;border-radius:3px;padding:1px 5px;letter-spacing:0.1em;">${sev.toUpperCase()}</div>
         </div>
-        <div style="color:#E8E6E0;font-size:11px;font-weight:bold;margin-bottom:10px;">${htmlEsc(p.malware || 'Unidentified Threat Payload')}</div>
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;margin-bottom:12px;background:rgba(0,0,0,0.3);padding:6px;border-radius:4px;">
-          <div><span style="color:#5C5A54;">TARGET IP</span><br/><span style="color:#00E5FF;font-family:monospace;">${htmlEsc(p.ip)}</span></div>
+        <div style="color:#E8E6E0;font-size:12px;font-weight:bold;margin-bottom:2px;">${htmlEsc(p.malware || 'Unidentified')}</div>
+        <div style="color:#5C5A54;font-size:9px;margin-bottom:10px;">📍 ${locus}</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;margin-bottom:8px;background:rgba(0,0,0,0.3);padding:6px;border-radius:4px;">
+          <div><span style="color:#5C5A54;">HOST IP</span><br/><span style="color:#00E5FF;font-family:monospace;">${htmlEsc(p.ip)}${p.port ? ':' + htmlEsc(String(p.port)) : ''}</span></div>
           <div><span style="color:#5C5A54;">STATUS</span><br/><span style="color:${statusColor};">${(p.status||'UNKNOWN').toUpperCase()}</span></div>
+          <div style="grid-column:1 / -1;"><span style="color:#5C5A54;">HOSTING / ASN</span><br/><span style="color:#E8E6E0;font-family:monospace;font-size:8px;">${htmlEsc(p.asn || p.isp || 'Unknown')}</span></div>
+          ${p.first_seen ? `<div><span style="color:#5C5A54;">FIRST SEEN</span><br/><span style="color:#E8E6E0;">${htmlEsc(String(p.first_seen))}</span></div>` : ''}
+          ${p.last_online ? `<div><span style="color:#5C5A54;">LAST ONLINE</span><br/><span style="color:#E8E6E0;">${htmlEsc(String(p.last_online))}</span></div>` : ''}
         </div>
         <div style="display:flex;gap:6px;">
-          <a href="https://feodotracker.abuse.ch/browse/" target="_blank" style="${linkStyle}flex:1;text-align:center;color:#E8E6E0;border:1px solid rgba(255,255,255,0.2);background:rgba(255,255,255,0.05);">THREAT INTEL ↗</a>
+          <a href="${idSafe(ref)}" target="_blank" style="${linkStyle}flex:1;text-align:center;color:#E8E6E0;border:1px solid rgba(255,255,255,0.2);background:rgba(255,255,255,0.05);">ABUSE.CH RECORD ↗</a>
         </div>
-        <button onclick="window.openOsirisIntel({ type: 'ip', ip: '${idSafe(p.ip)}', threat_type: '${idSafe(p.malware || p.threat_type || '')}', status: '${idSafe(p.status || '')}' })" style="width:100%;margin-top:8px;padding:8px 12px;background:linear-gradient(90deg, rgba(255,23,68,0.1) 0%, rgba(255,23,68,0.2) 100%);border:1px solid rgba(255,23,68,0.6);color:#FF1744;font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:bold;letter-spacing:0.15em;border-radius:4px;cursor:pointer;transition:all 0.2s;">DEEP DIVE ANALYTICS</button>
+        <button onclick="window.openOsirisIntel({ type: 'ip', ip: '${idSafe(p.ip)}', threat_type: '${idSafe(p.malware || p.threat_type || '')}', status: '${idSafe(p.status || '')}' })" style="width:100%;margin-top:8px;padding:8px 12px;background:linear-gradient(90deg, ${accent}1a 0%, ${accent}33 100%);border:1px solid ${accent}99;color:${accent};font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:bold;letter-spacing:0.15em;border-radius:4px;cursor:pointer;transition:all 0.2s;">DEEP DIVE ANALYTICS</button>
       </div>`);
     });
 
@@ -906,8 +928,10 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       if (!e.features?.length) return;
       const p = e.features[0].properties as any;
       const coords = (e.features[0].geometry as any).coordinates;
-      const color = p.type === 'military' ? '#FF1744' : p.type === 'tanker' ? '#FF9500' : '#00E5FF';
-      const icon = p.type === 'military' ? '⚔️' : p.type === 'tanker' ? '🛢️' : '🚢';
+      const shipColors: Record<string,string> = { military:'#FF1744', tanker:'#FF9500', cargo:'#00E5FF', passenger:'#66BB6A', fishing:'#AB47BC', hsc:'#FFD54F' };
+      const shipIcons: Record<string,string> = { military:'⚔️', tanker:'🛢️', cargo:'🚢', passenger:'🛳️', fishing:'🎣', hsc:'⚡' };
+      const color = shipColors[p.type] || '#00E5FF';
+      const icon = shipIcons[p.type] || '🚢';
       
       popup(coords, `<div style="${pStyle}border:1px solid ${color}60;box-shadow:inset 0 0 12px ${color}15;">
         <div style="display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid ${color}40;padding-bottom:6px;margin-bottom:8px;">
@@ -1156,7 +1180,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   // Malware Threats
   useEffect(() => {
     if (!mapReady) return;
-    setGeo('malware-nodes', activeLayers.malware && data.malware_threats ? data.malware_threats.map((t: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [t.lng, t.lat] }, properties: { ip: t.ip, malware: t.malware, status: t.status, threat_type: t.threat_type, country: t.country } })) : []);
+    setGeo('malware-nodes', activeLayers.malware && data.malware_threats ? data.malware_threats.map((t: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [t.lng, t.lat] }, properties: { ip: t.ip, malware: t.malware, status: t.status, threat_type: t.threat_type, severity: t.severity, country: t.country, city: t.city, isp: t.isp, asn: t.asn, port: t.port, first_seen: t.first_seen, last_online: t.last_online, reference: t.reference } })) : []);
   }, [mapReady, data.malware_threats, activeLayers.malware, setGeo]);
 
   // Network Mesh Generation (Nearest Neighbor Lattice)

--- a/src/components/ThreatFusionHUD.tsx
+++ b/src/components/ThreatFusionHUD.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Activity, ChevronDown, ChevronUp, Crosshair, TrendingUp, TrendingDown, Minus, Radar } from 'lucide-react';
+import { type Fusion, type Domain } from '@/lib/fusion';
+
+/**
+ * OSIRIS — Global Threat Fusion HUD
+ * Reads the server-computed /api/fusion endpoint (a ~2 KB, edge-cached payload)
+ * and renders a cinematic radial gauge + domain breakdown + rotating hotspots.
+ * One tiny request per client — the heavy six-feed fusion happens once on the
+ * server and is cached at Cloudflare's edge, so it stays cheap at 333K/month.
+ */
+
+interface Props {
+  onLocate?: (lat: number, lng: number) => void;
+}
+
+const DOMAIN_ABBR: Record<Domain, string> = {
+  CONFLICT: 'CONFLICT', CYBER: 'CYBER', SIGNALS: 'SIGNALS', SEISMIC: 'SEISMIC', AVIATION: 'AVIATION', ATMOSPHERIC: 'ATMOS',
+};
+
+function scoreColor(s: number): string {
+  if (s >= 80) return '#FF1744';
+  if (s >= 60) return '#FF5252';
+  if (s >= 40) return '#FF9500';
+  if (s >= 20) return '#FFD54F';
+  return '#00E676';
+}
+
+export default function ThreatFusionHUD({ onLocate }: Props) {
+  const [fusion, setFusion] = useState<Fusion | null>(null);
+  const [expanded, setExpanded] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [hotIdx, setHotIdx] = useState(0);
+  const [hoverDomain, setHoverDomain] = useState<Domain | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await fetch('/api/fusion', { signal: AbortSignal.timeout(30000) });
+      if (r.ok) setFusion(await r.json());
+    } catch {
+      /* keep last good read */
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    // Server payload is edge-cached (60s); polling every 60s just refreshes the read.
+    const iv = setInterval(refresh, 60000);
+    return () => clearInterval(iv);
+  }, [refresh]);
+
+  // Rotate hotspot ticker
+  useEffect(() => {
+    if (!fusion?.hotspots.length) return;
+    const iv = setInterval(() => setHotIdx(i => (i + 1) % fusion.hotspots.length), 3500);
+    return () => clearInterval(iv);
+  }, [fusion?.hotspots.length]);
+
+  const color = fusion?.level_color || '#00E676';
+  const overall = fusion?.overall ?? 0;
+  const level = fusion?.threatcon ?? 1;
+
+  // Radial gauge geometry
+  const R = 34, C = 2 * Math.PI * R;
+  const arc = (overall / 100) * C;
+
+  const TrendIcon = fusion?.trend === 'rising' ? TrendingUp : fusion?.trend === 'falling' ? TrendingDown : Minus;
+  const hot = fusion?.hotspots[hotIdx];
+  // The WHY panel follows the hovered bar, or defaults to the dominant driver.
+  const detail = fusion?.domains.find(d => d.domain === (hoverDomain ?? fusion.dominant_domain));
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}
+      className="glass-panel pointer-events-auto overflow-hidden"
+      style={{ width: 280, borderColor: `${color}55`, boxShadow: `0 0 28px -8px ${color}55, 0 4px 30px rgba(0,0,0,0.5)` }}
+    >
+      {/* Header */}
+      <button onClick={() => setExpanded(e => !e)} className="w-full flex items-center justify-between px-3 py-2 border-b" style={{ borderColor: `${color}33` }}>
+        <div className="flex items-center gap-2">
+          <Radar className="w-3.5 h-3.5" style={{ color }} />
+          <span className="hud-text text-[10px] text-[var(--text-primary)]">THREAT FUSION</span>
+          {loading && <span className="w-1.5 h-1.5 rounded-full animate-osiris-pulse" style={{ background: color }} />}
+        </div>
+        {expanded ? <ChevronUp className="w-3.5 h-3.5 text-[var(--text-muted)]" /> : <ChevronDown className="w-3.5 h-3.5 text-[var(--text-muted)]" />}
+      </button>
+
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} transition={{ duration: 0.25 }}>
+            {/* Gauge + level */}
+            <div className="flex items-center gap-3 px-3 py-3">
+              <div className="relative shrink-0" style={{ width: 84, height: 84 }}>
+                <svg width="84" height="84" viewBox="0 0 84 84" className="-rotate-90">
+                  <circle cx="42" cy="42" r={R} fill="none" stroke="rgba(255,255,255,0.06)" strokeWidth="6" />
+                  <motion.circle
+                    cx="42" cy="42" r={R} fill="none" stroke={color} strokeWidth="6" strokeLinecap="round"
+                    strokeDasharray={C} initial={{ strokeDashoffset: C }} animate={{ strokeDashoffset: C - arc }}
+                    transition={{ duration: 1, ease: [0.16, 1, 0.3, 1] }}
+                    style={{ filter: `drop-shadow(0 0 6px ${color})` }}
+                  />
+                </svg>
+                <div className="absolute inset-0 flex flex-col items-center justify-center">
+                  <span className="font-mono font-bold leading-none" style={{ color, fontSize: 26, textShadow: `0 0 12px ${color}99` }}>{level}</span>
+                  <span className="hud-label" style={{ fontSize: 6 }}>THREATCON</span>
+                </div>
+              </div>
+
+              <div className="flex-1 min-w-0">
+                <div className="font-mono font-bold text-[13px] tracking-wider" style={{ color }}>{fusion?.level_label || '—'}</div>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <span className="hud-value text-[11px]" style={{ color: 'var(--text-primary)' }}>{overall}<span className="text-[8px] text-[var(--text-muted)]">/100</span></span>
+                  <span className="flex items-center gap-0.5 text-[9px] font-mono" style={{ color: fusion?.trend === 'rising' ? '#FF5252' : fusion?.trend === 'falling' ? '#00E676' : 'var(--text-muted)' }}>
+                    <TrendIcon className="w-3 h-3" />{fusion?.delta ? (fusion.delta > 0 ? '+' : '') + fusion.delta : '0'}
+                  </span>
+                </div>
+                <div className="hud-label mt-1" style={{ fontSize: 6.5 }}>DOMINANT · <span style={{ color: 'var(--text-secondary)' }}>{fusion?.dominant_domain || '—'}</span></div>
+              </div>
+            </div>
+
+            {/* Domain bars — hover any bar to see WHY it scores that way */}
+            <div className="px-3 pb-1 space-y-1">
+              {fusion?.domains.map(d => {
+                const active = hoverDomain === d.domain;
+                return (
+                  <div
+                    key={d.domain}
+                    onMouseEnter={() => setHoverDomain(d.domain)}
+                    onMouseLeave={() => setHoverDomain(null)}
+                    className="flex items-center gap-2 rounded px-1 -mx-1 py-0.5 cursor-help transition-colors"
+                    style={{ background: active ? `${scoreColor(d.score)}14` : 'transparent' }}
+                  >
+                    <span className="hud-label w-[54px] shrink-0" style={{ fontSize: 7, color: active ? scoreColor(d.score) : undefined }}>{DOMAIN_ABBR[d.domain]}</span>
+                    <div className="flex-1 h-[5px] rounded-full overflow-hidden" style={{ background: 'rgba(255,255,255,0.06)' }}>
+                      <motion.div initial={{ width: 0 }} animate={{ width: `${d.score}%` }} transition={{ duration: 0.8, ease: 'easeOut' }}
+                        className="h-full rounded-full" style={{ background: scoreColor(d.score), boxShadow: `0 0 6px ${scoreColor(d.score)}88` }} />
+                    </div>
+                    <span className="font-mono text-[9px] w-5 text-right tabular-nums" style={{ color: scoreColor(d.score) }}>{d.score}</span>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* WHY panel — FIXED height so hovering never resizes the HUD (no flicker).
+                Evidence behind the hovered (or dominant) domain. */}
+            {detail && (
+              <div className="mx-3 mb-2 rounded-lg border overflow-hidden flex flex-col" style={{ height: 138, borderColor: `${scoreColor(detail.score)}33`, background: `${scoreColor(detail.score)}0a` }}>
+                <div className="flex items-center justify-between px-2.5 py-1.5 border-b shrink-0" style={{ borderColor: `${scoreColor(detail.score)}22` }}>
+                  <span className="font-mono font-bold text-[9px] tracking-wider" style={{ color: scoreColor(detail.score) }}>
+                    {DOMAIN_ABBR[detail.domain]} · {detail.score}/100
+                  </span>
+                  <span className="font-mono text-[7px] tracking-wider px-1 py-0.5 rounded" style={{ color: scoreColor(detail.score), background: `${scoreColor(detail.score)}18` }}>
+                    +{detail.contribution} PTS · WT {Math.round(detail.weight * 100)}%
+                  </span>
+                </div>
+                <div className="hud-label px-2.5 pt-1.5 shrink-0" style={{ fontSize: 6.5 }}>{detail.method}</div>
+                {/* Scrollable, fixed-height driver list — constant panel height regardless of count */}
+                <div className="flex-1 overflow-y-auto styled-scrollbar px-2.5 py-1 space-y-1">
+                  {detail.drivers.length === 0 && <div className="text-[9px] text-[var(--text-muted)]">No significant activity in this domain.</div>}
+                  {detail.drivers.map((dr, i) => (
+                    <div key={i} className="flex items-start gap-1.5">
+                      <span className="w-1 h-1 rounded-full mt-1.5 shrink-0" style={{ background: scoreColor(dr.sev ?? detail.score) }} />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-[9px] text-[var(--text-primary)] truncate leading-tight">{dr.label}</div>
+                        {dr.sub && <div className="text-[7.5px] text-[var(--text-muted)] font-mono truncate">{dr.sub}</div>}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="hud-label px-2.5 py-1 border-t shrink-0" style={{ fontSize: 6, borderColor: 'rgba(255,255,255,0.06)' }}>
+                  {hoverDomain ? 'HOVER-SELECTED' : `DOMINANT DRIVER · THREATCON ${level}`}
+                </div>
+              </div>
+            )}
+
+            {/* Hotspot ticker */}
+            {hot && (
+              <button
+                onClick={() => onLocate?.(hot.lat, hot.lng)}
+                className="w-full flex items-center gap-2 px-3 py-2 border-t text-left hover:bg-[var(--hover-accent)] transition-colors"
+                style={{ borderColor: `${color}22` }}
+                title="Locate on map"
+              >
+                <Crosshair className="w-3 h-3 shrink-0" style={{ color: scoreColor(hot.severity) }} />
+                <AnimatePresence mode="wait">
+                  <motion.div key={hotIdx} initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -4 }} transition={{ duration: 0.25 }} className="min-w-0 flex-1">
+                    <div className="text-[9px] font-mono truncate" style={{ color: 'var(--text-primary)' }}>{hot.label}</div>
+                    <div className="hud-label" style={{ fontSize: 6 }}>{hot.domain} · SEV {hot.severity}</div>
+                  </motion.div>
+                </AnimatePresence>
+                <span className="hud-label shrink-0" style={{ fontSize: 6 }}>{hotIdx + 1}/{fusion?.hotspots.length}</span>
+              </button>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}

--- a/src/lib/fusion.ts
+++ b/src/lib/fusion.ts
@@ -1,0 +1,220 @@
+/**
+ * OSIRIS — Global Threat Fusion (client-side)
+ *
+ * Pure scoring engine: takes the raw responses from the platform's live
+ * feeds and fuses them into a single weighted THREATCON level with
+ * per-domain breakdown and cross-domain hotspots. No I/O, fully testable.
+ */
+
+export type Domain = 'CONFLICT' | 'CYBER' | 'SIGNALS' | 'SEISMIC' | 'AVIATION' | 'ATMOSPHERIC';
+
+export interface DomainDriver {
+  label: string;   // the specific thing driving the score
+  sub?: string;    // supporting detail (location, family, magnitude…)
+  sev?: number;    // 0-100 severity for colouring
+}
+
+export interface DomainScore {
+  domain: Domain;
+  score: number;
+  headline: string;
+  count: number;
+  weight: number;        // this domain's weight in the composite
+  contribution: number;  // points it adds to the overall (score × weight)
+  method: string;        // one-line explanation of how the score is derived
+  drivers: DomainDriver[]; // the evidence — WHY this score
+}
+
+export interface Hotspot {
+  lat: number;
+  lng: number;
+  label: string;
+  domain: Domain;
+  severity: number;
+}
+
+export interface Fusion {
+  threatcon: number;
+  level_label: string;
+  level_color: string;
+  overall: number;
+  trend: 'rising' | 'falling' | 'steady';
+  delta: number;
+  dominant_domain: Domain | undefined;
+  domains: DomainScore[];
+  hotspots: Hotspot[];
+}
+
+export interface FusionInputs {
+  malware?: any;
+  quakes?: any;
+  weather?: any;
+  conflicts?: any;
+  flights?: any;
+  news?: any;
+}
+
+const WEIGHTS: Record<Domain, number> = {
+  CONFLICT: 0.28, CYBER: 0.20, SIGNALS: 0.15, SEISMIC: 0.13, AVIATION: 0.12, ATMOSPHERIC: 0.12,
+};
+const LEVELS = ['', 'GUARDED', 'ELEVATED', 'HIGH', 'SEVERE', 'CRITICAL'];
+const COLORS = ['', '#00E676', '#FFD54F', '#FF9500', '#FF5252', '#FF1744'];
+
+const clamp = (n: number, lo = 0, hi = 100) => Math.round(Math.max(lo, Math.min(hi, n)));
+const num = (v: any): number => (typeof v === 'number' && !Number.isNaN(v) ? v : 0);
+const decode = (s: string): string => s.replace(/&#39;/g, "'").replace(/&quot;/g, '"').replace(/&amp;/g, '&').replace(/&#\d+;/g, '');
+
+function push(domains: DomainScore[], d: Omit<DomainScore, 'weight' | 'contribution'>) {
+  const weight = WEIGHTS[d.domain];
+  domains.push({ ...d, weight, contribution: Math.round(d.score * weight) });
+}
+
+export function computeFusion(input: FusionInputs, prevOverall = 0): Fusion {
+  const { malware, quakes, weather, conflicts, flights, news } = input;
+  const hotspots: Hotspot[] = [];
+  const domains: DomainScore[] = [];
+
+  // CONFLICT — weighted by active war zones + escalation + live event tempo
+  {
+    const zones: any[] = conflicts?.zones || [];
+    const wars = zones.filter(z => z.severity === 'war');
+    const highs = zones.filter(z => z.severity === 'high' || z.severity === 'elevated');
+    const live = num(conflicts?.totalLiveEvents);
+    const score = clamp(wars.length * 20 + highs.length * 10 + live * 2);
+    const drivers: DomainDriver[] = [
+      ...[...wars, ...highs]
+        .sort((a, b) => (b.severity === 'war' ? 1 : 0) - (a.severity === 'war' ? 1 : 0))
+        .slice(0, 5)
+        .map(z => ({ label: z.label || 'Conflict zone', sub: String(z.severity || '').toUpperCase(), sev: z.severity === 'war' ? 95 : z.severity === 'high' ? 75 : 55 })),
+    ];
+    if (live > 0) drivers.push({ label: `${live} live conflict events`, sub: 'last 24h tempo', sev: clamp(live * 6) });
+    push(domains, {
+      domain: 'CONFLICT', score, count: zones.length,
+      headline: wars.length ? `${wars.length} active war zone${wars.length > 1 ? 's' : ''} · ${live} live events` : `${zones.length} monitored zones`,
+      method: 'war ×20 + escalating ×10 + live events ×2',
+      drivers,
+    });
+    for (const z of zones) {
+      if (z.lat == null) continue;
+      const sev = z.severity === 'war' ? 95 : z.severity === 'high' ? 75 : z.severity === 'elevated' ? 55 : 35;
+      hotspots.push({ lat: z.lat, lng: z.lng, label: z.label || 'Conflict zone', domain: 'CONFLICT', severity: sev });
+    }
+  }
+  // CYBER — botnet C2 weighted heavily over bulk distribution hosts
+  {
+    const threats: any[] = malware?.threats || [];
+    const c2 = num(malware?.stats?.by_type?.botnet_c2);
+    const families: any[] = malware?.stats?.top_families || [];
+    const score = clamp(c2 * 9 + threats.length * 0.15);
+    const drivers: DomainDriver[] = [];
+    if (c2 > 0) drivers.push({ label: `${c2} live botnet C2 server${c2 > 1 ? 's' : ''}`, sub: 'active command & control', sev: 90 });
+    for (const f of families.slice(0, 4)) drivers.push({ label: f.name || 'Unknown family', sub: `${f.count} hosts`, sev: clamp(num(f.count) * 2) });
+    push(domains, {
+      domain: 'CYBER', score, count: threats.length,
+      headline: `${threats.length} malware hosts · ${c2} botnet C2`,
+      method: 'botnet C2 ×9 + distribution hosts ×0.15',
+      drivers,
+    });
+    for (const t of threats.filter(t => t.severity === 'critical').slice(0, 8)) {
+      hotspots.push({ lat: t.lat, lng: t.lng, label: `${t.malware} C2 · ${t.country}`, domain: 'CYBER', severity: 90 });
+    }
+  }
+  // SIGNALS — high-priority OSINT news tempo
+  {
+    const items: any[] = news?.news || [];
+    const scores = items.map(n => num(n.risk_score));
+    const hot = scores.filter(s => s >= 8).length;
+    const avg = scores.length ? scores.reduce((a, b) => a + b, 0) / scores.length : 0;
+    const score = clamp(hot * 14 + avg * 4);
+    const drivers: DomainDriver[] = [...items]
+      .sort((a, b) => num(b.risk_score) - num(a.risk_score))
+      .slice(0, 5)
+      .map(n => ({ label: decode(String(n.title || 'Signal')).slice(0, 70), sub: `${n.source || 'OSINT'} · risk ${num(n.risk_score)}`, sev: clamp(num(n.risk_score) * 10) }));
+    push(domains, {
+      domain: 'SIGNALS', score, count: items.length,
+      headline: `${items.length} OSINT items · ${hot} high-priority`,
+      method: 'high-priority items ×14 + avg risk ×4',
+      drivers,
+    });
+    for (const n of items.filter(n => num(n.risk_score) >= 8 && Array.isArray(n.coords)).slice(0, 4)) {
+      hotspots.push({ lat: n.coords[0], lng: n.coords[1], label: decode(String(n.title || 'Signal')).slice(0, 60), domain: 'SIGNALS', severity: clamp(num(n.risk_score) * 10) });
+    }
+  }
+  // SEISMIC — driven by the strongest event + count of major quakes
+  {
+    const eq: any[] = quakes?.earthquakes || [];
+    const mags = eq.map(q => num(q.magnitude));
+    const maxMag = mags.length ? Math.max(...mags) : 0;
+    const strong = mags.filter(m => m >= 5).length;
+    const score = clamp(maxMag * 11 + strong * 5);
+    const drivers: DomainDriver[] = [...eq]
+      .sort((a, b) => num(b.magnitude) - num(a.magnitude))
+      .slice(0, 5)
+      .map(q => ({ label: `M${num(q.magnitude).toFixed(1)}`, sub: q.place || 'unknown', sev: clamp(num(q.magnitude) * 12) }));
+    push(domains, {
+      domain: 'SEISMIC', score, count: eq.length,
+      headline: eq.length ? `${eq.length} quakes · max M${maxMag.toFixed(1)}` : 'No significant seismicity',
+      method: 'max magnitude ×11 + M5.0+ count ×5',
+      drivers,
+    });
+    for (const q of eq.filter(q => num(q.magnitude) >= 5).slice(0, 4)) {
+      hotspots.push({ lat: q.lat, lng: q.lng, label: `M${num(q.magnitude).toFixed(1)} · ${q.place || 'quake'}`, domain: 'SEISMIC', severity: clamp(num(q.magnitude) * 12) });
+    }
+  }
+  // AVIATION — military air activity + GPS-denial (jamming) zones
+  {
+    const milFlights: any[] = flights?.military_flights || [];
+    const mil = milFlights.length;
+    const jam: any[] = flights?.gps_jamming || [];
+    const score = clamp(mil * 0.28 + jam.length * 8);
+    const drivers: DomainDriver[] = [];
+    if (mil > 0) drivers.push({ label: `${mil} military aircraft airborne`, sub: 'ADS-B tracked', sev: clamp(mil * 0.5) });
+    for (const j of [...jam].sort((a, b) => num(b.severity) - num(a.severity)).slice(0, 4)) {
+      drivers.push({ label: `GPS jamming zone`, sub: `interference ${num(j.severity)}%`, sev: clamp(num(j.severity)) });
+    }
+    push(domains, {
+      domain: 'AVIATION', score, count: mil,
+      headline: `${mil} military aircraft · ${jam.length} GPS-jam zones`,
+      method: 'military aircraft ×0.28 + GPS-jam zones ×8',
+      drivers,
+    });
+    for (const j of jam.slice(0, 4)) {
+      hotspots.push({ lat: j.lat, lng: j.lng, label: `GPS jamming · ${num(j.severity)}%`, domain: 'AVIATION', severity: clamp(num(j.severity)) });
+    }
+  }
+  // ATMOSPHERIC — active severe-weather events, high-severity weighted
+  {
+    const events: any[] = weather?.events || [];
+    const highEvents = events.filter(e => (e.severity || '').toLowerCase() === 'high');
+    const score = clamp(highEvents.length * 11 + events.length * 0.4);
+    const drivers: DomainDriver[] = highEvents.slice(0, 5).map(e => ({ label: e.type || 'Severe weather', sub: e.area || e.title || '', sev: 70 }));
+    if (!drivers.length && events.length) drivers.push({ label: `${events.length} active weather events`, sub: 'no high-severity', sev: 30 });
+    push(domains, {
+      domain: 'ATMOSPHERIC', score, count: events.length,
+      headline: `${events.length} severe-weather events · ${highEvents.length} high-severity`,
+      method: 'high-severity ×11 + all events ×0.4',
+      drivers,
+    });
+    for (const e of highEvents.filter(e => e.lat != null).slice(0, 3)) {
+      hotspots.push({ lat: e.lat, lng: e.lng, label: `${e.type} · ${e.area || ''}`.trim(), domain: 'ATMOSPHERIC', severity: 70 });
+    }
+  }
+
+  const overall = clamp(domains.reduce((s, d) => s + d.score * WEIGHTS[d.domain], 0));
+  const level = clamp(Math.ceil(overall / 20), 1, 5);
+  const delta = overall - prevOverall;
+  const trend: Fusion['trend'] = Math.abs(delta) < 1.5 ? 'steady' : delta > 0 ? 'rising' : 'falling';
+  const dominant = [...domains].sort((a, b) => b.score * WEIGHTS[b.domain] - a.score * WEIGHTS[a.domain])[0];
+
+  return {
+    threatcon: level,
+    level_label: LEVELS[level],
+    level_color: COLORS[level],
+    overall: Math.round(overall),
+    trend,
+    delta: Math.round(delta * 10) / 10,
+    dominant_domain: dominant?.domain,
+    domains: domains.sort((a, b) => b.score - a.score),
+    hotspots: hotspots.sort((a, b) => b.severity - a.severity).slice(0, 6),
+  };
+}


### PR DESCRIPTION
## Overview
A large session of work: a new **Global Threat Fusion** engine, turning the **maritime layer into a real-time keyless ship tracker**, and several **scale/reliability fixes** that matter at ~333K visitors/month behind Cloudflare. All verified in a production build on localhost.

## 🎯 Threat Fusion (new)
- **`/api/fusion`** computes the fusion **once on the server** and serves a **~3KB edge-cacheable payload**. Clients make one tiny request instead of pulling six heavy feeds each and recomputing — the IP-fetch-safe, instant-load design. `computeFusion()` is a pure, tested lib.
- **THREATCON HUD** — cinematic radial gauge, per-domain bars, rotating cross-domain hotspots — as a toggle in the right rail, plus a **live clickable THREATCON badge in the bottom bar**.
- **Hover any bar → WHY:** the scoring method, point contribution, weight %, and the real drivers (CONFLICT → *Ukraine/Gaza/Sudan wars*; SEISMIC → *M6.0 Japan*; CYBER → *5 botnet C2, Mozi 189 hosts*).
- **Stale-while-revalidate + degeneracy guard** — never blocks on a cold rebuild, never overwrites a good read with a bogus "all clear" when upstreams transiently fail.
- Fixed a **hover flicker** ("seizure") from the centered panel resizing — the WHY panel is now fixed-height with an internal scroll.

## ⚓ Maritime → real-time ship tracker (keyless)
- Added **Digitraffic marine AIS** (Finnish Transport Agency) as a **keyless** source — ~18K live vessels merged by MMSI, so the layer is populated **without `AIS_API_KEY`**. Keyed aisstream still adds global chokepoint coverage on top.
- Ship **types** → categories (cargo/tanker/passenger/fishing/military/hsc) with distinct map colours + popup icons.
- **Ports 51 → 81** (~30 major world docks added).
- Response **cached (30s)** + edge `Cache-Control`; capped at 8K ships for map/payload performance.
- Verified: **8,000 ships (7,999 named)**, 81 ports, keyless.

## 🛠 Reliability / scale fixes
- **proxy-tiles:** the map now loads CARTO basemap tiles **directly in the browser** (CORS-enabled). Proxying every tile through the server was poisoning its outbound connection pool and silently killing data feeds (CCTV, earthquakes, malware). This was the root cause of the recurring "162 cameras / nothing loading" reports.
- **/api/geo:** 3 IP-geolocation providers now **race in parallel** with **per-IP caching (1h)** + negative caching (30s). Was sequential + uncached — burning 15s per failed call and hammering per-IP limits. A real 333K-scale bug.
- **cctv:** per-region timeout budget so one hung camera network can't stall the whole batch → restores ~**9.6K cameras** (UDOT/Caltrans/TfL/ASFINAG all present).
- **malware:** never cache an empty/failed result.

## 🎨 UI/UX
- **Ghost Protocol off by default** (Core is default; Ghost is opt-in).
- Live malware **botnet mesh lines forced red**; severity-coloured threat dots.
- Unified/polished top-left **3D-globe / satellite** map controls.
- Design-system polish: branded text selection, accessible focus rings, snappier interactions, premium glass depth, reduced-motion support.

## ⚠️ Reviewer note
`CommandPalette.tsx` and `KeyboardShortcuts.tsx` were **pre-existing working-tree WIP not authored in this session** — included here only because `page.tsx` now imports `CommandPalette` and the app must build. Local `.claude/` and `docs/` are intentionally excluded. Happy to split those out if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019VxJFy9LhLKv2rutwuA8ad