### PR TITLE
Add optional source-reliability layer, new data sources & SOURCES health panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,20 @@ N2YO_API_KEY=
 #   Get it: https://aisstream.io/  (sign up → API Keys)
 AIS_API_KEY=
 
+# Shodan — "Shodan Exposed" map layer (internet-facing device search).
+# Requires a paid membership for search credits (the free key only covers the
+# on-demand IP lookups already used via the keyless internetdb.shodan.io
+# endpoint). Layer stays disabled with no errors if unset.
+#   Get it: https://account.shodan.io/  (Account → API Key)
+SHODAN_API_KEY=
+
+# WiGLE.net — wireless network (WiFi/BT/cell) geolocation, looked up on-demand
+# for the region dossier (right-click a point on the map). Free account; query
+# volume is capped by WiGLE's tier system. Both values required to enable it.
+#   Get it: https://wigle.net/account  (API name + token near the bottom)
+WIGLE_API_NAME=
+WIGLE_API_TOKEN=
+
 
 # ─────────────────────────────────────────────────────────────────────────
 #  RUNTIME

--- a/src/app/api/buoys/route.ts
+++ b/src/app/api/buoys/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { runSource } from '@/lib/sources';
+import { ndbcBuoys } from '@/lib/sources/adapters/ndbcBuoys';
+
+/**
+ * Osiris — NOAA NDBC Marine Buoys
+ * Real-time wind/wave/temperature observations from moored ocean buoys, keyless.
+ */
+
+export async function GET() {
+  const result = await runSource(ndbcBuoys);
+
+  return NextResponse.json({
+    buoys: result.data ?? [],
+    total: result.data?.length ?? 0,
+    timestamp: new Date().toISOString(),
+    source: result.sourceId,
+    stale: result.stale,
+    ...(result.error ? { error: result.error } : {}),
+  }, {
+    headers: { 'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=1200' },
+  });
+}

--- a/src/app/api/ransomware/route.ts
+++ b/src/app/api/ransomware/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { runSource } from '@/lib/sources';
+import { ransomwareTracker } from '@/lib/sources/adapters/ransomwareTracker';
+
+/**
+ * Osiris — ransomware.live Recent Victims
+ * Recently disclosed ransomware victims by group/country, keyless.
+ */
+
+export async function GET() {
+  const result = await runSource(ransomwareTracker);
+
+  return NextResponse.json({
+    victims: result.data ?? [],
+    total: result.data?.length ?? 0,
+    timestamp: new Date().toISOString(),
+    source: result.sourceId,
+    stale: result.stale,
+    ...(result.error ? { error: result.error } : {}),
+  }, {
+    headers: { 'Cache-Control': 'public, s-maxage=900, stale-while-revalidate=1800' },
+  });
+}

--- a/src/app/api/shodan-exposed/route.ts
+++ b/src/app/api/shodan-exposed/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { runSource } from '@/lib/sources';
+import { shodanExposed } from '@/lib/sources/adapters/shodanExposed';
+
+/**
+ * Osiris — Shodan Exposed Devices
+ * Opt-in, keyed (SHODAN_API_KEY). Disabled cleanly without a key.
+ */
+
+export async function GET() {
+  const result = await runSource(shodanExposed);
+
+  return NextResponse.json({
+    hosts: result.data ?? [],
+    total: result.data?.length ?? 0,
+    timestamp: new Date().toISOString(),
+    source: result.sourceId,
+    stale: result.stale,
+    ...(result.error ? { error: result.error } : {}),
+  }, {
+    headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
+  });
+}

--- a/src/app/api/sources/health/route.test.ts
+++ b/src/app/api/sources/health/route.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const { listAll, get } = vi.hoisted(() => ({ listAll: vi.fn(), get: vi.fn() }));
+vi.mock('@/lib/sources', () => ({
+  sourceRegistry: { listAll },
+  sourceHealth: { get },
+}));
+
+const { GET } = await import('./route');
+
+describe('GET /api/sources/health', () => {
+  it('returns a report entry per registered source with a summary count', async () => {
+    listAll.mockReturnValue([
+      { meta: { id: 'usgs', name: 'USGS', category: 'seismic', homepage: 'h', attribution: 'a', requiresKey: false }, isEnabled: () => true },
+      { meta: { id: 'shodan', name: 'Shodan', category: 'osint', homepage: 'h', attribution: 'a', requiresKey: true }, isEnabled: () => false },
+    ]);
+    get.mockImplementation((id: string) => ({ sourceId: id, status: 'ok', lastSuccessAt: null, lastErrorAt: null, lastLatencyMs: null, consecutiveFailures: 0 }));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.total).toBe(2);
+    expect(body.sources).toHaveLength(2);
+    expect(body.sources.find((s: any) => s.id === 'shodan').status).toBe('disabled');
+    expect(body.summary).toEqual({ ok: 1, degraded: 0, down: 0, unknown: 0, disabled: 1 });
+    expect(typeof body.timestamp).toBe('string');
+  });
+});

--- a/src/app/api/sources/health/route.ts
+++ b/src/app/api/sources/health/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { sourceRegistry, sourceHealth } from '@/lib/sources';
+import { buildSourceHealthReport, type SourceDisplayStatus } from '@/lib/sources/healthReport';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Osiris — Source health & provenance
+ * Enumerates every registered source with its live health status, so the
+ * SOURCES panel can show what's up, degraded, down, or disabled.
+ */
+
+const EMPTY_SUMMARY: Record<SourceDisplayStatus, number> = {
+  ok: 0, degraded: 0, down: 0, unknown: 0, disabled: 0,
+};
+
+export async function GET() {
+  const sources = buildSourceHealthReport(
+    sourceRegistry.listAll(),
+    (id) => sourceHealth.get(id),
+  );
+
+  const summary = { ...EMPTY_SUMMARY };
+  for (const s of sources) summary[s.status] += 1;
+
+  return NextResponse.json({
+    sources,
+    total: sources.length,
+    summary,
+    timestamp: new Date().toISOString(),
+  }, {
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}

--- a/src/app/api/tsunami/route.ts
+++ b/src/app/api/tsunami/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { runSource } from '@/lib/sources';
+import { noaaTsunami } from '@/lib/sources/adapters/noaaTsunami';
+
+/**
+ * Osiris — NOAA Tsunami Warning Center
+ * Recent tsunami information statements/warnings, keyless.
+ */
+
+export async function GET() {
+  const result = await runSource(noaaTsunami);
+
+  return NextResponse.json({
+    events: result.data ?? [],
+    total: result.data?.length ?? 0,
+    timestamp: new Date().toISOString(),
+    source: result.sourceId,
+    stale: result.stale,
+    ...(result.error ? { error: result.error } : {}),
+  }, {
+    headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+  });
+}

--- a/src/app/api/wigle-networks/route.ts
+++ b/src/app/api/wigle-networks/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { runSource } from '@/lib/sources';
+import { wigleNetworks } from '@/lib/sources/adapters/wigleNetworks';
+
+/**
+ * Osiris — WiGLE Wireless Networks (near a point)
+ * Opt-in, keyed (WIGLE_API_NAME + WIGLE_API_TOKEN). Disabled cleanly without
+ * credentials. Requires lat/lng — WiGLE's search API has no global feed.
+ */
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const lat = searchParams.get('lat');
+  const lng = searchParams.get('lng');
+  const radius = searchParams.get('radius') || '3';
+
+  if (!lat || !lng || isNaN(parseFloat(lat)) || isNaN(parseFloat(lng))) {
+    return NextResponse.json({ error: 'Missing lat/lng parameters' }, { status: 400 });
+  }
+
+  const result = await runSource(wigleNetworks, { lat, lng, radius });
+
+  return NextResponse.json({
+    networks: result.data ?? [],
+    total: result.data?.length ?? 0,
+    timestamp: new Date().toISOString(),
+    source: result.sourceId,
+    stale: result.stale,
+    ...(result.error ? { error: result.error } : {}),
+  }, {
+    headers: { 'Cache-Control': 'public, s-maxage=1800, stale-while-revalidate=3600' },
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,7 @@ const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
 const CameraViewer = dynamic(() => import('@/components/CameraViewer'));
 const OsintPanel = dynamic(() => import('@/components/OsintPanel'));
 const EntityGraphPanel = dynamic(() => import('@/components/EntityGraphPanel'));
+const SourceHealthPanel = dynamic(() => import('@/components/SourceHealthPanel'));
 const TokenPanel = dynamic(() => import('@/components/TokenPanel'));
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(false);
@@ -97,6 +98,7 @@ export default function Dashboard() {
   const [locationLabel, setLocationLabel] = useState('');
   const [regionDossier, setRegionDossier] = useState<any>(null);
   const [dossierLoading, setDossierLoading] = useState(false);
+  const [wigleNetworks, setWigleNetworks] = useState<any[] | null>(null);
   const [showSplash, setShowSplash] = useState(true);
   const [activeCamera, setActiveCamera] = useState<any>(null);
   const [spaceWeather, setSpaceWeather] = useState<any>(null);
@@ -106,9 +108,10 @@ export default function Dashboard() {
   const [showScmPanel, setShowScmPanel] = useState(true);
   const [showIntel, setShowIntel] = useState(false);
   const [showEntityGraph, setShowEntityGraph] = useState(false);
+  const [showSources, setShowSources] = useState(false);
   const [showDesktopSearch, setShowDesktopSearch] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [mobilePanel, setMobilePanel] = useState<'layers'|'markets'|'intel'|'search'|'recon'|null>(null);
+  const [mobilePanel, setMobilePanel] = useState<'layers'|'markets'|'intel'|'search'|'recon'|'sources'|null>(null);
   const [mapProjection, setMapProjection] = useState<'globe'|'mercator'>('globe');
   const [mapStyle, setMapStyle] = useState<'dark'|'satellite'>('dark');
   const [sweepData, setSweepData] = useState<any>(null);
@@ -147,6 +150,8 @@ export default function Dashboard() {
     earthquakes: true,
     fires: false,
     weather: false,
+    tsunami: false,
+    buoys: false,
     radiation: false,
     infrastructure: false,
     global_incidents: true,
@@ -159,6 +164,8 @@ export default function Dashboard() {
     sdk_naval: true,
     terrain_3d: false,
     malware: false,
+    ransomware: false,
+    shodan: false,
   });
   const [liveFeedUrl, setLiveFeedUrl] = useState<string | null>(null);
   const [liveFeedName, setLiveFeedName] = useState('');
@@ -281,11 +288,20 @@ export default function Dashboard() {
 
   // Region dossier (right-click)
   const handleRightClick = useCallback(async (coords: { lat: number; lng: number }) => {
-    setDossierLoading(true); setRegionDossier(null);
+    setDossierLoading(true); setRegionDossier(null); setWigleNetworks(null);
     try {
       const res = await fetch(`/api/region-dossier?lat=${coords.lat}&lng=${coords.lng}`);
       if (res.ok) setRegionDossier(await res.json());
     } catch (e) { console.warn('[OSIRIS] Suppressed error:', e instanceof Error ? e.message : e); } finally { setDossierLoading(false); }
+
+    // WiGLE nearby wireless networks — opt-in/keyed, silently empty without credentials
+    try {
+      const res = await fetch(`/api/wigle-networks?lat=${coords.lat}&lng=${coords.lng}`);
+      if (res.ok) {
+        const json = await res.json();
+        if (json.networks?.length) setWigleNetworks(json.networks);
+      }
+    } catch (e) { console.warn('[OSIRIS] Suppressed error:', e instanceof Error ? e.message : e); }
   }, []);
   // Entity click handler (hoisted from JSX to comply with Rules of Hooks - Fixes #113)
   const handleEntityClick = useCallback((entity: any) => {
@@ -418,6 +434,16 @@ export default function Dashboard() {
       fetchEndpoint('/api/weather', d => ({ weather_events: d.events }));
       layerFetchedRef.current.add('weather');
     }
+    // Tsunami
+    if (activeLayers.tsunami && !layerFetchedRef.current.has('tsunami')) {
+      fetchEndpoint('/api/tsunami', d => ({ tsunami: d.events }));
+      layerFetchedRef.current.add('tsunami');
+    }
+    // Ocean Buoys
+    if (activeLayers.buoys && !layerFetchedRef.current.has('buoys')) {
+      fetchEndpoint('/api/buoys', d => ({ buoys: d.buoys }));
+      layerFetchedRef.current.add('buoys');
+    }
     // Infrastructure
     if (activeLayers.infrastructure && !layerFetchedRef.current.has('infrastructure')) {
       fetchEndpoint('/api/infrastructure', d => ({ infrastructure: d.infrastructure }));
@@ -450,6 +476,18 @@ export default function Dashboard() {
     if (activeLayers.malware && !layerFetchedRef.current.has('malware')) {
       fetchEndpoint('/api/malware', d => ({ malware_threats: d.threats }));
       layerFetchedRef.current.add('malware');
+    }
+
+    // Ransomware Victims (ransomware.live)
+    if (activeLayers.ransomware && !layerFetchedRef.current.has('ransomware')) {
+      fetchEndpoint('/api/ransomware', d => ({ ransomware: d.victims }));
+      layerFetchedRef.current.add('ransomware');
+    }
+
+    // Shodan Exposed Devices (opt-in, requires SHODAN_API_KEY — empty without it)
+    if (activeLayers.shodan && !layerFetchedRef.current.has('shodan')) {
+      fetchEndpoint('/api/shodan-exposed', d => ({ shodan_hosts: d.hosts }));
+      layerFetchedRef.current.add('shodan');
     }
 
 
@@ -945,13 +983,26 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowEntityGraph(!showEntityGraph); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showEntityGraph ? 'bg-[#D4AF37]/20' : 'hover:bg-white/10'}`}>
+          <button onClick={() => { setShowEntityGraph(!showEntityGraph); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSources(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showEntityGraph ? 'bg-[#D4AF37]/20' : 'hover:bg-white/10'}`}>
             <Network className={`w-4 h-4 ${showEntityGraph ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowDesktopSearch(!showDesktopSearch); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDesktopSearch ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`}>
+          <button onClick={() => { setShowSources(!showSources); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showSources ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Source health">
+            <Activity className={`w-4 h-4 ${showSources ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
+          </button>
+          <AnimatePresence>
+            {showSources && (
+              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
+                <SourceHealthPanel />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
+        <div className="relative group">
+          <button onClick={() => { setShowDesktopSearch(!showDesktopSearch); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowEntityGraph(false); setShowSources(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDesktopSearch ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`}>
             <Search className={`w-4 h-4 ${showDesktopSearch ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
           <AnimatePresence>
@@ -1074,6 +1125,7 @@ export default function Dashboard() {
                 { id: 'markets' as const, icon: BarChart3, label: 'MARKETS' },
                 { id: 'intel' as const, icon: Newspaper, label: 'INTEL' },
                 { id: 'recon' as const, icon: Radar, label: 'RECON' },
+                { id: 'sources' as const, icon: Activity, label: 'SOURCES' },
                 { id: 'search' as const, icon: Search, label: 'SEARCH' },
               ].map(tab => (
                 <button key={tab.id} onClick={() => setMobilePanel(mobilePanel === tab.id ? null : tab.id)}
@@ -1098,7 +1150,7 @@ export default function Dashboard() {
                 <div className="px-3 pb-3">
                   <div className="flex items-center justify-between mb-2">
                     <span className="hud-text text-[9px] text-[var(--text-primary)]">
-                      {mobilePanel === 'layers' ? 'LAYERS & STATS' : mobilePanel === 'markets' ? 'MARKETS & INTEL' : mobilePanel === 'intel' ? 'INTEL FEED' : mobilePanel === 'recon' ? 'OSIRIS RECON' : 'SEARCH'}
+                      {mobilePanel === 'layers' ? 'LAYERS & STATS' : mobilePanel === 'markets' ? 'MARKETS & INTEL' : mobilePanel === 'intel' ? 'INTEL FEED' : mobilePanel === 'recon' ? 'OSIRIS RECON' : mobilePanel === 'sources' ? 'SOURCE HEALTH' : 'SEARCH'}
                     </span>
                     <button onClick={() => setMobilePanel(null)} className="text-[var(--text-muted)] p-1"><X className="w-4 h-4" /></button>
                   </div>
@@ -1132,6 +1184,7 @@ export default function Dashboard() {
                       <OsintPanel isOpen={true} onClose={() => setMobilePanel(null)} isMobile={true} onSweepVisualize={setSweepData} />
                     </div>
                   )}
+                  {mobilePanel === 'sources' && <SourceHealthPanel />}
                 </div>
               </motion.div>
             )}
@@ -1192,6 +1245,19 @@ export default function Dashboard() {
                 )}
                 {regionDossier.head_of_state && (<div><div className="hud-label mb-0.5">HEAD OF STATE</div><div className="text-xs text-[var(--gold-primary)]">{regionDossier.head_of_state.name}</div><div className="text-[8px] text-[var(--text-muted)]">{regionDossier.head_of_state.position}</div></div>)}
                 {regionDossier.wikipedia && (<div><div className="hud-label mb-1">INTELLIGENCE BRIEF</div><div className="flex gap-3">{regionDossier.wikipedia.thumbnail && <img src={regionDossier.wikipedia.thumbnail} alt="" className="w-14 h-14 rounded object-cover flex-shrink-0" />}<p className="text-[8px] text-[var(--text-secondary)] leading-relaxed">{regionDossier.wikipedia.extract}</p></div></div>)}
+                {wigleNetworks && wigleNetworks.length > 0 && (
+                  <div>
+                    <div className="hud-label mb-1">NEARBY WIRELESS NETWORKS · WIGLE</div>
+                    <div className="space-y-1 max-h-28 overflow-y-auto styled-scrollbar">
+                      {wigleNetworks.slice(0, 20).map((n: any) => (
+                        <div key={n.id} className="flex justify-between text-[8px] font-mono text-[var(--text-secondary)]">
+                          <span className="truncate">{n.ssid}</span>
+                          <span className="text-[var(--text-muted)]">{n.encryption || 'open'}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -43,6 +43,7 @@ const LAYER_GROUPS = [
     icon: Ship,
     layers: [
       { key: 'maritime', label: 'Maritime / Naval', dataKey: 'maritime_ships,maritime_ports,maritime_chokepoints' },
+      { key: 'buoys', label: 'Ocean Buoys', dataKey: 'buoys' },
     ],
   },
   {
@@ -76,6 +77,7 @@ const LAYER_GROUPS = [
       { key: 'earthquakes', label: 'Earthquakes', dataKey: 'earthquakes' },
       { key: 'fires', label: 'Active Fires', dataKey: 'fires' },
       { key: 'weather', label: 'Severe Weather', dataKey: 'weather_events' },
+      { key: 'tsunami', label: 'Tsunami Alerts', dataKey: 'tsunami' },
     ],
   },
   {
@@ -94,6 +96,8 @@ const LAYER_GROUPS = [
     icon: Network,
     layers: [
       { key: 'malware', label: 'Live Malware', dataKey: 'malware_threats' },
+      { key: 'ransomware', label: 'Ransomware Victims', dataKey: 'ransomware' },
+      { key: 'shodan', label: 'Shodan Exposed', dataKey: 'shodan_hosts' },
     ],
   },
   {

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback, memo } from 'react';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import { jitteredCentroid } from '@/lib/countryCentroids';
 
 interface OsirisMapProps {
   data: any;
@@ -181,7 +182,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       createDot(map, 'dot-fire', isGhost ? phantomPurple : '#E65100', 10);
       createDot(map, 'dot-cctv', cameraColor, 10);
 
-      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'malware-nodes', 'network-mesh'];
+      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'malware-nodes', 'network-mesh', 'tsunami', 'buoys', 'ransomware-nodes', 'shodan-nodes'];
       sources.forEach(s => map.addSource(s, { type: 'geojson', data: EMPTY_FC }));
 
       // Warning icon generator (parameterized — eliminates 3x copy-paste)
@@ -241,6 +242,24 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         'circle-color': '#E65100', 'circle-opacity': 0.45, 'circle-blur': 0.5,
       }});
 
+      // Tsunami — warning-red pulse ring + core
+      map.addLayer({ id: 'tsunami-glow', type: 'circle', source: 'tsunami', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,10, 5,18, 10,28],
+        'circle-color': '#D32F2F', 'circle-opacity': 0.12, 'circle-blur': 0.6,
+      }});
+      map.addLayer({ id: 'tsunami-circles', type: 'circle', source: 'tsunami', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,4, 5,7, 10,10],
+        'circle-color': '#D32F2F', 'circle-opacity': 0.9,
+        'circle-stroke-width': 1.5, 'circle-stroke-color': '#F9A825', 'circle-stroke-opacity': 0.8,
+      }});
+
+      // Ocean Buoys — teal maritime sensor dots
+      map.addLayer({ id: 'buoy-dots', type: 'circle', source: 'buoys', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,2, 5,4, 10,6],
+        'circle-color': '#26A69A', 'circle-opacity': 0.85,
+        'circle-stroke-width': 1, 'circle-stroke-color': '#000000', 'circle-stroke-opacity': 0.7,
+      }});
+
       // CCTV — outer glow ring (black/white depending on theme)
       map.addLayer({ id: 'cctv-glow', type: 'circle', source: 'cctv', paint: {
         'circle-radius': ['interpolate',['linear'],['zoom'], 1,5, 5,8, 10,14, 14,20],
@@ -277,6 +296,29 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         'text-field': ['get','malware'], 'text-size': 8, 'text-font': ['JetBrains Mono Bold', 'Open Sans Bold'],
         'text-offset': [0, 1.5], 'text-max-width': 10, 'text-allow-overlap': false,
       }, paint: { 'text-color': '#D32F2F', 'text-halo-color': '#111', 'text-halo-width': 1.5, 'text-opacity': 0.85 }});
+
+      // Ransomware victims (ransomware.live) — magenta threat. Country-level
+      // positions only (jittered centroid); precise victim location is unknown.
+      map.addLayer({ id: 'ransomware-glow', type: 'circle', source: 'ransomware-nodes', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,6, 5,12, 10,20],
+        'circle-color': '#C2185B', 'circle-opacity': 0.06, 'circle-blur': 0.5,
+      }});
+      map.addLayer({ id: 'ransomware-dots', type: 'circle', source: 'ransomware-nodes', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,2, 5,4, 10,6],
+        'circle-color': '#C2185B', 'circle-opacity': 0.9,
+        'circle-stroke-width': 1, 'circle-stroke-color': '#000000', 'circle-stroke-opacity': 0.8,
+      }});
+
+      // Shodan exposed devices (opt-in, keyed) — amber threat
+      map.addLayer({ id: 'shodan-glow', type: 'circle', source: 'shodan-nodes', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,6, 5,12, 10,20],
+        'circle-color': '#FFB300', 'circle-opacity': 0.06, 'circle-blur': 0.5,
+      }});
+      map.addLayer({ id: 'shodan-dots', type: 'circle', source: 'shodan-nodes', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,2, 5,4, 10,6],
+        'circle-color': '#FFB300', 'circle-opacity': 0.9,
+        'circle-stroke-width': 1, 'circle-stroke-color': '#000000', 'circle-stroke-opacity': 0.8,
+      }});
 
       // ── NETWORK INTEL MESH (SDK STYLE) ──
       map.addLayer({ id: 'network-mesh-atmo', type: 'line', source: 'network-mesh', paint: {
@@ -662,6 +704,37 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       </div>`);
     });
 
+    // ── Tsunami (NOAA NTWC) ──
+    map.on('click', 'tsunami-circles', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      popup(coords, `<div style="${pStyle}border:1px solid rgba(211,47,47,0.4);">
+        <div style="color:#D32F2F;font-size:12px;font-weight:700;margin-bottom:4px;">🌊 ${htmlEsc(p.title||'Tsunami Information Statement')}</div>
+        <div style="font-size:9px;color:#E8E6E0;margin-bottom:8px;">${htmlEsc(p.summary||'')}</div>
+        <div style="font-size:9px;color:#5C5A54;margin-bottom:8px;">UPDATED ${htmlEsc(p.updated||'—')}</div>
+        <a href="${urlSafe(p.url)}" target="_blank" style="${linkStyle}color:#D32F2F;border:1px solid rgba(211,47,47,0.4);background:rgba(211,47,47,0.1);">📊 NOAA TSUNAMI.GOV</a>
+      </div>`);
+    });
+
+    // ── Ocean Buoys (NOAA NDBC) ──
+    map.on('click', 'buoy-dots', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      popup(coords, `<div style="${pStyle}border:1px solid rgba(38,166,154,0.3);">
+        <div style="color:#26A69A;font-size:12px;font-weight:700;margin-bottom:6px;">⚓ BUOY ${htmlEsc(p.stationId)}</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:4px;font-size:9px;">
+          <div><span style="color:#5C5A54;">WIND</span><br/><span style="color:#E8E6E0;">${p.windSpeed ?? '—'} m/s</span></div>
+          <div><span style="color:#5C5A54;">GUST</span><br/><span style="color:#E8E6E0;">${p.gust ?? '—'} m/s</span></div>
+          <div><span style="color:#5C5A54;">WAVE HT</span><br/><span style="color:#E8E6E0;">${p.waveHeight ?? '—'} m</span></div>
+          <div><span style="color:#5C5A54;">PRESSURE</span><br/><span style="color:#E8E6E0;">${p.pressure ?? '—'} hPa</span></div>
+          <div><span style="color:#5C5A54;">AIR TEMP</span><br/><span style="color:#E8E6E0;">${p.airTemp ?? '—'}°C</span></div>
+          <div><span style="color:#5C5A54;">WATER TEMP</span><br/><span style="color:#E8E6E0;">${p.waterTemp ?? '—'}°C</span></div>
+        </div>
+      </div>`);
+    });
+
     // ── Satellites (SatNOGS powered) ──
     map.on('click', 'sat-dots', e => {
       if (!e.features?.length) return;
@@ -715,6 +788,45 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
           <a href="https://feodotracker.abuse.ch/browse/" target="_blank" style="${linkStyle}flex:1;text-align:center;color:#E8E6E0;border:1px solid rgba(255,255,255,0.2);background:rgba(255,255,255,0.05);">THREAT INTEL ↗</a>
         </div>
         <button onclick="window.openOsirisIntel({ type: 'ip', ip: '${idSafe(p.ip)}', threat_type: '${idSafe(p.malware || p.threat_type || '')}', status: '${idSafe(p.status || '')}' })" style="width:100%;margin-top:8px;padding:8px 12px;background:linear-gradient(90deg, rgba(255,23,68,0.1) 0%, rgba(255,23,68,0.2) 100%);border:1px solid rgba(255,23,68,0.6);color:#FF1744;font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:bold;letter-spacing:0.15em;border-radius:4px;cursor:pointer;transition:all 0.2s;">DEEP DIVE ANALYTICS</button>
+      </div>`);
+    });
+
+    // ── Ransomware Victims (ransomware.live) ──
+    map.on('click', 'ransomware-dots', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      popup(coords, `<div style="${pStyle}border:1px solid rgba(194,24,91,0.4);">
+        <div style="display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid rgba(194,24,91,0.3);padding-bottom:6px;margin-bottom:8px;">
+          <div style="color:#C2185B;font-size:12px;font-weight:700;letter-spacing:0.1em;">[ RANSOMWARE ]</div>
+          <div style="color:#5C5A54;font-size:9px;">${htmlEsc(p.country || 'UNKNOWN')} (approx.)</div>
+        </div>
+        <div style="color:#E8E6E0;font-size:11px;font-weight:bold;margin-bottom:6px;">${htmlEsc(p.victim || 'Unknown victim')}</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:4px;font-size:9px;margin-bottom:8px;">
+          <div><span style="color:#5C5A54;">GROUP</span><br/><span style="color:#C2185B;">${htmlEsc(p.group || 'unknown')}</span></div>
+          <div><span style="color:#5C5A54;">SECTOR</span><br/><span style="color:#E8E6E0;">${htmlEsc(p.activity || '—')}</span></div>
+        </div>
+        <div style="font-size:9px;color:#5C5A54;margin-bottom:8px;">PUBLISHED ${htmlEsc(p.published||'—')}</div>
+        ${p.url ? `<a href="${urlSafe(p.url)}" target="_blank" style="${linkStyle}color:#C2185B;border:1px solid rgba(194,24,91,0.4);background:rgba(194,24,91,0.1);">THREAT INTEL ↗</a>` : ''}
+      </div>`);
+    });
+
+    // ── Shodan Exposed Devices ──
+    map.on('click', 'shodan-dots', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      popup(coords, `<div style="${pStyle}border:1px solid rgba(255,179,0,0.4);">
+        <div style="display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid rgba(255,179,0,0.3);padding-bottom:6px;margin-bottom:8px;">
+          <div style="color:#FFB300;font-size:12px;font-weight:700;letter-spacing:0.1em;">[ SHODAN ]</div>
+          <div style="color:#5C5A54;font-size:9px;">${htmlEsc(p.country || 'UNKNOWN')}</div>
+        </div>
+        <div style="color:#E8E6E0;font-size:11px;font-weight:bold;margin-bottom:6px;">${htmlEsc(p.product || 'Unidentified service')}</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:4px;font-size:9px;margin-bottom:8px;">
+          <div><span style="color:#5C5A54;">IP:PORT</span><br/><span style="color:#FFB300;font-family:monospace;">${htmlEsc(p.ip)}:${p.port}</span></div>
+          <div><span style="color:#5C5A54;">ORG</span><br/><span style="color:#E8E6E0;">${htmlEsc(p.org || '—')}</span></div>
+        </div>
+        <a href="https://www.shodan.io/host/${idSafe(p.ip)}" target="_blank" style="${linkStyle}color:#FFB300;border:1px solid rgba(255,179,0,0.4);background:rgba(255,179,0,0.1);">SHODAN HOST DETAILS ↗</a>
       </div>`);
     });
 
@@ -798,7 +910,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     });
 
     // ── Generic hover for clickables ──
-    ['conflict-icons','cctv-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo','malware-dots'].forEach(layer => {
+    ['conflict-icons','cctv-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo','malware-dots','tsunami-circles','buoy-dots','ransomware-dots','shodan-dots'].forEach(layer => {
       map.on('mouseenter', layer, () => { map.getCanvas().style.cursor = 'pointer'; });
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
     });
@@ -1122,6 +1234,16 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
 
   useEffect(() => {
     if (!mapReady) return;
+    setGeo('tsunami', activeLayers.tsunami && data.tsunami ? data.tsunami.map((t: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [t.lng, t.lat] }, properties: { title: t.title, summary: t.summary, updated: t.updated, url: t.url } })) : []);
+  }, [mapReady, data.tsunami, activeLayers.tsunami, setGeo]);
+
+  useEffect(() => {
+    if (!mapReady) return;
+    setGeo('buoys', activeLayers.buoys && data.buoys ? data.buoys.map((b: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [b.lng, b.lat] }, properties: { stationId: b.stationId, windSpeed: b.windSpeed, windDir: b.windDir, gust: b.gust, waveHeight: b.waveHeight, pressure: b.pressure, airTemp: b.airTemp, waterTemp: b.waterTemp } })) : []);
+  }, [mapReady, data.buoys, activeLayers.buoys, setGeo]);
+
+  useEffect(() => {
+    if (!mapReady) return;
     const sats = data.satellites || [];
     const al = activeLayers as any;
     
@@ -1158,6 +1280,27 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     if (!mapReady) return;
     setGeo('malware-nodes', activeLayers.malware && data.malware_threats ? data.malware_threats.map((t: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [t.lng, t.lat] }, properties: { ip: t.ip, malware: t.malware, status: t.status, threat_type: t.threat_type, country: t.country } })) : []);
   }, [mapReady, data.malware_threats, activeLayers.malware, setGeo]);
+
+  // Ransomware victims — no precise location in source data, plotted at a jittered country centroid
+  useEffect(() => {
+    if (!mapReady) return;
+    const features = activeLayers.ransomware && data.ransomware
+      ? data.ransomware
+          .map((v: any, i: number) => {
+            const pos = jitteredCentroid(i, v.country);
+            if (!pos) return null;
+            return { type: 'Feature', geometry: { type: 'Point', coordinates: [pos.lng, pos.lat] }, properties: { victim: v.victim, group: v.group, country: v.country, activity: v.activity, published: v.published, url: v.url } };
+          })
+          .filter(Boolean)
+      : [];
+    setGeo('ransomware-nodes', features);
+  }, [mapReady, data.ransomware, activeLayers.ransomware, setGeo]);
+
+  // Shodan exposed devices (opt-in, keyed — empty data when disabled, not an error)
+  useEffect(() => {
+    if (!mapReady) return;
+    setGeo('shodan-nodes', activeLayers.shodan && data.shodan_hosts ? data.shodan_hosts.map((h: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [h.lng, h.lat] }, properties: { ip: h.ip, port: h.port, org: h.org, product: h.product, country: h.country, city: h.city } })) : []);
+  }, [mapReady, data.shodan_hosts, activeLayers.shodan, setGeo]);
 
   // Network Mesh Generation (Nearest Neighbor Lattice)
   useEffect(() => {
@@ -1364,6 +1507,10 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     setVis(['fl-military'], activeLayers.military);
     setVis(['cctv-glow','cctv-dots','cctv-label'], activeLayers.cctv);
     setVis(['fires-heat'], activeLayers.fires);
+    setVis(['tsunami-glow','tsunami-circles'], activeLayers.tsunami);
+    setVis(['buoy-dots'], activeLayers.buoys);
+    setVis(['ransomware-glow','ransomware-dots'], activeLayers.ransomware);
+    setVis(['shodan-glow','shodan-dots'], activeLayers.shodan);
     setVis(['weather-glow','weather-dots','weather-label'], activeLayers.weather);
     setVis(['infra-glow','infra-dots','infra-label'], activeLayers.infrastructure);
     setVis(['maritime-glow','maritime-dots','maritime-label'], activeLayers.maritime);

--- a/src/components/SourceHealthPanel.tsx
+++ b/src/components/SourceHealthPanel.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import { Activity, ExternalLink, RefreshCw } from 'lucide-react';
+import { relativeTime } from '@/lib/relativeTime';
+import type { SourceDisplayStatus, SourceHealthEntry } from '@/lib/sources/healthReport';
+
+interface HealthResponse {
+  sources: SourceHealthEntry[];
+  total: number;
+  summary: Record<SourceDisplayStatus, number>;
+  timestamp: string;
+}
+
+const STATUS_COLOR: Record<SourceDisplayStatus, string> = {
+  ok: 'var(--alert-green)',
+  degraded: 'var(--gold-primary)',
+  down: 'var(--alert-red)',
+  unknown: 'var(--text-muted)',
+  disabled: 'var(--text-muted)',
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  aviation: 'AVIATION', maritime: 'MARITIME', seismic: 'SEISMIC', fire: 'FIRE',
+  weather: 'WEATHER', space: 'SPACE', cyber: 'CYBER', conflict: 'CONFLICT',
+  disaster: 'DISASTER', news: 'NEWS', markets: 'MARKETS', osint: 'OSINT', other: 'OTHER',
+};
+
+const POLL_MS = 45_000;
+
+function StatusDot({ status }: { status: SourceDisplayStatus }) {
+  const color = STATUS_COLOR[status];
+  const pulse = status === 'ok' || status === 'degraded';
+  return (
+    <span
+      className={`inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 ${pulse ? 'animate-osiris-pulse' : ''}`}
+      style={{ background: color, boxShadow: `0 0 6px ${color}` }}
+    />
+  );
+}
+
+function groupByCategory(sources: SourceHealthEntry[]): [string, SourceHealthEntry[]][] {
+  const groups = new Map<string, SourceHealthEntry[]>();
+  for (const s of sources) {
+    const list = groups.get(s.category) ?? [];
+    list.push(s);
+    groups.set(s.category, list);
+  }
+  return Array.from(groups.entries());
+}
+
+export default function SourceHealthPanel() {
+  const [report, setReport] = useState<HealthResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [now, setNow] = useState<number>(() => Date.parse('2026-01-01T00:00:00.000Z'));
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/sources/health', { cache: 'no-store' });
+      if (res.ok) {
+        setReport(await res.json());
+        setNow(Date.now());
+      }
+    } catch { /* keep last-known report on transient failure */ }
+    finally { setLoading(false); }
+  }, []);
+
+  useEffect(() => {
+    // Polling an external system (the health API); every setState in load()
+    // runs after `await`, so there's no synchronous cascading render. `now` is
+    // refreshed inside load() alongside the report so freshness labels and the
+    // data they describe always update together.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+    const timer = setInterval(load, POLL_MS);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  const summary = report?.summary;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: 20 }}
+      className="glass-panel p-3 pointer-events-auto max-h-[70vh] flex flex-col"
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <Activity className="w-3.5 h-3.5 text-[var(--gold-primary)]" />
+          <span className="hud-text text-[12px] text-[var(--text-primary)]">SOURCES</span>
+          {report && (
+            <span className="text-[8px] font-mono text-[var(--text-muted)] tabular-nums">{report.total}</span>
+          )}
+        </div>
+        <button onClick={load} className="text-[var(--text-muted)] hover:text-[var(--gold-primary)] transition-colors" title="Refresh">
+          <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />
+        </button>
+      </div>
+
+      {summary && (
+        <div className="flex items-center gap-2.5 mb-2 pb-2 border-b border-[var(--border-secondary)] text-[8px] font-mono tabular-nums">
+          {(['ok', 'degraded', 'down', 'unknown', 'disabled'] as SourceDisplayStatus[])
+            .filter((k) => summary[k] > 0)
+            .map((k) => (
+              <div key={k} className="flex items-center gap-1">
+                <StatusDot status={k} />
+                <span className="text-[var(--text-secondary)]">{summary[k]}</span>
+                <span className="text-[var(--text-muted)] uppercase">{k}</span>
+              </div>
+            ))}
+        </div>
+      )}
+
+      <div className="overflow-y-auto styled-scrollbar flex flex-col gap-3">
+        {loading && !report && (
+          <div className="text-center py-6 text-[8px] font-mono text-[var(--text-muted)] tracking-widest">
+            POLLING SOURCE MESH...
+          </div>
+        )}
+        {report && groupByCategory(report.sources).map(([category, sources]) => (
+          <div key={category}>
+            <div className="hud-label mb-1">{CATEGORY_LABELS[category] ?? category.toUpperCase()}</div>
+            <div className="flex flex-col gap-0.5">
+              {sources.map((s) => (
+                <div key={s.id} className="flex items-center gap-2 px-1 py-1 rounded hover:bg-[var(--hover-accent)] transition-colors group">
+                  <StatusDot status={s.status} />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-[10px] font-mono text-[var(--text-primary)] truncate">{s.name}</div>
+                    <div className="text-[8px] font-mono text-[var(--text-muted)]">
+                      {s.status === 'disabled'
+                        ? 'requires API key'
+                        : `${s.attribution} · ${relativeTime(s.lastSuccessAt, now)}`}
+                    </div>
+                  </div>
+                  <a
+                    href={s.homepage}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="opacity-0 group-hover:opacity-100 text-[var(--text-muted)] hover:text-[var(--gold-primary)] transition-all flex-shrink-0"
+                    title={`Open ${s.attribution}`}
+                  >
+                    <ExternalLink className="w-3 h-3" />
+                  </a>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </motion.div>
+  );
+}

--- a/src/lib/countryCentroids.test.ts
+++ b/src/lib/countryCentroids.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { jitteredCentroid } from './countryCentroids';
+
+describe('jitteredCentroid', () => {
+  it('returns a position near the known centroid for a recognized country code', () => {
+    const pos = jitteredCentroid(0, 'US');
+    expect(pos).not.toBeNull();
+    expect(pos!.lng).toBeGreaterThan(-97 - 5);
+    expect(pos!.lng).toBeLessThan(-97 + 5);
+    expect(pos!.lat).toBeGreaterThan(38 - 5);
+    expect(pos!.lat).toBeLessThan(38 + 5);
+  });
+
+  it('returns null for an unrecognized country code', () => {
+    expect(jitteredCentroid(0, 'ZZ')).toBeNull();
+  });
+
+  it('returns null for an empty country code', () => {
+    expect(jitteredCentroid(0, '')).toBeNull();
+  });
+
+  it('produces different positions for different ids in the same country', () => {
+    const a = jitteredCentroid(1, 'US');
+    const b = jitteredCentroid(2, 'US');
+    expect(a).not.toEqual(b);
+  });
+
+  it('is case-insensitive on the country code', () => {
+    const upper = jitteredCentroid(5, 'US');
+    const lower = jitteredCentroid(5, 'us');
+    expect(lower).toEqual(upper);
+  });
+});

--- a/src/lib/countryCentroids.ts
+++ b/src/lib/countryCentroids.ts
@@ -1,0 +1,21 @@
+const COUNTRY_CENTROIDS: Record<string, [number, number]> = {
+  AF:[65,33],AL:[20,41],DZ:[3,28],AO:[18.5,-12.5],AR:[-64,-34],AM:[45,40],AU:[134,-25],AT:[14,47.5],AZ:[50,40.5],
+  BD:[90,24],BY:[28,53],BE:[4,50.8],BR:[-51,-10],BG:[25.5,42.7],CA:[-96,62],CL:[-71,-30],
+  CN:[105,35],CO:[-72,4],HR:[16,45.2],CZ:[15.5,49.8],DK:[10,56],EG:[30,27],FI:[26,64],
+  FR:[2,46],DE:[10,51],GR:[22,39],HK:[114.2,22.3],HU:[19.5,47],IN:[79,22],ID:[120,-5],
+  IR:[53,32],IQ:[44,33],IE:[-8,53],IL:[34.8,31.5],IT:[12.5,42.8],JP:[138,36],KZ:[67,48],
+  KE:[38,1],KR:[128,36],LT:[24,55.5],MY:[112,3],MX:[-102,23.5],NL:[5.5,52.5],NZ:[174,-41],
+  NG:[8,10],NO:[8,62],PK:[70,30],PA:[-80,9],PH:[122,12.5],PL:[19.5,52],PT:[-8,39.5],
+  RO:[25,46],RU:[100,60],SA:[45,25],SG:[103.8,1.35],ZA:[24,-29],ES:[-4,40],SE:[16,62],
+  CH:[8,47],TW:[121,23.7],TH:[101,15],TR:[35,39],UA:[32,49],AE:[54,24],GB:[-2,54],
+  US:[-97,38],VN:[106,16],
+};
+
+export function jitteredCentroid(id: number, countryCode: string): { lat: number; lng: number } | null {
+  const centroid = countryCode ? COUNTRY_CENTROIDS[countryCode.toUpperCase()] : undefined;
+  if (!centroid) return null;
+  const [lng, lat] = centroid;
+  const jLng = ((id * 173.7) % 200 - 100) / 100 * 4;
+  const jLat = ((id * 293.1) % 200 - 100) / 100 * 4;
+  return { lat: lat + jLat, lng: lng + jLng };
+}

--- a/src/lib/relativeTime.test.ts
+++ b/src/lib/relativeTime.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { relativeTime } from './relativeTime';
+
+const NOW = Date.parse('2026-07-06T12:00:00.000Z');
+
+describe('relativeTime', () => {
+  it('returns "never" for a null timestamp', () => {
+    expect(relativeTime(null, NOW)).toBe('never');
+  });
+
+  it('returns "now" for something within the last few seconds', () => {
+    expect(relativeTime('2026-07-06T11:59:58.000Z', NOW)).toBe('now');
+  });
+
+  it('formats seconds', () => {
+    expect(relativeTime('2026-07-06T11:59:20.000Z', NOW)).toBe('40s ago');
+  });
+
+  it('formats minutes', () => {
+    expect(relativeTime('2026-07-06T11:45:00.000Z', NOW)).toBe('15m ago');
+  });
+
+  it('formats hours', () => {
+    expect(relativeTime('2026-07-06T09:00:00.000Z', NOW)).toBe('3h ago');
+  });
+
+  it('formats days', () => {
+    expect(relativeTime('2026-07-04T12:00:00.000Z', NOW)).toBe('2d ago');
+  });
+
+  it('returns "never" for an unparseable timestamp', () => {
+    expect(relativeTime('not-a-date', NOW)).toBe('never');
+  });
+});

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -1,0 +1,20 @@
+/** Compact relative-time label ("now", "40s ago", "15m ago", "3h ago", "2d ago").
+ * Returns "never" for null or unparseable input. `now` is injectable for testing. */
+export function relativeTime(iso: string | null, now: number = Date.now()): string {
+  if (!iso) return 'never';
+  const then = Date.parse(iso);
+  if (isNaN(then)) return 'never';
+
+  const seconds = Math.max(0, Math.floor((now - then) / 1000));
+  if (seconds < 5) return 'now';
+  if (seconds < 60) return `${seconds}s ago`;
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/src/lib/sources/adapters/ndbcBuoys.test.ts
+++ b/src/lib/sources/adapters/ndbcBuoys.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parseNdbcText, ndbcBuoys } from './ndbcBuoys';
+
+afterEach(() => vi.unstubAllGlobals());
+
+const SAMPLE = [
+  '#STN       LAT      LON  YYYY MM DD hh mm WDIR WSPD   GST WVHT  DPD APD MWD   PRES  PTDY  ATMP  WTMP  DEWP  VIS   TIDE',
+  '#text      deg      deg   yr mo day hr mn degT  m/s   m/s   m   sec sec degT   hPa   hPa  degC  degC  degC  nmi     ft',
+  '14049   -12.000   65.000 2026 07 05 19 00 127   8.0  10.5   MM  MM   MM  MM 1015.9    MM  20.0  26.4    MM   MM     MM',
+  '99999    21.000  -23.000 2026 07 05 19 00  MM    MM    MM   MM  MM   MM  MM     MM    MM    MM    MM    MM   MM     MM',
+].join('\n');
+
+describe('parseNdbcText', () => {
+  it('parses a data row into a buoy observation', () => {
+    const result = parseNdbcText(SAMPLE);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ stationId: '14049', lat: -12.0, lng: 65.0, windSpeed: 8.0, waterTemp: 26.4, airTemp: 20.0 });
+  });
+
+  it('converts "MM" (missing) fields to null rather than NaN', () => {
+    const result = parseNdbcText(SAMPLE);
+    const secondStation = result.find((b) => b.stationId === '99999');
+    expect(secondStation?.windSpeed).toBeNull();
+    expect(secondStation?.waterTemp).toBeNull();
+  });
+
+  it('skips comment/header lines', () => {
+    const result = parseNdbcText('#STN header\n#text header\n');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('ndbcBuoys adapter', () => {
+  it('fetches and parses the latest_obs feed', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: async () => SAMPLE }));
+    const result = await ndbcBuoys.fetch({ signal: new AbortController().signal });
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('throws on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    await expect(ndbcBuoys.fetch({ signal: new AbortController().signal })).rejects.toThrow('500');
+  });
+});

--- a/src/lib/sources/adapters/ndbcBuoys.ts
+++ b/src/lib/sources/adapters/ndbcBuoys.ts
@@ -1,0 +1,73 @@
+import type { SourceAdapter } from '../types';
+
+export interface BuoyObservation {
+  stationId: string;
+  lat: number;
+  lng: number;
+  windDir: number | null;
+  windSpeed: number | null;
+  gust: number | null;
+  waveHeight: number | null;
+  pressure: number | null;
+  airTemp: number | null;
+  waterTemp: number | null;
+}
+
+const URL = 'https://www.ndbc.noaa.gov/data/latest_obs/latest_obs.txt';
+
+// NOAA marks missing readings as the literal string "MM".
+function parseNum(field: string | undefined): number | null {
+  if (!field || field === 'MM') return null;
+  const n = parseFloat(field);
+  return isNaN(n) ? null : n;
+}
+
+export function parseNdbcText(text: string): BuoyObservation[] {
+  const lines = text.split('\n').filter((l) => l.trim().length > 0 && !l.startsWith('#'));
+  const observations: BuoyObservation[] = [];
+
+  for (const line of lines) {
+    const cols = line.trim().split(/\s+/);
+    // STN LAT LON YYYY MM DD hh mm WDIR WSPD GST WVHT DPD APD MWD PRES PTDY ATMP WTMP DEWP VIS TIDE
+    if (cols.length < 19) continue;
+    const lat = parseNum(cols[1]);
+    const lng = parseNum(cols[2]);
+    if (lat === null || lng === null) continue;
+
+    observations.push({
+      stationId: cols[0],
+      lat,
+      lng,
+      windDir: parseNum(cols[8]),
+      windSpeed: parseNum(cols[9]),
+      gust: parseNum(cols[10]),
+      waveHeight: parseNum(cols[11]),
+      pressure: parseNum(cols[15]),
+      airTemp: parseNum(cols[17]),
+      waterTemp: parseNum(cols[18]),
+    });
+  }
+
+  return observations;
+}
+
+export const ndbcBuoys: SourceAdapter<BuoyObservation[]> = {
+  meta: {
+    id: 'ndbc-buoys',
+    name: 'NOAA NDBC Marine Buoys',
+    category: 'maritime',
+    homepage: 'https://www.ndbc.noaa.gov/',
+    license: 'Public domain (US Government work)',
+    requiresKey: false,
+    ttlSeconds: 600,
+    minIntervalMs: 60_000,
+    attribution: 'NOAA NDBC',
+  },
+  isEnabled: () => true,
+  async fetch({ signal }) {
+    const res = await fetch(URL, { signal });
+    if (!res.ok) throw new Error(`NDBC responded ${res.status}`);
+    const text = await res.text();
+    return parseNdbcText(text);
+  },
+};

--- a/src/lib/sources/adapters/noaaTsunami.test.ts
+++ b/src/lib/sources/adapters/noaaTsunami.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { noaaTsunami } from './noaaTsunami';
+
+afterEach(() => vi.unstubAllGlobals());
+
+const SAMPLE_ATOM = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#">
+  <entry>
+    <title>185 miles SW of Eugene, Oregon</title>
+    <updated>2026-06-29T11:39:40Z</updated>
+    <link rel="alternate" href="https://www.tsunami.gov/events/PAAQ/2026/06/29/x/1/WEAK51/WEAK51.txt"/>
+    <geo:lat>43.502</geo:lat>
+    <geo:long>-127.5</geo:long>
+    <summary>Tsunami Information Statement Number 1</summary>
+  </entry>
+</feed>`;
+
+describe('noaaTsunami adapter', () => {
+  it('parses an Atom entry into a tsunami event', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: async () => SAMPLE_ATOM }));
+    const result = await noaaTsunami.fetch({ signal: new AbortController().signal });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ title: '185 miles SW of Eugene, Oregon', lat: 43.502, lng: -127.5 });
+  });
+
+  it('skips entries missing coordinates', async () => {
+    const noCoords = SAMPLE_ATOM.replace(/<geo:lat>.*?<\/geo:lat>/, '');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: async () => noCoords }));
+    const result = await noaaTsunami.fetch({ signal: new AbortController().signal });
+    expect(result).toEqual([]);
+  });
+
+  it('throws on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    await expect(noaaTsunami.fetch({ signal: new AbortController().signal })).rejects.toThrow('500');
+  });
+});

--- a/src/lib/sources/adapters/noaaTsunami.ts
+++ b/src/lib/sources/adapters/noaaTsunami.ts
@@ -1,0 +1,64 @@
+import type { SourceAdapter } from '../types';
+
+export interface TsunamiEvent {
+  id: string;
+  title: string;
+  lat: number;
+  lng: number;
+  updated: string;
+  summary: string;
+  url: string;
+}
+
+// PAAQ = the NWS Pacific/Alaska Tsunami Warning Center's combined feed,
+// covering both the Pacific and Atlantic basins.
+const URL = 'https://www.tsunami.gov/events/xml/PAAQAtom.xml';
+
+function parseEntry(entryXml: string, index: number): TsunamiEvent | null {
+  const titleMatch = entryXml.match(/<title>(.*?)<\/title>/i);
+  const latMatch = entryXml.match(/<geo:lat>(.*?)<\/geo:lat>/i);
+  const lngMatch = entryXml.match(/<geo:long>(.*?)<\/geo:long>/i);
+  const updatedMatch = entryXml.match(/<updated>(.*?)<\/updated>/i);
+  const summaryMatch = entryXml.match(/<summary>(.*?)<\/summary>/i);
+  const linkMatch = entryXml.match(/<link[^>]*href="([^"]+)"/i);
+
+  if (!titleMatch || !latMatch || !lngMatch) return null;
+
+  return {
+    id: `tsunami-${index}`,
+    title: titleMatch[1],
+    lat: parseFloat(latMatch[1]),
+    lng: parseFloat(lngMatch[1]),
+    updated: updatedMatch ? updatedMatch[1] : '',
+    summary: summaryMatch ? summaryMatch[1] : '',
+    url: linkMatch ? linkMatch[1] : 'https://www.tsunami.gov/',
+  };
+}
+
+export const noaaTsunami: SourceAdapter<TsunamiEvent[]> = {
+  meta: {
+    id: 'noaa-tsunami',
+    name: 'NOAA Tsunami Warning Center',
+    category: 'disaster',
+    homepage: 'https://www.tsunami.gov/',
+    license: 'Public domain (US Government work)',
+    requiresKey: false,
+    ttlSeconds: 300,
+    minIntervalMs: 60_000,
+    attribution: 'NOAA NTWC',
+  },
+  isEnabled: () => true,
+  async fetch({ signal }) {
+    const res = await fetch(URL, { signal });
+    if (!res.ok) throw new Error(`NOAA Tsunami responded ${res.status}`);
+    const xml = await res.text();
+    const entries = xml.matchAll(/<entry>([\s\S]*?)<\/entry>/gi);
+    const events: TsunamiEvent[] = [];
+    let i = 0;
+    for (const match of entries) {
+      const parsed = parseEntry(match[1], i);
+      if (parsed) { events.push(parsed); i++; }
+    }
+    return events;
+  },
+};

--- a/src/lib/sources/adapters/ransomwareTracker.test.ts
+++ b/src/lib/sources/adapters/ransomwareTracker.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ransomwareTracker } from './ransomwareTracker';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('ransomwareTracker adapter', () => {
+  it('normalizes a victim record', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ victim: 'Acme Corp', group: 'lockbit', country: 'US', activity: 'Manufacturing', published: '2026-01-01', post_url: 'https://x.com/1' }],
+    }));
+    const result = await ransomwareTracker.fetch({ signal: new AbortController().signal });
+    expect(result).toEqual([{
+      id: 'ransomware-0', victim: 'Acme Corp', group: 'lockbit', country: 'US',
+      activity: 'Manufacturing', published: '2026-01-01', url: 'https://x.com/1',
+    }]);
+  });
+
+  it('caps at 100 entries', async () => {
+    const entries = Array.from({ length: 250 }, (_, i) => ({ victim: `V${i}`, group: 'g', country: 'US' }));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => entries }));
+    const result = await ransomwareTracker.fetch({ signal: new AbortController().signal });
+    expect(result).toHaveLength(100);
+  });
+
+  it('throws on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    await expect(ransomwareTracker.fetch({ signal: new AbortController().signal })).rejects.toThrow('500');
+  });
+});

--- a/src/lib/sources/adapters/ransomwareTracker.ts
+++ b/src/lib/sources/adapters/ransomwareTracker.ts
@@ -1,0 +1,51 @@
+import type { SourceAdapter } from '../types';
+
+export interface RansomwareVictim {
+  id: string;
+  victim: string;
+  group: string;
+  country: string;
+  activity: string | undefined;
+  published: string | undefined;
+  url: string | undefined;
+}
+
+interface RansomwareLiveEntry {
+  victim?: string;
+  group?: string;
+  country?: string;
+  activity?: string;
+  published?: string;
+  post_url?: string;
+}
+
+const URL = 'https://api.ransomware.live/v1/recentvictims';
+const MAX_ENTRIES = 100;
+
+export const ransomwareTracker: SourceAdapter<RansomwareVictim[]> = {
+  meta: {
+    id: 'ransomware-live',
+    name: 'ransomware.live Recent Victims',
+    category: 'cyber',
+    homepage: 'https://ransomware.live/',
+    requiresKey: false,
+    ttlSeconds: 900,
+    minIntervalMs: 300_000,
+    attribution: 'ransomware.live',
+  },
+  isEnabled: () => true,
+  async fetch({ signal }) {
+    const res = await fetch(URL, { signal });
+    if (!res.ok) throw new Error(`ransomware.live responded ${res.status}`);
+    const data = (await res.json()) as RansomwareLiveEntry[];
+    return data.slice(0, MAX_ENTRIES).map((entry, i) => ({
+      id: `ransomware-${i}`,
+      victim: entry.victim || 'Unknown',
+      group: entry.group || 'unknown',
+      country: entry.country || '',
+      activity: entry.activity,
+      published: entry.published,
+      url: entry.post_url,
+    }));
+  },
+};

--- a/src/lib/sources/adapters/shodanExposed.test.ts
+++ b/src/lib/sources/adapters/shodanExposed.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { shodanExposed } from './shodanExposed';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.SHODAN_API_KEY;
+});
+
+describe('shodanExposed adapter', () => {
+  describe('isEnabled', () => {
+    it('is disabled when SHODAN_API_KEY is unset', () => {
+      delete process.env.SHODAN_API_KEY;
+      expect(shodanExposed.isEnabled()).toBe(false);
+    });
+
+    it('is enabled when SHODAN_API_KEY is set', () => {
+      process.env.SHODAN_API_KEY = 'test-key';
+      expect(shodanExposed.isEnabled()).toBe(true);
+    });
+  });
+
+  describe('fetch', () => {
+    it('normalizes a match with a resolved location', async () => {
+      process.env.SHODAN_API_KEY = 'test-key';
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          matches: [{
+            ip_str: '1.2.3.4', port: 8080, org: 'Acme ISP', product: 'Webcam XYZ',
+            timestamp: '2026-01-01T00:00:00', location: { latitude: 10, longitude: 20, country_name: 'Testland', city: 'Testville' },
+          }],
+        }),
+      }));
+      const result = await shodanExposed.fetch({ signal: new AbortController().signal });
+      expect(result).toEqual([{
+        id: 'shodan-1.2.3.4-8080', lat: 10, lng: 20, ip: '1.2.3.4', port: 8080,
+        org: 'Acme ISP', product: 'Webcam XYZ', country: 'Testland', city: 'Testville', timestamp: '2026-01-01T00:00:00',
+      }]);
+    });
+
+    it('skips matches with no resolved location', async () => {
+      process.env.SHODAN_API_KEY = 'test-key';
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ matches: [{ ip_str: '1.2.3.4', port: 80, location: {} }] }),
+      }));
+      const result = await shodanExposed.fetch({ signal: new AbortController().signal });
+      expect(result).toEqual([]);
+    });
+
+    it('throws on a non-ok response', async () => {
+      process.env.SHODAN_API_KEY = 'test-key';
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+      await expect(shodanExposed.fetch({ signal: new AbortController().signal })).rejects.toThrow('401');
+    });
+  });
+});

--- a/src/lib/sources/adapters/shodanExposed.ts
+++ b/src/lib/sources/adapters/shodanExposed.ts
@@ -1,0 +1,75 @@
+import type { SourceAdapter } from '../types';
+
+export interface ShodanHost {
+  id: string;
+  lat: number;
+  lng: number;
+  ip: string;
+  port: number;
+  org: string | undefined;
+  product: string | undefined;
+  country: string | undefined;
+  city: string | undefined;
+  timestamp: string | undefined;
+}
+
+interface ShodanMatch {
+  ip_str?: string;
+  port?: number;
+  org?: string;
+  product?: string;
+  timestamp?: string;
+  location?: { latitude?: number; longitude?: number; country_name?: string; city?: string };
+}
+
+interface ShodanSearchResponse {
+  matches?: ShodanMatch[];
+}
+
+// A single, low-churn query — Shodan search credits are scarce on free/dev
+// keys, hence the long ttl/minInterval below.
+const QUERY = 'webcam';
+const MAX_ENTRIES = 100;
+
+export const shodanExposed: SourceAdapter<ShodanHost[]> = {
+  meta: {
+    id: 'shodan-exposed',
+    name: 'Shodan Exposed Devices',
+    category: 'osint',
+    homepage: 'https://www.shodan.io/',
+    requiresKey: true,
+    keyEnvVars: ['SHODAN_API_KEY'],
+    ttlSeconds: 3600,
+    minIntervalMs: 900_000,
+    attribution: 'Shodan',
+  },
+  isEnabled: () => !!process.env.SHODAN_API_KEY,
+  async fetch({ signal }) {
+    const key = process.env.SHODAN_API_KEY || '';
+    const url = `https://api.shodan.io/shodan/host/search?key=${encodeURIComponent(key)}&query=${encodeURIComponent(QUERY)}`;
+    const res = await fetch(url, { signal });
+    if (!res.ok) throw new Error(`Shodan responded ${res.status}`);
+    const data = (await res.json()) as ShodanSearchResponse;
+    const matches = data.matches ?? [];
+
+    const hosts: ShodanHost[] = [];
+    for (const m of matches.slice(0, MAX_ENTRIES)) {
+      const lat = m.location?.latitude;
+      const lng = m.location?.longitude;
+      if (lat == null || lng == null || !m.ip_str) continue;
+      hosts.push({
+        id: `shodan-${m.ip_str}-${m.port ?? 0}`,
+        lat,
+        lng,
+        ip: m.ip_str,
+        port: m.port ?? 0,
+        org: m.org,
+        product: m.product,
+        country: m.location?.country_name,
+        city: m.location?.city,
+        timestamp: m.timestamp,
+      });
+    }
+    return hosts;
+  },
+};

--- a/src/lib/sources/adapters/wigleNetworks.test.ts
+++ b/src/lib/sources/adapters/wigleNetworks.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { wigleNetworks } from './wigleNetworks';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.WIGLE_API_NAME;
+  delete process.env.WIGLE_API_TOKEN;
+});
+
+describe('wigleNetworks adapter', () => {
+  describe('isEnabled', () => {
+    it('is disabled when neither credential is set', () => {
+      expect(wigleNetworks.isEnabled()).toBe(false);
+    });
+
+    it('is disabled when only the API name is set', () => {
+      process.env.WIGLE_API_NAME = 'name';
+      expect(wigleNetworks.isEnabled()).toBe(false);
+    });
+
+    it('is enabled when both credentials are set', () => {
+      process.env.WIGLE_API_NAME = 'name';
+      process.env.WIGLE_API_TOKEN = 'token';
+      expect(wigleNetworks.isEnabled()).toBe(true);
+    });
+  });
+
+  describe('fetch', () => {
+    beforeEach(() => {
+      process.env.WIGLE_API_NAME = 'name';
+      process.env.WIGLE_API_TOKEN = 'token';
+    });
+
+    it('throws when lat/lng params are missing', async () => {
+      await expect(wigleNetworks.fetch({ signal: new AbortController().signal })).rejects.toThrow('lat/lng');
+    });
+
+    it('sends HTTP Basic auth built from the configured credentials', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ results: [] }) });
+      vi.stubGlobal('fetch', fetchMock);
+      await wigleNetworks.fetch({ signal: new AbortController().signal, params: { lat: '10', lng: '20' } });
+      const [, init] = fetchMock.mock.calls[0];
+      const expectedAuth = 'Basic ' + Buffer.from('name:token').toString('base64');
+      expect(init.headers.Authorization).toBe(expectedAuth);
+    });
+
+    it('normalizes a result with a resolved location', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          results: [{ trilat: 10.1, trilong: 20.1, ssid: 'MyNetwork', netid: 'AA:BB:CC:DD:EE:FF', encryption: 'wpa2', type: 'infra', lastupdt: '2026-01-01' }],
+        }),
+      }));
+      const result = await wigleNetworks.fetch({ signal: new AbortController().signal, params: { lat: '10', lng: '20' } });
+      expect(result).toEqual([{
+        id: 'wigle-AA:BB:CC:DD:EE:FF', lat: 10.1, lng: 20.1, ssid: 'MyNetwork', bssid: 'AA:BB:CC:DD:EE:FF',
+        encryption: 'wpa2', type: 'infra', lastUpdate: '2026-01-01',
+      }]);
+    });
+
+    it('skips results with no resolved location or netid', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ results: [{ ssid: 'NoCoords' }] }) }));
+      const result = await wigleNetworks.fetch({ signal: new AbortController().signal, params: { lat: '10', lng: '20' } });
+      expect(result).toEqual([]);
+    });
+
+    it('throws on a non-ok response', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 403 }));
+      await expect(wigleNetworks.fetch({ signal: new AbortController().signal, params: { lat: '10', lng: '20' } })).rejects.toThrow('403');
+    });
+  });
+});

--- a/src/lib/sources/adapters/wigleNetworks.ts
+++ b/src/lib/sources/adapters/wigleNetworks.ts
@@ -1,0 +1,81 @@
+import type { SourceAdapter } from '../types';
+
+export interface WigleNetwork {
+  id: string;
+  lat: number;
+  lng: number;
+  ssid: string;
+  bssid: string;
+  encryption: string | undefined;
+  type: string | undefined;
+  lastUpdate: string | undefined;
+}
+
+interface WigleResult {
+  trilat?: number;
+  trilong?: number;
+  ssid?: string;
+  netid?: string;
+  encryption?: string;
+  type?: string;
+  lastupdt?: string;
+}
+
+interface WigleSearchResponse {
+  results?: WigleResult[];
+}
+
+const MAX_ENTRIES = 100;
+const DEFAULT_RADIUS_KM = 3;
+const KM_PER_DEGREE_LAT = 111;
+
+// WiGLE's search API requires a bounding box (no global feed), so this
+// adapter is called on-demand for a point + radius rather than polled.
+export const wigleNetworks: SourceAdapter<WigleNetwork[]> = {
+  meta: {
+    id: 'wigle-networks',
+    name: 'WiGLE Wireless Networks',
+    category: 'osint',
+    homepage: 'https://wigle.net/',
+    requiresKey: true,
+    keyEnvVars: ['WIGLE_API_NAME', 'WIGLE_API_TOKEN'],
+    ttlSeconds: 1800,
+    minIntervalMs: 60_000,
+    attribution: 'WiGLE.net',
+  },
+  isEnabled: () => !!process.env.WIGLE_API_NAME && !!process.env.WIGLE_API_TOKEN,
+  async fetch({ signal, params }) {
+    const lat = parseFloat(params?.lat ?? '');
+    const lng = parseFloat(params?.lng ?? '');
+    if (isNaN(lat) || isNaN(lng)) throw new Error('WiGLE lookup requires lat/lng params');
+    const radiusKm = parseFloat(params?.radius ?? '') || DEFAULT_RADIUS_KM;
+    const dLat = radiusKm / KM_PER_DEGREE_LAT;
+    const dLng = radiusKm / (KM_PER_DEGREE_LAT * Math.cos((lat * Math.PI) / 180) || 1);
+
+    const name = process.env.WIGLE_API_NAME || '';
+    const token = process.env.WIGLE_API_TOKEN || '';
+    const auth = Buffer.from(`${name}:${token}`).toString('base64');
+
+    const url = `https://api.wigle.net/api/v2/network/search?latrange1=${lat - dLat}&latrange2=${lat + dLat}&longrange1=${lng - dLng}&longrange2=${lng + dLng}`;
+    const res = await fetch(url, { signal, headers: { Authorization: `Basic ${auth}` } });
+    if (!res.ok) throw new Error(`WiGLE responded ${res.status}`);
+    const data = (await res.json()) as WigleSearchResponse;
+    const results = data.results ?? [];
+
+    const networks: WigleNetwork[] = [];
+    for (const r of results.slice(0, MAX_ENTRIES)) {
+      if (r.trilat == null || r.trilong == null || !r.netid) continue;
+      networks.push({
+        id: `wigle-${r.netid}`,
+        lat: r.trilat,
+        lng: r.trilong,
+        ssid: r.ssid || '(hidden)',
+        bssid: r.netid,
+        encryption: r.encryption,
+        type: r.type,
+        lastUpdate: r.lastupdt,
+      });
+    }
+    return networks;
+  },
+};

--- a/src/lib/sources/cache.test.ts
+++ b/src/lib/sources/cache.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { createCache } from './cache';
+
+describe('createCache', () => {
+  it('returns undefined on a miss', () => {
+    const cache = createCache(() => 0);
+    expect(cache.get('missing')).toBeUndefined();
+  });
+
+  it('returns the value on a hit within the TTL window', () => {
+    let now = 1000;
+    const cache = createCache(() => now);
+    cache.set('k', { a: 1 }, 60);
+    now += 30_000;
+    expect(cache.get('k')).toEqual({ a: 1 });
+  });
+
+  it('returns undefined once the TTL has expired', () => {
+    let now = 1000;
+    const cache = createCache(() => now);
+    cache.set('k', 'v', 60);
+    now += 61_000;
+    expect(cache.get('k')).toBeUndefined();
+  });
+
+  it('getStale returns the value even after expiry', () => {
+    let now = 1000;
+    const cache = createCache(() => now);
+    cache.set('k', 'v', 60);
+    now += 61_000;
+    expect(cache.getStale('k')).toBe('v');
+  });
+
+  it('getStale returns undefined for a key that was never set', () => {
+    const cache = createCache(() => 0);
+    expect(cache.getStale('never')).toBeUndefined();
+  });
+
+  it('a later set overwrites the previous value and TTL', () => {
+    let now = 1000;
+    const cache = createCache(() => now);
+    cache.set('k', 'first', 60);
+    cache.set('k', 'second', 60);
+    expect(cache.get('k')).toBe('second');
+  });
+});

--- a/src/lib/sources/cache.ts
+++ b/src/lib/sources/cache.ts
@@ -1,0 +1,28 @@
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+export interface Cache {
+  get<T>(key: string): T | undefined;
+  set<T>(key: string, value: T, ttlSeconds: number): void;
+  getStale<T>(key: string): T | undefined;
+}
+
+export function createCache(now: () => number = Date.now): Cache {
+  const store = new Map<string, CacheEntry<unknown>>();
+
+  return {
+    get<T>(key: string): T | undefined {
+      const entry = store.get(key);
+      if (!entry || entry.expiresAt <= now()) return undefined;
+      return entry.value as T;
+    },
+    set<T>(key: string, value: T, ttlSeconds: number): void {
+      store.set(key, { value, expiresAt: now() + ttlSeconds * 1000 });
+    },
+    getStale<T>(key: string): T | undefined {
+      return store.get(key)?.value as T | undefined;
+    },
+  };
+}

--- a/src/lib/sources/health.test.ts
+++ b/src/lib/sources/health.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { createHealthTracker } from './health';
+
+describe('createHealthTracker', () => {
+  it('reports unknown status for a source with no recorded activity', () => {
+    const tracker = createHealthTracker(() => 1000);
+    const health = tracker.get('never-seen');
+    expect(health.status).toBe('unknown');
+    expect(health.lastSuccessAt).toBeNull();
+    expect(health.lastErrorAt).toBeNull();
+    expect(health.consecutiveFailures).toBe(0);
+  });
+
+  it('reports ok after a successful fetch and records latency/timestamp', () => {
+    const tracker = createHealthTracker(() => 5000);
+    tracker.recordSuccess('a', 120);
+    const health = tracker.get('a');
+    expect(health.status).toBe('ok');
+    expect(health.lastLatencyMs).toBe(120);
+    expect(health.lastSuccessAt).toBe(new Date(5000).toISOString());
+    expect(health.consecutiveFailures).toBe(0);
+  });
+
+  it('reports degraded after 1 or 2 consecutive failures', () => {
+    const tracker = createHealthTracker(() => 1000);
+    tracker.recordFailure('a');
+    expect(tracker.get('a').status).toBe('degraded');
+    expect(tracker.get('a').consecutiveFailures).toBe(1);
+
+    tracker.recordFailure('a');
+    expect(tracker.get('a').status).toBe('degraded');
+    expect(tracker.get('a').consecutiveFailures).toBe(2);
+  });
+
+  it('reports down after 3 or more consecutive failures', () => {
+    const tracker = createHealthTracker(() => 1000);
+    tracker.recordFailure('a');
+    tracker.recordFailure('a');
+    tracker.recordFailure('a');
+    expect(tracker.get('a').status).toBe('down');
+    expect(tracker.get('a').consecutiveFailures).toBe(3);
+  });
+
+  it('resets consecutiveFailures and returns to ok after a success', () => {
+    const tracker = createHealthTracker(() => 1000);
+    tracker.recordFailure('a');
+    tracker.recordFailure('a');
+    tracker.recordFailure('a');
+    tracker.recordSuccess('a', 50);
+    const health = tracker.get('a');
+    expect(health.status).toBe('ok');
+    expect(health.consecutiveFailures).toBe(0);
+  });
+
+  it('records lastErrorAt on failure without clearing lastSuccessAt history', () => {
+    let now = 1000;
+    const tracker = createHealthTracker(() => now);
+    tracker.recordSuccess('a', 10);
+    now = 2000;
+    tracker.recordFailure('a');
+    const health = tracker.get('a');
+    expect(health.lastSuccessAt).toBe(new Date(1000).toISOString());
+    expect(health.lastErrorAt).toBe(new Date(2000).toISOString());
+  });
+
+  it('tracks sources independently', () => {
+    const tracker = createHealthTracker(() => 1000);
+    tracker.recordFailure('a');
+    tracker.recordSuccess('b', 5);
+    expect(tracker.get('a').status).toBe('degraded');
+    expect(tracker.get('b').status).toBe('ok');
+  });
+
+  it('snapshot returns health for every source that has recorded activity', () => {
+    const tracker = createHealthTracker(() => 1000);
+    tracker.recordSuccess('a', 10);
+    tracker.recordFailure('b');
+    const snapshot = tracker.snapshot();
+    const ids = snapshot.map((h) => h.sourceId).sort();
+    expect(ids).toEqual(['a', 'b']);
+  });
+});

--- a/src/lib/sources/health.ts
+++ b/src/lib/sources/health.ts
@@ -1,0 +1,75 @@
+import type { SourceStatus } from './types';
+
+export interface SourceHealth {
+  sourceId: string;
+  status: SourceStatus;
+  lastSuccessAt: string | null;
+  lastErrorAt: string | null;
+  lastLatencyMs: number | null;
+  consecutiveFailures: number;
+}
+
+export interface HealthTracker {
+  recordSuccess(sourceId: string, latencyMs: number): void;
+  recordFailure(sourceId: string): void;
+  get(sourceId: string): SourceHealth;
+  snapshot(): SourceHealth[];
+}
+
+interface MutableHealth {
+  lastSuccessAt: string | null;
+  lastErrorAt: string | null;
+  lastLatencyMs: number | null;
+  consecutiveFailures: number;
+}
+
+function deriveStatus(consecutiveFailures: number, hasActivity: boolean): SourceStatus {
+  if (!hasActivity) return 'unknown';
+  if (consecutiveFailures >= 3) return 'down';
+  if (consecutiveFailures >= 1) return 'degraded';
+  return 'ok';
+}
+
+function toHealth(sourceId: string, entry: MutableHealth | undefined): SourceHealth {
+  const hasActivity = entry !== undefined;
+  const consecutiveFailures = entry?.consecutiveFailures ?? 0;
+  return {
+    sourceId,
+    status: deriveStatus(consecutiveFailures, hasActivity),
+    lastSuccessAt: entry?.lastSuccessAt ?? null,
+    lastErrorAt: entry?.lastErrorAt ?? null,
+    lastLatencyMs: entry?.lastLatencyMs ?? null,
+    consecutiveFailures,
+  };
+}
+
+export function createHealthTracker(now: () => number = Date.now): HealthTracker {
+  const store = new Map<string, MutableHealth>();
+
+  return {
+    recordSuccess(sourceId: string, latencyMs: number): void {
+      const existing = store.get(sourceId);
+      store.set(sourceId, {
+        lastSuccessAt: new Date(now()).toISOString(),
+        lastErrorAt: existing?.lastErrorAt ?? null,
+        lastLatencyMs: latencyMs,
+        consecutiveFailures: 0,
+      });
+    },
+    recordFailure(sourceId: string): void {
+      const existing = store.get(sourceId);
+      store.set(sourceId, {
+        lastSuccessAt: existing?.lastSuccessAt ?? null,
+        lastErrorAt: new Date(now()).toISOString(),
+        lastLatencyMs: existing?.lastLatencyMs ?? null,
+        consecutiveFailures: (existing?.consecutiveFailures ?? 0) + 1,
+      });
+    },
+    get(sourceId: string): SourceHealth {
+      return toHealth(sourceId, store.get(sourceId));
+    },
+    snapshot(): SourceHealth[] {
+      return Array.from(store.keys()).map((sourceId) => toHealth(sourceId, store.get(sourceId)));
+    },
+  };
+}

--- a/src/lib/sources/healthReport.test.ts
+++ b/src/lib/sources/healthReport.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { buildSourceHealthReport } from './healthReport';
+import type { SourceAdapter } from './types';
+import type { SourceHealth } from './health';
+
+function adapter(id: string, category: string, name: string, opts?: { requiresKey?: boolean; enabled?: boolean }): SourceAdapter<unknown> {
+  return {
+    meta: {
+      id,
+      name,
+      category: category as SourceAdapter<unknown>['meta']['category'],
+      homepage: `https://example.com/${id}`,
+      requiresKey: opts?.requiresKey ?? false,
+      ttlSeconds: 60,
+      minIntervalMs: 1000,
+      attribution: `Attr ${name}`,
+    },
+    isEnabled: () => opts?.enabled ?? true,
+    fetch: async () => ({}),
+  };
+}
+
+function health(id: string, over: Partial<SourceHealth> = {}): SourceHealth {
+  return {
+    sourceId: id,
+    status: 'unknown',
+    lastSuccessAt: null,
+    lastErrorAt: null,
+    lastLatencyMs: null,
+    consecutiveFailures: 0,
+    ...over,
+  };
+}
+
+describe('buildSourceHealthReport', () => {
+  it('merges adapter metadata with its health entry', () => {
+    const adapters = [adapter('usgs', 'seismic', 'USGS Quakes')];
+    const lookup = (id: string) => health(id, { status: 'ok', lastSuccessAt: '2026-01-01T00:00:00.000Z', lastLatencyMs: 42 });
+
+    const report = buildSourceHealthReport(adapters, lookup);
+
+    expect(report).toHaveLength(1);
+    expect(report[0]).toEqual({
+      id: 'usgs',
+      name: 'USGS Quakes',
+      category: 'seismic',
+      homepage: 'https://example.com/usgs',
+      attribution: 'Attr USGS Quakes',
+      requiresKey: false,
+      enabled: true,
+      status: 'ok',
+      lastSuccessAt: '2026-01-01T00:00:00.000Z',
+      lastErrorAt: null,
+      lastLatencyMs: 42,
+      consecutiveFailures: 0,
+    });
+  });
+
+  it('reports a keyed source with no key as disabled, ignoring its (unknown) health', () => {
+    const adapters = [adapter('shodan', 'osint', 'Shodan', { requiresKey: true, enabled: false })];
+    const report = buildSourceHealthReport(adapters, (id) => health(id));
+
+    expect(report[0].enabled).toBe(false);
+    expect(report[0].status).toBe('disabled');
+  });
+
+  it('keeps a keyed source enabled+ok when its key is present and it is healthy', () => {
+    const adapters = [adapter('shodan', 'osint', 'Shodan', { requiresKey: true, enabled: true })];
+    const report = buildSourceHealthReport(adapters, (id) => health(id, { status: 'ok' }));
+
+    expect(report[0].enabled).toBe(true);
+    expect(report[0].status).toBe('ok');
+  });
+
+  it('sorts by category then name for stable grouped display', () => {
+    const adapters = [
+      adapter('b', 'weather', 'Zeta'),
+      adapter('a', 'weather', 'Alpha'),
+      adapter('c', 'cyber', 'Beta'),
+    ];
+    const report = buildSourceHealthReport(adapters, (id) => health(id));
+
+    expect(report.map((r) => r.id)).toEqual(['c', 'a', 'b']);
+  });
+});

--- a/src/lib/sources/healthReport.ts
+++ b/src/lib/sources/healthReport.ts
@@ -1,0 +1,48 @@
+import type { SourceAdapter } from './types';
+import type { SourceHealth } from './health';
+
+/** Display status for the SOURCES panel: the runtime health, plus 'disabled'
+ * for keyed sources whose key isn't configured (they never run, so their raw
+ * health status stays 'unknown' — 'disabled' is the honest thing to show). */
+export type SourceDisplayStatus = 'ok' | 'degraded' | 'down' | 'unknown' | 'disabled';
+
+export interface SourceHealthEntry {
+  id: string;
+  name: string;
+  category: string;
+  homepage: string;
+  attribution: string;
+  requiresKey: boolean;
+  enabled: boolean;
+  status: SourceDisplayStatus;
+  lastSuccessAt: string | null;
+  lastErrorAt: string | null;
+  lastLatencyMs: number | null;
+  consecutiveFailures: number;
+}
+
+export function buildSourceHealthReport(
+  adapters: SourceAdapter<unknown>[],
+  getHealth: (id: string) => SourceHealth,
+): SourceHealthEntry[] {
+  return adapters
+    .map((a): SourceHealthEntry => {
+      const h = getHealth(a.meta.id);
+      const enabled = a.isEnabled();
+      return {
+        id: a.meta.id,
+        name: a.meta.name,
+        category: a.meta.category,
+        homepage: a.meta.homepage,
+        attribution: a.meta.attribution,
+        requiresKey: a.meta.requiresKey,
+        enabled,
+        status: enabled ? h.status : 'disabled',
+        lastSuccessAt: h.lastSuccessAt,
+        lastErrorAt: h.lastErrorAt,
+        lastLatencyMs: h.lastLatencyMs,
+        consecutiveFailures: h.consecutiveFailures,
+      };
+    })
+    .sort((a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name));
+}

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -1,0 +1,39 @@
+import { createCache } from './cache';
+import { createRateLimiter } from './rateLimit';
+import { createHealthTracker } from './health';
+import { createRunner } from './runSource';
+import { createRegistry } from './registry';
+import { registerAllSources } from './registerAll';
+
+// Survive Next.js dev-mode HMR module re-evaluation, same pattern used by the
+// SDK ingest/stream routes' globalForSDK.
+const globalForSources = globalThis as unknown as {
+  osirisSourcesSingleton?: {
+    cache: ReturnType<typeof createCache>;
+    rateLimit: ReturnType<typeof createRateLimiter>;
+    health: ReturnType<typeof createHealthTracker>;
+    runner: ReturnType<typeof createRunner>;
+    registry: ReturnType<typeof createRegistry>;
+  };
+};
+
+function build() {
+  const cache = createCache();
+  const rateLimit = createRateLimiter();
+  const health = createHealthTracker();
+  const runner = createRunner({ cache, rateLimit, health });
+  const registry = createRegistry();
+  registerAllSources(registry);
+  return { cache, rateLimit, health, runner, registry };
+}
+
+const singleton = globalForSources.osirisSourcesSingleton ?? build();
+globalForSources.osirisSourcesSingleton = singleton;
+
+export const sourceCache = singleton.cache;
+export const sourceRateLimit = singleton.rateLimit;
+export const sourceHealth = singleton.health;
+export const sourceRegistry = singleton.registry;
+export const { runSource, runWithFallback } = singleton.runner;
+
+export * from './types';

--- a/src/lib/sources/rateLimit.test.ts
+++ b/src/lib/sources/rateLimit.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRateLimiter } from './rateLimit';
+
+describe('createRateLimiter', () => {
+  it('does not wait on the first acquire for a source', async () => {
+    const wait = vi.fn().mockResolvedValue(undefined);
+    const limiter = createRateLimiter(() => 1000, wait);
+    await limiter.acquire('a', 5000);
+    expect(wait).not.toHaveBeenCalled();
+  });
+
+  it('waits for the remaining interval on a second acquire within the window', async () => {
+    let now = 1000;
+    const wait = vi.fn().mockResolvedValue(undefined);
+    const limiter = createRateLimiter(() => now, wait);
+    await limiter.acquire('a', 5000);
+    now = 3000; // 2000ms elapsed, 3000ms remaining
+    await limiter.acquire('a', 5000);
+    expect(wait).toHaveBeenCalledWith(3000);
+  });
+
+  it('does not wait if the interval has already fully elapsed', async () => {
+    let now = 1000;
+    const wait = vi.fn().mockResolvedValue(undefined);
+    const limiter = createRateLimiter(() => now, wait);
+    await limiter.acquire('a', 5000);
+    now = 6000; // 5000ms elapsed, exactly the interval
+    await limiter.acquire('a', 5000);
+    expect(wait).not.toHaveBeenCalled();
+  });
+
+  it('tracks each source independently', async () => {
+    let now = 1000;
+    const wait = vi.fn().mockResolvedValue(undefined);
+    const limiter = createRateLimiter(() => now, wait);
+    await limiter.acquire('a', 5000);
+    now = 1100;
+    await limiter.acquire('b', 5000);
+    expect(wait).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/sources/rateLimit.ts
+++ b/src/lib/sources/rateLimit.ts
@@ -1,0 +1,27 @@
+export interface RateLimiter {
+  acquire(sourceId: string, minIntervalMs: number): Promise<void>;
+}
+
+function defaultWait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function createRateLimiter(
+  now: () => number = Date.now,
+  wait: (ms: number) => Promise<void> = defaultWait,
+): RateLimiter {
+  const lastCallAt = new Map<string, number>();
+
+  return {
+    async acquire(sourceId: string, minIntervalMs: number): Promise<void> {
+      const last = lastCallAt.get(sourceId);
+      if (last !== undefined) {
+        const remaining = minIntervalMs - (now() - last);
+        if (remaining > 0) {
+          await wait(remaining);
+        }
+      }
+      lastCallAt.set(sourceId, now());
+    },
+  };
+}

--- a/src/lib/sources/registerAll.ts
+++ b/src/lib/sources/registerAll.ts
@@ -1,0 +1,20 @@
+import type { Registry } from './registry';
+import { ndbcBuoys } from './adapters/ndbcBuoys';
+import { noaaTsunami } from './adapters/noaaTsunami';
+import { ransomwareTracker } from './adapters/ransomwareTracker';
+import { shodanExposed } from './adapters/shodanExposed';
+import { wigleNetworks } from './adapters/wigleNetworks';
+
+const ALL_ADAPTERS = [
+  ndbcBuoys,
+  noaaTsunami,
+  ransomwareTracker,
+  shodanExposed,
+  wigleNetworks,
+];
+
+export function registerAllSources(registry: Registry): void {
+  for (const adapter of ALL_ADAPTERS) {
+    registry.registerSource(adapter as Parameters<typeof registry.registerSource>[0]);
+  }
+}

--- a/src/lib/sources/registry.test.ts
+++ b/src/lib/sources/registry.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRegistry } from './registry';
+import type { SourceAdapter } from './types';
+
+function makeAdapter(id: string, category: SourceAdapter<unknown>['meta']['category']): SourceAdapter<unknown> {
+  return {
+    meta: {
+      id,
+      name: id,
+      category,
+      homepage: 'https://example.com',
+      requiresKey: false,
+      ttlSeconds: 60,
+      minIntervalMs: 1000,
+      attribution: 'Example',
+    },
+    isEnabled: () => true,
+    fetch: async () => ({}),
+  };
+}
+
+describe('createRegistry', () => {
+  let registry: ReturnType<typeof createRegistry>;
+
+  beforeEach(() => {
+    registry = createRegistry();
+  });
+
+  it('returns undefined for an unregistered source id', () => {
+    expect(registry.getSource('missing')).toBeUndefined();
+  });
+
+  it('registers a source and retrieves it by id', () => {
+    const adapter = makeAdapter('usgs-earthquakes', 'seismic');
+    registry.registerSource(adapter);
+    expect(registry.getSource('usgs-earthquakes')).toBe(adapter);
+  });
+
+  it('lists all registered sources', () => {
+    registry.registerSource(makeAdapter('a', 'seismic'));
+    registry.registerSource(makeAdapter('b', 'weather'));
+    expect(registry.listAll().map((a) => a.meta.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('lists sources filtered by category', () => {
+    registry.registerSource(makeAdapter('a', 'seismic'));
+    registry.registerSource(makeAdapter('b', 'weather'));
+    registry.registerSource(makeAdapter('c', 'seismic'));
+    expect(registry.listByCategory('seismic').map((a) => a.meta.id).sort()).toEqual(['a', 'c']);
+  });
+
+  it('returns an empty array for a category with no registered sources', () => {
+    expect(registry.listByCategory('cyber')).toEqual([]);
+  });
+
+  it('registering a second adapter with the same id replaces the first', () => {
+    const first = makeAdapter('dup', 'seismic');
+    const second = makeAdapter('dup', 'weather');
+    registry.registerSource(first);
+    registry.registerSource(second);
+    expect(registry.getSource('dup')).toBe(second);
+    expect(registry.listAll()).toHaveLength(1);
+  });
+});

--- a/src/lib/sources/registry.ts
+++ b/src/lib/sources/registry.ts
@@ -1,0 +1,27 @@
+import type { SourceAdapter, SourceCategory } from './types';
+
+export interface Registry {
+  registerSource(adapter: SourceAdapter<unknown>): void;
+  getSource(id: string): SourceAdapter<unknown> | undefined;
+  listByCategory(category: SourceCategory): SourceAdapter<unknown>[];
+  listAll(): SourceAdapter<unknown>[];
+}
+
+export function createRegistry(): Registry {
+  const sources = new Map<string, SourceAdapter<unknown>>();
+
+  return {
+    registerSource(adapter: SourceAdapter<unknown>): void {
+      sources.set(adapter.meta.id, adapter);
+    },
+    getSource(id: string): SourceAdapter<unknown> | undefined {
+      return sources.get(id);
+    },
+    listByCategory(category: SourceCategory): SourceAdapter<unknown>[] {
+      return Array.from(sources.values()).filter((a) => a.meta.category === category);
+    },
+    listAll(): SourceAdapter<unknown>[] {
+      return Array.from(sources.values());
+    },
+  };
+}

--- a/src/lib/sources/runSource.test.ts
+++ b/src/lib/sources/runSource.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRunner } from './runSource';
+import type { Cache } from './cache';
+import type { RateLimiter } from './rateLimit';
+import type { HealthTracker } from './health';
+import type { SourceAdapter } from './types';
+
+function makeAdapter<T>(overrides: Partial<SourceAdapter<T>> = {}): SourceAdapter<T> {
+  return {
+    meta: {
+      id: 'test-source',
+      name: 'Test Source',
+      category: 'other',
+      homepage: 'https://example.com',
+      requiresKey: false,
+      ttlSeconds: 60,
+      minIntervalMs: 1000,
+      attribution: 'Example',
+    },
+    isEnabled: () => true,
+    fetch: vi.fn().mockResolvedValue({ ok: true }),
+    ...overrides,
+  };
+}
+
+function makeStubs() {
+  const cacheStore = new Map<string, unknown>();
+  const cache: Cache = {
+    get: vi.fn((key: string) => cacheStore.get(key)) as Cache['get'],
+    set: vi.fn((key: string, value: unknown) => { cacheStore.set(key, value); }) as Cache['set'],
+    getStale: vi.fn((key: string) => cacheStore.get(key)) as Cache['getStale'],
+  };
+  const rateLimit: RateLimiter = { acquire: vi.fn().mockResolvedValue(undefined) };
+  const health: HealthTracker = {
+    recordSuccess: vi.fn(),
+    recordFailure: vi.fn(),
+    get: vi.fn(),
+    snapshot: vi.fn().mockReturnValue([]),
+  };
+  return { cache, rateLimit, health, cacheStore };
+}
+
+describe('createRunner / runSource', () => {
+  it('returns status unknown without fetching when the adapter is disabled', async () => {
+    const { cache, rateLimit, health } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const adapter = makeAdapter({ isEnabled: () => false });
+
+    const result = await runner.runSource(adapter);
+
+    expect(result.status).toBe('unknown');
+    expect(adapter.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns a fresh cache hit without calling fetch or the rate limiter', async () => {
+    const { cache, rateLimit, health, cacheStore } = makeStubs();
+    cacheStore.set('test-source', { cached: true });
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const adapter = makeAdapter();
+
+    const result = await runner.runSource(adapter);
+
+    expect(result.status).toBe('ok');
+    expect(result.data).toEqual({ cached: true });
+    expect(result.stale).toBe(false);
+    expect(adapter.fetch).not.toHaveBeenCalled();
+    expect(rateLimit.acquire).not.toHaveBeenCalled();
+  });
+
+  it('acquires the rate limiter using the adapter minIntervalMs before fetching', async () => {
+    const { cache, rateLimit, health } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const adapter = makeAdapter();
+
+    await runner.runSource(adapter);
+
+    expect(rateLimit.acquire).toHaveBeenCalledWith('test-source', 1000);
+  });
+
+  it('on a successful fetch, caches the result and records health success', async () => {
+    const { cache, rateLimit, health } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const adapter = makeAdapter();
+
+    const result = await runner.runSource(adapter);
+
+    expect(result.status).toBe('ok');
+    expect(result.data).toEqual({ ok: true });
+    expect(cache.set).toHaveBeenCalledWith('test-source', { ok: true }, 60);
+    expect(health.recordSuccess).toHaveBeenCalled();
+  });
+
+  it('on a failed fetch with no cached fallback, records failure and returns down', async () => {
+    const { cache, rateLimit, health } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const adapter = makeAdapter({ fetch: vi.fn().mockRejectedValue(new Error('upstream 500')) });
+
+    const result = await runner.runSource(adapter);
+
+    expect(result.status).toBe('down');
+    expect(result.stale).toBe(false);
+    expect(result.error).toBe('upstream 500');
+    expect(health.recordFailure).toHaveBeenCalledWith('test-source');
+  });
+
+  it('on a failed fetch with a stale cache entry available, returns degraded stale data', async () => {
+    const { cache, rateLimit, health, cacheStore } = makeStubs();
+    // Simulate an expired cache entry: cache.get (fresh) misses, getStale hits.
+    cacheStore.set('test-source', { old: true });
+    cache.get = vi.fn().mockReturnValue(undefined);
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const adapter = makeAdapter({ fetch: vi.fn().mockRejectedValue(new Error('timeout')) });
+
+    const result = await runner.runSource(adapter);
+
+    expect(result.status).toBe('degraded');
+    expect(result.stale).toBe(true);
+    expect(result.data).toEqual({ old: true });
+    expect(result.error).toBe('timeout');
+  });
+
+  it('caches and rate-limits parameterized calls under a key that includes the params', async () => {
+    const { cache, rateLimit, health } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const adapter = makeAdapter();
+
+    await runner.runSource(adapter, { lat: '1', lng: '2' });
+
+    expect(rateLimit.acquire).toHaveBeenCalledWith('test-source:lat=1&lng=2', 1000);
+    expect(cache.set).toHaveBeenCalledWith('test-source:lat=1&lng=2', { ok: true }, 60);
+  });
+
+  it('produces the same cache key regardless of param insertion order', async () => {
+    const { cache, rateLimit, health } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const adapter = makeAdapter();
+
+    await runner.runSource(adapter, { lng: '2', lat: '1' });
+
+    expect(cache.set).toHaveBeenCalledWith('test-source:lat=1&lng=2', { ok: true }, 60);
+  });
+
+  it('two different param sets for the same adapter do not share a cache entry', async () => {
+    const { cache, rateLimit, health, cacheStore } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const adapter = makeAdapter();
+
+    cacheStore.set('test-source:lat=1&lng=2', { spot: 'A' });
+
+    const result = await runner.runSource(adapter, { lat: '9', lng: '9' });
+
+    // Different params -> cache miss -> falls through to a real fetch, not spot A's cached value.
+    expect(result.data).toEqual({ ok: true });
+    expect(adapter.fetch).toHaveBeenCalled();
+  });
+
+  it('reports health under the plain adapter id even for parameterized calls', async () => {
+    const { cache, rateLimit, health } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const adapter = makeAdapter({ fetch: vi.fn().mockRejectedValue(new Error('x')) });
+
+    const result = await runner.runSource(adapter, { lat: '1', lng: '2' });
+
+    expect(result.sourceId).toBe('test-source');
+    expect(health.recordFailure).toHaveBeenCalledWith('test-source');
+  });
+
+  it('with no params, behaves exactly as before (plain adapter id as the key)', async () => {
+    const { cache, rateLimit, health } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const adapter = makeAdapter();
+
+    await runner.runSource(adapter);
+
+    expect(rateLimit.acquire).toHaveBeenCalledWith('test-source', 1000);
+    expect(cache.set).toHaveBeenCalledWith('test-source', { ok: true }, 60);
+  });
+});
+
+describe('createRunner / runWithFallback', () => {
+  it('returns the primary result when it succeeds, never calling the secondary', async () => {
+    const { cache, rateLimit, health } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const primary = makeAdapter({ meta: { ...makeAdapter().meta, id: 'primary' } });
+    const secondary = makeAdapter({ meta: { ...makeAdapter().meta, id: 'secondary' } });
+
+    const result = await runner.runWithFallback([primary, secondary]);
+
+    expect(result.sourceId).toBe('primary');
+    expect(secondary.fetch).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the secondary when the primary fails', async () => {
+    const { cache, rateLimit, health } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const primary = makeAdapter({
+      meta: { ...makeAdapter().meta, id: 'primary' },
+      fetch: vi.fn().mockRejectedValue(new Error('down')),
+    });
+    const secondary = makeAdapter({ meta: { ...makeAdapter().meta, id: 'secondary' } });
+
+    const result = await runner.runWithFallback([primary, secondary]);
+
+    expect(result.sourceId).toBe('secondary');
+    expect(result.status).toBe('ok');
+  });
+
+  it('returns the last failure when every adapter in the chain fails', async () => {
+    const { cache, rateLimit, health } = makeStubs();
+    const runner = createRunner({ cache, rateLimit, health, now: () => 1000 });
+    const primary = makeAdapter({
+      meta: { ...makeAdapter().meta, id: 'primary' },
+      fetch: vi.fn().mockRejectedValue(new Error('down-1')),
+    });
+    const secondary = makeAdapter({
+      meta: { ...makeAdapter().meta, id: 'secondary' },
+      fetch: vi.fn().mockRejectedValue(new Error('down-2')),
+    });
+
+    const result = await runner.runWithFallback([primary, secondary]);
+
+    expect(result.sourceId).toBe('secondary');
+    expect(result.status).toBe('down');
+  });
+});

--- a/src/lib/sources/runSource.ts
+++ b/src/lib/sources/runSource.ts
@@ -1,0 +1,97 @@
+import type { Cache } from './cache';
+import type { RateLimiter } from './rateLimit';
+import type { HealthTracker } from './health';
+import type { NormalizedResult, SourceAdapter } from './types';
+
+export interface RunnerDeps {
+  cache: Cache;
+  rateLimit: RateLimiter;
+  health: HealthTracker;
+  now?: () => number;
+  timeoutMs?: number;
+}
+
+export interface Runner {
+  runSource<T>(adapter: SourceAdapter<T>, params?: Record<string, string>): Promise<NormalizedResult<T>>;
+  runWithFallback<T>(adapters: SourceAdapter<T>[], params?: Record<string, string>): Promise<NormalizedResult<T>>;
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * Cache/rate-limit key for a call. Parameterized adapters (e.g. a per-bbox
+ * satellite-imagery search) must not share a cache/rate-limit slot across
+ * different param sets, or one query's response would leak into another's.
+ * Health tracking intentionally stays keyed by the plain adapter id — health
+ * is about the underlying service, not any one parameterized query.
+ */
+function requestKey(id: string, params?: Record<string, string>): string {
+  if (!params || Object.keys(params).length === 0) return id;
+  const sorted = Object.keys(params).sort().map((k) => `${k}=${params[k]}`).join('&');
+  return `${id}:${sorted}`;
+}
+
+export function createRunner(deps: RunnerDeps): Runner {
+  const now = deps.now ?? Date.now;
+  const timeoutMs = deps.timeoutMs ?? 10_000;
+
+  function timestamp(): string {
+    return new Date(now()).toISOString();
+  }
+
+  async function runSource<T>(adapter: SourceAdapter<T>, params?: Record<string, string>): Promise<NormalizedResult<T>> {
+    const id = adapter.meta.id;
+    const key = requestKey(id, params);
+
+    if (!adapter.isEnabled()) {
+      return {
+        sourceId: id,
+        fetchedAt: timestamp(),
+        stale: false,
+        data: undefined,
+        status: 'unknown',
+        error: 'disabled: required API key not configured',
+      };
+    }
+
+    const cached = deps.cache.get<T>(key);
+    if (cached !== undefined) {
+      return { sourceId: id, fetchedAt: timestamp(), stale: false, data: cached, status: 'ok' };
+    }
+
+    await deps.rateLimit.acquire(key, adapter.meta.minIntervalMs);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const start = now();
+    try {
+      const data = await adapter.fetch({ signal: controller.signal, params });
+      deps.cache.set(key, data, adapter.meta.ttlSeconds);
+      deps.health.recordSuccess(id, now() - start);
+      return { sourceId: id, fetchedAt: timestamp(), stale: false, data, status: 'ok' };
+    } catch (e) {
+      deps.health.recordFailure(id);
+      const stale = deps.cache.getStale<T>(key);
+      if (stale !== undefined) {
+        return { sourceId: id, fetchedAt: timestamp(), stale: true, data: stale, status: 'degraded', error: errorMessage(e) };
+      }
+      return { sourceId: id, fetchedAt: timestamp(), stale: false, data: undefined, status: 'down', error: errorMessage(e) };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async function runWithFallback<T>(adapters: SourceAdapter<T>[], params?: Record<string, string>): Promise<NormalizedResult<T>> {
+    let last: NormalizedResult<T> | undefined;
+    for (const adapter of adapters) {
+      const result = await runSource(adapter, params);
+      if (result.status === 'ok') return result;
+      last = result;
+    }
+    return last as NormalizedResult<T>;
+  }
+
+  return { runSource, runWithFallback };
+}

--- a/src/lib/sources/types.ts
+++ b/src/lib/sources/types.ts
@@ -1,0 +1,49 @@
+export type SourceCategory =
+  | 'aviation' | 'maritime' | 'seismic' | 'fire' | 'weather' | 'space'
+  | 'cyber' | 'conflict' | 'disaster' | 'news' | 'markets' | 'osint' | 'other';
+
+export type SourceStatus = 'ok' | 'degraded' | 'down' | 'unknown';
+
+export interface SourceMeta {
+  /** Stable slug, e.g. 'usgs-earthquakes' */
+  id: string;
+  /** Display name, e.g. 'USGS Earthquake Feed' */
+  name: string;
+  category: SourceCategory;
+  /** Provenance link shown in the UI */
+  homepage: string;
+  license?: string;
+  requiresKey: boolean;
+  /** Env var names to check; adapter is disabled if any required key is missing */
+  keyEnvVars?: string[];
+  /** Cache lifetime in seconds */
+  ttlSeconds: number;
+  /** Minimum interval between upstream calls, in ms */
+  minIntervalMs: number;
+  /** Short credit shown in the UI provenance badge */
+  attribution: string;
+}
+
+export interface FetchContext {
+  signal: AbortSignal;
+  params?: Record<string, string>;
+}
+
+export interface NormalizedResult<T> {
+  sourceId: string;
+  /** ISO timestamp of when this data was fetched (or last successfully fetched, if stale) */
+  fetchedAt: string;
+  /** True if served from a stale cache entry after an upstream failure */
+  stale: boolean;
+  data: T | undefined;
+  status: SourceStatus;
+  error?: string;
+}
+
+export interface SourceAdapter<T> {
+  meta: SourceMeta;
+  /** False if requiresKey is true and a required env var is unset */
+  isEnabled(): boolean;
+  /** Fetch + normalize from upstream. Throws on failure. */
+  fetch(ctx: FetchContext): Promise<T>;
+}


### PR DESCRIPTION
## Summary

An **optional, purely additive** enhancement to Osiris — it doesn't change or replace any existing route or behavior. It adds a reliability toolkit, five new data sources built on it, and a panel to see feed health. Existing layers work exactly as they do today; everything here is new files plus a handful of additive edits (new layer toggles, new map layers, a new SOURCES button).

Huge thanks for building Osiris — this is meant to build *on* it, not restructure it. Happy to adjust anything to fit your conventions, or trim it down.

## 🛡️ Optional reliability layer (`src/lib/sources/**`, unit-tested)

A `SourceAdapter` framework any route can opt into via `runSource(...)`:
- **TTL caching** (fresh-vs-stale) — a transient upstream hiccup serves the last good data instead of an empty layer.
- **Per-source rate limiting** to stay within free-tier quotas.
- **Health tracking** (ok / degraded / down / unknown).
- **Fallback chains** (`runWithFallback`, e.g. FIRMS VIIRS → MODIS).
- HMR-safe singleton + a registry.

Your existing routes are **left untouched** — they can adopt this incrementally if/when you want. Nothing is forced onto them.

## 🌐 New sources (adapter + route + toggleable map layer)

Keyless: **NOAA Tsunami**, **NOAA NDBC ocean buoys** (900+ stations), **ransomware.live** recent victims (jittered country centroid, since records carry only a country).

Opt-in keyed, **disabled with no errors** until configured: **Shodan** "Exposed Devices" (`SHODAN_API_KEY`), **WiGLE** wireless lookup in the region dossier (`WIGLE_API_NAME` + `WIGLE_API_TOKEN`). Documented in `.env.example`.

## 📡 SOURCES panel + `GET /api/sources/health`

Reports each registered source's status, freshness and attribution. A new SOURCES tab (desktop tool strip + mobile nav) groups them with status dots and provider links; polls every 45s.

## Scope

- **37 new files**; the only edits to existing files are additive: `LayerPanel` (new toggles), `OsirisMap` (new layers/popups), `page.tsx` (new fetch blocks + SOURCES button), and `.env.example` (new opt-in keys).
- **Zero existing routes changed.**

## ✅ Verification

Clean production build; **88 unit tests pass**; dev server confirmed the new routes serve live data and keyed sources degrade gracefully when unset.

---

*Note: I also have a couple of small, unrelated fixes (a privacy fix for the analytics middleware, and a few data-source bugs I noticed) that I'm happy to send as separate focused PRs if useful.*
