### PR TITLE
fix(layers): use an unused icon for the NET & EVENT INTEL group

### DIFF
--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -5,7 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import {
   Plane, Satellite, Sun, AlertTriangle, Camera,
   CloudLightning, Ship, Network, Database, Ghost,
-  Flame, Tv, Radio, Mountain, Anchor, Globe2
+  Flame, Tv, Radio, Mountain, Anchor, Megaphone
 } from 'lucide-react';
 
 interface LayerPanelProps {
@@ -120,7 +120,7 @@ const LAYER_GROUPS: LayerGroupDef[] = [
   {
     label: 'NETINTEL',
     fullLabel: 'NET & EVENT INTEL',
-    icon: Globe2,
+    icon: Megaphone,
     layers: [
       { key: 'gdelt_events', label: 'GDELT Events', dataKey: 'gdelt_events' },
       { key: 'cf_outages', label: 'Internet Outages', dataKey: 'cf_outages', requires: 'cloudflare' },


### PR DESCRIPTION
Swaps one icon. No behaviour change.

`Globe2` was already in use: `SearchBar.tsx` renders it for geographic search results, and `page.tsx` renders the near-identical `Globe` in the main chrome. In the layer rail the group read as a duplicate.

`Megaphone` appears nowhere else in `src`, and shares no silhouette with what surrounds it — not the globes, not the arc shapes (`Radar`, `Wifi`), not the node-graphs (`Network`, `Share2`).

Still one icon for the whole group — no per-layer icons.

## Verification

Group icons read out of the rendered DOM at 1280×720, in rail order:

```
1 network          6 cloud-lightning
2 plane            7 triangle-alert
3 ship             8 network
4 satellite        9 megaphone      ← this PR
5 camera          10 sun
```

- `npm run build`: compiles
- `tsc --noEmit`: 16 errors, unchanged from master — all pre-existing (`WorldRemote.tsx` ×14, `cctv/proxy` ×1, `page.tsx` ×1)
- `/api/gdelt-events`: 200, unaffected

## Not addressed here

`Network` is still used twice in the rail — **OSIRIS SDK** (group 1) and **NETWORK INTEL** (group 8). That predates this branch and is left alone deliberately; `Waypoints`, `Server`, or `Share2` on the SDK group would resolve it in one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)