### PR TITLE
feat(chain): CHAIN INTEL panel — daily threat brief + wallet forensics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,22 @@ CLOUDFLARE_API_TOKEN=
 
 
 # ─────────────────────────────────────────────────────────────────────────
+#  CHAIN INTEL  ── optional; the RECON "CHAIN INTEL" tab works without these ──
+#  Baseline wallet forensics (BTC/ETH/SOL balance, transaction history,
+#  counterparties, OFAC SDN screening, risk scoring) is fully keyless via
+#  mempool.space, Blockscout and the public Solana RPC.
+#
+#  These only deepen it; /api/osint/crypto?probe=1 reports which are active:
+#    ETHERSCAN_API_KEY  https://etherscan.io/apis  — internal txs, richer ETH
+#    HELIUS_API_KEY     https://helius.dev         — parsed Solana transfers.
+#                       Without it, SOL transfer amounts and counterparties
+#                       stay blank: the public RPC lists signatures only.
+# ─────────────────────────────────────────────────────────────────────────
+ETHERSCAN_API_KEY=
+HELIUS_API_KEY=
+
+
+# ─────────────────────────────────────────────────────────────────────────
 #  OPTIONAL DATA-SOURCE KEYS  (not read by current code — future / upgrades)
 # ─────────────────────────────────────────────────────────────────────────
 

--- a/src/app/api/ai/overview/route.ts
+++ b/src/app/api/ai/overview/route.ts
@@ -1,7 +1,7 @@
 /**
  * ═══════════════════════════════════════════════════════════════
  *  OSIRIS — One-Click AI Overview
- *  POST /api/ai/overview   body: { mode: 'alerts' | 'markets', payload }
+ *  POST /api/ai/overview   body: { mode: 'alerts' | 'markets' | 'chain', payload }
  *
  *  Generates a punchy intelligence read-out for the Alerts or Markets
  *  panel. Uses Gemini when GEMINI_API_KEY_* is configured, otherwise
@@ -15,7 +15,7 @@ import { createGeminiClient, rotateApiKey } from '@/lib/ai-engine';
 
 export const dynamic = 'force-dynamic';
 
-type Mode = 'alerts' | 'markets';
+type Mode = 'alerts' | 'markets' | 'chain';
 
 function getEnvApiKeys(): string[] {
   const keys: string[] = [];
@@ -154,6 +154,67 @@ function digestAlerts(payload: any): Digest {
   return { summaryLine: `Global alert posture: ${level}.`, facts, highlights };
 }
 
+/**
+ * Chain-threat brief: exploits, crypto CVEs and OFAC wallet designations.
+ * Facts are stated with their figures so the heuristic path stays useful
+ * when no Gemini key is configured.
+ */
+function digestChain(payload: any): Digest {
+  const b = payload?.brief || payload || {};
+  const t = b.totals || {};
+  const exploits: any[] = Array.isArray(b.exploits) ? b.exploits : [];
+  const cves: any[] = Array.isArray(b.cves) ? b.cves : [];
+  const wallets: any[] = Array.isArray(b.sanctioned_wallets) ? b.sanctioned_wallets : [];
+
+  const facts: string[] = [];
+  const highlights: string[] = [];
+
+  const losses = num(t.exploit_losses_usd) ?? 0;
+  const usd = (n: number) =>
+    n >= 1e9 ? `$${(n / 1e9).toFixed(2)}B` : n >= 1e6 ? `$${(n / 1e6).toFixed(1)}M` : `$${Math.round(n).toLocaleString()}`;
+
+  if (exploits.length) {
+    facts.push(`${t.exploit_count ?? exploits.length} on-chain exploits in the last ${b.window_days ?? 30} days totalling ${usd(losses)} in losses.`);
+    const biggest = [...exploits].sort((a, b2) => (num(b2.amount_usd) ?? 0) - (num(a.amount_usd) ?? 0))[0];
+    if (biggest) {
+      facts.push(`Largest: ${biggest.name} on ${biggest.chain} — ${usd(num(biggest.amount_usd) ?? 0)} via ${biggest.technique}.`);
+      highlights.push(biggest.name);
+    }
+    // Which attack techniques actually dominate the window.
+    const byTech = new Map<string, number>();
+    for (const e of exploits) byTech.set(e.technique, (byTech.get(e.technique) || 0) + 1);
+    const top = [...byTech.entries()].sort((a, b2) => b2[1] - a[1])[0];
+    if (top && top[1] > 1) facts.push(`Most common technique: ${top[0]} (${top[1]} incidents).`);
+    const bridges = exploits.filter(e => e.bridge_hack).length;
+    if (bridges) facts.push(`${bridges} of these were bridge hacks.`);
+  } else {
+    facts.push('No on-chain exploits recorded in the window.');
+  }
+
+  if (cves.length) {
+    const crit = num(t.critical_cves) ?? 0;
+    facts.push(`${t.cve_count ?? cves.length} crypto-related CVEs published${crit ? `, ${crit} rated critical (CVSS ≥ 9)` : ''}.`);
+    const worst = [...cves].sort((a, b2) => (num(b2.cvss) ?? 0) - (num(a.cvss) ?? 0))[0];
+    if (worst?.cvss != null) {
+      facts.push(`Highest severity: ${worst.id} at CVSS ${worst.cvss}.`);
+      highlights.push(worst.id);
+    }
+  }
+
+  if (wallets.length) {
+    const byAsset = new Map<string, number>();
+    for (const w of wallets) byAsset.set(w.asset, (byAsset.get(w.asset) || 0) + 1);
+    const spread = [...byAsset.entries()].map(([a, n]) => `${n} ${a}`).join(', ');
+    facts.push(`${t.sanctioned_wallet_count ?? wallets.length} OFAC-designated wallets in scope (${spread}).`);
+  }
+
+  const summaryLine = exploits.length
+    ? `${usd(losses)} lost across ${t.exploit_count ?? exploits.length} on-chain incidents in the last ${b.window_days ?? 30} days.`
+    : 'Chain threat surface quiet across the selected window.';
+
+  return { summaryLine, facts, highlights };
+}
+
 /* ─────────────────────────── Renderers ─────────────────────────── */
 
 function heuristicOverview(mode: Mode, digest: Digest): string {
@@ -189,8 +250,12 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  const mode: Mode = body.mode === 'markets' ? 'markets' : 'alerts';
-  const digest = mode === 'markets' ? digestMarkets(body.payload) : digestAlerts(body.payload);
+  const mode: Mode =
+    body.mode === 'markets' ? 'markets' : body.mode === 'chain' ? 'chain' : 'alerts';
+  const digest =
+    mode === 'markets' ? digestMarkets(body.payload)
+    : mode === 'chain' ? digestChain(body.payload)
+    : digestAlerts(body.payload);
 
   const keys = getEnvApiKeys();
   let overview: string | null = null;

--- a/src/app/api/chain/daily/route.ts
+++ b/src/app/api/chain/daily/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { isRateLimited, getClientIp } from '@/lib/ssrf-guard';
+import { buildDailyBrief } from '@/lib/chainFeeds';
+
+/**
+ * OSIRIS — Daily chain-threat brief.
+ *
+ * Aggregates on-chain exploits (DefiLlama), crypto/blockchain CVEs (NVD)
+ * and newly designated OFAC wallets into one dated digest. Fully keyless.
+ * Sections degrade independently and report why via `degraded`.
+ */
+
+export const maxDuration = 60;
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const days = Math.min(120, Math.max(1, Number(searchParams.get('days')) || 30));
+  const force = searchParams.get('refresh') === '1';
+
+  if (isRateLimited(getClientIp(req), 30, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  try {
+    const brief = await buildDailyBrief(days, force);
+    return NextResponse.json(brief, {
+      // Matches the in-process cache; the upstreams move daily at most.
+      headers: { 'Cache-Control': 'public, s-maxage=1800, stale-while-revalidate=3600' },
+    });
+  } catch (e) {
+    console.error('[OSIRIS] daily brief failed:', e);
+    return NextResponse.json({ error: 'Failed to build daily brief' }, { status: 502 });
+  }
+}

--- a/src/app/api/osint/crypto/route.ts
+++ b/src/app/api/osint/crypto/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { isRateLimited, getClientIp } from '@/lib/ssrf-guard';
+import { analyseAddress, capabilities, detectChain, type Chain } from '@/lib/chainIntel';
+
+/**
+ * OSIRIS — On-chain wallet intelligence.
+ *
+ * Takes a BTC, ETH or SOL address and returns balance, activity profile,
+ * counterparty breakdown, OFAC screening and a transparent risk score.
+ * All baseline sources are keyless; ETHERSCAN_API_KEY / HELIUS_API_KEY
+ * deepen the result and are reported via `?probe=1`.
+ */
+
+export const maxDuration = 60;
+
+const CHAINS: Chain[] = ['bitcoin', 'ethereum', 'solana'];
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+
+  // Capability probe — lets the UI decide what to offer without an upstream call.
+  if (searchParams.get('probe') === '1') {
+    return NextResponse.json({ configured: true, ...capabilities() });
+  }
+
+  const address = (searchParams.get('address') || '').trim();
+  if (!address) {
+    return NextResponse.json({ error: 'Missing address parameter' }, { status: 400 });
+  }
+  if (address.length > 128) {
+    return NextResponse.json({ error: 'Address too long' }, { status: 400 });
+  }
+
+  const chainParam = searchParams.get('chain');
+  if (chainParam && !CHAINS.includes(chainParam as Chain)) {
+    return NextResponse.json(
+      { error: `Invalid chain. Allowed: ${CHAINS.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  if (!chainParam && !detectChain(address).chain) {
+    return NextResponse.json(
+      { error: 'Unrecognised address format. Expected a Bitcoin, Ethereum or Solana address.' },
+      { status: 400 }
+    );
+  }
+
+  if (isRateLimited(getClientIp(req), 20, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  try {
+    const intel = await analyseAddress(address, (chainParam as Chain) || undefined);
+    return NextResponse.json(
+      { ...intel, capabilities: capabilities(), timestamp: new Date().toISOString() },
+      { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300' } }
+    );
+  } catch (e) {
+    console.error('[OSIRIS] crypto intel failed:', e);
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Wallet lookup failed' },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Layers, BarChart3, Newspaper, Search, X, Globe, MapPinned, Radar, Satellite, Moon, ExternalLink, AlertTriangle, Activity, Database, Wifi, Play, Network, Crosshair, Bluetooth, Pentagon } from 'lucide-react';
+import { Layers, BarChart3, Newspaper, Search, X, Globe, MapPinned, Radar, Satellite, Moon, ExternalLink, AlertTriangle, Activity, Database, Wifi, Play, Network, Crosshair, Bluetooth, Pentagon, Bitcoin } from 'lucide-react';
 import IntelFeed from '@/components/IntelFeed';
 import MarketsPanel from '@/components/MarketsPanel';
 import ScmPanel from '@/components/ScmPanel';
@@ -20,6 +20,7 @@ import ArcGISPanel from '@/components/ArcGISPanel';
 const OsirisMap = dynamic(() => import('@/components/OsirisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
 const CameraViewer = dynamic(() => import('@/components/CameraViewer'));
+const ChainPanel = dynamic(() => import('@/components/ChainPanel'));
 const OsintPanel = dynamic(() => import('@/components/OsintPanel'));
 const EntityGraphPanel = dynamic(() => import('@/components/EntityGraphPanel'));
 const TokenPanel = dynamic(() => import('@/components/TokenPanel'));
@@ -104,6 +105,7 @@ export default function Dashboard() {
   const [showLayers, setShowLayers] = useState(true);
   const [showMarkets, setShowMarkets] = useState(false);
   const [showAlerts, setShowAlerts] = useState(false);
+  const [showChain, setShowChain] = useState(false);
   const [showScmPanel, setShowScmPanel] = useState(true);
   const [showIntel, setShowIntel] = useState(false);
   const [showEntityGraph, setShowEntityGraph] = useState(false);
@@ -997,7 +999,7 @@ export default function Dashboard() {
       {/* ── RIGHT TOOL STRIP (desktop only — mobile uses bottom nav) ── */}
       {!isMobile && <div className="absolute right-2 top-1/2 -translate-y-1/2 flex flex-col gap-2 z-[250] pointer-events-auto bg-black/40 backdrop-blur-sm p-1 rounded-full border border-white/5">
         <div className="relative group">
-          <button onClick={() => { setShowIntel(!showIntel); setShowMarkets(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showIntel ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`} title="OSINT Recon — IP lookup, network sweep, geolocation">
+          <button onClick={() => { setShowIntel(!showIntel); setShowMarkets(false); setShowAlerts(false); setShowChain(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showIntel ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`} title="OSINT Recon — IP lookup, network sweep, geolocation">
             <Radar className={`w-4 h-4 ${showIntel ? 'text-[var(--cyan-primary)]' : 'text-white/60'}`} />
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">RECON</span>
@@ -1017,7 +1019,7 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Markets — crypto prices, space weather, global indices">
+          <button onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); setShowChain(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Markets — crypto prices, space weather, global indices">
             <BarChart3 className={`w-4 h-4 ${showMarkets ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">MARKETS</span>
@@ -1031,7 +1033,7 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowAlerts(!showAlerts); setShowIntel(false); setShowMarkets(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showAlerts ? 'bg-[#FF3D3D]/20' : 'hover:bg-white/10'}`} title="Live Alerts — earthquakes, conflicts, breaking news">
+          <button onClick={() => { setShowAlerts(!showAlerts); setShowIntel(false); setShowMarkets(false); setShowEntityGraph(false); setShowChain(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showAlerts ? 'bg-[#FF3D3D]/20' : 'hover:bg-white/10'}`} title="Live Alerts — earthquakes, conflicts, breaking news">
             <AlertTriangle className={`w-4 h-4 ${showAlerts ? 'text-[#FF3D3D]' : 'text-white/60'}`} />
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ALERTS</span>
@@ -1045,7 +1047,21 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowEntityGraph(!showEntityGraph); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showEntityGraph ? 'bg-[#D4AF37]/20' : 'hover:bg-white/10'}`} title="Entity Graph — link analysis between tracked entities">
+          <button onClick={() => { setShowChain(!showChain); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showChain ? 'bg-[#F7931A]/20' : 'hover:bg-white/10'}`} title="Chain Intel — daily on-chain exploits, crypto CVEs, OFAC wallets, wallet forensics">
+            <Bitcoin className={`w-4 h-4 ${showChain ? 'text-[#F7931A]' : 'text-white/60'}`} />
+          </button>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">CHAIN</span>
+          <AnimatePresence>
+            {showChain && (
+              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-96">
+                <ChainPanel />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
+        <div className="relative group">
+          <button onClick={() => { setShowEntityGraph(!showEntityGraph); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowChain(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showEntityGraph ? 'bg-[#D4AF37]/20' : 'hover:bg-white/10'}`} title="Entity Graph — link analysis between tracked entities">
             <Network className={`w-4 h-4 ${showEntityGraph ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">GRAPH</span>

--- a/src/components/ChainPanel.tsx
+++ b/src/components/ChainPanel.tsx
@@ -1,0 +1,471 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef, memo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Bitcoin, Search, Loader2, AlertTriangle, Sparkles, RefreshCw,
+  ShieldAlert, Bug, Flame, Clock, Network, Layers, ExternalLink,
+} from 'lucide-react';
+
+/**
+ * OSIRIS — CHAIN INTEL panel.
+ *
+ * Two modes over one accent: an auto-refreshing daily threat brief
+ * (on-chain exploits, crypto CVEs, OFAC wallet designations) and
+ * per-wallet forensics. The AI overview mirrors the Alerts/Markets panels
+ * and works with no key via the route's heuristic fallback.
+ */
+
+const ACCENT = '#F7931A';
+const AUTO_REFRESH_MS = 15 * 60_000;
+
+const SEV_COLOR: Record<string, string> = {
+  critical: '#FF1744', high: '#FF3D3D', medium: '#FF9500', low: '#FFD700', info: '#00E676',
+};
+
+const usd = (n: number | null | undefined) => {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return '—';
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}B`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}M`;
+  if (n >= 1e3) return `$${(n / 1e3).toFixed(1)}K`;
+  return `$${Math.round(n)}`;
+};
+const num = (n: any, d = 4) =>
+  typeof n === 'number' && Number.isFinite(n) ? n.toLocaleString(undefined, { maximumFractionDigits: d }) : '—';
+const shortAddr = (a: string) => (a && a.length > 20 ? `${a.slice(0, 10)}…${a.slice(-8)}` : a);
+
+function Section({ title, icon: Icon, color, right }: { title: string; icon: any; color: string; right?: string }) {
+  return (
+    <div className="flex items-center gap-2 mt-3 mb-1.5 first:mt-0">
+      <Icon className="w-3.5 h-3.5" style={{ color }} />
+      <span className="text-[10px] font-mono font-bold tracking-widest" style={{ color }}>{title}</span>
+      <div className="flex-1 h-px" style={{ background: `${color}30` }} />
+      {right && <span className="text-[9px] font-mono text-[var(--text-muted)]">{right}</span>}
+    </div>
+  );
+}
+
+function Row({ label, value, color }: { label: string; value: any; color?: string }) {
+  if (value === undefined || value === null || value === '') return null;
+  return (
+    <div className="flex items-start gap-3 py-1.5 border-b border-[var(--border-secondary)]/20 last:border-0">
+      <span className="text-[9px] font-mono text-[var(--text-muted)] uppercase tracking-wider w-[90px] flex-shrink-0 pt-0.5">{label}</span>
+      <span className="text-[10px] font-mono break-all flex-1" style={{ color: color || 'var(--text-primary)' }}>{String(value)}</span>
+    </div>
+  );
+}
+
+function ChainPanelInner({ isMobile }: { isMobile?: boolean }) {
+  const [tab, setTab] = useState<'brief' | 'wallet'>('brief');
+
+  // ── daily brief ──
+  const [brief, setBrief] = useState<any>(null);
+  const [briefLoading, setBriefLoading] = useState(false);
+  const [briefError, setBriefError] = useState('');
+  const [days, setDays] = useState(30);
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
+
+  // ── ai overview ──
+  const [ai, setAi] = useState('');
+  const [aiLoading, setAiLoading] = useState(false);
+
+  // ── wallet ──
+  const [query, setQuery] = useState('');
+  const [wallet, setWallet] = useState<any>(null);
+  const [walletLoading, setWalletLoading] = useState(false);
+  const [walletError, setWalletError] = useState('');
+
+  const briefRef = useRef(brief);
+  briefRef.current = brief;
+
+  const loadBrief = useCallback(async (d: number, force = false) => {
+    setBriefLoading(true);
+    setBriefError('');
+    try {
+      const res = await fetch(`/api/chain/daily?days=${d}${force ? '&refresh=1' : ''}`, { cache: 'no-store' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Brief unavailable');
+      setBrief(data);
+      setLastRefresh(new Date());
+    } catch (e: any) {
+      setBriefError(e.message || 'Failed to load brief');
+    } finally {
+      setBriefLoading(false);
+    }
+  }, []);
+
+  // Initial load + unattended refresh. The upstreams move daily, so this is
+  // about keeping a long-open panel from going stale, not polling for ticks.
+  useEffect(() => { loadBrief(days); }, [days, loadBrief]);
+  useEffect(() => {
+    const t = setInterval(() => {
+      if (typeof document !== 'undefined' && document.hidden) return;
+      loadBrief(days, true);
+    }, AUTO_REFRESH_MS);
+    return () => clearInterval(t);
+  }, [days, loadBrief]);
+
+  const runAi = useCallback(async () => {
+    if (!briefRef.current) return;
+    setAiLoading(true);
+    setAi('');
+    try {
+      const res = await fetch('/api/ai/overview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: 'chain', payload: { brief: briefRef.current } }),
+      });
+      const d = await res.json();
+      setAi(d.overview || d.error || 'No overview returned.');
+    } catch {
+      setAi('AI overview unavailable.');
+    } finally {
+      setAiLoading(false);
+    }
+  }, []);
+
+  const runWallet = useCallback(async () => {
+    const q = query.trim();
+    if (!q || walletLoading) return;
+    setWalletLoading(true);
+    setWalletError('');
+    setWallet(null);
+    try {
+      const res = await fetch(`/api/osint/crypto?address=${encodeURIComponent(q)}`, { cache: 'no-store' });
+      const d = await res.json();
+      if (!res.ok) throw new Error(d.error || 'Lookup failed');
+      setWallet(d);
+    } catch (e: any) {
+      setWalletError(e.message || 'Network error');
+    } finally {
+      setWalletLoading(false);
+    }
+  }, [query, walletLoading]);
+
+  const t = brief?.totals;
+
+  return (
+    <div
+      className={`flex flex-col ${isMobile ? '' : 'max-h-[80vh]'} rounded-xl border overflow-hidden`}
+      style={{ borderColor: `${ACCENT}33`, background: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(24px)' }}
+    >
+      {/* header */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b" style={{ borderColor: `${ACCENT}22` }}>
+        <Bitcoin className="w-4 h-4" style={{ color: ACCENT }} />
+        <span className="text-[11px] font-mono font-bold tracking-widest" style={{ color: ACCENT }}>CHAIN INTEL</span>
+        <div className="flex-1" />
+        <button
+          onClick={() => (tab === 'brief' ? loadBrief(days, true) : runWallet())}
+          className="p-1 rounded hover:bg-white/10 transition-colors"
+          title="Refresh"
+        >
+          <RefreshCw className={`w-3 h-3 ${briefLoading ? 'animate-spin' : ''}`} style={{ color: ACCENT }} />
+        </button>
+      </div>
+
+      {/* tabs */}
+      <div className="flex gap-1 px-2 py-1.5 border-b" style={{ borderColor: `${ACCENT}18` }}>
+        {(['brief', 'wallet'] as const).map(id => (
+          <button
+            key={id}
+            onClick={() => setTab(id)}
+            className="px-2 py-1 rounded text-[9px] font-mono font-bold tracking-wider transition-colors"
+            style={{
+              color: tab === id ? ACCENT : 'var(--text-muted)',
+              background: tab === id ? `${ACCENT}1a` : 'transparent',
+              border: `1px solid ${tab === id ? `${ACCENT}55` : 'transparent'}`,
+            }}
+          >
+            {id === 'brief' ? 'DAILY BRIEF' : 'WALLET FORENSICS'}
+          </button>
+        ))}
+      </div>
+
+      <div className="overflow-y-auto px-3 py-2 flex-1">
+        {tab === 'brief' && (
+          <>
+            {/* window selector */}
+            <div className="flex items-center gap-1 mb-2">
+              <span className="text-[9px] font-mono text-[var(--text-muted)] mr-1">WINDOW</span>
+              {[7, 30, 90].map(d => (
+                <button
+                  key={d}
+                  onClick={() => setDays(d)}
+                  className="px-1.5 py-0.5 rounded text-[9px] font-mono transition-colors"
+                  style={{
+                    color: days === d ? ACCENT : 'var(--text-muted)',
+                    background: days === d ? `${ACCENT}1a` : 'transparent',
+                    border: `1px solid ${days === d ? `${ACCENT}55` : 'rgba(255,255,255,0.1)'}`,
+                  }}
+                >
+                  {d}D
+                </button>
+              ))}
+              {lastRefresh && (
+                <span className="ml-auto text-[8px] font-mono text-[var(--text-muted)]">
+                  {lastRefresh.toLocaleTimeString()}
+                </span>
+              )}
+            </div>
+
+            {briefLoading && !brief && (
+              <div className="flex items-center gap-2 py-6 justify-center">
+                <Loader2 className="w-4 h-4 animate-spin" style={{ color: ACCENT }} />
+                <span className="text-[10px] font-mono text-[var(--text-muted)]">Building brief…</span>
+              </div>
+            )}
+            {briefError && (
+              <div className="text-[10px] font-mono text-red-400 py-2">{briefError}</div>
+            )}
+
+            {brief && (
+              <>
+                {/* headline counters */}
+                <div className="grid grid-cols-3 gap-1.5 mb-2">
+                  {[
+                    { label: 'LOSSES', value: usd(t?.exploit_losses_usd), color: '#FF3D3D' },
+                    { label: 'EXPLOITS', value: t?.exploit_count ?? 0, color: '#FF9500' },
+                    { label: 'CVES', value: t?.cve_count ?? 0, color: '#E040FB' },
+                  ].map(c => (
+                    <div key={c.label} className="rounded border px-2 py-1.5" style={{ borderColor: `${c.color}33`, background: `${c.color}0d` }}>
+                      <div className="text-[8px] font-mono text-[var(--text-muted)]">{c.label}</div>
+                      <div className="text-[12px] font-mono font-bold" style={{ color: c.color }}>{c.value}</div>
+                    </div>
+                  ))}
+                </div>
+
+                {/* AI overview */}
+                <button
+                  onClick={runAi}
+                  disabled={aiLoading}
+                  className="w-full flex items-center justify-center gap-1.5 py-1.5 rounded text-[9px] font-mono font-bold tracking-wider transition-colors disabled:opacity-50"
+                  style={{ color: ACCENT, background: `${ACCENT}14`, border: `1px solid ${ACCENT}44` }}
+                >
+                  {aiLoading ? <Loader2 className="w-3 h-3 animate-spin" /> : <Sparkles className="w-3 h-3" />}
+                  AI OVERVIEW
+                </button>
+                {ai && (
+                  <div className="mt-1.5 px-2 py-1.5 rounded border text-[10px] font-mono leading-relaxed whitespace-pre-wrap"
+                    style={{ borderColor: `${ACCENT}33`, background: `${ACCENT}0a`, color: 'var(--text-secondary)' }}>
+                    {ai}
+                  </div>
+                )}
+
+                {/* exploits */}
+                <Section title="ON-CHAIN EXPLOITS" icon={Flame} color="#FF3D3D" right={`${brief.exploits.length} shown`} />
+                {brief.exploits.length === 0 && (
+                  <div className="text-[9px] font-mono text-[var(--text-muted)] py-1">None in window.</div>
+                )}
+                {brief.exploits.slice(0, 12).map((e: any, i: number) => (
+                  <div key={i} className="py-1.5 border-b border-[var(--border-secondary)]/20 last:border-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-[10px] font-mono font-bold text-[#FF3D3D] flex-1 break-all">{e.name}</span>
+                      <span className="text-[10px] font-mono font-bold text-[#FF9500]">{usd(e.amount_usd)}</span>
+                    </div>
+                    <div className="flex items-center gap-2 text-[9px] font-mono text-[var(--text-muted)] mt-0.5">
+                      <span>{String(e.date).slice(0, 10)}</span>
+                      <span className="text-[var(--text-secondary)]">{e.chain}</span>
+                      {e.bridge_hack && <span className="text-[#E040FB]">BRIDGE</span>}
+                    </div>
+                    <div className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug">{e.technique}</div>
+                  </div>
+                ))}
+
+                {/* cves */}
+                <Section title="CRYPTO CVES" icon={Bug} color="#E040FB" right={`${brief.cves.length} shown`} />
+                {brief.cves.length === 0 && (
+                  <div className="text-[9px] font-mono text-[var(--text-muted)] py-1">None published in window.</div>
+                )}
+                {brief.cves.slice(0, 10).map((c: any, i: number) => {
+                  const sev = String(c.severity || '').toLowerCase();
+                  const col = SEV_COLOR[sev] || '#9B978E';
+                  return (
+                    <div key={i} className="py-1.5 border-b border-[var(--border-secondary)]/20 last:border-0">
+                      <div className="flex items-center gap-2">
+                        <a href={c.url} target="_blank" rel="noopener noreferrer"
+                          className="text-[10px] font-mono font-bold hover:underline flex items-center gap-1" style={{ color: col }}>
+                          {c.id} <ExternalLink className="w-2.5 h-2.5" />
+                        </a>
+                        {c.cvss != null && (
+                          <span className="text-[9px] font-mono font-bold" style={{ color: col }}>CVSS {c.cvss}</span>
+                        )}
+                        <span className="ml-auto text-[8px] font-mono text-[var(--text-muted)]">{String(c.published).slice(0, 10)}</span>
+                      </div>
+                      <div className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug mt-0.5">
+                        {String(c.description).slice(0, 180)}{c.description.length > 180 ? '…' : ''}
+                      </div>
+                    </div>
+                  );
+                })}
+
+                {/* sanctions */}
+                <Section title="OFAC DESIGNATED WALLETS" icon={ShieldAlert} color="#FFD700" right={`${t?.sanctioned_wallet_count ?? 0} total`} />
+                {brief.sanctioned_wallets.slice(0, 10).map((w: any, i: number) => (
+                  <div key={i} className="flex items-center gap-2 py-1 text-[9px] font-mono">
+                    <span className="w-[34px] font-bold text-[#FFD700]">{w.asset}</span>
+                    <span className="flex-1 break-all text-[var(--text-primary)]">{shortAddr(w.address)}</span>
+                    <span className="text-[var(--text-muted)]">{w.first_seen ? String(w.first_seen).slice(0, 10) : ''}</span>
+                  </div>
+                ))}
+
+                {brief.degraded?.length > 0 && (
+                  <div className="mt-3 px-2 py-1.5 rounded border border-white/10 bg-white/[0.03]">
+                    <span className="text-[9px] font-mono text-[var(--text-muted)] block mb-0.5">DEGRADED SOURCES</span>
+                    {brief.degraded.map((d: string, i: number) => (
+                      <div key={i} className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug">↳ {d}</div>
+                    ))}
+                  </div>
+                )}
+
+                <div className="mt-2 text-[8px] font-mono text-[var(--text-muted)]">
+                  Sources: {(brief.sources || []).join(' · ')} · auto-refresh 15m
+                </div>
+              </>
+            )}
+          </>
+        )}
+
+        {tab === 'wallet' && (
+          <>
+            <div className="flex gap-1 mb-2">
+              <input
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && runWallet()}
+                placeholder="BTC, ETH or SOL wallet address"
+                className="flex-1 px-2 py-1.5 rounded text-[10px] font-mono bg-black/40 border text-[var(--text-primary)] outline-none"
+                style={{ borderColor: `${ACCENT}33` }}
+              />
+              <button
+                onClick={runWallet}
+                disabled={walletLoading || !query.trim()}
+                className="px-2 rounded text-[9px] font-mono font-bold disabled:opacity-40"
+                style={{ color: ACCENT, background: `${ACCENT}18`, border: `1px solid ${ACCENT}44` }}
+              >
+                {walletLoading ? <Loader2 className="w-3 h-3 animate-spin" /> : <Search className="w-3 h-3" />}
+              </button>
+            </div>
+
+            {walletError && <div className="text-[10px] font-mono text-red-400 py-2">{walletError}</div>}
+
+            {wallet && (
+              <>
+                {wallet.sanctions?.hit && (
+                  <div className="mb-2 px-2 py-2 rounded border border-red-500/40 bg-red-500/15">
+                    <div className="flex items-center gap-2 mb-1">
+                      <AlertTriangle className="w-3.5 h-3.5 text-red-400" />
+                      <span className="text-[10px] font-mono font-bold text-red-400 tracking-wider">OFAC SANCTIONED WALLET</span>
+                    </div>
+                    {(wallet.sanctions.entries || []).map((e: any, i: number) => (
+                      <div key={i} className="text-[9px] font-mono text-red-200 break-all">↳ {e.name}</div>
+                    ))}
+                  </div>
+                )}
+
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="px-2 py-0.5 rounded text-[9px] font-mono font-bold border"
+                    style={{ color: ACCENT, borderColor: `${ACCENT}55`, background: `${ACCENT}18` }}>
+                    {wallet.chain_label?.toUpperCase()}
+                  </span>
+                  <span className="px-2 py-0.5 rounded text-[9px] font-mono font-bold border"
+                    style={{
+                      color: SEV_COLOR[wallet.risk?.level] || '#00E676',
+                      borderColor: `${SEV_COLOR[wallet.risk?.level] || '#00E676'}55`,
+                      background: `${SEV_COLOR[wallet.risk?.level] || '#00E676'}18`,
+                    }}>
+                    RISK {wallet.risk?.score} · {String(wallet.risk?.level || '').toUpperCase()}
+                  </span>
+                </div>
+
+                <Row label="Address" value={wallet.address} color={ACCENT} />
+                <Row label="Balance" value={`${num(wallet.balance?.native, 8)} ${wallet.symbol}`} color="#00E676" />
+                <Row label="Value (USD)" value={wallet.balance?.usd != null ? `$${num(wallet.balance.usd, 2)}` : 'price unavailable'} />
+                <Row label="Transactions" value={wallet.activity?.tx_count?.toLocaleString()} />
+                <Row label="Last active" value={wallet.activity?.last_seen ? `${String(wallet.activity.last_seen).slice(0, 10)} (${wallet.activity.dormant_days}d ago)` : null} />
+                <Row label="Age" value={wallet.activity?.age_days != null ? `${wallet.activity.age_days} days` : 'unknown — history exceeds sample'} />
+
+                {wallet.labels?.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mt-2">
+                    {wallet.labels.map((l: string, i: number) => (
+                      <span key={i} className="px-1.5 py-0.5 rounded text-[9px] font-mono border border-white/15 text-[var(--text-secondary)] bg-white/5">{l}</span>
+                    ))}
+                  </div>
+                )}
+
+                {wallet.flow && (
+                  <>
+                    <Section title="FLOW" icon={Layers} color={ACCENT} />
+                    <Row label="Total in" value={`${num(wallet.flow.total_in)} ${wallet.symbol}`} color="#00E676" />
+                    <Row label="Total out" value={`${num(wallet.flow.total_out)} ${wallet.symbol}`} color="#FF9500" />
+                    <Row label="Net" value={`${num(wallet.flow.net)} ${wallet.symbol}`} />
+                  </>
+                )}
+
+                {wallet.risk?.factors?.length > 0 && (
+                  <>
+                    <Section title="RISK FACTORS" icon={AlertTriangle} color={SEV_COLOR[wallet.risk.level] || '#00E676'} />
+                    {wallet.risk.factors.map((f: any, i: number) => (
+                      <div key={i} className="py-1.5 border-b border-[var(--border-secondary)]/20 last:border-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-[9px] font-mono font-bold" style={{ color: SEV_COLOR[f.severity] || '#00E676' }}>{f.label}</span>
+                          {f.weight > 0 && <span className="text-[8px] font-mono text-[var(--text-muted)]">+{f.weight}</span>}
+                        </div>
+                        <div className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug mt-0.5">{f.detail}</div>
+                      </div>
+                    ))}
+                  </>
+                )}
+
+                {wallet.counterparties?.length > 0 && (
+                  <>
+                    <Section title={`COUNTERPARTIES (${wallet.counterparties.length})`} icon={Network} color={ACCENT} />
+                    {wallet.counterparties.slice(0, 10).map((c: any, i: number) => (
+                      <div key={i} className="flex items-center gap-2 py-1 text-[9px] font-mono">
+                        <span className={`w-[34px] font-bold ${c.direction === 'out' ? 'text-[#FF9500]' : c.direction === 'in' ? 'text-[#00E676]' : 'text-[var(--text-muted)]'}`}>
+                          {c.direction.toUpperCase()}
+                        </span>
+                        <span className="flex-1 break-all text-[var(--text-primary)]">{shortAddr(c.address)}</span>
+                        <span className="text-[var(--text-muted)]">{c.txs}×</span>
+                      </div>
+                    ))}
+                  </>
+                )}
+
+                {wallet.transactions?.length > 0 && (
+                  <>
+                    <Section title={`RECENT TRANSACTIONS (${wallet.transactions.length})`} icon={Clock} color={ACCENT} />
+                    {wallet.transactions.slice(0, 10).map((tx: any, i: number) => (
+                      <div key={i} className="flex items-center gap-2 py-1 text-[9px] font-mono">
+                        <span className={`w-[34px] font-bold ${tx.direction === 'out' ? 'text-[#FF9500]' : tx.direction === 'in' ? 'text-[#00E676]' : 'text-[var(--text-muted)]'}`}>
+                          {tx.direction === 'unknown' ? '—' : tx.direction.toUpperCase()}
+                        </span>
+                        <span className="text-[var(--text-muted)] w-[62px]">{tx.time ? String(tx.time).slice(0, 10) : 'pending'}</span>
+                        <span className="flex-1 break-all text-[var(--text-primary)]">{shortAddr(tx.hash)}</span>
+                        {tx.failed && <span className="text-[#FF3D3D]">FAIL</span>}
+                      </div>
+                    ))}
+                  </>
+                )}
+
+                {wallet.partial?.length > 0 && (
+                  <div className="mt-3 px-2 py-1.5 rounded border border-white/10 bg-white/[0.03]">
+                    <span className="text-[9px] font-mono text-[var(--text-muted)] block mb-0.5">COVERAGE LIMITS</span>
+                    {wallet.partial.map((p: string, i: number) => (
+                      <div key={i} className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug">↳ {p}</div>
+                    ))}
+                  </div>
+                )}
+
+                <div className="mt-2 text-[8px] font-mono text-[var(--text-muted)]">
+                  Sources: {(wallet.sources || []).join(' · ')}
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default memo(ChainPanelInner);

--- a/src/lib/chainFeeds.ts
+++ b/src/lib/chainFeeds.ts
@@ -1,0 +1,256 @@
+import { allEntries, type SanctionEntry } from '@/lib/sanctions';
+
+/**
+ * ═══════════════════════════════════════════════════════════════
+ *  OSIRIS — Daily chain-threat brief
+ *
+ *  Three independent keyless feeds, each verified against live data:
+ *    exploits   DefiLlama /hacks       — dated on-chain incidents + losses
+ *    cves       NVD 2.0 keyword+range  — crypto/blockchain vulnerabilities
+ *    sanctions  OpenSanctions OFAC SDN — designated wallet addresses
+ *
+ *  Sections degrade independently: one dead upstream must never blank the
+ *  brief, so every collector resolves to an empty section plus a stated
+ *  reason rather than rejecting.
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+export interface Exploit {
+  name: string;
+  date: string;
+  amount_usd: number | null;
+  chain: string;
+  classification: string;
+  technique: string;
+  target_type: string;
+  bridge_hack: boolean;
+  returned_funds: number | null;
+  source: string | null;
+}
+
+export interface CveItem {
+  id: string;
+  published: string;
+  cvss: number | null;
+  severity: string | null;
+  description: string;
+  matched: string;
+  url: string;
+}
+
+export interface SanctionedWallet {
+  address: string;
+  asset: 'BTC' | 'ETH' | 'XMR' | 'TRX' | 'OTHER';
+  entity: string;
+  programs: string[];
+  first_seen: string | null;
+}
+
+export interface DailyBrief {
+  generated_at: string;
+  window_days: number;
+  exploits: Exploit[];
+  cves: CveItem[];
+  sanctioned_wallets: SanctionedWallet[];
+  totals: {
+    exploit_count: number;
+    exploit_losses_usd: number;
+    cve_count: number;
+    critical_cves: number;
+    sanctioned_wallet_count: number;
+  };
+  /** Sections that failed or are incomplete, with the reason. */
+  degraded: string[];
+  sources: string[];
+}
+
+/* ── cache ───────────────────────────────────────────────────── */
+
+/** The underlying feeds move on a daily cadence; NVD also rate-limits
+ *  keyless callers hard, so anything shorter than this is wasted work. */
+const TTL = 30 * 60_000;
+/** A brief that lost a source is cached only briefly, so one flaky minute
+ *  cannot leave the panel showing an empty day for the next half hour. */
+const DEGRADED_TTL = 90_000;
+let cache: { at: number; days: number; brief: DailyBrief } | null = null;
+
+/* ── collectors ──────────────────────────────────────────────── */
+
+async function getJson(url: string, timeoutMs = 20000): Promise<any> {
+  // Outbound connections here intermittently hit UND_ERR_CONNECT_TIMEOUT on a
+  // long-lived server even while the network is healthy. One retry on a fresh
+  // connection clears it; without it a blip blanks a whole section.
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await fetch(url, {
+        signal: AbortSignal.timeout(timeoutMs),
+        headers: { Accept: 'application/json' },
+      });
+      if (!res.ok) throw new Error(`${new URL(url).host} responded ${res.status}`);
+      return await res.json();
+    } catch (e) {
+      lastError = e;
+      if (attempt === 0) await new Promise(r => setTimeout(r, 750));
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error('request failed');
+}
+
+async function collectExploits(days: number): Promise<{ items: Exploit[]; degraded: string[] }> {
+  try {
+    const raw = await getJson('https://api.llama.fi/hacks', 25000);
+    const list: any[] = Array.isArray(raw) ? raw : raw?.hacks || [];
+    const cutoff = Date.now() - days * 864e5;
+
+    const items = list
+      // DefiLlama dates are unix seconds.
+      .filter(h => typeof h?.date === 'number' && h.date * 1000 >= cutoff)
+      .sort((a, b) => b.date - a.date)
+      .map((h): Exploit => ({
+        name: String(h.name || 'Unnamed incident'),
+        date: new Date(h.date * 1000).toISOString(),
+        amount_usd: typeof h.amount === 'number' ? h.amount : null,
+        chain: Array.isArray(h.chain) ? h.chain.join(', ') : String(h.chain || 'unknown'),
+        classification: String(h.classification || 'Unclassified'),
+        technique: String(h.technique || 'Unspecified'),
+        target_type: String(h.targetType || 'unknown'),
+        bridge_hack: !!h.bridgeHack,
+        returned_funds: typeof h.returnedFunds === 'number' ? h.returnedFunds : null,
+        source: typeof h.source === 'string' ? h.source : null,
+      }));
+
+    return { items, degraded: [] };
+  } catch (e) {
+    return { items: [], degraded: [`Exploit feed unavailable (${e instanceof Error ? e.message : 'error'})`] };
+  }
+}
+
+/** Terms that surface crypto-relevant CVEs in NVD's full-text index. */
+const CVE_KEYWORDS = ['blockchain', 'cryptocurrency', 'wallet', 'smart contract'];
+
+async function collectCves(days: number): Promise<{ items: CveItem[]; degraded: string[] }> {
+  const iso = (d: Date) => `${d.toISOString().slice(0, 19)}.000`;
+  // NVD caps a single query at a 120-day publication window.
+  const span = Math.min(days, 119);
+  const start = iso(new Date(Date.now() - span * 864e5));
+  const end = iso(new Date());
+
+  const byId = new Map<string, CveItem>();
+  const degraded: string[] = [];
+
+  for (const kw of CVE_KEYWORDS) {
+    try {
+      const url =
+        `https://services.nvd.nist.gov/rest/json/cves/2.0?keywordSearch=${encodeURIComponent(kw)}` +
+        `&pubStartDate=${encodeURIComponent(start)}&pubEndDate=${encodeURIComponent(end)}&resultsPerPage=40`;
+      const d = await getJson(url, 25000);
+
+      for (const v of d?.vulnerabilities || []) {
+        const c = v?.cve;
+        if (!c?.id || byId.has(c.id)) continue;
+        const m =
+          c.metrics?.cvssMetricV31?.[0] || c.metrics?.cvssMetricV30?.[0] || c.metrics?.cvssMetricV2?.[0];
+        byId.set(c.id, {
+          id: c.id,
+          published: c.published || '',
+          cvss: typeof m?.cvssData?.baseScore === 'number' ? m.cvssData.baseScore : null,
+          severity: m?.cvssData?.baseSeverity || m?.baseSeverity || null,
+          description: ((c.descriptions || []).find((x: any) => x.lang === 'en')?.value || '').slice(0, 400),
+          matched: kw,
+          url: `https://nvd.nist.gov/vuln/detail/${c.id}`,
+        });
+      }
+      // Keyless NVD allows ~5 requests / 30s; space them out.
+      await new Promise(r => setTimeout(r, 1200));
+    } catch (e) {
+      degraded.push(`CVE term "${kw}" unavailable (${e instanceof Error ? e.message : 'error'})`);
+    }
+  }
+
+  const items = [...byId.values()].sort(
+    (a, b) => (Date.parse(b.published) || 0) - (Date.parse(a.published) || 0)
+  );
+  return { items, degraded };
+}
+
+/** Address shapes used to classify a designated wallet by asset. */
+const ASSET_PATTERNS: [SanctionedWallet['asset'], RegExp][] = [
+  ['ETH', /^0x[a-fA-F0-9]{40}$/],
+  ['BTC', /^(bc1[a-z0-9]{25,62}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})$/],
+  ['XMR', /^4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}$/],
+  ['TRX', /^T[1-9A-HJ-NP-Za-km-z]{33}$/],
+];
+
+function classifyAsset(name: string): SanctionedWallet['asset'] | null {
+  for (const [asset, re] of ASSET_PATTERNS) if (re.test(name)) return asset;
+  return null;
+}
+
+/**
+ * OFAC designates crypto wallets as standalone entries whose *name* is the
+ * address itself, so scanning names by address shape is the correct filter.
+ */
+async function collectSanctionedWallets(days: number): Promise<{ items: SanctionedWallet[]; degraded: string[] }> {
+  try {
+    const entries = await allEntries();
+    const cutoff = Date.now() - days * 864e5;
+    const items: SanctionedWallet[] = [];
+
+    for (const e of entries as SanctionEntry[]) {
+      const asset = classifyAsset(e.name);
+      if (!asset) continue;
+      const seen = e.first_seen ? Date.parse(e.first_seen) : NaN;
+      if (Number.isFinite(seen) && seen < cutoff) continue;
+      items.push({
+        address: e.name,
+        asset,
+        entity: e.aliases[0] || e.sanctions || 'OFAC SDN designation',
+        programs: e.programs,
+        first_seen: e.first_seen ?? null,
+      });
+    }
+
+    items.sort((a, b) => (Date.parse(b.first_seen || '') || 0) - (Date.parse(a.first_seen || '') || 0));
+    return { items, degraded: [] };
+  } catch (e) {
+    return { items: [], degraded: [`Sanctions list unavailable (${e instanceof Error ? e.message : 'error'})`] };
+  }
+}
+
+/* ── entry point ─────────────────────────────────────────────── */
+
+export async function buildDailyBrief(days = 30, force = false): Promise<DailyBrief> {
+  if (!force && cache && cache.days === days) {
+    const ttl = cache.brief.degraded.length ? DEGRADED_TTL : TTL;
+    if (Date.now() - cache.at < ttl) return cache.brief;
+  }
+
+  // Deliberately sequential. The result is cached for TTL, so total latency
+  // barely matters, and firing six concurrent connections alongside the app's
+  // existing feed polling is enough to exhaust the connection pool — outbound
+  // connects then time out and whole sections drop out of the brief.
+  const ex = await collectExploits(days);
+  const cve = await collectCves(days);
+  const sanc = await collectSanctionedWallets(days);
+
+  const brief: DailyBrief = {
+    generated_at: new Date().toISOString(),
+    window_days: days,
+    exploits: ex.items.slice(0, 40),
+    cves: cve.items.slice(0, 40),
+    sanctioned_wallets: sanc.items.slice(0, 40),
+    totals: {
+      exploit_count: ex.items.length,
+      exploit_losses_usd: ex.items.reduce((s, e) => s + (e.amount_usd || 0), 0),
+      cve_count: cve.items.length,
+      critical_cves: cve.items.filter(c => (c.cvss ?? 0) >= 9).length,
+      sanctioned_wallet_count: sanc.items.length,
+    },
+    degraded: [...ex.degraded, ...cve.degraded, ...sanc.degraded],
+    sources: ['DefiLlama', 'NVD (NIST)', 'OpenSanctions / US OFAC SDN'],
+  };
+
+  cache = { at: Date.now(), days, brief };
+  return brief;
+}

--- a/src/lib/chainIntel.ts
+++ b/src/lib/chainIntel.ts
@@ -1,0 +1,615 @@
+import { matchExact, type SanctionEntry } from '@/lib/sanctions';
+
+/**
+ * ═══════════════════════════════════════════════════════════════
+ *  OSIRIS — On-chain wallet intelligence (BTC / ETH / SOL)
+ *
+ *  Every source here is keyless and was verified against live data:
+ *    BTC  mempool.space REST
+ *    ETH  Blockscout v2 REST (also yields ENS + a spot exchange rate)
+ *    SOL  public Solana JSON-RPC
+ *    USD  CoinGecko simple/price
+ *
+ *  Optional keys (ETHERSCAN_API_KEY / HELIUS_API_KEY) unlock deeper data
+ *  and are reported through capabilities(). Absent keys degrade the
+ *  response, never break it.
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+export type Chain = 'bitcoin' | 'ethereum' | 'solana';
+
+const CHAIN_META: Record<Chain, { label: string; symbol: string; decimals: number; coingecko: string }> = {
+  bitcoin: { label: 'Bitcoin', symbol: 'BTC', decimals: 8, coingecko: 'bitcoin' },
+  ethereum: { label: 'Ethereum', symbol: 'ETH', decimals: 18, coingecko: 'ethereum' },
+  solana: { label: 'Solana', symbol: 'SOL', decimals: 9, coingecko: 'solana' },
+};
+
+const RE_ETH = /^0x[a-fA-F0-9]{40}$/;
+const RE_BTC_BECH32 = /^bc1[a-z0-9]{25,62}$/;
+const RE_BTC_LEGACY = /^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/;
+const RE_BASE58 = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+
+export interface ChainDetection {
+  chain: Chain | null;
+  /** Base58 lengths overlap between BTC legacy and Solana; true when the
+   *  format alone cannot decide and `chain` is a best guess. */
+  ambiguous: boolean;
+}
+
+/**
+ * Format-based chain detection. Order matters: ETH and bech32 are
+ * unambiguous, while a 32–34 char base58 string beginning 1/3 is valid for
+ * both BTC legacy and Solana — those resolve to BTC and set `ambiguous`,
+ * which the caller can override with an explicit chain.
+ */
+export function detectChain(addressRaw: string): ChainDetection {
+  const address = addressRaw.trim();
+  if (RE_ETH.test(address)) return { chain: 'ethereum', ambiguous: false };
+  if (RE_BTC_BECH32.test(address)) return { chain: 'bitcoin', ambiguous: false };
+  if (RE_BTC_LEGACY.test(address)) {
+    return { chain: 'bitcoin', ambiguous: RE_BASE58.test(address) };
+  }
+  if (RE_BASE58.test(address)) return { chain: 'solana', ambiguous: false };
+  return { chain: null, ambiguous: false };
+}
+
+export interface Counterparty {
+  address: string;
+  direction: 'in' | 'out' | 'both';
+  txs: number;
+  value: number;
+}
+
+export interface TxSummary {
+  hash: string;
+  time: string | null;
+  direction: 'in' | 'out' | 'self' | 'unknown';
+  value: number;
+  counterparty: string | null;
+  fee?: number;
+  failed?: boolean;
+}
+
+export type Severity = 'info' | 'low' | 'medium' | 'high' | 'critical';
+
+export interface RiskFactor {
+  code: string;
+  label: string;
+  severity: Severity;
+  /** Points contributed to the 0–100 score. */
+  weight: number;
+  /** The observation that triggered it — always states the evidence. */
+  detail: string;
+}
+
+export interface WalletIntel {
+  address: string;
+  chain: Chain;
+  chain_label: string;
+  symbol: string;
+  ambiguous_chain: boolean;
+  balance: { native: number; usd: number | null; price_usd: number | null };
+  activity: {
+    tx_count: number;
+    /** Earliest transaction *in the sampled window* — not necessarily the
+     *  address's first ever, unless `history_complete` is true. */
+    first_seen: string | null;
+    last_seen: string | null;
+    /** Null whenever history is incomplete: the true first transaction is
+     *  older than the sample and any age derived from it would be wrong. */
+    age_days: number | null;
+    dormant_days: number | null;
+    sample_size: number;
+    history_complete: boolean;
+  };
+  flow: { total_in: number; total_out: number; net: number } | null;
+  counterparties: Counterparty[];
+  transactions: TxSummary[];
+  sanctions: { screened: boolean; hit: boolean; entries: SanctionEntry[] };
+  risk: { score: number; level: Severity; factors: RiskFactor[] };
+  labels: string[];
+  tokens: { symbol: string; name: string; amount: number | null }[];
+  sources: string[];
+  partial: string[];
+}
+
+/* ── fetch helpers ───────────────────────────────────────────── */
+
+async function getJson(url: string, timeoutMs = 15000, init?: RequestInit): Promise<any> {
+  const res = await fetch(url, {
+    ...init,
+    signal: AbortSignal.timeout(timeoutMs),
+    headers: { Accept: 'application/json', ...(init?.headers || {}) },
+  });
+  if (!res.ok) throw new Error(`${new URL(url).host} responded ${res.status}`);
+  return res.json();
+}
+
+async function rpc(url: string, method: string, params: any[], timeoutMs = 15000): Promise<any> {
+  const body = await getJson(url, timeoutMs, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  });
+  if (body.error) throw new Error(`${method}: ${body.error.message || 'RPC error'}`);
+  return body.result;
+}
+
+/**
+ * Spot USD price. CoinGecko's keyless tier rate-limits hard enough that a
+ * per-lookup call starts returning nothing after a handful of scans, so
+ * prices are cached process-wide and all three chains are fetched at once.
+ * A stale price beats no price; failure is non-fatal either way.
+ */
+const PRICE_TTL = 120_000;
+let priceCache: { at: number; usd: Partial<Record<Chain, number>> } | null = null;
+
+async function fetchPrice(chain: Chain): Promise<number | null> {
+  if (priceCache && Date.now() - priceCache.at < PRICE_TTL) {
+    return priceCache.usd[chain] ?? null;
+  }
+  try {
+    const ids = (Object.keys(CHAIN_META) as Chain[]).map(c => CHAIN_META[c].coingecko).join(',');
+    const d = await getJson(
+      `https://api.coingecko.com/api/v3/simple/price?ids=${ids}&vs_currencies=usd`,
+      10000
+    );
+    const usd: Partial<Record<Chain, number>> = {};
+    for (const c of Object.keys(CHAIN_META) as Chain[]) {
+      const v = d?.[CHAIN_META[c].coingecko]?.usd;
+      if (typeof v === 'number') usd[c] = v;
+    }
+    if (Object.keys(usd).length) priceCache = { at: Date.now(), usd };
+    return usd[chain] ?? priceCache?.usd[chain] ?? null;
+  } catch (e) {
+    console.warn('[OSIRIS] price lookup failed:', e instanceof Error ? e.message : e);
+    // Serve the last known price rather than blanking the USD column.
+    return priceCache?.usd[chain] ?? null;
+  }
+}
+
+/* ── per-chain collectors ────────────────────────────────────── */
+
+const TX_PAGE = 50;
+
+interface RawWallet {
+  balance: number;
+  tx_count: number;
+  /** True only when the sample provably covers the address's whole history.
+   *  Each collector decides this differently — see the per-chain notes. */
+  history_complete: boolean;
+  flow: { total_in: number; total_out: number; net: number } | null;
+  transactions: TxSummary[];
+  labels: string[];
+  tokens: { symbol: string; name: string; amount: number | null }[];
+  sources: string[];
+  partial: string[];
+}
+
+async function collectBitcoin(address: string): Promise<RawWallet> {
+  const base = 'https://mempool.space/api';
+  const info = await getJson(`${base}/address/${encodeURIComponent(address)}`);
+  const cs = info.chain_stats || {};
+  const sats = (n: number) => (Number(n) || 0) / 1e8;
+
+  const totalIn = sats(cs.funded_txo_sum);
+  const totalOut = sats(cs.spent_txo_sum);
+
+  const partial: string[] = [];
+  let transactions: TxSummary[] = [];
+  try {
+    const txs = await getJson(`${base}/address/${encodeURIComponent(address)}/txs`, 20000);
+    transactions = (Array.isArray(txs) ? txs : []).map((t: any): TxSummary => {
+      // Sum this address's side of the ledger on both legs of the tx.
+      const inFrom = (t.vin || []).reduce(
+        (s: number, v: any) => s + (v?.prevout?.scriptpubkey_address === address ? Number(v.prevout.value) || 0 : 0),
+        0
+      );
+      const outTo = (t.vout || []).reduce(
+        (s: number, v: any) => s + (v?.scriptpubkey_address === address ? Number(v.value) || 0 : 0),
+        0
+      );
+      const spent = sats(inFrom);
+      const received = sats(outTo);
+      const direction: TxSummary['direction'] =
+        spent > 0 && received > 0 ? 'self' : spent > 0 ? 'out' : received > 0 ? 'in' : 'unknown';
+
+      // Counterparty = the largest party on the opposite leg.
+      const pool =
+        direction === 'out'
+          ? (t.vout || []).filter((v: any) => v?.scriptpubkey_address && v.scriptpubkey_address !== address)
+          : (t.vin || [])
+              .map((v: any) => v?.prevout)
+              .filter((p: any) => p?.scriptpubkey_address && p.scriptpubkey_address !== address);
+      const top = pool.sort((a: any, b: any) => (Number(b?.value) || 0) - (Number(a?.value) || 0))[0];
+
+      return {
+        hash: t.txid,
+        time: t.status?.block_time ? new Date(t.status.block_time * 1000).toISOString() : null,
+        direction,
+        value: direction === 'out' ? spent - received : received,
+        counterparty: top?.scriptpubkey_address || null,
+        fee: sats(t.fee),
+      };
+    });
+  } catch (e) {
+    partial.push(`transaction history unavailable (${e instanceof Error ? e.message : 'error'})`);
+  }
+
+  // mempool.space reports a true lifetime tx_count, so completeness is exact.
+  const txCount = Number(cs.tx_count) || 0;
+  return {
+    balance: totalIn - totalOut,
+    tx_count: txCount,
+    history_complete: transactions.length >= txCount,
+    flow: { total_in: totalIn, total_out: totalOut, net: totalIn - totalOut },
+    transactions,
+    labels: [],
+    tokens: [],
+    sources: ['mempool.space'],
+    partial,
+  };
+}
+
+async function collectEthereum(address: string): Promise<RawWallet> {
+  const base = 'https://eth.blockscout.com/api/v2';
+  const info = await getJson(`${base}/addresses/${encodeURIComponent(address)}`);
+  const balance = Number(info.coin_balance || 0) / 1e18;
+
+  const labels: string[] = [];
+  if (info.ens_domain_name) labels.push(`ENS: ${info.ens_domain_name}`);
+  // Blockscout sets is_contract for any address holding code, including EOAs
+  // carrying an EIP-7702 delegation — those have no deployment transaction.
+  // Calling those "smart contract" is wrong, so distinguish on the creation tx.
+  if (info.is_contract) {
+    if (info.creation_transaction_hash) {
+      labels.push(info.is_verified ? 'Smart contract (verified source)' : 'Smart contract');
+    } else {
+      labels.push('Code at address, no deployment tx (EIP-7702 delegation)');
+    }
+  }
+  if (info.has_beacon_chain_withdrawals) labels.push('Beacon chain withdrawals');
+
+  const partial: string[] = [];
+  let transactions: TxSummary[] = [];
+  let txCount = 0;
+  try {
+    const txs = await getJson(`${base}/addresses/${encodeURIComponent(address)}/transactions`, 25000);
+    const items = Array.isArray(txs.items) ? txs.items : [];
+    txCount = items.length;
+    const lower = address.toLowerCase();
+    transactions = items.map((t: any): TxSummary => {
+      const from = (t.from?.hash || '').toLowerCase();
+      const to = (t.to?.hash || '').toLowerCase();
+      const direction: TxSummary['direction'] =
+        from === lower && to === lower ? 'self' : from === lower ? 'out' : to === lower ? 'in' : 'unknown';
+      return {
+        hash: t.hash,
+        time: t.timestamp || null,
+        direction,
+        value: Number(t.value || 0) / 1e18,
+        counterparty: direction === 'out' ? t.to?.hash || null : t.from?.hash || null,
+        fee: t.fee?.value ? Number(t.fee.value) / 1e18 : undefined,
+        failed: t.status === 'error' || t.result === 'error',
+      };
+    });
+  } catch (e) {
+    partial.push(`transaction history unavailable (${e instanceof Error ? e.message : 'error'})`);
+  }
+
+  let tokens: RawWallet['tokens'] = [];
+  try {
+    const tb = await getJson(`${base}/addresses/${encodeURIComponent(address)}/token-balances`, 15000);
+    tokens = (Array.isArray(tb) ? tb : [])
+      .slice(0, 25)
+      .map((t: any) => {
+        const dec = Number(t.token?.decimals);
+        const raw = Number(t.value);
+        return {
+          symbol: t.token?.symbol || '???',
+          name: t.token?.name || 'Unknown token',
+          amount: Number.isFinite(raw) && Number.isFinite(dec) ? raw / 10 ** dec : null,
+        };
+      });
+  } catch {
+    partial.push('token balances unavailable');
+  }
+
+  // Blockscout reports totals only across the paged window, so derive flow
+  // from the transactions actually seen rather than implying a full history.
+  const flow = transactions.length
+    ? {
+        total_in: transactions.filter(t => t.direction === 'in').reduce((s, t) => s + t.value, 0),
+        total_out: transactions.filter(t => t.direction === 'out').reduce((s, t) => s + t.value, 0),
+        net: 0,
+      }
+    : null;
+  if (flow) flow.net = flow.total_in - flow.total_out;
+
+  return {
+    balance,
+    tx_count: txCount,
+    // Blockscout pages newest-first and exposes no lifetime total; a page that
+    // came back short is the only proof we reached the beginning.
+    history_complete: transactions.length > 0 && transactions.length < TX_PAGE,
+    flow,
+    transactions,
+    labels,
+    tokens,
+    sources: ['Blockscout'],
+    partial,
+  };
+}
+
+async function collectSolana(address: string): Promise<RawWallet> {
+  const url = 'https://api.mainnet-beta.solana.com';
+  const lamports = await rpc(url, 'getBalance', [address]);
+  const balance = (Number(lamports?.value) || 0) / 1e9;
+
+  const partial: string[] = [];
+  let transactions: TxSummary[] = [];
+  try {
+    const sigs = await rpc(url, 'getSignaturesForAddress', [address, { limit: 50 }], 20000);
+    transactions = (Array.isArray(sigs) ? sigs : []).map((s: any): TxSummary => ({
+      hash: s.signature,
+      time: s.blockTime ? new Date(s.blockTime * 1000).toISOString() : null,
+      // Signature listings carry no transfer legs; resolving direction and
+      // amounts needs a per-tx fetch, which the public RPC rate-limits hard.
+      direction: 'unknown',
+      value: 0,
+      counterparty: null,
+      failed: !!s.err,
+    }));
+  } catch (e) {
+    partial.push(`signature history unavailable (${e instanceof Error ? e.message : 'error'})`);
+  }
+  partial.push('Solana transfer amounts and counterparties require a keyed RPC provider (HELIUS_API_KEY)');
+
+  let tokens: RawWallet['tokens'] = [];
+  try {
+    const accs = await rpc(
+      url,
+      'getTokenAccountsByOwner',
+      [address, { programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' }, { encoding: 'jsonParsed' }],
+      20000
+    );
+    tokens = (accs?.value || [])
+      .slice(0, 25)
+      .map((a: any) => {
+        const info = a?.account?.data?.parsed?.info;
+        return {
+          symbol: (info?.mint || '').slice(0, 6) || '???',
+          name: `SPL mint ${info?.mint || 'unknown'}`,
+          amount: info?.tokenAmount?.uiAmount ?? null,
+        };
+      })
+      .filter((t: any) => t.amount === null || t.amount > 0);
+  } catch {
+    partial.push('token accounts unavailable');
+  }
+
+  return {
+    balance,
+    tx_count: transactions.length,
+    // Same reasoning as Ethereum: a full page means more signatures remain.
+    history_complete: transactions.length > 0 && transactions.length < TX_PAGE,
+    flow: null,
+    transactions,
+    labels: [],
+    tokens,
+    sources: ['Solana JSON-RPC'],
+    partial,
+  };
+}
+
+/* ── analysis ────────────────────────────────────────────────── */
+
+function aggregateCounterparties(txs: TxSummary[]): Counterparty[] {
+  const map = new Map<string, Counterparty>();
+  for (const t of txs) {
+    if (!t.counterparty) continue;
+    const existing = map.get(t.counterparty);
+    const dir = t.direction === 'in' || t.direction === 'out' ? t.direction : null;
+    if (existing) {
+      existing.txs += 1;
+      existing.value += t.value;
+      if (dir && existing.direction !== dir && existing.direction !== 'both') existing.direction = 'both';
+    } else {
+      map.set(t.counterparty, {
+        address: t.counterparty,
+        direction: dir ?? 'both',
+        txs: 1,
+        value: t.value,
+      });
+    }
+  }
+  return [...map.values()].sort((a, b) => b.txs - a.txs || b.value - a.value).slice(0, 15);
+}
+
+const LEVEL_ORDER: Severity[] = ['info', 'low', 'medium', 'high', 'critical'];
+
+function scoreRisk(
+  factors: RiskFactor[]
+): { score: number; level: Severity } {
+  const score = Math.max(0, Math.min(100, factors.reduce((s, f) => s + f.weight, 0)));
+  const highest = factors.reduce<Severity>(
+    (acc, f) => (LEVEL_ORDER.indexOf(f.severity) > LEVEL_ORDER.indexOf(acc) ? f.severity : acc),
+    'info'
+  );
+  // A sanctions hit must never be diluted by an otherwise-quiet wallet.
+  if (highest === 'critical') return { score: Math.max(score, 95), level: 'critical' };
+  const level: Severity = score >= 70 ? 'high' : score >= 40 ? 'medium' : score >= 15 ? 'low' : 'info';
+  return { score, level };
+}
+
+function buildFactors(
+  raw: RawWallet,
+  meta: { symbol: string },
+  activity: WalletIntel['activity'],
+  counterparties: Counterparty[],
+  sanctionHits: SanctionEntry[]
+): RiskFactor[] {
+  const f: RiskFactor[] = [];
+
+  if (sanctionHits.length) {
+    f.push({
+      code: 'OFAC_SDN',
+      label: 'OFAC-sanctioned address',
+      severity: 'critical',
+      weight: 100,
+      detail: `Listed on the US OFAC SDN list as: ${sanctionHits.slice(0, 3).map(e => e.name).join('; ')}`,
+    });
+  }
+
+  if (activity.age_days !== null && activity.age_days < 7) {
+    f.push({
+      code: 'NEW_ADDRESS',
+      label: 'Recently created',
+      severity: 'low',
+      weight: 10,
+      detail: `First activity ${activity.age_days} day(s) ago.`,
+    });
+  }
+
+  if (activity.dormant_days !== null && activity.age_days !== null && activity.dormant_days > 365 && activity.age_days > 400) {
+    f.push({
+      code: 'DORMANT',
+      label: 'Long dormant',
+      severity: 'info',
+      weight: 5,
+      detail: `No activity for ${activity.dormant_days} days.`,
+    });
+  }
+
+  if (raw.tx_count > 10000) {
+    f.push({
+      code: 'HIGH_VOLUME',
+      label: 'Exchange-scale activity',
+      severity: 'info',
+      weight: 5,
+      detail: `${raw.tx_count.toLocaleString()} transactions — consistent with an exchange, service or pooled wallet rather than a personal one.`,
+    });
+  }
+
+  // Fan-out is only informative for wallets that aren't obviously services —
+  // an exchange spreading across many counterparties is its normal operation.
+  if (counterparties.length >= 12 && raw.tx_count <= 10000) {
+    f.push({
+      code: 'FAN_PATTERN',
+      label: 'High counterparty fan-out',
+      severity: 'medium',
+      weight: 20,
+      detail: `${counterparties.length} distinct counterparties across ${raw.transactions.length} sampled transactions — a distribution pattern also seen in mixing and payout scripts.`,
+    });
+  }
+
+  const failed = raw.transactions.filter(t => t.failed).length;
+  if (failed >= 5) {
+    f.push({
+      code: 'FAILED_TXS',
+      label: 'Repeated failed transactions',
+      severity: 'low',
+      weight: 8,
+      detail: `${failed} of ${raw.transactions.length} sampled transactions failed.`,
+    });
+  }
+
+  if (raw.flow && raw.flow.total_in > 0 && raw.balance / raw.flow.total_in < 0.01 && raw.tx_count > 5) {
+    f.push({
+      code: 'DRAINED',
+      label: 'Swept balance',
+      severity: 'medium',
+      weight: 15,
+      detail: `Received ${raw.flow.total_in.toFixed(4)} ${meta.symbol} but retains ${raw.balance.toFixed(4)} — funds were forwarded on rather than held.`,
+    });
+  }
+
+  if (!f.length) {
+    f.push({
+      code: 'NOMINAL',
+      label: 'No risk indicators',
+      severity: 'info',
+      weight: 0,
+      detail: 'Nothing in the sampled data matched a risk heuristic.',
+    });
+  }
+
+  return f;
+}
+
+/* ── capabilities ────────────────────────────────────────────── */
+
+export function capabilities() {
+  return {
+    etherscan: !!process.env.ETHERSCAN_API_KEY,
+    helius: !!process.env.HELIUS_API_KEY,
+  };
+}
+
+/* ── entry point ─────────────────────────────────────────────── */
+
+export async function analyseAddress(addressRaw: string, chainOverride?: Chain): Promise<WalletIntel> {
+  const address = addressRaw.trim();
+  const detection = detectChain(address);
+  const chain = chainOverride ?? detection.chain;
+  if (!chain) throw new Error('Unrecognised address format for BTC, ETH or SOL');
+
+  const meta = CHAIN_META[chain];
+
+  const [raw, price, sanctionHits] = await Promise.all([
+    chain === 'bitcoin'
+      ? collectBitcoin(address)
+      : chain === 'ethereum'
+        ? collectEthereum(address)
+        : collectSolana(address),
+    fetchPrice(chain),
+    // OFAC lists sanctioned wallets as entity names, so an exact-name lookup
+    // is the correct screen; normalisation lower-cases both sides.
+    matchExact(address).catch(() => [] as SanctionEntry[]),
+  ]);
+
+  const times = raw.transactions.map(t => t.time).filter((t): t is string => !!t).sort();
+  const firstSeen = times[0] ?? null;
+  const lastSeen = times[times.length - 1] ?? null;
+  const day = 86_400_000;
+  // Chain APIs page newest-first, so the sample only reaches the true first
+  // transaction when it covers the whole history. Deriving an age from a
+  // partial sample would report a 2009 address as days old.
+  const historyComplete = raw.history_complete;
+  const activity: WalletIntel['activity'] = {
+    tx_count: raw.tx_count,
+    first_seen: firstSeen,
+    last_seen: lastSeen,
+    age_days: historyComplete && firstSeen ? Math.floor((Date.now() - Date.parse(firstSeen)) / day) : null,
+    dormant_days: lastSeen ? Math.floor((Date.now() - Date.parse(lastSeen)) / day) : null,
+    sample_size: raw.transactions.length,
+    history_complete: historyComplete,
+  };
+
+  const counterparties = aggregateCounterparties(raw.transactions);
+  const factors = buildFactors(raw, meta, activity, counterparties, sanctionHits);
+  const risk = scoreRisk(factors);
+
+  return {
+    address,
+    chain,
+    chain_label: meta.label,
+    symbol: meta.symbol,
+    ambiguous_chain: detection.ambiguous && !chainOverride,
+    balance: {
+      native: raw.balance,
+      usd: price !== null ? raw.balance * price : null,
+      price_usd: price,
+    },
+    activity,
+    flow: raw.flow,
+    counterparties,
+    transactions: raw.transactions.slice(0, 25),
+    sanctions: { screened: true, hit: sanctionHits.length > 0, entries: sanctionHits.slice(0, 5) },
+    risk: { ...risk, factors },
+    labels: raw.labels,
+    tokens: raw.tokens,
+    sources: [...raw.sources, 'CoinGecko', 'OpenSanctions / US OFAC SDN'],
+    partial: raw.partial,
+  };
+}

--- a/src/lib/sanctions.ts
+++ b/src/lib/sanctions.ts
@@ -243,3 +243,13 @@ export async function indexSize(): Promise<number> {
   const list = await loadList();
   return list.entries.length;
 }
+
+/**
+ * Every indexed entry, for callers that need to scan rather than look up —
+ * e.g. pulling the designated crypto wallets out of the list. Returns the
+ * cached array directly; treat it as read-only.
+ */
+export async function allEntries(): Promise<readonly SanctionEntry[]> {
+  const list = await loadList();
+  return list.entries;
+}


### PR DESCRIPTION
Adds a dedicated right-rail tool for blockchain intelligence, between **Live Alerts** and **Entity Graph**. Two tabs over one accent.

## DAILY BRIEF

Three keyless feeds over a switchable 7/30/90-day window, refreshing unattended every 15 minutes (skips hidden tabs).

| Feed | Source | Live at time of writing (30d) |
|---|---|---|
| On-chain exploits | DefiLlama | 29 incidents, **$131.0M** lost |
| Crypto/blockchain CVEs | NVD, date-ranged, 4 search terms | 12 published |
| OFAC-designated wallets | OpenSanctions, classified by address shape | 21 (BTC/ETH/XMR/TRX) |

Real dated incidents, e.g. *AFX Bridge on Arbitrum — $24.1M via private key compromise*.

## WALLET FORENSICS

BTC, ETH or SOL address in; balance and USD value, transaction history, counterparty breakdown, token holdings, ENS, OFAC screening and a risk score out. Every risk factor carries the observation that triggered it rather than an opaque number.

Chain is detected from address format. Base58 lengths overlap between BTC legacy and Solana, so an ambiguous address resolves to Bitcoin, says so in the UI, and can be overridden with `?chain=`.

## AI OVERVIEW

New `chain` mode alongside `alerts`/`markets`, reporting largest incident, dominant technique, bridge-hack share, CVE severity ceiling and sanctions spread. **No key required** — the heuristic path states the same figures, same as the other panels.

## Sanctions screening is real, not decorative

OFAC lists designated wallets as entity *names*, so the existing OpenSanctions index already matches them and needed no change. Verified against a listed BTC address, which returns **100/critical** with the SDN entry attached.

`sanctions.ts` gains `allEntries()` so callers can scan the list as well as look up. Existing exports untouched.

## Three things deliberately not claimed

All three produced plausible-looking but false output before being fixed:

1. **Age from a partial sample.** Chain APIs page newest-first, so a first-seen drawn from the latest 50 txs is wrong — the Satoshi genesis address reported as 0 days old and fired a "recently created" risk factor. Age is now withheld unless the sample provably covers full history.
2. **EOAs labelled as contracts.** Blockscout sets `is_contract` for addresses carrying an EIP-7702 delegation; those have no deployment tx. `vitalik.eth` was being called a smart contract.
3. **Fan-out on exchange wallets.** Spreading across many counterparties is normal operation at that scale, so the factor no longer fires above 10k transactions.

## Reliability

Brief collectors run **sequentially**, not concurrently. Fired in parallel they added six connections on top of the app's existing feed polling, which exhausted the connection pool — outbound connects then timed out with `UND_ERR_CONNECT_TIMEOUT` (including to `localhost`) and whole sections dropped out. The result is cached, so the latency costs nothing. This took `degraded` from three failures to none.

Sections degrade independently and name what failed. A degraded brief caches for 90s rather than the full 30m, so one flaky minute cannot leave the panel showing an empty day for half an hour. Every outbound call retries once on a fresh connection.

Prices are cached process-wide for 120s across all three chains; per-lookup calls were being throttled to nothing by CoinGecko's keyless tier during back-to-back scans.

## Keys

Everything above works with **no keys**. `ETHERSCAN_API_KEY` / `HELIUS_API_KEY` only deepen results and are reported via `?probe=1`; absent keys degrade the report, never break it. Solana transfer amounts and counterparties are surfaced as a stated coverage limit — the public RPC lists signatures without transfer legs, and `HELIUS_API_KEY` resolves that.

## Verification

- `npm run build`: compiles, `/api/chain/daily` and `/api/osint/crypto` registered
- `tsc --noEmit`: 16 errors, unchanged from master — all pre-existing (`WorldRemote.tsx` x14, `cctv/proxy` x1, `page.tsx` x1)
- Both tabs driven end-to-end in the browser, no console errors
- Wallet lookups verified against live data on all three chains: Satoshi genesis (57.32 BTC), vitalik.eth (ENS + 25 tokens), a Binance SOL wallet (645k SOL), and an OFAC-listed address

## Not included

No map plotting of exploit locations, and the connection-pool exhaustion above is pre-existing and affects other feeds too — both left out of scope deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)