### PR TITLE
feat(layers): NET & EVENT INTEL — real GDELT events + Cloudflare Radar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,19 @@ SCANNER_KEY=
 
 
 # ─────────────────────────────────────────────────────────────────────────
+#  CLOUDFLARE RADAR  ── read by the code; enables two map layers ──
+#  Powers the "Internet Outages" and "Attack Origins" layers under
+#  NET & EVENT INTEL (https://radar.cloudflare.com/).
+#  Free: any Cloudflare account → My Profile → API Tokens → Create Token →
+#  Custom token with permission "Account · Radar · Read".
+#  Leave empty to disable — /api/cloudflare-radar returns 503 and both layer
+#  toggles stay hidden in the UI. The GDELT Events layer is unaffected and
+#  needs no key.
+# ─────────────────────────────────────────────────────────────────────────
+CLOUDFLARE_API_TOKEN=
+
+
+# ─────────────────────────────────────────────────────────────────────────
 #  OPTIONAL DATA-SOURCE KEYS  (not read by current code — future / upgrades)
 # ─────────────────────────────────────────────────────────────────────────
 

--- a/src/app/api/cloudflare-radar/route.ts
+++ b/src/app/api/cloudflare-radar/route.ts
@@ -1,0 +1,211 @@
+import { NextResponse } from 'next/server';
+import { centroidFor } from '@/lib/countryCentroids';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * OSIRIS — Cloudflare Radar (internet disruption + attack origin)
+ * Source: https://radar.cloudflare.com/  (API docs: developers.cloudflare.com/radar)
+ *
+ * Requires CLOUDFLARE_API_TOKEN — a free Cloudflare account token scoped to
+ * "Radar: Read". Fails closed: with no token the route reports itself
+ * unconfigured and the map layer stays hidden, mirroring /api/scanner.
+ *
+ * The token is read server-side only and is never included in a response.
+ */
+
+const RADAR_BASE = 'https://api.cloudflare.com/client/v4/radar';
+
+interface RadarOutage {
+  id: string;
+  lat: number;
+  lng: number;
+  country: string;
+  country_name: string;
+  scope: string;
+  event_type: string;
+  cause: string;
+  description: string;
+  start: string;
+  end: string | null;
+  ongoing: boolean;
+  url: string;
+}
+
+interface RadarAttackOrigin {
+  country: string;
+  country_name: string;
+  lat: number;
+  lng: number;
+  /** Share of observed layer-3 attack traffic, as a percentage. */
+  share: number;
+}
+
+/* Minimal shapes for the slices of the Radar payload we consume. Everything is
+   optional because Cloudflare adds and reorders fields between API versions. */
+interface RawAnnotation {
+  id?: string;
+  locations?: string[];
+  locationsDetails?: Array<{ code?: string; name?: string }>;
+  scope?: string;
+  eventType?: string;
+  outage?: { outageCause?: string; outageType?: string };
+  description?: string;
+  startDate?: string;
+  endDate?: string | null;
+  linkedUrl?: string;
+}
+
+interface RawTopLocation {
+  originCountryAlpha2?: string;
+  clientCountryAlpha2?: string;
+  originCountry?: string;
+  originCountryName?: string;
+  clientCountryName?: string;
+  value?: string | number;
+}
+
+interface RadarResult {
+  annotations?: RawAnnotation[];
+  top_0?: RawTopLocation[];
+  top0?: RawTopLocation[];
+}
+
+function isConfigured() {
+  return Boolean(process.env.CLOUDFLARE_API_TOKEN);
+}
+
+async function radarFetch(path: string, signal: AbortSignal): Promise<RadarResult> {
+  const res = await fetch(`${RADAR_BASE}${path}`, {
+    signal,
+    cache: 'no-store',
+    headers: {
+      Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
+      Accept: 'application/json',
+    },
+  });
+  if (!res.ok) throw new Error(`Radar ${path} responded ${res.status}`);
+  const json = await res.json();
+  // Cloudflare wraps everything in { success, errors, result }.
+  if (json?.success === false) {
+    const detail = json?.errors?.[0]?.message || 'unknown error';
+    throw new Error(`Radar ${path} rejected the request: ${detail}`);
+  }
+  return json?.result ?? {};
+}
+
+function mapOutages(result: RadarResult): RadarOutage[] {
+  const annotations = result?.annotations ?? [];
+  const out: RadarOutage[] = [];
+
+  for (const a of annotations) {
+    // An annotation can name several locations; emit one marker per located country.
+    const codes: string[] = Array.isArray(a?.locations) ? a.locations : [];
+    const names: Record<string, string> = {};
+    for (const d of a?.locationsDetails ?? []) {
+      if (d?.code) names[d.code] = d.name ?? d.code;
+    }
+
+    for (const code of codes) {
+      const c = centroidFor(code);
+      if (!c) continue;
+      out.push({
+        id: `${a?.id ?? 'outage'}-${code}`,
+        lng: c[0],
+        lat: c[1],
+        country: code,
+        country_name: names[code] || code,
+        scope: a?.scope || '',
+        event_type: a?.eventType || 'OUTAGE',
+        cause: a?.outage?.outageCause || a?.outage?.outageType || '',
+        description: a?.description || '',
+        start: a?.startDate || '',
+        end: a?.endDate || null,
+        ongoing: !a?.endDate,
+        url: a?.linkedUrl || '',
+      });
+    }
+  }
+  return out;
+}
+
+function mapAttackOrigins(result: RadarResult): RadarAttackOrigin[] {
+  // Top-N endpoints return the series under `top_0`.
+  const rows = result?.top_0 ?? result?.top0 ?? [];
+  const out: RadarAttackOrigin[] = [];
+
+  for (const r of rows) {
+    const code = r?.originCountryAlpha2 ?? r?.clientCountryAlpha2 ?? r?.originCountry;
+    const c = centroidFor(code);
+    if (!c) continue;
+    out.push({
+      country: String(code).toUpperCase(),
+      country_name: r?.originCountryName ?? r?.clientCountryName ?? String(code),
+      lng: c[0],
+      lat: c[1],
+      share: Number(Number(r?.value).toFixed(2)) || 0,
+    });
+  }
+  return out;
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+
+  // Capability probe — lets the UI decide whether to show the layer without
+  // provoking an upstream call. Always 200 so it is cheap and unambiguous.
+  if (searchParams.get('probe') === '1') {
+    return NextResponse.json({ configured: isConfigured(), source: 'Cloudflare Radar' });
+  }
+
+  if (!isConfigured()) {
+    return NextResponse.json(
+      {
+        configured: false,
+        outages: [],
+        attack_origins: [],
+        error: 'Cloudflare Radar not configured',
+        hint: 'Set CLOUDFLARE_API_TOKEN (Cloudflare account → API Tokens → Radar: Read) in .env',
+      },
+      { status: 503 }
+    );
+  }
+
+  const signal = AbortSignal.timeout(20000);
+
+  // Degrade per-section rather than all-or-nothing: one endpoint failing should
+  // not blank the whole layer.
+  const [outagesRes, attacksRes] = await Promise.allSettled([
+    radarFetch('/annotations/outages?limit=50&format=json', signal),
+    radarFetch('/attacks/layer3/top/locations/origin?limit=25&format=json', signal),
+  ]);
+
+  const outages = outagesRes.status === 'fulfilled' ? mapOutages(outagesRes.value) : [];
+  const attack_origins = attacksRes.status === 'fulfilled' ? mapAttackOrigins(attacksRes.value) : [];
+
+  const errors: string[] = [];
+  if (outagesRes.status === 'rejected') errors.push(`outages: ${outagesRes.reason?.message ?? 'failed'}`);
+  if (attacksRes.status === 'rejected') errors.push(`attack_origins: ${attacksRes.reason?.message ?? 'failed'}`);
+
+  if (outages.length === 0 && attack_origins.length === 0 && errors.length > 0) {
+    console.error('[OSIRIS] Cloudflare Radar fetch failed:', errors.join('; '));
+    return NextResponse.json(
+      { configured: true, outages: [], attack_origins: [], error: 'Cloudflare Radar unavailable', errors },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      configured: true,
+      outages,
+      attack_origins,
+      total_outages: outages.length,
+      total_attack_origins: attack_origins.length,
+      ...(errors.length > 0 ? { partial: true, errors } : {}),
+      source: 'Cloudflare Radar',
+      timestamp: new Date().toISOString(),
+    },
+    { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' } }
+  );
+}

--- a/src/app/api/gdelt-events/route.ts
+++ b/src/app/api/gdelt-events/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { fetchGdeltEvents } from '@/lib/gdeltEvents';
+
+export const maxDuration = 60;
+
+/**
+ * OSIRIS — GDELT 2.0 Geocoded Events
+ * Source: GDELT Project 15-minute Events export — free, no auth required.
+ * https://www.gdeltproject.org/
+ *
+ * Distinct from /api/gdelt, which despite its name reads GDACS disaster alerts.
+ * This route serves actual GDELT event records with ActionGeo coordinates.
+ */
+
+const MAX_LIMIT = 2000;
+
+function parseQuads(raw: string | null): number[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map(v => Number(v.trim()))
+    .filter(v => v >= 1 && v <= 4);
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+
+  const quads = parseQuads(searchParams.get('quad'));
+  const minArticles = Math.max(1, Number(searchParams.get('min_articles')) || 1);
+  const limit = Math.min(MAX_LIMIT, Math.max(1, Number(searchParams.get('limit')) || 600));
+
+  try {
+    const { events, window, scanned } = await fetchGdeltEvents({ quads, minArticles, limit });
+
+    return NextResponse.json(
+      {
+        events,
+        total: events.length,
+        scanned,
+        window,
+        source: 'GDELT 2.0 Events',
+        timestamp: new Date().toISOString(),
+      },
+      {
+        // GDELT publishes a new export every 15 minutes, so anything under that
+        // is wasted work. Serve stale while revalidating to absorb bursts.
+        headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+      }
+    );
+  } catch (error) {
+    console.error('[OSIRIS] GDELT events fetch failed:', error);
+    return NextResponse.json(
+      { events: [], total: 0, error: 'Failed to fetch GDELT events' },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -165,7 +165,12 @@ export default function Dashboard() {
     terrain_3d: false,
     malware: false,
     cyber_attacks: false,
+    gdelt_events: false,
+    cf_outages: false,
+    cf_attacks: false,
   });
+  // Server-side capability flags — gate layers that need credentials.
+  const [capabilities, setCapabilities] = useState<Record<string, boolean>>({});
   const [liveFeedUrl, setLiveFeedUrl] = useState<string | null>(null);
   const [liveFeedName, setLiveFeedName] = useState('');
   const [liveFeedEmbedAllowed, setLiveFeedEmbedAllowed] = useState(true);
@@ -191,6 +196,13 @@ export default function Dashboard() {
         return next;
       });
     }
+
+    // Probe which credential-gated feeds this deployment has configured, so the
+    // layer panel can hide toggles that could never return data.
+    fetch('/api/cloudflare-radar?probe=1')
+      .then(r => (r.ok ? r.json() : null))
+      .then(p => { if (p) setCapabilities(c => ({ ...c, cloudflare: !!p.configured })); })
+      .catch(() => { /* leave the layer hidden */ });
 
     // Delay geolocation until map is ready (after splash screen clears)
     const geoTimer = setTimeout(() => {
@@ -462,6 +474,22 @@ export default function Dashboard() {
     if ((activeLayers as any).cyber_attacks && !layerFetchedRef.current.has('cyber_attacks')) {
       fetchEndpoint('/api/cyber-attacks', d => ({ cyber_attacks: d.attacks }));
       layerFetchedRef.current.add('cyber_attacks');
+    }
+
+    // GDELT 2.0 geocoded events
+    if ((activeLayers as any).gdelt_events && !layerFetchedRef.current.has('gdelt_events')) {
+      fetchEndpoint('/api/gdelt-events?limit=600', d => ({ gdelt_events: d.events }));
+      layerFetchedRef.current.add('gdelt_events');
+    }
+
+    // Cloudflare Radar — one request backs both layers
+    const wantsRadar = (activeLayers as any).cf_outages || (activeLayers as any).cf_attacks;
+    if (wantsRadar && !layerFetchedRef.current.has('cloudflare_radar')) {
+      fetchEndpoint('/api/cloudflare-radar', d => ({
+        cf_outages: d.outages ?? [],
+        cf_attack_origins: d.attack_origins ?? [],
+      }));
+      layerFetchedRef.current.add('cloudflare_radar');
     }
 
 
@@ -942,7 +970,7 @@ export default function Dashboard() {
 
 
       {/* ── NEW SIDEBAR (Root Level) ── */}
-      {showLayers && !isMobile && <LayerPanel data={data} activeLayers={activeLayers} setActiveLayers={setActiveLayers} theme={osirisTheme} setTheme={setOsirisTheme} />}
+      {showLayers && !isMobile && <LayerPanel data={data} activeLayers={activeLayers} setActiveLayers={setActiveLayers} theme={osirisTheme} setTheme={setOsirisTheme} capabilities={capabilities} />}
 
 
 
@@ -1214,7 +1242,7 @@ export default function Dashboard() {
                           <div><div className="hud-label" style={{fontSize:'6px'}}>NUC</div><div className="hud-value text-[9px]" style={{color:'var(--accent-nuclear)'}}>{(data.infrastructure?.length||0)}</div></div>
                         </div>
                       </div>
-                      <LayerPanel data={data} activeLayers={activeLayers} setActiveLayers={setActiveLayers} isMobile={true} theme={osirisTheme} setTheme={setOsirisTheme} />
+                      <LayerPanel data={data} activeLayers={activeLayers} setActiveLayers={setActiveLayers} isMobile={true} theme={osirisTheme} setTheme={setOsirisTheme} capabilities={capabilities} />
                       <div className="mt-8">
                         <ViewPresets onNavigate={(lat, lng, zoom) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMapView(v => ({ ...v, zoom })); setMobilePanel(null); }} />
                       </div>

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -15,9 +15,29 @@ interface LayerPanelProps {
   isMobile?: boolean;
   theme?: 'core' | 'ghost';
   setTheme?: (theme: 'core' | 'ghost') => void;
+  /** Server-side capabilities, e.g. { cloudflare: true }. Layers declaring a
+   *  `requires` key stay hidden until the matching capability is present. */
+  capabilities?: Record<string, boolean>;
 }
 
-const LAYER_GROUPS = [
+interface LayerDef {
+  key: string;
+  label: string;
+  dataKey: string;
+  /** Reads a bucket out of data.category_counts instead of a top-level array. */
+  catKey?: string;
+  /** Capability that must be configured server-side for this layer to appear. */
+  requires?: string;
+}
+
+interface LayerGroupDef {
+  label: string;
+  fullLabel: string;
+  icon: React.ComponentType<{ className?: string; style?: React.CSSProperties }>;
+  layers: LayerDef[];
+}
+
+const LAYER_GROUPS: LayerGroupDef[] = [
   {
     label: 'SDK',
     fullLabel: 'OSIRIS SDK',
@@ -98,6 +118,16 @@ const LAYER_GROUPS = [
     ],
   },
   {
+    label: 'NETINTEL',
+    fullLabel: 'NET & EVENT INTEL',
+    icon: Radar,
+    layers: [
+      { key: 'gdelt_events', label: 'GDELT Events', dataKey: 'gdelt_events' },
+      { key: 'cf_outages', label: 'Internet Outages', dataKey: 'cf_outages', requires: 'cloudflare' },
+      { key: 'cf_attacks', label: 'Attack Origins', dataKey: 'cf_attack_origins', requires: 'cloudflare' },
+    ],
+  },
+  {
     label: 'DISPLAY',
     fullLabel: 'DISPLAY',
     icon: Sun,
@@ -139,10 +169,17 @@ function ToggleSwitch({ active, onClick }: { active: boolean; onClick: () => voi
   );
 }
 
-function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'core', setTheme }: LayerPanelProps) {
+function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'core', setTheme, capabilities = {} }: LayerPanelProps) {
   const [hoveredGroup, setHoveredGroup] = useState<string | null>(null);
 
   const toggle = (key: string) => setActiveLayers((prev: any) => ({ ...prev, [key]: !prev[key] }));
+
+  /* Drop layers whose backing capability is not configured, then drop any group
+     left with nothing to show. */
+  const visibleGroups = LAYER_GROUPS.map(g => ({
+    ...g,
+    layers: g.layers.filter(l => !l.requires || capabilities[l.requires]),
+  })).filter(g => g.layers.length > 0);
 
   const getCount = (dk: string, catKey?: string): number | null => {
     if (!dk) return null;
@@ -164,7 +201,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
   if (isMobile) {
     return (
       <div className="flex flex-col gap-5 py-2">
-        {LAYER_GROUPS.map((group) => (
+        {visibleGroups.map((group) => (
           <div key={group.label} className="flex flex-col gap-2">
             <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-white/30 border-b border-white/[0.06] pb-1.5">
               {group.fullLabel}
@@ -228,7 +265,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
       }}
     >
       <div className="flex-1 flex flex-col items-center gap-1">
-        {LAYER_GROUPS.map((group) => {
+        {visibleGroups.map((group) => {
           const groupActive = group.layers.some(l => activeLayers[l.key]);
           const isHovered = hoveredGroup === group.label;
           const Icon = group.icon;

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -189,7 +189,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       createDot(map, 'dot-fire', isGhost ? phantomPurple : '#E65100', 10);
       createDot(map, 'dot-cctv', cameraColor, 10);
 
-      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'malware-nodes', 'network-mesh', 'cyber-arcs', 'cyber-heads', 'cyber-impacts'];
+      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','gps-jamming','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','sigint-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'malware-nodes', 'network-mesh', 'cyber-arcs', 'cyber-heads', 'cyber-impacts', 'gdelt-events', 'cf-outages', 'cf-attacks'];
       sources.forEach(s => map.addSource(s, { type: 'geojson', data: EMPTY_FC }));
 
       // Warning icon generator (parameterized — eliminates 3x copy-paste)
@@ -340,6 +340,51 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       map.addLayer({ id: 'gdelt-dots', type: 'circle', source: 'gdelt', paint: {
         'circle-radius': 4, 'circle-color': '#D32F2F', 'circle-opacity': 0.5, 'circle-stroke-width': 1, 'circle-stroke-color': '#D32F2F', 'circle-stroke-opacity': 0.25,
       }});
+
+      /* ── GDELT 2.0 Events — coloured by CAMEO QuadClass so cooperation and
+         conflict are separable at a glance, sized by article volume. ── */
+      map.addLayer({ id: 'gdelt-events-dots', type: 'circle', source: 'gdelt-events', paint: {
+        'circle-radius': ['interpolate',['linear'],['get','articles'], 1,3, 10,5, 50,8, 200,12],
+        'circle-color': ['match',['get','quad'],
+          1,'#00E676',   // verbal cooperation
+          2,'#00E5FF',   // material cooperation
+          3,'#FF9500',   // verbal conflict
+          4,'#FF3D3D',   // material conflict
+          '#9B978E'],
+        'circle-opacity': 0.75,
+        'circle-stroke-width': 1,
+        'circle-stroke-color': '#000000',
+        'circle-stroke-opacity': 0.6,
+      }});
+
+      /* ── Cloudflare Radar — internet outages (country-scoped) ── */
+      map.addLayer({ id: 'cf-outage-halo', type: 'circle', source: 'cf-outages', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,14, 5,26, 10,40],
+        'circle-color': '#FFB300', 'circle-opacity': 0.12, 'circle-blur': 0.9,
+      }});
+      map.addLayer({ id: 'cf-outage-dots', type: 'circle', source: 'cf-outages', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,4, 5,6, 10,9],
+        // Resolved outages read cooler than ongoing ones.
+        'circle-color': ['case',['get','ongoing'],'#FFB300','#8B7325'],
+        'circle-opacity': 0.9,
+        'circle-stroke-width': 1.5, 'circle-stroke-color': '#000000', 'circle-stroke-opacity': 0.7,
+      }});
+      map.addLayer({ id: 'cf-outage-label', type: 'symbol', source: 'cf-outages', minzoom: 3, layout: {
+        'text-field': ['get','country_name'], 'text-size': 9, 'text-font': ['JetBrains Mono Bold', 'Open Sans Bold'],
+        'text-offset': [0, 1.4], 'text-max-width': 12, 'text-allow-overlap': false,
+      }, paint: { 'text-color': '#FFB300', 'text-halo-color': '#000', 'text-halo-width': 1.5, 'text-opacity': 0.85 }});
+
+      /* ── Cloudflare Radar — layer-3 attack origin share ── */
+      map.addLayer({ id: 'cf-attack-dots', type: 'circle', source: 'cf-attacks', paint: {
+        'circle-radius': ['interpolate',['linear'],['get','share'], 0,4, 5,9, 20,16, 50,24],
+        'circle-color': '#FF3D3D', 'circle-opacity': 0.35, 'circle-blur': 0.3,
+        'circle-stroke-width': 1, 'circle-stroke-color': '#FF3D3D', 'circle-stroke-opacity': 0.7,
+      }});
+      map.addLayer({ id: 'cf-attack-label', type: 'symbol', source: 'cf-attacks', minzoom: 2, layout: {
+        'text-field': ['concat',['get','country'],' ',['to-string',['get','share']],'%'],
+        'text-size': 9, 'text-font': ['JetBrains Mono Bold', 'Open Sans Bold'],
+        'text-offset': [0, 1.6], 'text-allow-overlap': false,
+      }, paint: { 'text-color': '#FF6B6B', 'text-halo-color': '#000', 'text-halo-width': 1.5, 'text-opacity': 0.9 }});
 
       // GPS Jamming — crimson
       map.addLayer({ id: 'jam-fill', type: 'circle', source: 'gps-jamming', paint: { 'circle-radius': 30, 'circle-color': '#D32F2F', 'circle-opacity': 0.12, 'circle-blur': 1 }});
@@ -758,6 +803,85 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     });
 
 
+    // ── GDELT 2.0 Events ──
+    const QUAD_COLOR: Record<string, string> = { '1': '#00E676', '2': '#00E5FF', '3': '#FF9500', '4': '#FF3D3D' };
+    map.on('click', 'gdelt-events-dots', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      const accent = QUAD_COLOR[String(p.quad)] ?? '#9B978E';
+      const src = urlSafe(p.url);
+      const tone = Number(p.tone);
+      popup(coords, `
+      <div style="${pStyle}border:1px solid ${accent}66;min-width:250px;">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:10px;">
+          <span style="width:7px;height:7px;border-radius:50%;background:${accent};box-shadow:0 0 8px ${accent};"></span>
+          <span style="color:${accent};font-size:10px;font-weight:700;letter-spacing:0.15em;">${htmlEsc(p.quad_label)}</span>
+        </div>
+        <div style="color:#E8E6E0;font-size:12px;font-weight:700;margin-bottom:8px;">${htmlEsc(p.name)}</div>
+        <div style="display:grid;grid-template-columns:auto 1fr;gap:3px 10px;font-size:10px;color:#9B978E;">
+          <span style="opacity:0.6;">Goldstein</span><span style="color:${Number(p.goldstein) < 0 ? '#FF3D3D' : '#00E676'};">${htmlEsc(p.goldstein)}</span>
+          <span style="opacity:0.6;">Avg tone</span><span style="color:${tone < 0 ? '#FF9500' : '#00E676'};">${htmlEsc(p.tone)}</span>
+          <span style="opacity:0.6;">Articles</span><span style="color:#E8E6E0;">${htmlEsc(p.articles)}</span>
+          <span style="opacity:0.6;">Country</span><span style="color:#E8E6E0;">${htmlEsc(p.country || '—')}</span>
+        </div>
+        <div style="margin-top:8px;font-size:9px;color:#5C5A54;">GDELT 2.0 · ${htmlEsc(String(p.date).slice(0, 16).replace('T', ' '))}Z</div>
+        ${src !== '#' ? `<a href="${src}" target="_blank" rel="noopener noreferrer" style="${linkStyle}color:${accent};border:1px solid ${accent}66;background:${accent}1a;">SOURCE ARTICLE</a>` : ''}
+      </div>`);
+    });
+
+    // ── Cloudflare Radar: internet outage ──
+    map.on('click', 'cf-outage-dots', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      // MapLibre serialises feature properties, so booleans can arrive as strings.
+      const ongoing = p.ongoing === true || p.ongoing === 'true';
+      const accent = ongoing ? '#FFB300' : '#8B7325';
+      const src = urlSafe(p.url);
+      popup(coords, `
+      <div style="${pStyle}border:1px solid ${accent}66;min-width:250px;">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:10px;">
+          <span style="width:7px;height:7px;border-radius:50%;background:${accent};box-shadow:0 0 8px ${accent};"></span>
+          <span style="color:${accent};font-size:10px;font-weight:700;letter-spacing:0.15em;">
+            ${ongoing ? 'ONGOING OUTAGE' : 'RESOLVED OUTAGE'}
+          </span>
+        </div>
+        <div style="color:#E8E6E0;font-size:12px;font-weight:700;margin-bottom:8px;">${htmlEsc(p.country_name)}</div>
+        ${p.description ? `<div style="color:#9B978E;font-size:10px;line-height:1.6;margin-bottom:8px;">${htmlEsc(p.description)}</div>` : ''}
+        <div style="display:grid;grid-template-columns:auto 1fr;gap:3px 10px;font-size:10px;color:#9B978E;">
+          <span style="opacity:0.6;">Cause</span><span style="color:#E8E6E0;">${htmlEsc(p.cause || 'Unspecified')}</span>
+          <span style="opacity:0.6;">Scope</span><span style="color:#E8E6E0;">${htmlEsc(p.scope || 'Nationwide')}</span>
+          <span style="opacity:0.6;">Started</span><span style="color:#E8E6E0;">${htmlEsc(String(p.start).slice(0, 16).replace('T', ' '))}</span>
+          ${p.end ? `<span style="opacity:0.6;">Ended</span><span style="color:#E8E6E0;">${htmlEsc(String(p.end).slice(0, 16).replace('T', ' '))}</span>` : ''}
+        </div>
+        <div style="margin-top:8px;font-size:9px;color:#5C5A54;">Cloudflare Radar</div>
+        ${src !== '#' ? `<a href="${src}" target="_blank" rel="noopener noreferrer" style="${linkStyle}color:${accent};border:1px solid ${accent}66;background:${accent}1a;">RADAR DETAIL</a>` : ''}
+      </div>`);
+    });
+
+    // ── Cloudflare Radar: attack origin share ──
+    map.on('click', 'cf-attack-dots', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      popup(coords, `
+      <div style="${pStyle}border:1px solid rgba(255,61,61,0.4);min-width:230px;">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:10px;">
+          <span style="width:7px;height:7px;border-radius:50%;background:#FF3D3D;box-shadow:0 0 8px #FF3D3D;"></span>
+          <span style="color:#FF3D3D;font-size:10px;font-weight:700;letter-spacing:0.15em;">L3 ATTACK ORIGIN</span>
+        </div>
+        <div style="color:#E8E6E0;font-size:12px;font-weight:700;margin-bottom:8px;">${htmlEsc(p.country_name)}</div>
+        <div style="display:grid;grid-template-columns:auto 1fr;gap:3px 10px;font-size:10px;color:#9B978E;">
+          <span style="opacity:0.6;">Share</span><span style="color:#FF6B6B;font-weight:700;">${htmlEsc(p.share)}%</span>
+          <span style="opacity:0.6;">Code</span><span style="color:#E8E6E0;">${htmlEsc(p.country)}</span>
+        </div>
+        <div style="margin-top:8px;font-size:9px;color:#5C5A54;line-height:1.5;">
+          Share of observed layer-3 attack traffic by origin · Cloudflare Radar
+        </div>
+      </div>`);
+    });
+
     // ── GDELT Conflicts (with source article) ──
     map.on('click', 'gdelt-dots', e => {
       if (!e.features?.length) return;
@@ -865,7 +989,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     });
 
     // ── Generic hover for clickables ──
-    ['conflict-icons','cctv-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo','malware-dots','cyber-heads'].forEach(layer => {
+    ['conflict-icons','cctv-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','sigint-news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo','malware-dots','cyber-heads','gdelt-events-dots','cf-outage-dots','cf-attack-dots'].forEach(layer => {
       map.on('mouseenter', layer, () => { map.getCanvas().style.cursor = 'pointer'; });
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
     });
@@ -1220,6 +1344,46 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     setGeo('gdelt', activeLayers.global_incidents && data.gdelt ? data.gdelt.map((e: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [e.lng, e.lat] }, properties: { name: e.name } })) : []);
   }, [mapReady, data.gdelt, activeLayers.global_incidents, setGeo]);
 
+  /* ── GDELT 2.0 Events ── */
+  useEffect(() => {
+    if (!mapReady) return;
+    const al = activeLayers as any;
+    setGeo('gdelt-events', al.gdelt_events && data.gdelt_events ? data.gdelt_events.map((e: any) => ({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [e.lng, e.lat] },
+      properties: {
+        name: e.name, country: e.country, quad: e.quad, quad_label: e.quad_label,
+        tone: e.tone, goldstein: e.goldstein, articles: e.articles, url: e.url, date: e.date,
+      },
+    })) : []);
+  }, [mapReady, data.gdelt_events, (activeLayers as any).gdelt_events, setGeo]);
+
+  /* ── Cloudflare Radar: outages ── */
+  useEffect(() => {
+    if (!mapReady) return;
+    const al = activeLayers as any;
+    setGeo('cf-outages', al.cf_outages && data.cf_outages ? data.cf_outages.map((o: any) => ({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [o.lng, o.lat] },
+      properties: {
+        country: o.country, country_name: o.country_name, scope: o.scope, cause: o.cause,
+        event_type: o.event_type, description: o.description, start: o.start, end: o.end,
+        ongoing: !!o.ongoing, url: o.url,
+      },
+    })) : []);
+  }, [mapReady, data.cf_outages, (activeLayers as any).cf_outages, setGeo]);
+
+  /* ── Cloudflare Radar: attack origins ── */
+  useEffect(() => {
+    if (!mapReady) return;
+    const al = activeLayers as any;
+    setGeo('cf-attacks', al.cf_attacks && data.cf_attack_origins ? data.cf_attack_origins.map((a: any) => ({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [a.lng, a.lat] },
+      properties: { country: a.country, country_name: a.country_name, share: a.share },
+    })) : []);
+  }, [mapReady, data.cf_attack_origins, (activeLayers as any).cf_attacks, setGeo]);
+
   // Malware Threats
   useEffect(() => {
     if (!mapReady) return;
@@ -1503,6 +1667,9 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     const anySat = activeLayers.satellites || (activeLayers as any).sat_comms || (activeLayers as any).sat_military || (activeLayers as any).sat_navigation || (activeLayers as any).sat_earth || (activeLayers as any).sat_science;
     setVis(['sat-glow','sat-dots'], anySat);
     setVis(['gdelt-dots'], activeLayers.global_incidents);
+    setVis(['gdelt-events-dots'], (activeLayers as any).gdelt_events);
+    setVis(['cf-outage-halo','cf-outage-dots','cf-outage-label'], (activeLayers as any).cf_outages);
+    setVis(['cf-attack-dots','cf-attack-label'], (activeLayers as any).cf_attacks);
 
     setVis(['malware-glow','malware-dots','malware-label'], activeLayers.malware);
     setVis(['network-mesh-atmo', 'network-mesh-glow', 'network-mesh-core'], activeLayers.internet_outages || activeLayers.malware);

--- a/src/lib/countryCentroids.ts
+++ b/src/lib/countryCentroids.ts
@@ -1,0 +1,42 @@
+/**
+ * ISO 3166-1 alpha-2 → approximate country centroid as [lng, lat].
+ *
+ * Used to place country-scoped feeds (Cloudflare Radar outages and attack
+ * origins) on the map. These are eyeballed centroids for marker placement,
+ * not survey-grade geometry — do not use them for distance maths.
+ *
+ * NOTE: /api/radar carries its own copy of this table. Consolidating the two
+ * is worthwhile but would touch a working route, so it is left for a
+ * dedicated change.
+ */
+export const COUNTRY_CENTROIDS: Record<string, [number, number]> = {
+  AF:[65,33],AL:[20,41],DZ:[3,28],AO:[18.5,-12.5],AR:[-64,-34],AM:[45,40],AU:[134,-25],AT:[14,47.5],AZ:[50,40.5],
+  BD:[90,24],BY:[28,53],BE:[4,50.8],BR:[-51,-10],BG:[25.5,42.7],KH:[105,12.5],CM:[12,6],CA:[-96,62],CL:[-71,-30],
+  CN:[105,35],CO:[-72,4],CD:[24,-3],CG:[15.8,-0.2],HR:[16,45.2],CU:[-79.5,22],CZ:[15.5,49.8],DK:[10,56],
+  EC:[-78.5,-2],EG:[30,27],ET:[39.5,9],FI:[26,64],FR:[2,46],DE:[10,51],GH:[-1.5,8],GR:[22,39],
+  GT:[-90.4,15.5],HN:[-86.6,14.8],HU:[19.5,47],IN:[79,22],ID:[120,-5],IR:[53,32],IQ:[44,33],IE:[-8,53],
+  IL:[34.8,31.5],IT:[12.5,42.8],JP:[138,36],JO:[36.5,31],KZ:[67,48],KE:[38,1],KW:[47.5,29.5],
+  LB:[35.8,33.9],LY:[17,27],LT:[24,55.5],MG:[47,-19],MY:[112,3],MX:[-102,23.5],MA:[-6,32],
+  MZ:[35,-18.2],MM:[96.5,22],NP:[84,28.2],NL:[5.5,52.5],NZ:[174,-41],NG:[8,10],NO:[8,62],
+  PK:[70,30],PS:[35.2,31.9],PA:[-80,9],PE:[-76,-10],PH:[122,12.5],PL:[19.5,52],PT:[-8,39.5],
+  RO:[25,46],RU:[100,60],SA:[45,25],SN:[-14.5,14.5],RS:[21,44],SG:[103.8,1.35],SK:[19.5,48.7],
+  ZA:[24,-29],KR:[128,36],ES:[-4,40],SD:[30,15],SE:[16,62],CH:[8,47],SY:[38,35],TW:[121,23.7],
+  TZ:[35,-6],TH:[101,15],TR:[35,39],UA:[32,49],AE:[54,24],GB:[-2,54],US:[-97,38],UZ:[65,41.5],
+  VE:[-66,8],VN:[106,16],YE:[48,15.5],ZM:[28,-14],ZW:[30,-20],
+  // Additional territories that appear in Cloudflare Radar reporting.
+  BA:[18,44],EE:[26,59],GE:[43.5,42],IS:[-19,65],LV:[25,57],LU:[6.1,49.8],MD:[29,47],
+  MK:[21.7,41.6],ME:[19.3,42.8],CY:[33,35],MT:[14.4,35.9],SI:[15,46.1],AZO:[-28,38.5],
+  BO:[-64,-17],CR:[-84,10],DO:[-70.7,19],SV:[-89,13.8],JM:[-77.3,18.1],NI:[-85,12.9],
+  PY:[-58,-23],UY:[-56,-33],TT:[-61.2,10.7],PR:[-66.5,18.2],
+  BF:[-1.7,12.3],CI:[-5.5,7.5],ET2:[39.5,9],GA:[11.8,-0.8],GN:[-10,10.5],ML:[-4,17],
+  MR:[-10.9,20],NE:[8,17.6],RW:[30,-2],SO:[46,5],SS:[31,7],TN:[9.5,34],UG:[32.4,1.4],
+  BH:[50.5,26],OM:[56,21],QA:[51.2,25.3],LK:[81,7.5],BT:[90.4,27.4],LA:[103,18],
+  MN:[104,46],PG:[144,-6],FJ:[178,-17.8],KG:[74.6,41.2],TJ:[71,38.9],TM:[59.5,39],
+  HK:[114.2,22.3],MO:[113.5,22.2],BN:[114.7,4.5],MV:[73.5,3.2],
+};
+
+/** Returns [lng, lat] for a country code, or null when unknown. */
+export function centroidFor(code: string | null | undefined): [number, number] | null {
+  if (!code) return null;
+  return COUNTRY_CENTROIDS[code.toUpperCase()] ?? null;
+}

--- a/src/lib/gdeltEvents.ts
+++ b/src/lib/gdeltEvents.ts
@@ -1,0 +1,255 @@
+import { inflateRawSync } from 'zlib';
+import { get as httpGet } from 'http';
+
+/**
+ * ═══════════════════════════════════════════════════════════════
+ *  GDELT 2.0 Events — 15-minute export reader
+ *
+ *  GDELT publishes a ZIP-compressed, tab-separated Events export every
+ *  15 minutes at data.gdeltproject.org. Unlike the DOC API (which is
+ *  aggressively rate-limited and only exposes a *publisher* country), these
+ *  records carry real ActionGeo coordinates for where the event occurred.
+ *
+ *  The archives hold a single deflated entry, so we read the local file
+ *  header and inflate it directly rather than pulling in a ZIP dependency.
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+const LASTUPDATE_URL = 'http://data.gdeltproject.org/gdeltv2/lastupdate.txt';
+
+/**
+ * GDELT's file host is plain HTTP only — its HTTPS certificate belongs to
+ * Google Cloud Storage and does not cover the domain, so TLS is not an option.
+ *
+ * It also advertises AAAA records ahead of A records. Hosts without working
+ * IPv6 egress see the platform fetch() pick the first address and stall until
+ * its connect timeout, so we go through Node's http client with family: 4 to
+ * pin the request to IPv4 instead of depending on Happy Eyeballs behaviour we
+ * do not control.
+ */
+function httpGetBufferIPv4(url: string, timeoutMs: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const req = httpGet(url, { family: 4, timeout: timeoutMs }, res => {
+      const status = res.statusCode ?? 0;
+
+      if (status >= 300 && status < 400 && res.headers.location) {
+        res.resume();
+        resolve(httpGetBufferIPv4(new URL(res.headers.location, url).toString(), timeoutMs));
+        return;
+      }
+      if (status !== 200) {
+        res.resume();
+        reject(new Error(`${url} responded ${status}`));
+        return;
+      }
+
+      const chunks: Buffer[] = [];
+      res.on('data', c => chunks.push(c as Buffer));
+      res.on('end', () => resolve(Buffer.concat(chunks)));
+      res.on('error', reject);
+    });
+
+    req.on('timeout', () => req.destroy(new Error(`${url} timed out after ${timeoutMs}ms`)));
+    req.on('error', reject);
+  });
+}
+
+/** Column offsets in the 61-field GDELT 2.0 Events export. */
+const COL = {
+  globalEventId: 0,
+  sqlDate: 1,
+  eventCode: 26,
+  eventRootCode: 28,
+  quadClass: 29,
+  goldstein: 30,
+  numMentions: 31,
+  numSources: 32,
+  numArticles: 33,
+  avgTone: 34,
+  actionGeoFullName: 52,
+  actionGeoCountry: 53,
+  actionGeoLat: 56,
+  actionGeoLong: 57,
+  dateAdded: 59,
+  sourceUrl: 60,
+} as const;
+
+/** CAMEO QuadClass — the axis that makes this feed useful on a threat map. */
+export const QUAD_LABELS: Record<number, string> = {
+  1: 'Verbal Cooperation',
+  2: 'Material Cooperation',
+  3: 'Verbal Conflict',
+  4: 'Material Conflict',
+};
+
+export interface GdeltEvent {
+  id: string;
+  lat: number;
+  lng: number;
+  name: string;
+  country: string;
+  event_code: string;
+  root_code: string;
+  quad: number;
+  quad_label: string;
+  /** −10 (most conflictual) … +10 (most cooperative) */
+  goldstein: number;
+  /** Average document tone, roughly −100…+100 but usually −20…+20 */
+  tone: number;
+  articles: number;
+  sources: number;
+  url: string;
+  date: string;
+}
+
+/** Extracts the single deflated entry from a ZIP buffer. */
+function unzipSingleEntry(buf: Buffer): string {
+  if (buf.length < 30 || buf.readUInt32LE(0) !== 0x04034b50) {
+    throw new Error('Not a ZIP archive');
+  }
+  const method = buf.readUInt16LE(8);
+  const compressedSize = buf.readUInt32LE(18);
+  const nameLen = buf.readUInt16LE(26);
+  const extraLen = buf.readUInt16LE(28);
+  const start = 30 + nameLen + extraLen;
+
+  // A streamed archive can report size 0 here and defer to the data descriptor;
+  // in that case take everything up to the central directory.
+  const end = compressedSize > 0 ? start + compressedSize : buf.indexOf('PK\x01\x02', start, 'binary');
+  const body = buf.subarray(start, end > start ? end : undefined);
+
+  // 8 = deflate, 0 = stored. GDELT uses deflate.
+  return (method === 8 ? inflateRawSync(body) : body).toString('utf8');
+}
+
+/** Rewinds a `YYYYMMDDHHMMSS.export.CSV.zip` URL by n 15-minute windows. */
+function previousWindowUrl(url: string, stepsBack: number): string | null {
+  const m = url.match(/(\d{14})\.export\.CSV\.zip$/);
+  if (!m) return null;
+  const s = m[1];
+  const t = Date.UTC(
+    Number(s.slice(0, 4)),
+    Number(s.slice(4, 6)) - 1,
+    Number(s.slice(6, 8)),
+    Number(s.slice(8, 10)),
+    Number(s.slice(10, 12)),
+    Number(s.slice(12, 14))
+  );
+  if (!Number.isFinite(t)) return null;
+  const d = new Date(t - stepsBack * 15 * 60_000);
+  const p = (n: number) => String(n).padStart(2, '0');
+  const stamp =
+    `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}` +
+    `${p(d.getUTCHours())}${p(d.getUTCMinutes())}${p(d.getUTCSeconds())}`;
+  return url.replace(/\d{14}\.export\.CSV\.zip$/, `${stamp}.export.CSV.zip`);
+}
+
+/**
+ * lastupdate.txt can name an archive a moment before it is actually published,
+ * so the advertised URL 404s at the 15-minute boundary. Walk back through
+ * earlier windows rather than failing the whole request.
+ */
+async function fetchExportWithFallback(url: string): Promise<{ csv: string; url: string }> {
+  const candidates = [url, ...[1, 2, 3].map(n => previousWindowUrl(url, n)).filter((u): u is string => !!u)];
+  let lastError: unknown;
+
+  for (const candidate of candidates) {
+    try {
+      return { csv: unzipSingleEntry(await httpGetBufferIPv4(candidate, 20000)), url: candidate };
+    } catch (e) {
+      lastError = e;
+      // Only a missing archive is worth retrying an earlier window for.
+      if (!(e instanceof Error && / responded 404$/.test(e.message))) throw e;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error('GDELT export unavailable');
+}
+
+/** GDELT dates are `YYYYMMDDHHMMSS` (DATEADDED) or `YYYYMMDD` (SQLDATE). */
+function parseGdeltDate(dateAdded: string, sqlDate: string): string {
+  const s = /^\d{14}$/.test(dateAdded) ? dateAdded : null;
+  if (s) {
+    return `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}T${s.slice(8, 10)}:${s.slice(10, 12)}:${s.slice(12, 14)}Z`;
+  }
+  if (/^\d{8}$/.test(sqlDate)) {
+    return `${sqlDate.slice(0, 4)}-${sqlDate.slice(4, 6)}-${sqlDate.slice(6, 8)}T00:00:00Z`;
+  }
+  return new Date().toISOString();
+}
+
+export interface FetchOptions {
+  /** Keep only these QuadClass values. Empty means keep all. */
+  quads?: number[];
+  /** Drop events backed by fewer than this many articles. */
+  minArticles?: number;
+  /** Maximum events to return, newest-by-file-order first. */
+  limit?: number;
+}
+
+export interface GdeltEventsResult {
+  events: GdeltEvent[];
+  /** Name of the 15-minute export the data came from. */
+  window: string;
+  /** Rows in the export before filtering. */
+  scanned: number;
+}
+
+export async function fetchGdeltEvents(opts: FetchOptions = {}): Promise<GdeltEventsResult> {
+  const { quads = [], minArticles = 1, limit = 600 } = opts;
+
+  const manifest = (await httpGetBufferIPv4(LASTUPDATE_URL, 12000)).toString('utf8');
+
+  const exportUrl = manifest
+    .split('\n')
+    .map(l => l.trim())
+    .find(l => l.includes('.export.CSV.zip'))
+    ?.split(/\s+/)
+    .pop();
+  if (!exportUrl) throw new Error('No export archive listed in lastupdate.txt');
+
+  const { csv, url: resolvedUrl } = await fetchExportWithFallback(exportUrl);
+  const rows = csv.split('\n');
+  const events: GdeltEvent[] = [];
+
+  for (const row of rows) {
+    if (events.length >= limit) break;
+    if (!row) continue;
+    const c = row.split('\t');
+    if (c.length < 61) continue;
+
+    const lat = Number(c[COL.actionGeoLat]);
+    const lng = Number(c[COL.actionGeoLong]);
+    // Ungeocoded rows carry empty coordinates; 0,0 is the null-island artefact.
+    if (!Number.isFinite(lat) || !Number.isFinite(lng) || (lat === 0 && lng === 0)) continue;
+
+    const articles = Number(c[COL.numArticles]) || 0;
+    if (articles < minArticles) continue;
+
+    const quad = Number(c[COL.quadClass]) || 0;
+    if (quads.length > 0 && !quads.includes(quad)) continue;
+
+    events.push({
+      id: c[COL.globalEventId],
+      lat,
+      lng,
+      name: c[COL.actionGeoFullName] || 'Unknown location',
+      country: c[COL.actionGeoCountry] || '',
+      event_code: c[COL.eventCode] || '',
+      root_code: c[COL.eventRootCode] || '',
+      quad,
+      quad_label: QUAD_LABELS[quad] || 'Unclassified',
+      goldstein: Number(c[COL.goldstein]) || 0,
+      tone: Number(Number(c[COL.avgTone]).toFixed(2)) || 0,
+      articles,
+      sources: Number(c[COL.numSources]) || 0,
+      url: c[COL.sourceUrl]?.trim() || '',
+      date: parseGdeltDate(c[COL.dateAdded], c[COL.sqlDate]),
+    });
+  }
+
+  return {
+    events,
+    window: resolvedUrl.split('/').pop() || '',
+    scanned: rows.length,
+  };
+}


### PR DESCRIPTION
Adds a **NET & EVENT INTEL** group to the left layer panel with three toggles, backed by two new endpoints.

> **Base branch:** this targets `docs-api` (#246) rather than `master`, so the diff shows only the layer work. Retarget to `master` once #246 merges.

## GDELT 2.0 Events — `/api/gdelt-events` (keyless)

**`/api/gdelt` is not GDELT.** It reads GDACS disaster alerts from `gdacs.org`, despite a header comment claiming to be the *"GDELT 2.0 GeoJSON API"* and to have replaced an RSS scraper with "actual GDELT geo-coded events". Real GDELT was never integrated.

This route reads the genuine 15-minute Events export, which carries `ActionGeo` coordinates for **where an event occurred** — not where an article was published, which is all the DOC API's `sourcecountry` would have given us.

Markers are coloured by CAMEO QuadClass (verbal/material cooperation vs conflict) and sized by article volume. Popups expose Goldstein scale, average tone, source count, and the originating article.

The existing GDACS-backed "Global Incidents" layer is **untouched** — it also feeds `/api/stats`, so repointing or renaming it is a separate change.

### Three problems found by testing against live data

1. **The file host is HTTP-only.** Its HTTPS certificate belongs to Google Cloud Storage and does not cover the domain, so TLS is not an option.
2. **It advertises AAAA records ahead of A records.** Hosts without working IPv6 egress see the platform `fetch()` pick the first address and stall until its connect timeout. Requests go through `node:http` with `family: 4` rather than depending on Happy Eyeballs behaviour we don't control.
3. **`lastupdate.txt` can name an archive before it is published.** Observed live — `20260730000000` and `...234500` both 404'd. A 404 now walks back up to three 15-minute windows instead of failing the request.

Archives are single-entry ZIPs, inflated with `zlib` rather than adding a ZIP dependency.

### Validation

Full parse-and-normalise path run against the live export:

```
window        : 20260729233000.export.CSV.zip
rows scanned  : 1002
events kept   : 600
invalid coords: 0
bad dates     : 0
unclassified  : 0
quad spread   : {"Verbal Cooperation":326,"Material Conflict":113,
                 "Material Cooperation":84,"Verbal Conflict":77}
http urls     : 600 / 600
```

## Cloudflare Radar — `/api/cloudflare-radar` (token-gated)

Internet outage annotations and layer-3 attack origin share, placed by country centroid.

Requires `CLOUDFLARE_API_TOKEN` scoped to *Radar: Read* and **fails closed** exactly like `/api/scanner`: unset returns 503 and both toggles stay hidden. A `?probe=1` capability check lets the panel decide without provoking an upstream call. The token is read server-side only and never appears in a response. Sections degrade independently, so one failing endpoint cannot blank the layer.

⚠️ **Not verified against live data** — I had no token. It is written to the documented response shape with defensive parsing throughout. Worth a reviewer with a token confirming the mapping before this is relied on.

## UI

`LayerPanel` gains an optional `capabilities` map and a `requires` field per layer; groups left empty after filtering are dropped entirely. Layer definitions are now explicitly typed, which also removed an implicit `any`.

All upstream-supplied strings in map popups go through the existing `htmlEsc` / `urlSafe` helpers.

## Verification

- `tsc --noEmit`: no errors in new or modified files (16 total, unchanged from baseline — all pre-existing in `WorldRemote.tsx`, `cctv/proxy`, `page.tsx`)
- `npm run build`: compiles, both routes registered
- `eslint`: 12 → 11 issues on `LayerPanel.tsx`; new files clean
- Capability gating confirmed live: probe reports `configured:false`, data call 503s, toggles hidden

## Follow-ups

- `/api/gdelt` should be renamed or repointed so it stops claiming to be GDELT. The docs in #246 currently describe it as "Geocoded world events from the GDELT project", which is wrong and needs correcting once this lands.
- `COUNTRY_CENTROIDS` now exists in both `src/lib/countryCentroids.ts` and `/api/radar`. Consolidating means touching a working route, so it is deliberately left out of scope.
