### PR TITLE
fix(privacy): fail closed on analytics when Umami env vars are unset

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,23 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest, NextFetchEvent } from 'next/server';
 
+// Analytics is opt-in and fails closed. This previously hardcoded a Umami
+// website ID and an internal Umami host, so every self-hosted deployment
+// silently reported its visitors' IPs to that instance. Analytics now fire
+// only when BOTH UMAMI_WEBSITE_ID and UMAMI_HOST are explicitly configured.
+const UMAMI_WEBSITE_ID = process.env.UMAMI_WEBSITE_ID;
+const UMAMI_HOST = process.env.UMAMI_HOST;
+
 export function middleware(request: NextRequest, event: NextFetchEvent) {
+  if (!UMAMI_WEBSITE_ID || !UMAMI_HOST) {
+    return NextResponse.next();
+  }
+
   const url = request.nextUrl.pathname;
-  
+
   const ip = request.headers.get('cf-connecting-ip') || request.headers.get('x-forwarded-for') || '127.0.0.1';
   const userAgent = request.headers.get('user-agent') || 'Unknown OSIRIS Client';
-  
+
   const basePayload = {
     hostname: request.nextUrl.hostname,
     language: "en-US",
@@ -14,16 +25,18 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
     screen: "1920x1080",
     title: "OSIRIS",
     url: url,
-    website: process.env.UMAMI_WEBSITE_ID || "cd8f216c-fc3f-45f5-ba1a-e10309a61d18"
+    website: UMAMI_WEBSITE_ID,
   };
 
-  const pageView = fetch('http://umami-umami-1:3000/api/send', {
+  const endpoint = `${UMAMI_HOST.replace(/\/$/, '')}/api/send`;
+
+  const pageView = fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'User-Agent': userAgent, 'x-forwarded-for': ip },
     body: JSON.stringify({ payload: basePayload, type: "event" })
   }).catch(() => {});
 
-  const ipEvent = fetch('http://umami-umami-1:3000/api/send', {
+  const ipEvent = fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'User-Agent': userAgent, 'x-forwarded-for': ip },
     body: JSON.stringify({


### PR DESCRIPTION
## Problem

`src/middleware.ts` ships a hardcoded Umami website ID and an internal Umami host:

```js
website: process.env.UMAMI_WEBSITE_ID || "cd8f216c-fc3f-45f5-ba1a-e10309a61d18"
...
fetch('http://umami-umami-1:3000/api/send', ...)  // + a "Network Log" event carrying the visitor IP
```

Because the website ID falls back to a hardcoded value, **any self-hosted deployment silently reports its visitors' IPs** (via the `Network Log` event) to whatever Umami instance answers at that address — without the operator opting in.

## Fix

Analytics now **fail closed**: they fire only when **both** `UMAMI_WEBSITE_ID` and `UMAMI_HOST` are set, and the host comes from env instead of a hardcoded internal address.

- No behavior change for a deployment that sets those env vars.
- Self-hosters no longer leak visitor IPs by default.

Tiny, self-contained change — split out from a larger enhancement PR so it can be reviewed on its own.
