### PR TITLE
Fixed typo in README.md

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [master]
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+
+# Two quick pushes to master must not race to overwrite the `latest` tag.
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # arm64 is built under emulation — needed for CasaOS on ARM SBCs.
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=short
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -27,10 +27,10 @@ Open <http://localhost:3000>.
 
 What the compose file does:
 
-- **`image:` + `build:`** — `image:` points at a prebuilt registry image; the
-  `build:` block is a fallback. `docker compose up -d` uses the registry image
-  if it's available locally or pullable, otherwise builds from the local
-  `Dockerfile`. Run `docker compose pull` to fetch the latest published image.
+- **`build:`** — compose builds the image locally from the `Dockerfile`, so
+  you always run the code you just cloned. To run the prebuilt registry image
+  instead, add `image: ghcr.io/simplifaisoul/osiris:latest` to the `osiris`
+  service and drop the `build:` block.
 - **`env_file: .env` (`required: false`)** — if a `.env` file exists its
   values are injected into the container; if it's missing, OSIRIS still starts
   with the keyless feeds.
@@ -43,7 +43,6 @@ What the compose file does:
 Common commands:
 
 ```bash
-docker compose pull             # fetch latest published image
 docker compose logs -f          # follow logs
 docker compose up -d --build    # rebuild locally after pulling new code
 docker compose down             # stop & remove
@@ -51,21 +50,18 @@ docker compose down             # stop & remove
 
 ### Pull the prebuilt image from GHCR
 
-A prebuilt multi-arch-friendly image is published to the GitHub Container
-Registry, so you can run OSIRIS without building anything:
+A prebuilt image for `linux/amd64` and `linux/arm64` is published to the GitHub
+Container Registry on every push to `master` and every `v*.*.*` tag, so you can
+run OSIRIS without building anything:
 
 ```bash
-docker pull ghcr.io/aiacos/osiris:latest      # or a pinned tag, e.g. :0.1.0
+docker pull ghcr.io/simplifaisoul/osiris:latest   # or a pinned tag, e.g. :0.1.0
 docker run -d --name osiris \
   -p 3005:3000 --env-file .env --restart unless-stopped \
-  ghcr.io/aiacos/osiris:latest
+  ghcr.io/simplifaisoul/osiris:latest
 ```
 
-> If the package is **private**, authenticate first with a GitHub token that
-> has `read:packages`:
-> `echo $TOKEN | docker login ghcr.io -u <github-user> --password-stdin`.
-> Make it public from the package's **Settings → Danger Zone → Change
-> visibility** to allow anonymous pulls.
+The package is public — no `docker login` is required to pull it.
 
 ### Plain `docker run`
 
@@ -106,8 +102,8 @@ metadata.
 > CasaOS stores imported compose files under `/var/lib/casaos/apps/`, so a
 > relative `build:` context may not resolve there. If importing the YAML
 > directly, either build/tag `osiris:latest` first
-> (`docker build -t osiris:latest /path/to/osiris`) or set `image:` to a
-> prebuilt registry image.
+> (`docker build -t osiris:latest /path/to/osiris`) or replace the `build:`
+> block with `image: ghcr.io/simplifaisoul/osiris:latest`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ CasaOS and API-key guide.
 **Prebuilt image (GHCR)** — skip the build and pull it directly:
 
 ```bash
-docker pull ghcr.io/aiacos/osiris:latest
-docker run -d -p 3000:3000 --env-file .env ghcr.io/aiacos/osiris:latest
+docker pull ghcr.io/simplifaisoul/osiris:latest
+docker run -d -p 3000:3000 --env-file .env ghcr.io/simplifaisoul/osiris:latest
 ```
 
 **Custom port** — the container always listens on `3000`; set `OSIRIS_PORT` in

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Open [http://localhost:3000](http://localhost:3000)
 ```bash
 git clone https://github.com/simplifaisoul/osiris.git
 cd osiris
-cp .env.template .env     # optional — configure keys / port
+cp .env.example .env     # optional — configure keys / port
 docker compose up -d
 ```
 
@@ -169,7 +169,7 @@ editing the compose file.
 ### Environment Variables
 
 OSIRIS works **partially without any API keys** — all core feeds use public,
-keyless sources. Copy [`.env.template`](.env.template) to `.env` and set only
+keyless sources. Copy [`.env.example`](.env.example) to `.env` and set only
 what you need:
 
 ```env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 name: osiris
 services:
   osiris:
-    # Pulls the prebuilt image from GitHub Container Registry. The `build:`
-    # block is kept as a fallback: `docker compose up -d` uses the registry
-    # image if present/pullable, otherwise builds locally from the Dockerfile.
-    # Run `docker compose pull` to fetch the latest published image.
+    # Builds locally from the Dockerfile so you always run the cloned code.
+    # To use the prebuilt image instead, replace the `build:` block below with
+    # `image: ghcr.io/simplifaisoul/osiris:latest`.
     build:
       context: .
       dockerfile: Dockerfile
@@ -82,10 +81,10 @@ x-casaos:
     en_us: Real-time global OSINT intelligence dashboard
   title:
     en_us: OSIRIS
-  icon: https://raw.githubusercontent.com/Aiacos/osiris/master/public/casaos-icon.png
-  thumbnail: https://raw.githubusercontent.com/Aiacos/osiris/master/public/og-image.png
+  icon: https://raw.githubusercontent.com/simplifaisoul/osiris/master/public/casaos-icon.png
+  thumbnail: https://raw.githubusercontent.com/simplifaisoul/osiris/master/public/og-image.png
   screenshot_link:
-    - https://raw.githubusercontent.com/Aiacos/osiris/master/public/og-image.png
+    - https://raw.githubusercontent.com/simplifaisoul/osiris/master/public/og-image.png
   scheme: http
   hostname: ""
   port_map: "3000"


### PR DESCRIPTION
Fixed .env.template typo to .env.example