### PR TITLE
feat(docs): in-app documentation and API reference at /docs

### DIFF
--- a/src/app/docs/CommandPalette.tsx
+++ b/src/app/docs/CommandPalette.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { API_GROUPS, endpointId } from './apiCatalog';
+
+export interface PaletteItem {
+  id: string;
+  label: string;
+  hint: string;
+  kind: 'Guide' | 'Endpoint';
+  group?: string;
+}
+
+export function buildPaletteItems(guideSections: { id: string; title: string }[]): PaletteItem[] {
+  const guide: PaletteItem[] = guideSections.map(s => ({
+    id: s.id,
+    label: s.title,
+    hint: 'Guide section',
+    kind: 'Guide',
+  }));
+
+  const endpoints: PaletteItem[] = API_GROUPS.flatMap(g =>
+    g.endpoints.map(ep => ({
+      id: endpointId(ep),
+      label: ep.path,
+      hint: ep.summary,
+      kind: 'Endpoint' as const,
+      group: g.title,
+    }))
+  );
+
+  return [...guide, ...endpoints];
+}
+
+export default function CommandPalette({
+  open,
+  onClose,
+  items,
+}: {
+  open: boolean;
+  onClose: () => void;
+  items: PaletteItem[];
+}) {
+  const [query, setQuery] = useState('');
+  const [cursor, setCursor] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items.slice(0, 40);
+    return items
+      .map(it => {
+        const label = it.label.toLowerCase();
+        // Rank exact prefix matches above substring matches above hint matches.
+        let score = -1;
+        if (label.startsWith(q)) score = 0;
+        else if (label.includes(q)) score = 1;
+        else if (it.hint.toLowerCase().includes(q)) score = 2;
+        return { it, score };
+      })
+      .filter(r => r.score >= 0)
+      .sort((a, b) => a.score - b.score)
+      .slice(0, 40)
+      .map(r => r.it);
+  }, [items, query]);
+
+  // Reset per opening, and focus the field.
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setCursor(0);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  useEffect(() => setCursor(0), [query]);
+
+  // Keep the highlighted row inside the scroll viewport.
+  useEffect(() => {
+    listRef.current?.querySelector('[data-active="true"]')?.scrollIntoView({ block: 'nearest' });
+  }, [cursor]);
+
+  const go = (id: string) => {
+    onClose();
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      history.replaceState(null, '', `#${id}`);
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setCursor(c => Math.min(c + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setCursor(c => Math.max(c - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (results[cursor]) go(results[cursor].id);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[500] flex items-start justify-center pt-[12vh] px-4 bg-black/70 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Search documentation"
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        className="w-full max-w-xl rounded-xl border border-white/[0.12] bg-[#0A0A12] shadow-[0_20px_70px_rgba(0,0,0,0.7)] overflow-hidden"
+      >
+        <div className="flex items-center gap-2.5 px-4 h-12 border-b border-white/[0.07]">
+          <svg viewBox="0 0 24 24" className="w-4 h-4 text-[var(--text-muted)] shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <circle cx="11" cy="11" r="7" />
+            <path d="m20 20-3.5-3.5" />
+          </svg>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Search sections and endpoints…"
+            aria-label="Search documentation"
+            className="flex-1 bg-transparent text-[13px] font-mono text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none"
+          />
+          <kbd className="text-[9px] font-mono px-1.5 py-0.5 rounded border border-white/10 text-[var(--text-muted)]">
+            ESC
+          </kbd>
+        </div>
+
+        <div ref={listRef} className="max-h-[52vh] overflow-y-auto styled-scrollbar py-1.5">
+          {results.length === 0 && (
+            <div className="px-4 py-8 text-center text-[12px] font-mono text-[var(--text-muted)]">
+              No matches for “{query}”
+            </div>
+          )}
+          {results.map((it, i) => (
+            <button
+              key={`${it.kind}-${it.id}`}
+              data-active={i === cursor}
+              onMouseEnter={() => setCursor(i)}
+              onClick={() => go(it.id)}
+              className={`w-full text-left px-4 py-2 flex items-center gap-3 transition-colors ${
+                i === cursor ? 'bg-[var(--gold-primary)]/10' : ''
+              }`}
+            >
+              <span
+                className={`text-[8px] font-mono tracking-widest uppercase px-1.5 py-0.5 rounded border shrink-0 ${
+                  it.kind === 'Endpoint'
+                    ? 'text-[var(--cyan-primary)] border-[var(--cyan-primary)]/25'
+                    : 'text-[var(--gold-primary)] border-[var(--gold-primary)]/25'
+                }`}
+              >
+                {it.kind === 'Endpoint' ? 'API' : 'Doc'}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block font-mono text-[12px] text-[var(--text-primary)] truncate">{it.label}</span>
+                <span className="block text-[11px] text-[var(--text-muted)] truncate">{it.hint}</span>
+              </span>
+              {i === cursor && (
+                <kbd className="text-[9px] font-mono px-1.5 py-0.5 rounded border border-white/10 text-[var(--text-muted)] shrink-0">
+                  ↵
+                </kbd>
+              )}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-4 px-4 h-9 border-t border-white/[0.07] text-[9px] font-mono text-[var(--text-muted)]">
+          <span className="flex items-center gap-1">
+            <kbd className="px-1 py-0.5 rounded border border-white/10">↑</kbd>
+            <kbd className="px-1 py-0.5 rounded border border-white/10">↓</kbd> navigate
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="px-1 py-0.5 rounded border border-white/10">↵</kbd> jump
+          </span>
+          <span className="ml-auto">{results.length} results</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/docs/DocsClient.tsx
+++ b/src/app/docs/DocsClient.tsx
@@ -1,0 +1,652 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { API_GROUPS, ENDPOINT_COUNT, endpointId } from './apiCatalog';
+import { Callout, Code, CodeBlock, Pre, Section } from './docsPrimitives';
+import EndpointCard from './EndpointCard';
+import CommandPalette, { buildPaletteItems } from './CommandPalette';
+
+const GUIDE_SECTIONS = [
+  { id: 'overview', title: 'Overview' },
+  { id: 'quickstart', title: 'Quick Start' },
+  { id: 'self-hosting', title: 'Self-Hosting' },
+  { id: 'configuration', title: 'Configuration' },
+  { id: 'interface', title: 'Interface Guide' },
+  { id: 'shortcuts', title: 'Keyboard Shortcuts' },
+];
+
+const API_SECTIONS = [
+  { id: 'api', title: 'Conventions' },
+  ...API_GROUPS.map(g => ({ id: `api-${g.id}`, title: g.title })),
+];
+
+const ALL_SECTIONS = [...GUIDE_SECTIONS, ...API_SECTIONS];
+const FALLBACK_ORIGIN = 'https://osirisai.live';
+
+export default function DocsClient() {
+  const [active, setActive] = useState('overview');
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [navOpen, setNavOpen] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [origin, setOrigin] = useState(FALLBACK_ORIGIN);
+  const mainRef = useRef<HTMLElement>(null);
+
+  const paletteItems = useMemo(() => buildPaletteItems(ALL_SECTIONS), []);
+
+  /* Snippets should reference the instance the reader is actually on. */
+  useEffect(() => setOrigin(window.location.origin), []);
+
+  /* Belt-and-braces scroll unlock: globals.css handles this via :has(),
+     but release the lock imperatively for engines without :has() support. */
+  useEffect(() => {
+    const supportsHas = typeof CSS !== 'undefined' && CSS.supports?.('selector(:has(*))');
+    if (supportsHas) return;
+    const { documentElement: html, body } = document;
+    const prev = { html: html.style.cssText, body: body.style.cssText };
+    for (const el of [html, body]) {
+      el.style.height = 'auto';
+      el.style.overflowY = 'auto';
+      el.style.overflowX = 'hidden';
+    }
+    return () => {
+      html.style.cssText = prev.html;
+      body.style.cssText = prev.body;
+    };
+  }, []);
+
+  /* Scroll-spy + reading progress. */
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      entries => {
+        const visible = entries
+          .filter(e => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]) setActive(visible[0].target.id);
+      },
+      { rootMargin: '-96px 0px -72% 0px', threshold: 0 }
+    );
+    ALL_SECTIONS.forEach(s => {
+      const el = document.getElementById(s.id);
+      if (el) observer.observe(el);
+    });
+
+    const onScroll = () => {
+      const max = document.documentElement.scrollHeight - window.innerHeight;
+      setProgress(max > 0 ? Math.min(100, (window.scrollY / max) * 100) : 0);
+    };
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('scroll', onScroll);
+    };
+  }, []);
+
+  /* ⌘K / Ctrl-K, and "/" as a plain-keyboard alternative. */
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const typing = ['INPUT', 'TEXTAREA'].includes((e.target as HTMLElement)?.tagName);
+      if ((e.key === 'k' && (e.metaKey || e.ctrlKey)) || (e.key === '/' && !typing)) {
+        e.preventDefault();
+        setPaletteOpen(true);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  /* Close the mobile drawer once a destination is chosen. */
+  const closeNav = useCallback(() => setNavOpen(false), []);
+
+  const activeIdx = ALL_SECTIONS.findIndex(s => s.id === active);
+  const prev = activeIdx > 0 ? ALL_SECTIONS[activeIdx - 1] : null;
+  const next = activeIdx >= 0 && activeIdx < ALL_SECTIONS.length - 1 ? ALL_SECTIONS[activeIdx + 1] : null;
+
+  const navLink = (s: { id: string; title: string }) => (
+    <a
+      key={s.id}
+      href={`#${s.id}`}
+      onClick={closeNav}
+      className={`relative block pl-4 pr-3 py-[7px] text-[12.5px] rounded-r-md transition-all duration-200 ${
+        active === s.id
+          ? 'text-[var(--gold-primary)] bg-[var(--gold-primary)]/[0.07] font-medium'
+          : 'text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-white/[0.03]'
+      }`}
+    >
+      <span
+        className={`absolute left-0 top-1/2 -translate-y-1/2 w-[2px] rounded-full transition-all duration-200 ${
+          active === s.id ? 'h-[70%] bg-[var(--gold-primary)]' : 'h-0 bg-transparent'
+        }`}
+      />
+      {s.title}
+    </a>
+  );
+
+  return (
+    <div className="docs-root min-h-screen bg-[var(--bg-void)] text-[var(--text-primary)] antialiased">
+      {/* Ambient wash — keeps the page from reading as a flat black slab */}
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 z-0"
+        style={{
+          background:
+            'radial-gradient(900px 480px at 12% -8%, rgba(212,175,55,0.07), transparent 65%), radial-gradient(760px 420px at 92% 4%, rgba(0,229,255,0.05), transparent 62%)',
+        }}
+      />
+
+      <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} items={paletteItems} />
+
+      {/* ── Header ── */}
+      <header className="sticky top-0 z-[300] border-b border-white/[0.06] bg-[var(--bg-void)]/85 backdrop-blur-xl">
+        <div className="max-w-[1600px] mx-auto px-4 md:px-8 h-14 flex items-center gap-3">
+          <Link href="/" className="flex items-center gap-2.5 shrink-0 group">
+            <svg
+              viewBox="0 0 650 500"
+              className="w-6 h-6 text-[var(--gold-primary)] transition-all group-hover:drop-shadow-[0_0_10px_rgba(212,175,55,0.6)]"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M158.66,157a70.231,70.231,0,0,0-14.44,42.81,70.235,70.235,0,1,0,140.47,0,70.231,70.231,0,0,0-14.28-42.81h-111.75z" />
+              <path d="m140.86,465.53c-6.7333,0-8.7137-5.4462-12.181-25.899-2.4479-14.774-7.1068-28.463-10.502-43.043-3.0219-13.117-5.6425-20.332-9.6694-26.618-6.5526-10.229-6.3011-20.921,0.71691-30.481,6.33-8.6232,6.827-11.121,6.5471-32.901-0.13783-10.725-0.56403-21.286-0.94711-23.468-0.88077-5.0179-4.6148-7.6923-13.904-9.9586-8.4827-2.0695-16.525-2.2933-41.967-1.1681-18.144,0.80245-20.457,0.72323-22.75-0.77901-5.627-3.687-2.9527-8.8405,12.261-23.626,15.69-15.249,23.876-24.688,38.811-44.75,26.839-36.053,30.927-40.83,57.501-49.189,19.575-6.1582,26.691-9.0119,62.031-10.06,24.654-0.7309,38.767,2.5963,45.357,3.3466,25.219,2.8716,66.247,14.877,91.933,26.083,13.581,5.9249,14.042,6.1723,30.115,16.152,11.981,7.4391,18.733,10.459,35.44,15.034,34.886,9.553,56.753,7.7583,92,10.378,9.2579,0.68808,49.298,3.5149,74.5,4.4784,30.689,1.1732,35.835-2.0376,38.423,0.54994,2.0315,2.0315,0.5636,8.1815,0.6024,14.306,0.0237,3.7378-0.18399,7.6642-0.48569,11.602-8.1923-1.424-8.0353-1.3676-26.54-2.9165-1.6808-0.14069-16.718-1.6695-44.5-4.1726-11.867-1.0692-70.326-2.8448-105.5-3.9248-16.997-0.52189-34.357-4.7228-51-1.2347-5.7624,1.2076,2.387-1.1161-16,7.4812-36.313,14.051-55.853,23.79-104.5,32.83-30.774,4.5201-33.208,4.9745-36.376,7.2909-1.7456,1.2764-1.662,1.6171,1.6767,6.8363,3.5642,5.5717,14.275,15.81,29.699,28.389,51.619,43.564,115.05,77.431,162.89,98.598,22.221,9.5122,37.55,14.655,50.108,16.811,61.892,13.654,134.26-9.4938,136.11-56.959,0.0489-1.256,0.49928-6.001-0.1398-12.079-0.44539-4.2357-0.89625-7.3216-2.2932-11.095-3.9795-10.75-12.413-20.407-28.672-21.755-11.746,0.022-20.375,6.1561-23.95,16.17-4.5622,12.78,1.3185,27.071,14.023,29.565,6.6403,1.3038,11.222-0.5256,14.271-4.4679,3.3424-4.3221,3.72-12.026,1.3559-15.634-2.2757-3.4732-7.2459-5.2754-10.824-3.9248-3.6125,1.3636-4.9933,0.36555-0.6538-3.1839,0.38036-0.24867,0.77844-0.4586,1.191-0.63136,6.6675-2.7918,17.127,4.1226,17.913,14.135,0.7119,11.495-7.7045,20.279-19.249,20.94-6.5659,0.37574-14.594-1.9665-20.026-7.8035-13.425-14.428-9.1712-34.885,2.9586-45.762,4.6131-4.1366,7.7535-6.0583,14.065-7.4773,19.37-4.3554,37.69,4.5134,45.528,24.301,3.5645,8.9992,3.7675,16.201,3.8515,23.221,0.70438,58.895-65.742,87.202-131.95,82.517-28.009-2.4123-46.229-6.8095-80.495-20.915-36.58-12.09-143.44-68.32-207.96-120.33-18.846-15.317-30.511-22.813-33.055-21.24-0.61585,0.38062-0.98989,11.992-0.99221,30.802-0.004,28.758-0.1019,30.352-2.0717,33.583-3.2793,5.3791-4.935,17.725-5.9822,44.608-1.6327,41.914-2.675,60.915-3.4439,62.778-1.3963,3.383-7.0306,4.6642-13.289,4.6642z" />
+            </svg>
+            <span className="flex flex-col leading-none">
+              <span className="text-[13px] font-bold tracking-[0.3em] text-[var(--gold-primary)] font-mono">
+                OSIRIS
+              </span>
+              <span className="text-[7px] font-mono tracking-[0.22em] text-[var(--text-muted)] uppercase mt-[3px]">
+                Docs
+              </span>
+            </span>
+          </Link>
+
+          <div className="flex-1" />
+
+          {/* Palette trigger */}
+          <button
+            onClick={() => setPaletteOpen(true)}
+            className="group flex items-center gap-2 px-3 h-8 rounded-lg border border-white/[0.08] bg-white/[0.02] hover:border-[var(--gold-primary)]/30 hover:bg-white/[0.04] transition-colors"
+            aria-label="Search documentation"
+          >
+            <svg viewBox="0 0 24 24" className="w-3.5 h-3.5 text-[var(--text-muted)] group-hover:text-[var(--gold-primary)] transition-colors" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <circle cx="11" cy="11" r="7" />
+              <path d="m20 20-3.5-3.5" />
+            </svg>
+            <span className="hidden sm:inline text-[11.5px] text-[var(--text-muted)] font-mono">Search</span>
+            <kbd className="hidden sm:inline text-[9px] font-mono px-1.5 py-0.5 rounded border border-white/10 text-[var(--text-muted)]">
+              ⌘K
+            </kbd>
+          </button>
+
+          <a
+            href="https://github.com/simplifaisoul/osiris"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub repository"
+            className="hidden sm:flex items-center justify-center w-8 h-8 rounded-lg border border-white/[0.08] bg-white/[0.02] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:border-white/20 transition-colors"
+          >
+            <svg viewBox="0 0 24 24" className="w-3.5 h-3.5" fill="currentColor">
+              <path d="M12 .5C5.73.5.5 5.73.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.54-3.88-1.54-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.71 1.26 3.37.96.1-.75.4-1.26.73-1.55-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5Z" />
+            </svg>
+          </a>
+
+          <Link
+            href="/"
+            className="hidden md:inline-flex items-center gap-1.5 text-[10px] font-mono tracking-[0.15em] uppercase px-3 h-8 rounded-lg border border-[var(--gold-primary)]/30 bg-[var(--gold-primary)]/[0.08] text-[var(--gold-primary)] hover:bg-[var(--gold-primary)]/[0.18] transition-colors"
+          >
+            Launch Map
+            <svg viewBox="0 0 24 24" className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </Link>
+
+          <button
+            onClick={() => setNavOpen(v => !v)}
+            aria-label="Toggle navigation"
+            aria-expanded={navOpen}
+            className="lg:hidden w-8 h-8 flex items-center justify-center rounded-lg border border-white/[0.08] text-[var(--text-muted)] hover:text-[var(--gold-primary)]"
+          >
+            <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              {navOpen ? <path d="M18 6 6 18M6 6l12 12" /> : <path d="M3 6h18M3 12h18M3 18h18" />}
+            </svg>
+          </button>
+        </div>
+
+        {/* Reading progress */}
+        <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-transparent">
+          <div
+            className="h-full bg-gradient-to-r from-[var(--gold-primary)] to-[var(--cyan-primary)] transition-[width] duration-150"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </header>
+
+      {/* Mobile drawer scrim */}
+      {navOpen && (
+        <div className="lg:hidden fixed inset-0 top-14 z-[250] bg-black/60 backdrop-blur-sm" onClick={closeNav} />
+      )}
+
+      <div className="relative z-10 max-w-[1600px] mx-auto px-4 md:px-8 flex gap-8 xl:gap-12">
+        {/* ── Left sidebar ── */}
+        <nav
+          className={`${
+            navOpen
+              ? 'translate-x-0 opacity-100'
+              : '-translate-x-4 opacity-0 pointer-events-none lg:translate-x-0 lg:opacity-100 lg:pointer-events-auto'
+          } fixed lg:sticky top-14 left-0 bottom-0 lg:bottom-auto z-[260] lg:z-auto w-64 lg:w-56 shrink-0 lg:h-[calc(100vh-3.5rem)] overflow-y-auto styled-scrollbar bg-[var(--bg-void)] lg:bg-transparent border-r lg:border-r-0 border-white/[0.06] py-6 pr-2 pl-2 lg:pl-0 transition-all duration-200`}
+        >
+          <div className="text-[9px] font-mono tracking-[0.3em] uppercase text-[var(--text-muted)]/70 pl-4 mb-2">
+            Guide
+          </div>
+          {GUIDE_SECTIONS.map(navLink)}
+
+          <div className="text-[9px] font-mono tracking-[0.3em] uppercase text-[var(--text-muted)]/70 pl-4 mb-2 mt-7">
+            API Reference
+          </div>
+          {API_SECTIONS.map(navLink)}
+
+          <div className="mt-8 mx-2 rounded-lg border border-white/[0.07] bg-white/[0.02] p-3">
+            <div className="text-[10px] font-mono text-[var(--text-secondary)] leading-relaxed">
+              <span className="text-[var(--gold-primary)] font-bold">{ENDPOINT_COUNT}</span> endpoints, no key
+              required.
+            </div>
+          </div>
+        </nav>
+
+        {/* ── Content ── */}
+        <main ref={mainRef} className="flex-1 min-w-0 py-12 lg:py-16 max-w-3xl">
+          {/* Hero */}
+          <div className="mb-20">
+            <div className="inline-flex items-center gap-2 px-2.5 py-1 rounded-full border border-[var(--cyan-primary)]/20 bg-[var(--cyan-primary)]/[0.05] mb-6">
+              <span className="w-1.5 h-1.5 rounded-full bg-[var(--alert-green)] animate-pulse" />
+              <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-secondary)]">
+                Open Source · MIT
+              </span>
+            </div>
+
+            <h1 className="text-[38px] md:text-[52px] leading-[1.05] font-bold tracking-[-0.02em] mb-5">
+              <span className="text-[var(--text-heading)]">Build on the</span>
+              <br />
+              <span className="bg-gradient-to-r from-[var(--gold-primary)] via-[#F0D060] to-[var(--cyan-primary)] bg-clip-text text-transparent">
+                OSIRIS platform
+              </span>
+            </h1>
+
+            <p className="text-[15px] leading-[1.75] text-[var(--text-secondary)] max-w-[42rem]">
+              OSIRIS aggregates aviation, maritime, seismic, conflict, cyber, and OSINT feeds onto a single
+              GPU-rendered map — and exposes every one of them as a plain HTTP endpoint. This is the same API the
+              dashboard runs on. There is no separate, privileged internal tier.
+            </p>
+
+            <div className="flex flex-wrap gap-3 mt-8">
+              <a
+                href="#quickstart"
+                className="inline-flex items-center gap-2 px-4 h-10 rounded-lg text-[12px] font-mono tracking-wider uppercase border border-[var(--gold-primary)]/40 bg-[var(--gold-primary)]/10 text-[var(--gold-primary)] hover:bg-[var(--gold-primary)]/20 transition-colors"
+              >
+                Quick Start
+                <svg viewBox="0 0 24 24" className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </a>
+              <a
+                href="#api"
+                className="inline-flex items-center gap-2 px-4 h-10 rounded-lg text-[12px] font-mono tracking-wider uppercase border border-white/[0.1] bg-white/[0.02] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:border-white/20 transition-colors"
+              >
+                API Reference
+              </a>
+            </div>
+
+            <div className="grid grid-cols-3 gap-3 mt-10">
+              {[
+                { n: String(ENDPOINT_COUNT), l: 'Endpoints' },
+                { n: '20+', l: 'Live feeds' },
+                { n: '0', l: 'Keys required' },
+              ].map(s => (
+                <div key={s.l} className="rounded-xl border border-white/[0.07] bg-white/[0.015] px-4 py-3">
+                  <div className="text-[24px] font-bold text-[var(--gold-primary)] font-mono leading-none">{s.n}</div>
+                  <div className="text-[10px] font-mono tracking-[0.15em] uppercase text-[var(--text-muted)] mt-1.5">
+                    {s.l}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* ── GUIDE ── */}
+          <Section id="overview" eyebrow="Guide" title="Overview">
+            <p>
+              Every data point on the map is rendered through WebGL via MapLibre GL, which is what lets the interface
+              hold thousands of concurrent entities at 60fps. The application is a Next.js app: the map and HUD run in
+              the browser, and each live feed is normalised by a route under <Code>/api</Code> before it reaches the
+              client.
+            </p>
+            <p>
+              That boundary is deliberate. Upstream sources disagree about formats, rate limits, and CORS policy, so
+              the API layer absorbs those differences and hands back consistent JSON.
+            </p>
+            <Callout tone="good" title="No credentials needed">
+              Aviation, maritime, satellites, fires, earthquakes, weather, news, and CVE data all come from public
+              keyless feeds. Keys only matter for the optional RECON scanner and for raising rate limits.
+            </Callout>
+          </Section>
+
+          <Section id="quickstart" eyebrow="Guide" title="Quick Start">
+            <p>
+              Every read endpoint is a plain <Code>GET</Code> returning JSON. Nothing below needs authentication —
+              paste any of it into a terminal.
+            </p>
+            <CodeBlock
+              label="Fetch live aircraft"
+              tabs={[
+                { label: 'cURL', lang: 'bash', code: `curl -s ${origin}/api/flights | jq '.commercial_flights | length'` },
+                {
+                  label: 'JavaScript',
+                  lang: 'javascript',
+                  code: `const res = await fetch("${origin}/api/flights");
+const { commercial_flights, military_flights } = await res.json();
+console.log(commercial_flights.length, "commercial;", military_flights.length, "military");`,
+                },
+                {
+                  label: 'Python',
+                  lang: 'python',
+                  code: `import requests
+
+data = requests.get("${origin}/api/flights").json()
+print(len(data["commercial_flights"]), "commercial")`,
+                },
+              ]}
+            />
+            <p>
+              If you only need magnitudes rather than geometry, <Code>/api/stats</Code> is the right endpoint to poll —
+              it collapses the heavy feeds into a handful of counters.
+            </p>
+            <Pre label="Aggregate counters" lang="bash">{`curl -s ${origin}/api/stats
+# { "stats": { "flights": 9241, "sats": 2043, "cctv": 2117,
+#              "weather": 58, "nuclear": 191, "incidents": 412 },
+#   "timestamp": "2026-07-29T12:00:00Z" }`}</Pre>
+            <p>The OSINT lookups each take one subject, so they compose cleanly in a pipeline:</p>
+            <Pre label="Passive subdomain enumeration" lang="bash">{`curl -s "${origin}/api/osint/certs?domain=example.com" | jq -r '.subdomains[]'`}</Pre>
+            <Callout tone="info" title="Try before you write code">
+              Every GET endpoint in the reference below has a <strong>Send request</strong> button that runs it against
+              this instance and shows the live response.
+            </Callout>
+          </Section>
+
+          <Section id="self-hosting" eyebrow="Guide" title="Self-Hosting">
+            <p>OSIRIS needs Node 20+ and no database. A local instance is three commands:</p>
+            <Pre label="Local development" lang="bash">{`git clone https://github.com/simplifaisoul/osiris.git
+cd osiris
+npm install
+npm run dev        # http://localhost:3000`}</Pre>
+            <p>For a production build, or to run the checks:</p>
+            <Pre label="Build and test" lang="bash">{`npm run build && npm start
+npm run lint
+npm test           # vitest
+npm run test:live  # includes tests that hit live upstream feeds`}</Pre>
+            <p>
+              A <Code>Dockerfile</Code> and <Code>docker-compose.yml</Code> ship with the repository. The container
+              always listens on port 3000 internally; <Code>OSIRIS_PORT</Code> controls the host port it is published
+              on.
+            </p>
+            <Pre label="Docker" lang="bash">{`cp .env.example .env
+docker compose up -d`}</Pre>
+          </Section>
+
+          <Section id="configuration" eyebrow="Guide" title="Configuration">
+            <p>
+              Copy <Code>.env.example</Code> to <Code>.env</Code>. Read that file before filling anything in — most of
+              the keys it lists are reserved for future sources and are not consumed by the current code.
+            </p>
+            <h3 className="text-[13px] font-mono tracking-[0.15em] uppercase text-[var(--text-primary)] pt-2">
+              Read by the application
+            </h3>
+            <div className="space-y-2">
+              {[
+                {
+                  k: 'SCANNER_URL / SCANNER_KEY',
+                  v: 'Points at the separate RECON scanner backend. SCANNER_KEY must equal that backend’s OSIRIS_KEY. Leave both empty to disable RECON — /api/scanner then returns 503 by design.',
+                },
+                {
+                  k: 'SDK_INGEST_KEY',
+                  v: 'Shared secret for /api/sdk/ingest. The endpoint fails closed: while this is unset, ingestion is disabled and returns 503.',
+                },
+                {
+                  k: 'OSIRIS_TELEGRAM_CHANNELS',
+                  v: 'Comma-separated public Telegram channel names (no @) for the Telegram OSINT layer, overriding the curated default set.',
+                },
+                {
+                  k: 'OSIRIS_PORT',
+                  v: 'Host port the UI is published on. The container itself always listens on 3000.',
+                },
+              ].map(row => (
+                <div
+                  key={row.k}
+                  className="rounded-xl border border-white/[0.07] bg-white/[0.015] p-3.5 hover:border-white/[0.13] transition-colors"
+                >
+                  <div className="font-mono text-[11.5px] text-[var(--gold-primary)] mb-1.5">{row.k}</div>
+                  <div className="text-[12.5px] leading-[1.7] text-[var(--text-secondary)]">{row.v}</div>
+                </div>
+              ))}
+            </div>
+            <h3 className="text-[13px] font-mono tracking-[0.15em] uppercase text-[var(--text-primary)] pt-4">
+              Optional — higher rate limits only
+            </h3>
+            <p>
+              <Code>FIRMS_API_KEY</Code>, <Code>OPENSKY_CLIENT_ID</Code>, <Code>OPENSKY_CLIENT_SECRET</Code>,{' '}
+              <Code>N2YO_API_KEY</Code>, <Code>AIS_API_KEY</Code>. The public keyless feeds are used unless you extend
+              the code to prefer these.
+            </p>
+            <Callout tone="warn" title="Secrets hygiene">
+              Generate secrets with <Code>openssl rand -hex 32</Code>. Never commit a populated <Code>.env</Code> —
+              only <Code>.env.example</Code> belongs in version control.
+            </Callout>
+          </Section>
+
+          <Section id="interface" eyebrow="Guide" title="Interface Guide">
+            <p>
+              The map fills the viewport and every control floats above it. Panels are toggles rather than
+              destinations, so you can build up exactly the picture you need and drop the rest.
+            </p>
+            <div className="grid sm:grid-cols-2 gap-2.5">
+              {[
+                {
+                  k: 'Layer Panel',
+                  v: 'The left rail. Switches individual feeds on and off, and carries the theme selector.',
+                },
+                {
+                  k: 'RECON Toolkit',
+                  v: 'DNS, WHOIS, certificate transparency, IP and ASN enrichment, breach checks, sanctions, CVE lookup, port scanning.',
+                },
+                {
+                  k: 'Intel Feed',
+                  v: 'A running stream of incoming events across every enabled feed.',
+                },
+                {
+                  k: 'Region Dossier',
+                  v: 'Right-click the map for a composite summary of that location from every feed covering it.',
+                },
+                {
+                  k: 'Entity Graph',
+                  v: 'Link analysis, expanding one node at a time into its neighbours.',
+                },
+                {
+                  k: 'Status Bar',
+                  v: 'Community and docs links on the left, then a live ticker of prices and significant seismic events.',
+                },
+              ].map(row => (
+                <div
+                  key={row.k}
+                  className="rounded-xl border border-white/[0.07] bg-white/[0.015] p-3.5 hover:border-[var(--cyan-primary)]/25 transition-colors"
+                >
+                  <div className="font-mono text-[11.5px] text-[var(--cyan-primary)] mb-1.5">{row.k}</div>
+                  <div className="text-[12.5px] leading-[1.7] text-[var(--text-secondary)]">{row.v}</div>
+                </div>
+              ))}
+            </div>
+          </Section>
+
+          <Section id="shortcuts" eyebrow="Guide" title="Keyboard Shortcuts">
+            <p>
+              Press <Code>?</Code> at any time inside the application to bring up this list.
+            </p>
+            <div className="grid sm:grid-cols-2 gap-2">
+              {[
+                { key: 'F', desc: 'Toggle fullscreen' },
+                { key: 'S', desc: 'Share current view' },
+                { key: 'L', desc: 'Toggle layer panel' },
+                { key: 'M', desc: 'Toggle markets panel' },
+                { key: 'I', desc: 'Toggle intel feed' },
+                { key: 'R', desc: 'Reset to global view' },
+                { key: '?', desc: 'Show help' },
+                { key: 'ESC', desc: 'Close panels / popups' },
+              ].map(s => (
+                <div
+                  key={s.key}
+                  className="flex items-center gap-3 rounded-xl border border-white/[0.07] bg-white/[0.015] px-3.5 py-2.5"
+                >
+                  <kbd className="font-mono text-[11px] min-w-[2.4rem] text-center px-2 py-1 rounded-md border border-[var(--gold-primary)]/30 bg-[var(--gold-primary)]/[0.08] text-[var(--gold-primary)]">
+                    {s.key}
+                  </kbd>
+                  <span className="text-[12.5px] text-[var(--text-secondary)]">{s.desc}</span>
+                </div>
+              ))}
+            </div>
+            <p className="pt-2">
+              In these docs, <Code>⌘K</Code> (or <Code>/</Code>) opens search from anywhere on the page.
+            </p>
+          </Section>
+
+          {/* ── API REFERENCE ── */}
+          <Section id="api" eyebrow="API Reference" title="Conventions">
+            <p>
+              All routes live under <Code>/api</Code> on whatever origin serves the application. Reads are{' '}
+              <Code>GET</Code>, writes are <Code>POST</Code> with a JSON body. Nothing requires authentication except{' '}
+              <Code>/api/sdk/ingest</Code> and <Code>/api/github-webhook</Code>.
+            </p>
+            <div className="space-y-2.5">
+              {[
+                {
+                  k: 'Errors',
+                  v: 'Failures return a non-2xx status with an `error` key, often alongside `detail` carrying the upstream message. Most routes proxy third parties, so treat upstream failure as normal — check response.ok before reading the body.',
+                },
+                {
+                  k: 'Caching',
+                  v: 'Routes set their own Cache-Control TTLs: typically 45–60s for fast-moving feeds, up to a day for static reference data. Polling faster than the TTL gains nothing but load. Where a route advertises refreshInterval, use it.',
+                },
+                {
+                  k: 'Rate limits',
+                  v: 'The three AI endpoints allow 5 requests per minute per IP and return 429 beyond that. Other routes are bounded indirectly by their upstream sources.',
+                },
+                { k: 'Timestamps', v: 'Every timestamp field is ISO 8601 in UTC.' },
+              ].map(row => (
+                <div key={row.k} className="rounded-xl border border-white/[0.07] bg-white/[0.015] p-3.5">
+                  <div className="font-mono text-[11.5px] text-[var(--gold-primary)] mb-1.5">{row.k}</div>
+                  <div className="text-[12.5px] leading-[1.7] text-[var(--text-secondary)]">{row.v}</div>
+                </div>
+              ))}
+            </div>
+            <Callout tone="warn" title="Responsible use">
+              The RECON scanner and <Code>/api/osint/sweep</Code> generate traffic against the targets you name. Only
+              point them at infrastructure you own or have written authorisation to test. The remaining OSINT routes
+              are passive and query third-party datasets rather than the subject itself.
+            </Callout>
+          </Section>
+
+          {API_GROUPS.map(group => (
+            <Section key={group.id} id={`api-${group.id}`} eyebrow="API Reference" title={group.title}>
+              <p>{group.blurb}</p>
+              <div className="space-y-2.5 pt-1">
+                {group.endpoints.map(ep => (
+                  <EndpointCard key={endpointId(ep)} ep={ep} origin={origin} />
+                ))}
+              </div>
+            </Section>
+          ))}
+
+          {/* Prev / next */}
+          {(prev || next) && (
+            <div className="grid sm:grid-cols-2 gap-3 mt-4 mb-12">
+              {prev ? (
+                <a
+                  href={`#${prev.id}`}
+                  className="rounded-xl border border-white/[0.07] bg-white/[0.015] p-4 hover:border-[var(--gold-primary)]/30 transition-colors"
+                >
+                  <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1">
+                    ← Previous
+                  </div>
+                  <div className="text-[13px] text-[var(--text-primary)]">{prev.title}</div>
+                </a>
+              ) : (
+                <div />
+              )}
+              {next && (
+                <a
+                  href={`#${next.id}`}
+                  className="rounded-xl border border-white/[0.07] bg-white/[0.015] p-4 hover:border-[var(--gold-primary)]/30 transition-colors sm:text-right"
+                >
+                  <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1">
+                    Next →
+                  </div>
+                  <div className="text-[13px] text-[var(--text-primary)]">{next.title}</div>
+                </a>
+              )}
+            </div>
+          )}
+
+          {/* Footer */}
+          <footer className="border-t border-white/[0.06] pt-6 pb-16 flex flex-wrap items-center gap-x-5 gap-y-2 text-[11px] font-mono text-[var(--text-muted)]">
+            {[
+              { href: 'https://github.com/simplifaisoul/osiris', label: 'GitHub' },
+              { href: 'https://discord.gg/EPaFD5FFKf', label: 'Discord' },
+              { href: 'https://x.com/soulsimplifai', label: 'X' },
+              { href: 'https://github.com/simplifaisoul/osiris/issues', label: 'Report an issue' },
+            ].map(l => (
+              <a
+                key={l.label}
+                href={l.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-[var(--gold-primary)] transition-colors"
+              >
+                {l.label}
+              </a>
+            ))}
+            <span className="ml-auto opacity-60">MIT Licensed</span>
+          </footer>
+        </main>
+
+        {/* ── Right rail: on this page ── */}
+        <aside className="hidden xl:block w-52 shrink-0 sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto styled-scrollbar py-16">
+          <div className="text-[9px] font-mono tracking-[0.3em] uppercase text-[var(--text-muted)]/70 mb-3">
+            On this page
+          </div>
+          <div className="space-y-0.5">
+            {ALL_SECTIONS.map(s => (
+              <a
+                key={s.id}
+                href={`#${s.id}`}
+                className={`block text-[11.5px] py-1 transition-colors ${
+                  active === s.id
+                    ? 'text-[var(--gold-primary)]'
+                    : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+                }`}
+              >
+                {s.title}
+              </a>
+            ))}
+          </div>
+
+          <button
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            className="mt-6 flex items-center gap-1.5 text-[10px] font-mono tracking-[0.15em] uppercase text-[var(--text-muted)] hover:text-[var(--gold-primary)] transition-colors"
+          >
+            <svg viewBox="0 0 24 24" className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m18 15-6-6-6 6" />
+            </svg>
+            Back to top
+          </button>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/docs/EndpointCard.tsx
+++ b/src/app/docs/EndpointCard.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { endpointId, type ApiEndpoint } from './apiCatalog';
+import { CodeBlock, CopyButton, type CodeTab } from './docsPrimitives';
+
+const METHOD_STYLES: Record<string, string> = {
+  GET: 'text-[#00E676] border-[#00E676]/30 bg-[#00E676]/10',
+  POST: 'text-[#FF9500] border-[#FF9500]/30 bg-[#FF9500]/10',
+};
+
+/* ─────────────────────────────────────────────────────────────
+   Request snippet generation
+   ───────────────────────────────────────────────────────────── */
+
+function buildTabs(ep: ApiEndpoint, url: string): CodeTab[] {
+  const method = Array.isArray(ep.method) ? ep.method[0] : ep.method;
+  const isPost = method === 'POST';
+  const body = ep.bodyExample || '{}';
+
+  const curl = isPost
+    ? `curl -s -X POST "${url}" \\
+  -H "Content-Type: application/json" \\
+  -d '${body}'`
+    : `curl -s "${url}"`;
+
+  const js = isPost
+    ? `const res = await fetch("${url}", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(${body.replace(/\n/g, '\n  ')})
+});
+const data = await res.json();`
+    : `const res = await fetch("${url}");
+const data = await res.json();`;
+
+  const py = isPost
+    ? `import requests
+
+r = requests.post(
+    "${url}",
+    json=${body.replace(/\n/g, '\n    ').replace(/true/g, 'True').replace(/false/g, 'False').replace(/null/g, 'None')},
+)
+data = r.json()`
+    : `import requests
+
+r = requests.get("${url}")
+data = r.json()`;
+
+  return [
+    { label: 'cURL', lang: 'bash', code: curl },
+    { label: 'JavaScript', lang: 'javascript', code: js },
+    { label: 'Python', lang: 'python', code: py },
+  ];
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Endpoint card
+   ───────────────────────────────────────────────────────────── */
+
+export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: string }) {
+  const methods = Array.isArray(ep.method) ? ep.method : [ep.method];
+  const primary = methods[0];
+  const id = endpointId(ep);
+
+  const [open, setOpen] = useState(false);
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries((ep.params || []).map(p => [p.name, (p.example || '').split(' | ')[0] || '']))
+  );
+
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<{ status: number; ms: number; body: string; ok: boolean } | null>(null);
+
+  /** Live URL reflecting whatever the reader has typed into the param inputs. */
+  const liveUrl = useMemo(() => {
+    const qs = (ep.params || [])
+      .filter(p => values[p.name]?.trim())
+      .map(p => `${p.name}=${encodeURIComponent(values[p.name].trim())}`)
+      .join('&');
+    return `${ep.path}${qs ? `?${qs}` : ''}`;
+  }, [ep, values]);
+
+  const tabs = useMemo(() => buildTabs(ep, `${origin}${liveUrl}`), [ep, origin, liveUrl]);
+
+  const canTry = primary === 'GET' && !ep.requiresAuth;
+  const missingRequired = (ep.params || []).filter(p => p.required && !values[p.name]?.trim());
+
+  const run = async () => {
+    setRunning(true);
+    setResult(null);
+    const started = performance.now();
+    try {
+      const res = await fetch(liveUrl, { headers: { Accept: 'application/json' } });
+      const ms = Math.round(performance.now() - started);
+      const text = await res.text();
+      let pretty = text;
+      try {
+        pretty = JSON.stringify(JSON.parse(text), null, 2);
+      } catch {
+        /* not JSON — show the raw body */
+      }
+      const truncated = pretty.length > 4000 ? `${pretty.slice(0, 4000)}\n\n… truncated` : pretty;
+      setResult({ status: res.status, ms, body: truncated, ok: res.ok });
+    } catch (e) {
+      setResult({
+        status: 0,
+        ms: Math.round(performance.now() - started),
+        ok: false,
+        body: `Request failed: ${e instanceof Error ? e.message : String(e)}`,
+      });
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div
+      id={id}
+      className={`scroll-mt-28 rounded-xl border bg-white/[0.012] transition-colors ${
+        open ? 'border-[var(--gold-primary)]/30' : 'border-white/[0.07] hover:border-white/[0.14]'
+      }`}
+    >
+      {/* ── Header row ── */}
+      <button
+        onClick={() => setOpen(v => !v)}
+        aria-expanded={open}
+        className="w-full text-left p-4 flex items-start gap-3 group"
+      >
+        <div className="flex flex-col gap-1 shrink-0 pt-0.5">
+          {methods.map(m => (
+            <span
+              key={m}
+              className={`text-[9px] font-mono font-bold tracking-widest px-1.5 py-0.5 rounded border text-center ${METHOD_STYLES[m]}`}
+            >
+              {m}
+            </span>
+          ))}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-[12.5px] text-[var(--text-primary)] font-medium break-all mb-1">
+            {ep.path}
+          </div>
+          <p className="text-[12.5px] leading-relaxed text-[var(--text-secondary)]">{ep.summary}</p>
+        </div>
+
+        <svg
+          viewBox="0 0 24 24"
+          className={`w-4 h-4 shrink-0 mt-0.5 text-[var(--text-muted)] group-hover:text-[var(--gold-primary)] transition-all ${
+            open ? 'rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+
+      {/* ── Expanded detail ── */}
+      {open && (
+        <div className="px-4 pb-4 -mt-1">
+          {/* Params */}
+          {ep.params && ep.params.length > 0 && (
+            <div className="mb-4">
+              <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-2">
+                Query parameters
+              </div>
+              <div className="space-y-2">
+                {ep.params.map(p => (
+                  <div key={p.name} className="grid grid-cols-1 sm:grid-cols-[minmax(0,9rem)_1fr] gap-x-3 gap-y-1 items-start">
+                    <div className="flex items-center gap-1.5 pt-1.5">
+                      <span className="font-mono text-[11.5px] text-[var(--gold-primary)]">{p.name}</span>
+                      {p.required ? (
+                        <span className="text-[8px] font-mono tracking-wider uppercase text-[var(--alert-red)]/80">
+                          required
+                        </span>
+                      ) : (
+                        <span className="text-[8px] font-mono tracking-wider uppercase text-[var(--text-muted)]">
+                          optional
+                        </span>
+                      )}
+                    </div>
+                    <div className="min-w-0">
+                      <input
+                        value={values[p.name] ?? ''}
+                        onChange={e => setValues(v => ({ ...v, [p.name]: e.target.value }))}
+                        placeholder={p.example || p.name}
+                        aria-label={`${p.name} value`}
+                        className="w-full px-2.5 py-1.5 rounded-md text-[11.5px] font-mono bg-black/40 border border-white/[0.08] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]/60 focus:outline-none focus:border-[var(--gold-primary)]/40"
+                      />
+                      <p className="text-[11.5px] leading-relaxed text-[var(--text-secondary)] mt-1">{p.desc}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Request body */}
+          {ep.bodyExample && (
+            <>
+              <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1">
+                Request body
+              </div>
+              <CodeBlock dense tabs={[{ label: 'JSON', lang: 'json', code: ep.bodyExample }]} />
+            </>
+          )}
+
+          {/* Request snippets */}
+          <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1 mt-4">
+            Request
+          </div>
+          <CodeBlock dense tabs={tabs} />
+
+          {/* Try it */}
+          <div className="flex flex-wrap items-center gap-2 mt-3">
+            {canTry ? (
+              <>
+                <button
+                  onClick={run}
+                  disabled={running || missingRequired.length > 0}
+                  className="inline-flex items-center gap-1.5 text-[10px] font-mono tracking-[0.15em] uppercase px-3 py-1.5 rounded-md border border-[var(--gold-primary)]/40 bg-[var(--gold-primary)]/10 text-[var(--gold-primary)] hover:bg-[var(--gold-primary)]/20 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  {running ? (
+                    <span className="w-2.5 h-2.5 rounded-full border border-current border-t-transparent animate-spin" />
+                  ) : (
+                    <svg viewBox="0 0 24 24" className="w-3 h-3" fill="currentColor">
+                      <path d="M8 5v14l11-7z" />
+                    </svg>
+                  )}
+                  {running ? 'Running' : 'Send request'}
+                </button>
+                {missingRequired.length > 0 && (
+                  <span className="text-[10px] font-mono text-[var(--text-muted)]">
+                    Fill {missingRequired.map(p => p.name).join(', ')} first
+                  </span>
+                )}
+                <CopyButton value={`${origin}${liveUrl}`} />
+              </>
+            ) : (
+              <span className="text-[10px] font-mono text-[var(--text-muted)]">
+                {ep.requiresAuth
+                  ? 'Requires a credential — run this from your own client.'
+                  : 'POST endpoint — run this from your own client.'}
+              </span>
+            )}
+          </div>
+
+          {/* Live response */}
+          {result && (
+            <div className="mt-3">
+              <div className="flex items-center gap-2 mb-1">
+                <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)]">
+                  Response
+                </span>
+                <span
+                  className={`text-[9px] font-mono font-bold px-1.5 py-0.5 rounded border ${
+                    result.ok
+                      ? 'text-[#00E676] border-[#00E676]/30 bg-[#00E676]/10'
+                      : 'text-[#FF3D3D] border-[#FF3D3D]/30 bg-[#FF3D3D]/10'
+                  }`}
+                >
+                  {result.status || 'ERR'}
+                </span>
+                <span className="text-[9px] font-mono text-[var(--text-muted)]">{result.ms}ms</span>
+              </div>
+              <CodeBlock dense tabs={[{ label: 'JSON', lang: 'json', code: result.body }]} />
+            </div>
+          )}
+
+          {/* Returns */}
+          <div className="mt-4">
+            <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1.5">
+              Response keys
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {ep.returns.map(r => (
+                <span
+                  key={r}
+                  className="font-mono text-[10.5px] px-1.5 py-0.5 rounded bg-[var(--cyan-primary)]/[0.07] border border-[var(--cyan-primary)]/20 text-[var(--cyan-primary)]/90"
+                >
+                  {r}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Env */}
+          {ep.env && ep.env.length > 0 && (
+            <div className="mt-3 flex flex-wrap items-center gap-1.5">
+              <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)]">
+                Environment
+              </span>
+              {ep.env.map(e => (
+                <span
+                  key={e}
+                  className="font-mono text-[10.5px] px-1.5 py-0.5 rounded bg-[var(--gold-primary)]/[0.07] border border-[var(--gold-primary)]/20 text-[var(--gold-primary)]"
+                >
+                  {e}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Notes */}
+          {ep.notes && (
+            <p className="mt-4 text-[12px] leading-[1.75] text-[var(--text-muted)] border-l-2 border-[var(--gold-primary)]/25 pl-3">
+              {ep.notes}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/docs/apiCatalog.ts
+++ b/src/app/docs/apiCatalog.ts
@@ -1,0 +1,639 @@
+/**
+ * ═══════════════════════════════════════════════════════════════
+ *  OSIRIS — API Catalog
+ *  Machine-readable description of every public route under /api.
+ *  Kept in sync by hand with src/app/api/ * /route.ts
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+export type HttpMethod = 'GET' | 'POST';
+
+export interface ApiParam {
+  name: string;
+  required?: boolean;
+  desc: string;
+  example?: string;
+}
+
+export interface ApiEndpoint {
+  /** Path relative to the deployment origin, e.g. `/api/flights` */
+  path: string;
+  method: HttpMethod | HttpMethod[];
+  summary: string;
+  /** Query-string parameters (GET) */
+  params?: ApiParam[];
+  /** Top-level keys present on a 2xx response */
+  returns: string[];
+  /** Free-form notes: caching, auth, upstream source, failure modes */
+  notes?: string;
+  /** Environment variables the route reads */
+  env?: string[];
+  /** Pretty-printed JSON request body, for POST routes */
+  bodyExample?: string;
+  /** True when the route needs a credential the docs cannot supply */
+  requiresAuth?: boolean;
+}
+
+/** Stable DOM id / deep-link anchor for an endpoint. */
+export function endpointId(ep: ApiEndpoint): string {
+  const method = Array.isArray(ep.method) ? ep.method[0] : ep.method;
+  return `ep-${method}-${ep.path.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '')}`.toLowerCase();
+}
+
+/** Example request URL with required params filled from their documented examples. */
+export function sampleUrl(ep: ApiEndpoint, origin = ''): string {
+  const qs = (ep.params || [])
+    .filter(p => p.required || p.example)
+    .map(p => `${p.name}=${encodeURIComponent((p.example || '').split(' | ')[0] || 'value')}`)
+    .join('&');
+  return `${origin}${ep.path}${qs ? `?${qs}` : ''}`;
+}
+
+export interface ApiGroup {
+  id: string;
+  title: string;
+  blurb: string;
+  endpoints: ApiEndpoint[];
+}
+
+export const API_GROUPS: ApiGroup[] = [
+  {
+    id: 'system',
+    title: 'System',
+    blurb: 'Liveness and aggregate counters. Safe to poll from monitoring.',
+    endpoints: [
+      {
+        path: '/api/health',
+        method: 'GET',
+        summary: 'Liveness probe. Never touches an upstream feed, so it stays fast under load.',
+        returns: ['status', 'platform', 'version', 'uptime', 'timestamp', 'endpoints'],
+        notes: '`status` is the literal string `operational`. `uptime` is process uptime in seconds.',
+      },
+      {
+        path: '/api/stats',
+        method: 'GET',
+        summary:
+          'Fans out to the heavy feeds in parallel and returns only the counts — roughly 100 bytes instead of 10 MB of GeoJSON.',
+        returns: ['stats', 'timestamp'],
+        notes:
+          '`stats` contains `flights`, `sats`, `cctv`, `weather`, `nuclear`, `incidents`. Cached `s-maxage=30, stale-while-revalidate=60`, so 10k concurrent dashboard boots collapse into one upstream fetch per minute.',
+      },
+    ],
+  },
+  {
+    id: 'aviation-space',
+    title: 'Aviation & Space',
+    blurb: 'Aircraft, orbital objects, and heliophysics.',
+    endpoints: [
+      {
+        path: '/api/flights',
+        method: 'GET',
+        summary: 'Live ADS-B aircraft, bucketed by class.',
+        returns: ['commercial_flights', 'private_flights', 'private_jets', 'military_flights', 'source'],
+        notes:
+          'Keyless via adsb.lol. Each bucket is an array; sum them for a total. `OPENSKY_CLIENT_ID` / `OPENSKY_CLIENT_SECRET` are reserved for higher rate limits and are not required.',
+      },
+      {
+        path: '/api/satellites',
+        method: 'GET',
+        summary: 'Tracked orbital objects with TLE-derived positions.',
+        returns: ['satellites', 'total', 'category_counts', 'raw_count', 'timestamp'],
+        notes: 'Sourced from celestrak.org. `category_counts` breaks the set down by mission type.',
+      },
+      {
+        path: '/api/space-weather',
+        method: 'GET',
+        summary: 'Geomagnetic conditions and solar flare activity from NOAA SWPC.',
+        returns: [
+          'kp_index',
+          'kp_timestamp',
+          'storm_level',
+          'storm_color',
+          'solar_flares',
+          'alerts',
+          'timestamp',
+        ],
+        notes: '`storm_color` is a hex string the HUD renders directly, so clients need no severity lookup table.',
+      },
+    ],
+  },
+  {
+    id: 'earth',
+    title: 'Earth & Environment',
+    blurb: 'Seismic, fire, atmospheric, and orbital-imagery feeds.',
+    endpoints: [
+      {
+        path: '/api/earthquakes',
+        method: 'GET',
+        summary: 'Recent seismic events from the USGS feed.',
+        returns: ['earthquakes', 'total', 'timestamp'],
+        notes: 'M2.5+ over the trailing day. Each event carries `magnitude`, `place`, `depth`, `time`, `tsunami`, `alert`.',
+      },
+      {
+        path: '/api/fires',
+        method: 'GET',
+        summary: 'Active wildfire hotspots from NASA FIRMS.',
+        returns: ['fires', 'total', 'source', 'timestamp'],
+        env: ['FIRMS_API_KEY'],
+        notes: 'Uses the keyless FIRMS CSV by default; the key only matters if you switch to the per-area API.',
+      },
+      {
+        path: '/api/weather',
+        method: 'GET',
+        summary: 'Severe weather and natural events from NASA EONET.',
+        returns: ['events', 'total', 'timestamp'],
+      },
+      {
+        path: '/api/air-quality',
+        method: 'GET',
+        summary: 'Ground station air quality readings.',
+        returns: ['stations', 'total', 'timestamp'],
+      },
+      {
+        path: '/api/radar',
+        method: 'GET',
+        summary: 'GPS interference and navigation outage reporting.',
+        returns: ['outages', 'total', 'source', 'timestamp'],
+      },
+      {
+        path: '/api/sentinel',
+        method: 'GET',
+        summary: 'Sentinel satellite imagery scenes covering a point.',
+        params: [
+          { name: 'lat', required: true, desc: 'Latitude of the point of interest.', example: '51.5072' },
+          { name: 'lng', required: true, desc: 'Longitude of the point of interest.', example: '-0.1276' },
+          { name: 'radius', desc: 'Search radius in kilometres.', example: '50' },
+          { name: 'days', desc: 'How far back to search, in days.', example: '30' },
+        ],
+        returns: ['scenes', 'timestamp'],
+      },
+    ],
+  },
+  {
+    id: 'geopolitical',
+    title: 'Geopolitical',
+    blurb: 'Conflict zones, frontlines, event streams, and country-level risk.',
+    endpoints: [
+      {
+        path: '/api/conflicts',
+        method: 'GET',
+        summary: 'Active conflict zones joined with live incident reporting.',
+        returns: [
+          'zones',
+          'activeWarzones',
+          'liveEvents',
+          'totalZones',
+          'totalLiveEvents',
+          'sources',
+          'refreshInterval',
+          'timestamp',
+        ],
+        notes: '`refreshInterval` is the server’s recommended client poll interval in milliseconds — honour it rather than hard-coding your own.',
+      },
+      {
+        path: '/api/frontlines',
+        method: 'GET',
+        summary: 'Frontline geometry for active theatres.',
+        returns: ['frontlines', 'timestamp'],
+      },
+      {
+        path: '/api/gdelt',
+        method: 'GET',
+        summary: 'Geocoded world events from the GDELT project.',
+        returns: ['events', 'total', 'source', 'timestamp'],
+      },
+      {
+        path: '/api/country-risk',
+        method: 'GET',
+        summary: 'Per-country risk scoring alongside market session state.',
+        returns: ['countries', 'exchanges', 'open_exchanges', 'total_exchanges', 'timestamp'],
+      },
+      {
+        path: '/api/region-dossier',
+        method: 'GET',
+        summary: 'Composite intelligence summary for a map location — the panel behind a map right-click.',
+        params: [
+          { name: 'lat', required: true, desc: 'Latitude of the region.', example: '48.3794' },
+          { name: 'lng', required: true, desc: 'Longitude of the region.', example: '31.1656' },
+        ],
+        returns: ['coordinates', '…dossier sections'],
+      },
+    ],
+  },
+  {
+    id: 'media-markets',
+    title: 'Media & Markets',
+    blurb: 'News aggregation, live broadcast streams, and financial instruments.',
+    endpoints: [
+      {
+        path: '/api/news',
+        method: 'GET',
+        summary: 'Aggregated OSINT news items.',
+        returns: ['news', 'total', 'timestamp'],
+      },
+      {
+        path: '/api/live-news',
+        method: 'GET',
+        summary: '24/7 broadcast streams grouped by category.',
+        returns: ['feeds', 'categories', 'total', 'timestamp'],
+      },
+      {
+        path: '/api/markets',
+        method: 'GET',
+        summary: 'Defence-sector equities and commodities.',
+        returns: ['stocks', 'timestamp'],
+      },
+      {
+        path: '/api/crypto',
+        method: 'GET',
+        summary: 'Spot prices for the assets shown in the status ticker.',
+        returns: ['…price series'],
+      },
+      {
+        path: '/api/scm-suppliers',
+        method: 'GET',
+        summary: 'Supply-chain suppliers with criticality flags.',
+        returns: ['suppliers', 'total', 'critical_count', 'timestamp'],
+      },
+    ],
+  },
+  {
+    id: 'surveillance',
+    title: 'Surveillance & Infrastructure',
+    blurb: 'Camera networks, fixed infrastructure, maritime traffic, and tile/stream proxies.',
+    endpoints: [
+      {
+        path: '/api/cctv',
+        method: 'GET',
+        summary: 'Public camera networks, optionally filtered by region or radius.',
+        params: [
+          { name: 'region', desc: 'Restrict to a named provider region.', example: 'london' },
+          { name: 'lat', desc: 'Latitude for a radius search.', example: '51.5072' },
+          { name: 'lng', desc: 'Longitude for a radius search.', example: '-0.1276' },
+          { name: 'radius', desc: 'Radius in kilometres. Requires `lat` and `lng`.', example: '25' },
+        ],
+        returns: ['cameras', 'regions', 'total', 'timestamp'],
+      },
+      {
+        path: '/api/cctv/stream-status',
+        method: 'GET',
+        summary: 'Probes whether a camera stream is reachable before the player commits to it.',
+        params: [{ name: 'url', required: true, desc: 'Stream URL to probe.' }],
+        returns: ['available', 'blocked', 'provider', 'reason'],
+        notes: '`blocked` distinguishes an upstream refusing our origin from a stream that is simply offline.',
+      },
+      {
+        path: '/api/cctv/proxy',
+        method: 'GET',
+        summary: 'Same-origin proxy for camera streams that set restrictive CORS headers.',
+        params: [{ name: 'url', required: true, desc: 'Upstream stream URL.' }],
+        returns: ['domain', 'failed', 'error'],
+        notes: 'Allow-listed by domain. Not a general-purpose open proxy.',
+      },
+      {
+        path: '/api/infrastructure',
+        method: 'GET',
+        summary: 'Fixed strategic infrastructure — nuclear sites, plants, and facilities.',
+        returns: ['infrastructure', 'total', 'timestamp'],
+      },
+      {
+        path: '/api/maritime',
+        method: 'GET',
+        summary: 'Ports, chokepoints, and vessel positions.',
+        returns: ['ports', 'chokepoints', 'ships', 'total_ports', 'total_chokepoints', 'total_ships', 'timestamp'],
+        env: ['AIS_API_KEY'],
+      },
+      {
+        path: '/api/arcgis',
+        method: 'GET',
+        summary: 'Queries a configured ArcGIS feature service.',
+        params: [
+          { name: 'service', desc: 'Service identifier to query.' },
+          { name: 'q', desc: 'Attribute query string.' },
+          { name: 'bbox', desc: 'Bounding box filter, `minLng,minLat,maxLng,maxLat`.' },
+        ],
+        returns: ['…feature collection'],
+      },
+      {
+        path: '/api/proxy-tiles',
+        method: 'GET',
+        summary: 'Same-origin raster tile proxy for basemaps that block cross-origin reads.',
+        params: [{ name: 'url', required: true, desc: 'Upstream tile URL.' }],
+        returns: ['…binary tile'],
+      },
+      {
+        path: '/api/geo',
+        method: 'GET',
+        summary: 'Geolocates the calling client by IP.',
+        returns: ['status', 'query', 'city', 'regionName', 'country', 'lat', 'lon', 'isp', 'org'],
+      },
+    ],
+  },
+  {
+    id: 'cyber',
+    title: 'Cyber Threat',
+    blurb: 'Vulnerability, attack, and malware telemetry.',
+    endpoints: [
+      {
+        path: '/api/cyber-threats',
+        method: 'GET',
+        summary: 'Recent CVE disclosures with rollup statistics.',
+        returns: ['threats', 'stats'],
+      },
+      {
+        path: '/api/cyber-attacks',
+        method: 'GET',
+        summary: 'Observed attack events for the live threat map.',
+        returns: ['attacks', 'total'],
+      },
+      {
+        path: '/api/malware',
+        method: 'GET',
+        summary: 'Malware indicators from public trackers.',
+        returns: ['threats', 'total', 'source', 'timestamp'],
+      },
+    ],
+  },
+  {
+    id: 'osint',
+    title: 'OSINT Toolkit',
+    blurb:
+      'The lookup tools behind the RECON panel. Every route takes a single subject and returns a normalised result, so they compose well in scripts.',
+    endpoints: [
+      {
+        path: '/api/osint/dns',
+        method: 'GET',
+        summary: 'Resolves A, AAAA, MX, NS, TXT, and SOA records.',
+        params: [{ name: 'domain', required: true, desc: 'Domain to resolve.', example: 'example.com' }],
+        returns: ['…record sets'],
+      },
+      {
+        path: '/api/osint/whois',
+        method: 'GET',
+        summary: 'Registration and registrar detail for a domain.',
+        params: [{ name: 'domain', required: true, desc: 'Domain to look up.', example: 'example.com' }],
+        returns: ['…registration record'],
+      },
+      {
+        path: '/api/osint/certs',
+        method: 'GET',
+        summary: 'Certificate transparency search — an effective passive subdomain enumerator.',
+        params: [{ name: 'domain', required: true, desc: 'Apex domain to search.', example: 'example.com' }],
+        returns: ['certificates', 'subdomains', 'total_certs', 'unique_subdomains', 'timestamp'],
+      },
+      {
+        path: '/api/osint/ip',
+        method: 'GET',
+        summary: 'Geolocation, ASN, and network ownership for an address.',
+        params: [{ name: 'ip', required: true, desc: 'IPv4 or IPv6 address.', example: '8.8.8.8' }],
+        returns: ['…address record'],
+      },
+      {
+        path: '/api/osint/shodan',
+        method: 'GET',
+        summary: 'Exposed services, banners, and known vulnerabilities for a host.',
+        params: [{ name: 'ip', required: true, desc: 'Address to query.', example: '8.8.8.8' }],
+        returns: ['status', 'ports', 'hostnames', 'cpes', 'vulns', 'tags', 'detail'],
+      },
+      {
+        path: '/api/osint/bgp',
+        method: 'GET',
+        summary: 'ASN, prefix, and peering relationships.',
+        params: [{ name: 'query', required: true, desc: 'ASN, prefix, or IP.', example: 'AS15169' }],
+        returns: ['…routing record'],
+      },
+      {
+        path: '/api/osint/mac',
+        method: 'GET',
+        summary: 'Resolves a MAC address or OUI prefix to its hardware vendor.',
+        params: [{ name: 'mac', required: true, desc: 'MAC address or OUI prefix.', example: '00:1A:2B:3C:4D:5E' }],
+        returns: ['mac', 'prefix', 'vendor', 'address', 'detail'],
+      },
+      {
+        path: '/api/osint/phone',
+        method: 'GET',
+        summary: 'Validates and classifies a phone number in E.164 form.',
+        params: [{ name: 'number', required: true, desc: 'Number in international format.', example: '+442071234567' }],
+        returns: [
+          'valid',
+          'number',
+          'country_code',
+          'region',
+          'line_type',
+          'national',
+          'international',
+          'lat',
+          'query',
+        ],
+      },
+      {
+        path: '/api/osint/github',
+        method: 'GET',
+        summary: 'Public profile metadata for a GitHub account.',
+        params: [{ name: 'user', required: true, desc: 'GitHub username.', example: 'torvalds' }],
+        returns: ['username', 'name', 'bio', 'company', 'location', 'blog', 'email', 'twitter', 'public_repos'],
+      },
+      {
+        path: '/api/osint/leaks',
+        method: 'GET',
+        summary: 'Checks an address against known breach corpora.',
+        params: [{ name: 'email', required: true, desc: 'Email address to check.' }],
+        returns: ['breached', 'breaches', 'data_exposed', 'detail'],
+      },
+      {
+        path: '/api/osint/cve',
+        method: 'GET',
+        summary: 'Full NVD record for a single CVE identifier.',
+        params: [{ name: 'cve', required: true, desc: 'CVE ID.', example: 'CVE-2021-44228' }],
+        returns: ['id', 'description', 'cvss', 'cvss_vector', 'severity', 'published', 'references', 'source'],
+      },
+      {
+        path: '/api/osint/sanctions',
+        method: 'GET',
+        summary: 'Searches the OpenSanctions mirror of the US OFAC SDN list.',
+        params: [
+          { name: 'query', required: true, desc: 'Name of a person, organisation, or vessel.' },
+          { name: 'schema', desc: 'Entity type filter.', example: 'Person | Organization | Vessel' },
+          { name: 'limit', desc: 'Maximum results to return.', example: '10' },
+        ],
+        returns: ['schema', 'total', 'source', 'timestamp'],
+      },
+      {
+        path: '/api/osint/threats',
+        method: 'GET',
+        summary: 'Reputation and threat-intel enrichment for an indicator.',
+        params: [{ name: 'query', required: true, desc: 'IP, domain, or file hash.' }],
+        returns: ['…enrichment record'],
+      },
+      {
+        path: '/api/osint/sweep',
+        method: 'GET',
+        summary: 'Sweeps a single address or a CIDR range for reachable hosts.',
+        params: [
+          { name: 'ip', desc: 'Single address to sweep.' },
+          { name: 'cidr', desc: 'CIDR range to sweep. Use instead of `ip`.', example: '192.0.2.0/24' },
+        ],
+        returns: ['target_ip', '…sweep results'],
+        notes: 'Only sweep ranges you are authorised to test.',
+      },
+    ],
+  },
+  {
+    id: 'recon',
+    title: 'Recon Scanner',
+    blurb: 'Active scanning, delegated to a separate backend so the web tier never runs scans itself.',
+    endpoints: [
+      {
+        path: '/api/scanner',
+        method: 'GET',
+        summary: 'Runs a scan against a target via the OSIRIS scanner backend.',
+        params: [
+          {
+            name: 'type',
+            required: true,
+            desc: 'Scan type.',
+            example: 'quick | ssl | headers | rdns | subdomains | tech | whois | geoloc | vuln',
+          },
+          { name: 'target', required: true, desc: 'Host, domain, or address to scan.' },
+        ],
+        returns: ['detail', 'hint', 'failed', 'error'],
+        env: ['SCANNER_URL', 'SCANNER_KEY'],
+        notes:
+          'Returns 503 when `SCANNER_URL` / `SCANNER_KEY` are unset — that is the supported way to disable RECON. `SCANNER_KEY` must equal the backend’s `OSIRIS_KEY`.',
+      },
+    ],
+  },
+  {
+    id: 'graph',
+    title: 'Entity Graph',
+    blurb: 'Link analysis over entities surfaced elsewhere in the platform.',
+    endpoints: [
+      {
+        path: '/api/entity/expand',
+        method: 'GET',
+        summary: 'Expands one graph node into its neighbours.',
+        params: [
+          { name: 'id', required: true, desc: 'Entity identifier to expand.' },
+          { name: 'type', required: true, desc: 'Entity type, which selects the expansion strategy.' },
+        ],
+        returns: ['…nodes and edges'],
+      },
+    ],
+  },
+  {
+    id: 'ai',
+    title: 'AI Analysis',
+    blurb:
+      'Gemini-backed correlation over feed data you supply. All three are POST, all three are rate limited to 5 requests per minute per IP.',
+    endpoints: [
+      {
+        path: '/api/ai/analyze',
+        method: 'POST',
+        summary: 'Cross-feed correlation and threat assessment over an intelligence context.',
+        returns: ['…analysis'],
+        notes:
+          'Body is an `IntelligenceContext`. Exceeding the limit returns 429. Feed it straight from the read endpoints — the shape matches what they return.',
+        bodyExample: `{
+  "earthquakes": [],
+  "news": [],
+  "threats": [],
+  "cyberAlerts": [],
+  "timestamp": "2026-07-29T12:00:00Z"
+}`,
+      },
+      {
+        path: '/api/ai/briefing',
+        method: 'POST',
+        summary: 'Structured threat briefing in the style of a daily intelligence product.',
+        returns: ['…briefing'],
+        notes: 'Same `IntelligenceContext` body and same rate limit as `/api/ai/analyze`.',
+        bodyExample: `{
+  "earthquakes": [],
+  "news": [],
+  "threats": [],
+  "cyberAlerts": [],
+  "timestamp": "2026-07-29T12:00:00Z"
+}`,
+      },
+      {
+        path: '/api/ai/overview',
+        method: 'POST',
+        summary: 'Short headline highlights for the overview panel.',
+        returns: ['highlights', 'generatedAt'],
+        bodyExample: `{
+  "earthquakes": [],
+  "news": [],
+  "threats": [],
+  "cyberAlerts": [],
+  "timestamp": "2026-07-29T12:00:00Z"
+}`,
+      },
+    ],
+  },
+  {
+    id: 'sdk',
+    title: 'Polybolos SDK',
+    blurb:
+      'Push entities from an external platform into the Common Operating Picture, and stream the merged picture back out.',
+    endpoints: [
+      {
+        path: '/api/sdk/ingest',
+        method: 'POST',
+        summary: 'Accepts Polybolos-format entities from an external system and merges them into the map.',
+        returns: ['accepted', 'rejected', 'errors', 'timestamp'],
+        env: ['SDK_INGEST_KEY'],
+        requiresAuth: true,
+        notes:
+          'Each entity needs `id`, `position.lat`, and `position.lng`; everything else is defaulted. Stored ids are namespaced to `ext-{source}-{id}`, so two platforms can push the same id safely. Fails closed: 503 when `SDK_INGEST_KEY` is unset, 401 on key mismatch, 400 on a malformed payload.',
+        bodyExample: `{
+  "source": "lattice",
+  "apiKey": "$SDK_INGEST_KEY",
+  "entities": [
+    {
+      "id": "TRK-4471",
+      "name": "UNKNOWN SURFACE CONTACT",
+      "domain": "SEA",
+      "entityType": "TRACK",
+      "position": { "lat": 36.14, "lng": -5.35, "heading": 271, "speed": 14.2 },
+      "threat": "UNKNOWN",
+      "classification": "UNCLASSIFIED",
+      "confidence": 0.86
+    }
+  ]
+}`,
+      },
+      {
+        path: '/api/sdk/ingest',
+        method: 'GET',
+        summary: 'Reports how many external entities are currently held, plus recent ingest history.',
+        returns: ['sdk', 'version', 'entityCount', 'recentIngestions', 'timestamp'],
+      },
+      {
+        path: '/api/sdk/stream',
+        method: 'GET',
+        summary: 'Server-Sent Events stream of normalised entities as they arrive.',
+        returns: ['…SSE event stream'],
+        notes:
+          'Opens with a `status` event carrying `connected`, `entityCount`, `feedCount`, `latticeStatus`, and `lastUpdate`. Consume with `EventSource`, not `fetch`.',
+      },
+    ],
+  },
+  {
+    id: 'webhooks',
+    title: 'Webhooks',
+    blurb: 'Inbound hooks from external services.',
+    endpoints: [
+      {
+        path: '/api/github-webhook',
+        method: 'POST',
+        summary: 'Receives GitHub repository events.',
+        returns: ['success', 'message', 'error'],
+        requiresAuth: true,
+        notes: 'Signature-verified. Unsigned or mismatched deliveries are rejected with 401.',
+      },
+    ],
+  },
+];
+
+/** Total endpoint count, derived rather than hard-coded so it cannot drift. */
+export const ENDPOINT_COUNT = API_GROUPS.reduce((n, g) => n + g.endpoints.length, 0);

--- a/src/app/docs/docsPrimitives.tsx
+++ b/src/app/docs/docsPrimitives.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import { useState } from 'react';
+
+/* ─────────────────────────────────────────────────────────────
+   Inline code
+   ───────────────────────────────────────────────────────────── */
+
+export function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="font-mono text-[11.5px] px-1.5 py-0.5 rounded-[4px] bg-[var(--cyan-primary)]/[0.07] border border-[var(--cyan-primary)]/15 text-[var(--cyan-primary)] whitespace-nowrap">
+      {children}
+    </code>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Copy button
+   ───────────────────────────────────────────────────────────── */
+
+export function CopyButton({ value, className = '' }: { value: string; className?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard blocked on insecure origins — leave the control inert */
+    }
+  };
+
+  return (
+    <button
+      onClick={copy}
+      aria-label={copied ? 'Copied' : 'Copy to clipboard'}
+      className={`inline-flex items-center gap-1 text-[9px] font-mono tracking-[0.15em] uppercase px-2 py-1 rounded-[5px] border transition-all duration-200 ${
+        copied
+          ? 'border-[var(--alert-green)]/40 bg-[var(--alert-green)]/10 text-[var(--alert-green)]'
+          : 'border-white/10 bg-black/60 text-[var(--text-muted)] hover:text-[var(--gold-primary)] hover:border-[var(--gold-primary)]/40'
+      } ${className}`}
+    >
+      {copied ? (
+        <svg viewBox="0 0 24 24" className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      ) : (
+        <svg viewBox="0 0 24 24" className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="9" y="9" width="11" height="11" rx="2" />
+          <path d="M5 15V5a2 2 0 0 1 2-2h10" />
+        </svg>
+      )}
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Syntax highlighting — deliberately minimal.
+   A full tokenizer is not worth the bundle here; these are short,
+   well-formed snippets in three known languages.
+   ───────────────────────────────────────────────────────────── */
+
+/* Escapes every character that could open a tag or break an attribute. This runs
+   BEFORE any span injection below, so highlighted output can never contain
+   markup originating from the source string — which matters because live API
+   responses from the "Send request" runner are rendered through here. */
+function escapeHtml(s: string) {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Upper bound on what we will tokenize, to keep pathological payloads cheap. */
+const MAX_HIGHLIGHT_CHARS = 20_000;
+
+function highlight(source: string, lang: string): string {
+  // Oversized input is escaped but left untokenized rather than run through
+  // every regex pass.
+  if (source.length > MAX_HIGHLIGHT_CHARS) return escapeHtml(source);
+
+  let html = escapeHtml(source);
+
+  if (lang === 'json') {
+    html = html
+      .replace(/&quot;([^&]*?)&quot;(\s*:)/g, '<span class="tok-key">&quot;$1&quot;</span>$2')
+      .replace(/:\s*&quot;([^&]*?)&quot;/g, ': <span class="tok-str">&quot;$1&quot;</span>')
+      .replace(/\b(true|false|null)\b/g, '<span class="tok-lit">$1</span>')
+      .replace(/\b(-?\d+\.?\d*)\b/g, '<span class="tok-num">$1</span>');
+    return html;
+  }
+
+  if (lang === 'bash') {
+    html = html
+      .replace(/(^|\n)(\s*)(#.*)/g, '$1$2<span class="tok-com">$3</span>')
+      .replace(/\b(curl|jq|npm|git|docker|cd|cp|openssl|compose)\b/g, '<span class="tok-fn">$1</span>')
+      .replace(/(\s)(-{1,2}[a-zA-Z][\w-]*)/g, '$1<span class="tok-lit">$2</span>')
+      .replace(/(&quot;[^&]*?&quot;|&#39;[^&]*?&#39;)/g, '<span class="tok-str">$1</span>');
+    return html;
+  }
+
+  // javascript / python
+  html = html
+    .replace(/(^|\n)(\s*)(#[^\n]*)/g, '$1$2<span class="tok-com">$3</span>')
+    .replace(/(\/\/[^\n]*)/g, '<span class="tok-com">$1</span>')
+    .replace(
+      /\b(const|let|var|await|async|function|return|import|from|def|print|if|else|for|in|with|as)\b/g,
+      '<span class="tok-kw">$1</span>'
+    )
+    .replace(/\b(fetch|json|requests|get|post|dumps|len)\b(?=\s*[(.])/g, '<span class="tok-fn">$1</span>')
+    .replace(/(&quot;[^&\n]*?&quot;|&#39;[^&\n]*?&#39;|`[^`\n]*?`)/g, '<span class="tok-str">$1</span>');
+  return html;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Code block — optionally with language tabs
+   ───────────────────────────────────────────────────────────── */
+
+export interface CodeTab {
+  label: string;
+  lang: string;
+  code: string;
+}
+
+export function CodeBlock({
+  tabs,
+  label,
+  dense = false,
+}: {
+  tabs: CodeTab[];
+  label?: string;
+  dense?: boolean;
+}) {
+  const [idx, setIdx] = useState(0);
+  const active = tabs[Math.min(idx, tabs.length - 1)];
+
+  return (
+    <div className={`rounded-xl border border-white/[0.08] bg-[#07070D] overflow-hidden ${dense ? 'my-3' : 'my-5'}`}>
+      <div className="flex items-center gap-1 px-2 h-9 border-b border-white/[0.07] bg-white/[0.015]">
+        {label && !tabs.length && (
+          <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] px-2">{label}</span>
+        )}
+        {tabs.length > 1 ? (
+          tabs.map((t, i) => (
+            <button
+              key={t.label}
+              onClick={() => setIdx(i)}
+              className={`text-[10px] font-mono tracking-wider px-2.5 py-1 rounded-[5px] transition-colors ${
+                i === idx
+                  ? 'text-[var(--gold-primary)] bg-[var(--gold-primary)]/10'
+                  : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+              }`}
+            >
+              {t.label}
+            </button>
+          ))
+        ) : (
+          <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] px-2">
+            {label || tabs[0]?.label}
+          </span>
+        )}
+        <div className="flex-1" />
+        <CopyButton value={active?.code || ''} className="mr-1" />
+      </div>
+
+      <pre className="overflow-x-auto styled-scrollbar p-4 text-[11.5px] leading-[1.7] font-mono docs-code">
+        <code dangerouslySetInnerHTML={{ __html: highlight(active?.code || '', active?.lang || 'bash') }} />
+      </pre>
+    </div>
+  );
+}
+
+/** Convenience wrapper for a single, untabbed snippet. */
+export function Pre({ children, label, lang = 'bash' }: { children: string; label?: string; lang?: string }) {
+  return <CodeBlock tabs={[{ label: label || lang, lang, code: children }]} label={label} />;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Callout
+   ───────────────────────────────────────────────────────────── */
+
+const CALLOUT_TONES = {
+  info: { border: 'var(--cyan-primary)', icon: 'M12 16v-4M12 8h.01', label: 'Note' },
+  warn: { border: 'var(--alert-orange)', icon: 'M12 9v4M12 17h.01', label: 'Caution' },
+  good: { border: 'var(--alert-green)', icon: 'M20 6 9 17l-5-5', label: 'Tip' },
+};
+
+export function Callout({
+  tone = 'info',
+  title,
+  children,
+}: {
+  tone?: keyof typeof CALLOUT_TONES;
+  title?: string;
+  children: React.ReactNode;
+}) {
+  const t = CALLOUT_TONES[tone];
+  return (
+    <div
+      className="rounded-xl p-4 my-5 border bg-white/[0.015]"
+      style={{ borderColor: `color-mix(in srgb, ${t.border} 25%, transparent)` }}
+    >
+      <div className="flex items-center gap-2 mb-1.5">
+        <svg
+          viewBox="0 0 24 24"
+          className="w-3.5 h-3.5 shrink-0"
+          fill="none"
+          stroke={t.border}
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          {tone !== 'good' && <circle cx="12" cy="12" r="9" />}
+          <path d={t.icon} />
+        </svg>
+        <span className="text-[10px] font-mono tracking-[0.2em] uppercase" style={{ color: t.border }}>
+          {title || t.label}
+        </span>
+      </div>
+      <div className="text-[12.5px] leading-[1.75] text-[var(--text-secondary)]">{children}</div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Section with an anchor link
+   ───────────────────────────────────────────────────────────── */
+
+export function Section({
+  id,
+  title,
+  eyebrow,
+  children,
+}: {
+  id: string;
+  title: string;
+  eyebrow?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="scroll-mt-28 mb-20">
+      {eyebrow && (
+        <div className="text-[9px] font-mono tracking-[0.3em] uppercase text-[var(--cyan-primary)]/60 mb-2">
+          {eyebrow}
+        </div>
+      )}
+      <h2 className="group flex items-center gap-2 text-[22px] md:text-[26px] font-bold text-[var(--text-heading)] tracking-tight mb-5">
+        {title}
+        <a
+          href={`#${id}`}
+          aria-label={`Link to ${title}`}
+          className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity text-[var(--gold-primary)]/50 hover:text-[var(--gold-primary)]"
+        >
+          <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.5 1.5" />
+            <path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.5-1.5" />
+          </svg>
+        </a>
+      </h2>
+      <div className="space-y-4 text-[13.5px] leading-[1.8] text-[var(--text-secondary)]">{children}</div>
+    </section>
+  );
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import DocsClient from './DocsClient';
+import { ENDPOINT_COUNT } from './apiCatalog';
+
+export const metadata: Metadata = {
+  title: 'Documentation & API Reference',
+  description: `Official OSIRIS documentation — self-hosting guide, interface reference, and the complete API reference for all ${ENDPOINT_COUNT} endpoints covering aviation, maritime, seismic, conflict, cyber, and OSINT feeds. No API key required.`,
+  alternates: { canonical: '/docs' },
+  openGraph: {
+    title: 'OSIRIS — Documentation & API Reference',
+    description: `Self-hosting guide, interface reference, and the complete API reference for all ${ENDPOINT_COUNT} OSIRIS endpoints.`,
+    url: '/docs',
+    type: 'article',
+  },
+};
+
+export default function DocsPage() {
+  return <DocsClient />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -139,6 +139,33 @@ html, body {
   -webkit-tap-highlight-color: transparent;
 }
 
+/* ── Scrollable document pages (docs) ──
+   The rules above lock the viewport for the fullscreen map. Long-form pages
+   opt out by rendering .docs-root, which releases the lock without affecting
+   the map. */
+html:has(.docs-root),
+html:has(.docs-root) body {
+  height: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:has(.docs-root),
+  html:has(.docs-root) body { scroll-behavior: auto; }
+}
+
+/* ── Docs code tokens ── */
+.docs-code { color: #C9D1D9; }
+.docs-code .tok-key { color: var(--gold-primary); }
+.docs-code .tok-str { color: #A5D6A7; }
+.docs-code .tok-num { color: #F0D060; }
+.docs-code .tok-lit { color: #B388FF; }
+.docs-code .tok-kw  { color: #FF7B9C; }
+.docs-code .tok-fn  { color: var(--cyan-primary); }
+.docs-code .tok-com { color: #5C5A54; font-style: italic; }
+
 /* ── Scrollbar ── */
 .styled-scrollbar::-webkit-scrollbar { width: 3px; }
 .styled-scrollbar::-webkit-scrollbar-track { background: transparent; }

--- a/src/components/GlobalStatusBar.tsx
+++ b/src/components/GlobalStatusBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { motion } from 'framer-motion';
 
 interface CryptoPrice { symbol: string; price: number; change24h?: number; }
@@ -16,6 +17,13 @@ const DiscordIcon = () => (
 const XIcon = () => (
   <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
     <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z"/>
+  </svg>
+);
+
+const DocsIcon = () => (
+  <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M4 4.5A1.5 1.5 0 0 1 5.5 3H10a2 2 0 0 1 2 2 2 2 0 0 1 2-2h4.5A1.5 1.5 0 0 1 20 4.5v13a1.5 1.5 0 0 1-1.5 1.5H14a2 2 0 0 0-2 2 2 2 0 0 0-2-2H5.5A1.5 1.5 0 0 1 4 17.5z"/>
+    <path d="M12 7v14"/>
   </svg>
 );
 
@@ -122,7 +130,9 @@ export default function GlobalStatusBar() {
     return () => clearInterval(iv);
   }, []);
 
-  if (crypto.length === 0 && quakes.length === 0) return null;
+  // Keep the bar mounted even with no feed data — the left-hand community and
+  // docs links must stay reachable when CoinGecko/USGS are rate-limited or down.
+  const hasTicker = crypto.length > 0 || quakes.length > 0;
 
   const solPrice = crypto.find(c => c.symbol === 'SOL');
 
@@ -131,7 +141,7 @@ export default function GlobalStatusBar() {
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: 3, duration: 0.6 }}
-      className="hidden md:block absolute bottom-0 left-0 right-0 z-[198] pointer-events-none"
+      className="hidden md:block absolute bottom-0 left-0 right-0 z-[210] pointer-events-none"
     >
       <div className="h-[28px] overflow-hidden bg-[#0a0a0f]/95 border-t border-white/[0.06] flex items-center text-[9px] font-mono tracking-wider backdrop-blur-xl relative">
         {/* Animated scan line */}
@@ -151,11 +161,18 @@ export default function GlobalStatusBar() {
           >
             <XIcon />
           </a>
+          {/* Documentation & API reference */}
+          <Link href="/docs" prefetch title="Documentation & API Reference" aria-label="Documentation & API Reference"
+            className="h-full px-3 flex items-center gap-1.5 bg-[var(--gold-primary)]/10 text-[var(--gold-primary)]/80 hover:text-[var(--gold-primary)] hover:bg-[var(--gold-primary)]/25 border-r border-white/[0.04] transition-all duration-200"
+          >
+            <DocsIcon />
+            <span className="text-[8px] font-bold tracking-[0.15em] uppercase">Docs</span>
+          </Link>
         </div>
 
         {/* ── CENTER: Scrolling ticker ── */}
         <div className="flex-1 overflow-hidden relative" style={{ maskImage: 'linear-gradient(to right, transparent, black 3%, black 97%, transparent)' }}>
-          <div className="flex items-center animate-ticker whitespace-nowrap">
+          <div className={`flex items-center animate-ticker whitespace-nowrap ${hasTicker ? '' : 'hidden'}`}>
             {[...Array(4)].map((_, repeatIdx) => (
               <span key={repeatIdx} className="inline-flex items-center">
                 {/* Crypto prices */}


### PR DESCRIPTION
Adds a first-party documentation site at `/docs`, reachable from a new **Docs** button in the bottom-left status bar next to Discord and X.

## What's in it

**Guide** — overview, quick start, self-hosting, configuration, interface tour, keyboard shortcuts.

**API reference** — all **55 routes** under `/api`, grouped by domain. Methods, query params, response keys, env vars, caching behaviour, and auth were read out of the route sources rather than assumed, so the reference documents what the code actually does:

- `/api/scanner` returns 503 when `SCANNER_URL`/`SCANNER_KEY` are unset — documented as the supported way to disable RECON
- `/api/sdk/ingest` fails closed: 503 unset key, 401 mismatch, 400 malformed
- The three `/api/ai/*` routes are 5 req/min per IP, 429 beyond
- `/api/stats` advertises its `s-maxage=30` collapse behaviour

## Notable behaviour

- **Command palette** over sections and endpoints, bound to `⌘K` / `Ctrl-K` and `/`
- **Runnable endpoints** — every GET has editable params and a Send button that fires against the current origin and renders the live response with status and latency
- **cURL / JavaScript / Python** snippets generated per endpoint, updating live as you edit params
- Scroll-spy sidebar, "on this page" rail, reading progress, deep-linkable endpoint anchors, mobile drawer

## Bugs fixed along the way

**Long-form pages could not scroll.** `globals.css` locks `html, body` to `overflow: hidden` for the fullscreen map, which any document-flow page inherits. Long-form pages now opt out via `html:has(.docs-root)` — higher specificity than the base rule, so the map is untouched. Includes an imperative fallback for engines without `:has()` and a `prefers-reduced-motion` guard.

**The status bar's links were unclickable.** `GlobalStatusBar` sat at `z-[198]`, while `page.tsx:1256` renders a `pointer-events-auto` overlay at `z-[200]` anchored to `left: 72px` — directly over the social cluster, swallowing its clicks. Raised the bar to `z-[210]`. This fixes the existing Discord and X links too, not just the new button.

**The status bar vanished on feed failure.** It returned `null` when both the crypto and earthquake fetches came back empty, taking the community links off the page whenever CoinGecko or USGS rate-limited. The bar now stays mounted and only the ticker is conditional.

## Security

The docs highlighter renders via `dangerouslySetInnerHTML`, which matters because live API responses flow through it from the request runner. Input is fully HTML-escaped (including quotes) before any span injection, and payloads over 20k chars skip tokenization. The runner itself is same-origin only, with paths from the static catalog and `encodeURIComponent` on all user input, so it cannot be aimed at another host.

## Verification

- `tsc --noEmit` clean across all new and modified files
- `/` and `/docs` both return 200; no errors or hydration warnings in the dev log
- Docs button click-through confirmed working after the z-index fix

Pre-existing type errors in `WorldRemote.tsx`, `cctv/proxy`, and `page.tsx` are untouched and unrelated.


