### PR TITLE
fix: three data-source bugs (satellite TLE, Sentinel sortby, stats counts)

### DIFF
--- a/src/app/api/satellites/route.ts
+++ b/src/app/api/satellites/route.ts
@@ -214,7 +214,7 @@ function parseTLEText(text: string): { name: string; line1: string; line2: strin
   const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0);
   const sats: { name: string; line1: string; line2: string }[] = [];
   let i = 0;
-  while (i < lines.length - 2) {
+  while (i < lines.length - 1) {
     if (!lines[i].startsWith('1') && lines[i + 1]?.startsWith('1') && lines[i + 2]?.startsWith('2')) {
       sats.push({ name: lines[i].replace(/^0\s+/, '').trim(), line1: lines[i + 1], line2: lines[i + 2] });
       i += 3;

--- a/src/app/api/sentinel/route.ts
+++ b/src/app/api/sentinel/route.ts
@@ -33,7 +33,7 @@ export async function GET(req: Request) {
           bbox,
           datetime,
           limit: 20,
-          sortby: [{ field: 'datetime', direction: 'desc' }],
+          sortby: [{ field: 'properties.datetime', direction: 'desc' }],
         }),
       });
       if (res.ok) {
@@ -56,7 +56,7 @@ export async function GET(req: Request) {
             bbox,
             datetime,
             limit: 20,
-            sortby: [{ field: 'datetime', direction: 'desc' }],
+            sortby: [{ field: 'properties.datetime', direction: 'desc' }],
           }),
         });
         if (res.ok) {

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -57,7 +57,7 @@ export async function GET(req: Request) {
 
     if (weatherRes.status === 'fulfilled' && weatherRes.value.ok) {
       const data = await weatherRes.value.json();
-      weather = data.weather_events?.length || 0;
+      weather = data.events?.length || 0;
     }
 
     if (infraRes.status === 'fulfilled' && infraRes.value.ok) {
@@ -67,7 +67,7 @@ export async function GET(req: Request) {
 
     if (gdeltRes.status === 'fulfilled' && gdeltRes.value.ok) {
         const data = await gdeltRes.value.json();
-        incidents = data.gdelt?.length || 0;
+        incidents = data.events?.length || 0;
     }
 
     return NextResponse.json({


### PR DESCRIPTION
Three small, independent bug fixes to existing routes — each verified against a live dev server. Happy to split into separate PRs if you'd prefer.

## 1. Satellite TLE parser drops a trailing 2-line TLE

`parseTLEText` loops while `i < lines.length - 2`, so a bare 2-line TLE (`1 …` / `2 …`) at the very end of a feed is never reached. The 3-line branch already guards its `lines[i+2]` lookahead with optional chaining, so widening the bound to `- 1` is safe.

```diff
- while (i < lines.length - 2) {
+ while (i < lines.length - 1) {
```

## 2. Sentinel Element84 queries silently 400

Both Element84 Earth Search queries sort by `datetime`, but Element84's STAC requires the queryable path `properties.datetime`. The bare field returns a **400**, so `res.ok` is false, Sentinel-1 and Sentinel-2 both return nothing, and every request falls through to the Copernicus fallback.

```diff
- sortby: [{ field: 'datetime', direction: 'desc' }],
+ sortby: [{ field: 'properties.datetime', direction: 'desc' }],
```

**Before:** `source: copernicus`. **After:** `source: element84`, 20 scenes / 314 total. ✅

## 3. Dashboard weather + incident counts are always 0

`/api/stats` reads `data.weather_events` and `data.gdelt`, but `/api/weather` and `/api/gdelt` both return `{ events: [...] }` — so those fields are always `undefined` and both counters render 0.

```diff
- weather = data.weather_events?.length || 0;
+ weather = data.events?.length || 0;
...
- incidents = data.gdelt?.length || 0;
+ incidents = data.events?.length || 0;
```

**Before:** `weather: 0, incidents: 0`. **After:** `weather: 56, incidents: 212`. ✅

## Verification
Clean production build; all three confirmed live on a dev server (values above).
