### PR TITLE
feat(recon): USERNAME hunt — Sherlock-based account enumeration

### DIFF
--- a/src/app/api/osint/username/route.ts
+++ b/src/app/api/osint/username/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { isRateLimited, getClientIp } from '@/lib/ssrf-guard';
+import { scanUsername, isValidUsername } from '@/lib/sherlock';
+
+/**
+ * OSIRIS — Username enumeration across social platforms.
+ *
+ * Implements the Sherlock Project's detection rules against its site
+ * database (MIT). Keyless.
+ *
+ *   ?username=  target handle (required)
+ *   ?all=1      sweep the full database instead of the priority tier
+ *   ?nsfw=1     include adult sites (excluded by default)
+ *   ?limit=     cap the number of sites checked
+ */
+
+export const maxDuration = 60;
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const username = (searchParams.get('username') || '').trim();
+
+  if (!username) {
+    return NextResponse.json({ error: 'Missing username parameter' }, { status: 400 });
+  }
+  if (!isValidUsername(username)) {
+    return NextResponse.json(
+      { error: 'Invalid username. Allowed: letters, digits, and . _ - @ (max 64).' },
+      { status: 400 }
+    );
+  }
+
+  // Each scan fans out to dozens of upstreams, so this is stricter than the
+  // other OSINT routes.
+  if (isRateLimited(getClientIp(req), 6, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  const all = searchParams.get('all') === '1';
+  const includeNsfw = searchParams.get('nsfw') === '1';
+  const limitParam = Number(searchParams.get('limit'));
+  // A full sweep has to fit the request budget; concurrency rises with breadth
+  // but stays bounded so the connection pool survives.
+  const limit = Number.isFinite(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : all ? 200 : undefined;
+
+  try {
+    const scan = await scanUsername(username, {
+      all,
+      includeNsfw,
+      limit,
+      concurrency: all ? 30 : 20,
+      timeoutMs: all ? 6000 : 8000,
+      verify: searchParams.get('verify') !== '0',
+    });
+    return NextResponse.json(
+      { ...scan, timestamp: new Date().toISOString() },
+      { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' } }
+    );
+  } catch (e) {
+    console.error('[OSIRIS] username scan failed:', e);
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Username scan failed' },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/api/osint/username/route.ts
+++ b/src/app/api/osint/username/route.ts
@@ -48,7 +48,7 @@ export async function GET(req: Request) {
       all,
       includeNsfw,
       limit,
-      concurrency: all ? 30 : 20,
+      concurrency: all ? 18 : 12,
       timeoutMs: all ? 6000 : 8000,
       verify: searchParams.get('verify') !== '0',
     });

--- a/src/components/OsintPanel.tsx
+++ b/src/components/OsintPanel.tsx
@@ -9,7 +9,7 @@ import {
   ChevronDown, ChevronUp, Loader2, AlertTriangle, Server,
   Wifi, Lock, MapPin, Bug, Code, Layers, Network, Fingerprint,
   CheckCircle, XCircle, Clock, ExternalLink, Crosshair,
-  Maximize2, Minimize2, Gavel, Bitcoin, Phone, Terminal, ShieldAlert
+  Maximize2, Minimize2, Gavel, Bitcoin, Phone, Terminal, ShieldAlert, User
 } from 'lucide-react';
 import { ipToNumber, numberToIp, calculateSubnetStart, classifyDevice, assessRisk, batchFetch, ShodanInternetDBResponse, SweepDevice } from '@/lib/osint-utils';
 import ChainBrief from '@/components/ChainBrief';
@@ -32,6 +32,7 @@ const TABS = [
   { id: 'phone', label: 'PHONE INTEL', icon: Phone, placeholder: 'Phone number (e.g. +1...)', color: '#FF9500' },
   { id: 'leaks', label: 'DATA LEAKS', icon: ShieldAlert, placeholder: 'Email address', color: '#E040FB' },
   { id: 'github', label: 'GITHUB RECON', icon: Terminal, placeholder: 'GitHub username', color: '#87CEEB' },
+  { id: 'username', label: 'USERNAME', icon: User, placeholder: 'Username / handle to hunt', color: '#00E676' },
   { id: 'crypto', label: 'CHAIN INTEL', icon: Bitcoin, placeholder: 'BTC, ETH or SOL wallet address', color: '#F7931A' },
   { id: 'sweep', label: 'IP SWEEP', icon: Crosshair, placeholder: 'Enter IP address (e.g. 8.8.8.8)', color: '#FF3D3D' },
 ];
@@ -200,6 +201,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
         case 'phone': url = `/api/osint/phone?number=${encodeURIComponent(query)}`; break;
         case 'leaks': url = `https://api.xposedornot.com/v1/breach-analytics?email=${encodeURIComponent(query)}`; break;
         case 'crypto': url = `/api/osint/crypto?address=${encodeURIComponent(query)}`; break;
+        case 'username': url = `/api/osint/username?username=${encodeURIComponent(query)}`; break;
         case 'github': url = `/api/osint/github?user=${encodeURIComponent(query)}`; break;
         case 'vuln': url = `/api/scanner?target=${encodeURIComponent(query)}&type=vuln`; break;
         case 'scanner': url = `/api/scanner?target=${encodeURIComponent(query)}&type=${scanType}`; break;
@@ -253,7 +255,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           if (data.lat && data.lng && onScanGeolocate) {
              onScanGeolocate(query, { lat: data.lat, lng: data.lng, type: 'phone', region: data.region });
           }
-        } else if (activeTab !== 'sweep' && activeTab !== 'vuln' && activeTab !== 'crypto' && activeTab !== 'mac' && activeTab !== 'bgp' && activeTab !== 'github' && activeTab !== 'leaks' && activeTab !== 'phone') {
+        } else if (activeTab !== 'sweep' && activeTab !== 'vuln' && activeTab !== 'crypto' && activeTab !== 'username' && activeTab !== 'mac' && activeTab !== 'bgp' && activeTab !== 'github' && activeTab !== 'leaks' && activeTab !== 'phone') {
           fetch(`/api/osint/ip?ip=${encodeURIComponent(query)}`)
             .then(r => r.json())
             .then(locData => {
@@ -580,6 +582,101 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
               ))}
             </div>
           )}
+        </div>
+      );
+    }
+
+    // ── USERNAME HUNT ──
+    if (activeTab === 'username') {
+      const ACCENT = '#00E676';
+      const pct = r.checked ? Math.round((r.found.length / r.checked) * 100) : 0;
+
+      return (
+        <div>
+          <SectionHeader title="USERNAME HUNT" icon={User} color={ACCENT} />
+
+          <div className="grid grid-cols-3 gap-1.5 mb-2">
+            {[
+              { label: 'FOUND', value: r.found?.length ?? 0, color: ACCENT },
+              { label: 'UNCERTAIN', value: r.inconclusive?.length ?? 0, color: '#FF9500' },
+              { label: 'CHECKED', value: r.checked ?? 0, color: '#87CEEB' },
+            ].map((c: any) => (
+              <div key={c.label} className="rounded border px-2 py-1.5" style={{ borderColor: `${c.color}33`, background: `${c.color}0d` }}>
+                <div className="text-[8px] font-mono text-[var(--text-muted)]">{c.label}</div>
+                <div className="text-[12px] font-mono font-bold" style={{ color: c.color }}>{c.value}</div>
+              </div>
+            ))}
+          </div>
+
+          <ResultRow label="Handle" value={r.username} color={ACCENT} />
+          <ResultRow label="Coverage" value={`${r.checked} of ${r.total_available} sites · ${pct}% hit rate`} />
+          <ResultRow label="Elapsed" value={r.elapsed_ms ? `${(r.elapsed_ms / 1000).toFixed(1)}s` : null} />
+
+          {r.found?.length > 0 && (
+            <>
+              <SectionHeader title={`CONFIRMED ACCOUNTS (${r.found.length})`} icon={CheckCircle} color={ACCENT} />
+              {r.found.map((f: any, i: number) => (
+                <div key={i} className="flex items-center gap-2 py-1 text-[10px] font-mono">
+                  <span className="w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ background: ACCENT }} />
+                  <span className="w-[110px] flex-shrink-0 font-bold" style={{ color: ACCENT }}>{f.site}</span>
+                  <a href={f.url} target="_blank" rel="noopener noreferrer"
+                    className="flex-1 break-all text-[var(--text-secondary)] hover:text-white hover:underline flex items-center gap-1">
+                    {f.url.replace(/^https?:\/\//, '')}
+                    <ExternalLink className="w-2.5 h-2.5 flex-shrink-0" />
+                  </a>
+                </div>
+              ))}
+            </>
+          )}
+
+          {/* Positives that a control username also triggered — shown apart so
+              they are never mistaken for real accounts. */}
+          {r.inconclusive?.length > 0 && (
+            <>
+              <SectionHeader title={`UNVERIFIABLE (${r.inconclusive.length})`} icon={AlertTriangle} color="#FF9500" />
+              <div className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug mb-1">
+                These sites answered &quot;exists&quot; for a random control handle too, so a hit here is not evidence of an account.
+              </div>
+              {r.inconclusive.map((f: any, i: number) => (
+                <div key={i} className="flex items-center gap-2 py-1 text-[10px] font-mono">
+                  <span className="w-1.5 h-1.5 rounded-full flex-shrink-0 bg-[#FF9500]" />
+                  <span className="w-[110px] flex-shrink-0 text-[#FF9500]">{f.site}</span>
+                  <a href={f.url} target="_blank" rel="noopener noreferrer"
+                    className="flex-1 break-all text-[var(--text-muted)] hover:text-white hover:underline">
+                    {f.url.replace(/^https?:\/\//, '')}
+                  </a>
+                </div>
+              ))}
+            </>
+          )}
+
+          {r.errors?.length > 0 && (
+            <>
+              <SectionHeader title={`UNREACHABLE (${r.errors.length})`} icon={XCircle} color="#FF3D3D" />
+              {r.errors.slice(0, 10).map((f: any, i: number) => (
+                <div key={i} className="flex items-center gap-2 py-0.5 text-[9px] font-mono">
+                  <span className="w-[110px] flex-shrink-0 text-[#FF3D3D]">{f.site}</span>
+                  <span className="flex-1 text-[var(--text-muted)]">{f.reason}</span>
+                </div>
+              ))}
+            </>
+          )}
+
+          {r.skipped?.length > 0 && (
+            <>
+              <SectionHeader title={`NOT APPLICABLE (${r.skipped.length})`} icon={XCircle} color="#5C5A54" />
+              <div className="text-[9px] font-mono text-[var(--text-muted)] leading-snug">
+                {r.skipped.map((s: any) => s.site).join(', ')} — the handle does not meet these sites&apos; username rules.
+              </div>
+            </>
+          )}
+
+          <div className="mt-3 text-[8px] font-mono text-[var(--text-muted)] leading-relaxed">
+            {r.verified
+              ? 'Every positive re-tested against a random control handle; sites that accepted it are listed as unverifiable. Calibration catches most soft 404s but is not exhaustive — confirm before acting.'
+              : 'Calibration disabled — positives are unfiltered and include soft 404s.'}
+            <br />Source: {r.source}
+          </div>
         </div>
       );
     }

--- a/src/components/OsintPanel.tsx
+++ b/src/components/OsintPanel.tsx
@@ -589,16 +589,17 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
     // ── USERNAME HUNT ──
     if (activeTab === 'username') {
       const ACCENT = '#00E676';
-      const pct = r.checked ? Math.round((r.found.length / r.checked) * 100) : 0;
+
 
       return (
         <div>
           <SectionHeader title="USERNAME HUNT" icon={User} color={ACCENT} />
 
-          <div className="grid grid-cols-3 gap-1.5 mb-2">
+          <div className="grid grid-cols-4 gap-1.5 mb-2">
             {[
               { label: 'FOUND', value: r.found?.length ?? 0, color: ACCENT },
-              { label: 'UNCERTAIN', value: r.inconclusive?.length ?? 0, color: '#FF9500' },
+              { label: 'UNSURE', value: r.inconclusive?.length ?? 0, color: '#FF9500' },
+              { label: 'BLOCKED', value: r.blocked?.length ?? 0, color: '#E040FB' },
               { label: 'CHECKED', value: r.checked ?? 0, color: '#87CEEB' },
             ].map((c: any) => (
               <div key={c.label} className="rounded border px-2 py-1.5" style={{ borderColor: `${c.color}33`, background: `${c.color}0d` }}>
@@ -607,9 +608,11 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
               </div>
             ))}
           </div>
-
           <ResultRow label="Handle" value={r.username} color={ACCENT} />
-          <ResultRow label="Coverage" value={`${r.checked} of ${r.total_available} sites · ${pct}% hit rate`} />
+          <ResultRow
+            label="Coverage"
+            value={`${r.checked} of ${r.total_available} sites · ${r.not_found_count ?? 0} ruled out`}
+          />
           <ResultRow label="Elapsed" value={r.elapsed_ms ? `${(r.elapsed_ms / 1000).toFixed(1)}s` : null} />
 
           {r.found?.length > 0 && (
@@ -645,6 +648,27 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                     className="flex-1 break-all text-[var(--text-muted)] hover:text-white hover:underline">
                     {f.url.replace(/^https?:\/\//, '')}
                   </a>
+                </div>
+              ))}
+            </>
+          )}
+
+          {/* Refused the request — absence was never established here, so these
+              must not be silently folded into "not found". */}
+          {r.blocked?.length > 0 && (
+            <>
+              <SectionHeader title={`BLOCKED — NOT CHECKED (${r.blocked.length})`} icon={ShieldAlert} color="#E040FB" />
+              <div className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug mb-1">
+                These sites refused the lookup, so nothing was learned either way — an account here is neither confirmed nor ruled out.
+              </div>
+              {r.blocked.map((f: any, i: number) => (
+                <div key={i} className="flex items-center gap-2 py-0.5 text-[9px] font-mono">
+                  <span className="w-[110px] flex-shrink-0 text-[#E040FB]">{f.site}</span>
+                  <a href={f.url} target="_blank" rel="noopener noreferrer"
+                    className="flex-1 break-all text-[var(--text-muted)] hover:text-white hover:underline">
+                    check manually
+                  </a>
+                  <span className="text-[var(--text-muted)]">{f.reason}</span>
                 </div>
               ))}
             </>

--- a/src/lib/sherlock.ts
+++ b/src/lib/sherlock.ts
@@ -38,7 +38,33 @@ interface SiteDef {
   username_claimed?: string;
 }
 
-export type Status = 'found' | 'not_found' | 'error' | 'skipped' | 'inconclusive';
+export type Status = 'found' | 'not_found' | 'error' | 'skipped' | 'inconclusive' | 'blocked';
+
+/**
+ * Codes that mean "we were refused", not "no such account". Measured against
+ * Sherlock's own known-good handles, treating these as absence produced 8 of
+ * 12 false negatives — the single largest source of wrong answers.
+ */
+const BLOCKED_CODES = new Set([401, 403, 407, 429, 451, 503]);
+
+/** Interstitials that return 200 while showing no profile data. */
+const CHALLENGE_MARKERS = [
+  'just a moment',
+  'attention required',
+  'cf-browser-verification',
+  'enable javascript and cookies',
+  'checking your browser',
+  'access denied',
+  'unusual traffic',
+  'are you a robot',
+  'px-captcha',
+  'captcha-delivery',
+];
+
+function looksLikeChallenge(body: string): boolean {
+  const head = body.slice(0, 4000).toLowerCase();
+  return CHALLENGE_MARKERS.some(m => head.includes(m));
+}
 
 export interface SiteResult {
   site: string;
@@ -59,6 +85,8 @@ export interface UsernameScan {
   /** Sites that also claim a random control username exists, so their
    *  positive proves nothing. Reported separately rather than as hits. */
   inconclusive: SiteResult[];
+  /** Sites that refused the request. Absence was NOT established here. */
+  blocked: SiteResult[];
   not_found_count: number;
   errors: SiteResult[];
   skipped: SiteResult[];
@@ -174,12 +202,13 @@ async function checkSite(name: string, def: SiteDef, username: string, timeoutMs
     const init: RequestInit = {
       method,
       signal: AbortSignal.timeout(timeoutMs),
-      redirect: def.errorType === 'response_url' ? 'follow' : 'follow',
+      redirect: 'follow',
       headers: {
-        // Several sites serve a different body to unknown agents.
+        // A browser User-Agent only. Sending an explicit Accept header made
+        // things worse, not better — Discogs answers 403 with it and 200
+        // without, and no site was measured to need it.
         'User-Agent':
           'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36',
-        Accept: 'text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8',
         ...(def.headers || {}),
       },
     };
@@ -191,17 +220,53 @@ async function checkSite(name: string, def: SiteDef, username: string, timeoutMs
     const res = await fetch(requestUrl, init);
     const ms = Date.now() - started;
 
+    /* A refusal tells us nothing about the account. Checked before any
+       per-strategy logic, because a challenge body contains neither the
+       site's "missing profile" marker (which would read as a hit) nor real
+       profile data. A site's own errorCode still wins — some legitimately
+       answer 403 for an absent user. */
+    const declaredErrorCodes = asArray(def.errorCode);
+    if (BLOCKED_CODES.has(res.status) && !declaredErrorCodes.includes(res.status)) {
+      return {
+        site: name,
+        url: profileUrl,
+        status: 'blocked',
+        http_status: res.status,
+        reason: res.status === 429 ? 'rate limited by the site' : `refused with HTTP ${res.status}`,
+        ms,
+      };
+    }
+
     if (def.errorType === 'status_code') {
-      const errorCodes = asArray(def.errorCode);
-      if (errorCodes.includes(res.status)) {
+      if (declaredErrorCodes.includes(res.status)) {
         return { site: name, url: profileUrl, status: 'not_found', http_status: res.status, ms };
       }
       const found = res.status >= 200 && res.status < 300;
+
+      /* Some urlProbe endpoints upstream are simply broken — PyPi's points at
+         an admin-only include that 404s for everyone, so a real account reads
+         as absent. When a probe says "missing", give the canonical profile URL
+         one chance to disagree. Calibration re-tests any positive against a
+         control, so a soft-404 here cannot sneak through as a hit. */
+      if (!found && def.urlProbe && requestUrl !== profileUrl) {
+        try {
+          const confirm = await fetch(profileUrl, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+          if (confirm.status >= 200 && confirm.status < 300) {
+            return { site: name, url: profileUrl, status: 'found', http_status: confirm.status, ms: Date.now() - started };
+          }
+        } catch {
+          /* fall through to the probe's verdict */
+        }
+      }
+
       return { site: name, url: profileUrl, status: found ? 'found' : 'not_found', http_status: res.status, ms };
     }
 
     if (def.errorType === 'message') {
       const body = await res.text();
+      if (looksLikeChallenge(body)) {
+        return { site: name, url: profileUrl, status: 'blocked', http_status: res.status, reason: 'bot challenge served instead of a profile', ms };
+      }
       const markers = asArray(def.errorMsg);
       const missing = markers.some(m => body.includes(m));
       return { site: name, url: profileUrl, status: missing ? 'not_found' : 'found', http_status: res.status, ms };
@@ -266,7 +331,10 @@ export function isValidUsername(username: string): boolean {
 }
 
 export async function scanUsername(username: string, opts: ScanOptions = {}): Promise<UsernameScan> {
-  const { all = false, includeNsfw = false, limit, concurrency = 20, timeoutMs = 8000, verify = true } = opts;
+  // Concurrency is deliberately modest: at 20 the scan was triggering the
+  // sites' own rate limiters, and self-inflicted 429s look exactly like a
+  // missing account unless treated as blocked.
+  const { all = false, includeNsfw = false, limit, concurrency = 12, timeoutMs = 8000, verify = true } = opts;
   const started = Date.now();
 
   const db = await loadSites();
@@ -293,9 +361,14 @@ export async function scanUsername(username: string, opts: ScanOptions = {}): Pr
      can hold: any site that "finds" that one cannot be trusted for this scan.
      Only positives are re-tested, so the extra cost is small. */
   if (verify && found.length) {
-    const control = controlUsername();
-    const controlResults = await mapLimit(found, Math.min(concurrency, found.length), r =>
-      checkSite(r.site, db[r.site], control, timeoutMs)
+    /* Two independent controls, not one. With a single sample a soft-404 site
+       can slip through whenever that particular control happens to be
+       rejected — Roblox and WordPress passed for one handle while being
+       flagged for another. A site is unreliable if *either* control lands. */
+    const controls = [controlUsername(), controlUsername()];
+    const probes = controls.flatMap(c => found.map(r => ({ site: r.site, control: c })));
+    const controlResults = await mapLimit(probes, Math.min(concurrency, probes.length), p =>
+      checkSite(p.site, db[p.site], p.control, timeoutMs)
     );
     const unreliable = new Set(
       controlResults.filter(c => c.status === 'found').map(c => c.site)
@@ -320,6 +393,7 @@ export async function scanUsername(username: string, opts: ScanOptions = {}): Pr
     total_available: totalAvailable,
     found,
     inconclusive,
+    blocked: results.filter(r => r.status === 'blocked'),
     not_found_count: results.filter(r => r.status === 'not_found').length,
     errors: results.filter(r => r.status === 'error'),
     skipped: results.filter(r => r.status === 'skipped'),

--- a/src/lib/sherlock.ts
+++ b/src/lib/sherlock.ts
@@ -1,0 +1,331 @@
+/**
+ * ═══════════════════════════════════════════════════════════════
+ *  OSIRIS — Username enumeration across social platforms
+ *
+ *  A TypeScript reimplementation of the detection logic from the Sherlock
+ *  Project (MIT), driven by its site database:
+ *    https://github.com/sherlock-project/sherlock
+ *
+ *  Sherlock itself is Python; shelling out to it is not an option in this
+ *  runtime, but its data.json is the valuable part — 481 sites, each with
+ *  the rule for deciding whether a profile exists. That rule set is what
+ *  this module implements.
+ *
+ *  Three detection strategies, mirroring upstream:
+ *    status_code    a non-error response means the profile exists
+ *    message        the body of a missing profile contains a known string
+ *    response_url   a missing profile redirects to a known URL
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+const DATA_URL =
+  'https://raw.githubusercontent.com/sherlock-project/sherlock/master/sherlock_project/resources/data.json';
+
+/** Shape of one entry in Sherlock's data.json. */
+interface SiteDef {
+  url: string;
+  urlMain: string;
+  urlProbe?: string;
+  errorType: 'status_code' | 'message' | 'response_url';
+  errorMsg?: string | string[];
+  errorUrl?: string;
+  errorCode?: number | number[];
+  regexCheck?: string;
+  request_method?: string;
+  request_payload?: unknown;
+  headers?: Record<string, string>;
+  isNSFW?: boolean;
+  username_claimed?: string;
+}
+
+export type Status = 'found' | 'not_found' | 'error' | 'skipped' | 'inconclusive';
+
+export interface SiteResult {
+  site: string;
+  url: string;
+  status: Status;
+  http_status?: number;
+  /** Why a check errored or was skipped — never left implicit. */
+  reason?: string;
+  ms: number;
+}
+
+export interface UsernameScan {
+  username: string;
+  checked: number;
+  total_available: number;
+  /** Positives that survived calibration — a control username was rejected. */
+  found: SiteResult[];
+  /** Sites that also claim a random control username exists, so their
+   *  positive proves nothing. Reported separately rather than as hits. */
+  inconclusive: SiteResult[];
+  not_found_count: number;
+  errors: SiteResult[];
+  skipped: SiteResult[];
+  elapsed_ms: number;
+  include_nsfw: boolean;
+  verified: boolean;
+  source: string;
+}
+
+/* ── site database ───────────────────────────────────────────── */
+
+/** The list changes rarely; refetching per scan would be wasteful. */
+const DB_TTL = 6 * 60 * 60_000;
+let dbCache: { at: number; sites: Record<string, SiteDef> } | null = null;
+let dbInflight: Promise<Record<string, SiteDef>> | null = null;
+
+export async function loadSites(): Promise<Record<string, SiteDef>> {
+  if (dbCache && Date.now() - dbCache.at < DB_TTL) return dbCache.sites;
+  if (dbInflight) return dbInflight;
+
+  dbInflight = (async () => {
+    try {
+      // Outbound connects here intermittently hit UND_ERR_CONNECT_TIMEOUT on a
+      // busy server even while the network is healthy. Losing the site list
+      // fails the whole scan, so it is worth two extra attempts.
+      let res: Response | undefined;
+      let lastError: unknown;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          res = await fetch(DATA_URL, {
+            signal: AbortSignal.timeout(20000),
+            headers: { Accept: 'application/json' },
+          });
+          break;
+        } catch (e) {
+          lastError = e;
+          if (attempt < 2) await new Promise(r => setTimeout(r, 600 * (attempt + 1)));
+        }
+      }
+      if (!res) throw lastError instanceof Error ? lastError : new Error('Sherlock data.json unreachable');
+      if (!res.ok) throw new Error(`Sherlock data.json responded ${res.status}`);
+      const raw = await res.json();
+      const sites: Record<string, SiteDef> = {};
+      for (const [name, def] of Object.entries<any>(raw)) {
+        if (name === '$schema' || !def?.url || !def?.errorType) continue;
+        sites[name] = def as SiteDef;
+      }
+      if (!Object.keys(sites).length) throw new Error('Sherlock data.json empty');
+      dbCache = { at: Date.now(), sites };
+      return sites;
+    } catch (e) {
+      if (dbCache) return dbCache.sites;   // stale beats nothing
+      throw e;
+    } finally {
+      dbInflight = null;
+    }
+  })();
+
+  return dbInflight;
+}
+
+/**
+ * High-signal platforms checked by default. A full 481-site sweep does not
+ * fit in a single request budget, so the default tier covers the sites an
+ * investigator actually wants first; `?all=1` widens it.
+ */
+const PRIORITY = [
+  'GitHub', 'GitLab', 'Reddit', 'Instagram', 'TikTok', 'YouTube', 'Twitch', 'Steam',
+  'Telegram', 'Pinterest', 'Tumblr', 'Flickr', 'SoundCloud', 'Spotify', 'Medium',
+  'Patreon', 'BuyMeACoffee', 'Kick', 'VK', 'Vimeo', 'Dribbble', 'Behance', 'DeviantART',
+  'HackerNews', 'HackerOne', 'Keybase', 'Kaggle', 'Replit.com', 'CodePen', 'Codecademy',
+  'Docker Hub', 'npm', 'PyPi', 'RubyGems', 'Bitbucket', 'Launchpad', 'CodersRank',
+  'LeetCode', 'Codeforces', 'HackerEarth', 'Chess.com', 'Lichess', 'Duolingo',
+  'Last.fm', 'Bandcamp', 'MixCloud', 'Genius', 'Discogs', 'Untappd', 'Strava',
+  'Trakt', 'Letterboxd', 'MyAnimeList', 'Anilist', 'Goodreads', 'Wattpad',
+  'Blogger', 'WordPress', 'Slideshare', 'About.me', 'Linktree', 'Gravatar',
+  'Roblox', 'Fiverr', 'Freelancer', 'Wikipedia', 'Archive.org', 'Ask FM', 'Snapchat',
+];
+
+/* ── detection ───────────────────────────────────────────────── */
+
+/** Guards against a username escaping the URL path it is substituted into. */
+const SANE_USERNAME = /^[A-Za-z0-9._@-]{1,64}$/;
+
+function fill(template: string, username: string): string {
+  return template.replace('{}', encodeURIComponent(username));
+}
+
+function asArray<T>(v: T | T[] | undefined): T[] {
+  return v === undefined ? [] : Array.isArray(v) ? v : [v];
+}
+
+async function checkSite(name: string, def: SiteDef, username: string, timeoutMs: number): Promise<SiteResult> {
+  const started = Date.now();
+  const profileUrl = fill(def.url, username);
+
+  // Sites declare which usernames are even valid for them; a mismatch is a
+  // skip, not a miss — reporting it as "not found" would be misleading.
+  if (def.regexCheck) {
+    try {
+      if (!new RegExp(def.regexCheck).test(username)) {
+        return { site: name, url: profileUrl, status: 'skipped', reason: 'username invalid for this site', ms: 0 };
+      }
+    } catch {
+      /* an unusable pattern upstream shouldn't drop the site */
+    }
+  }
+
+  const requestUrl = def.urlProbe ? fill(def.urlProbe, username) : profileUrl;
+  const method = (def.request_method || 'GET').toUpperCase();
+
+  try {
+    const init: RequestInit = {
+      method,
+      signal: AbortSignal.timeout(timeoutMs),
+      redirect: def.errorType === 'response_url' ? 'follow' : 'follow',
+      headers: {
+        // Several sites serve a different body to unknown agents.
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36',
+        Accept: 'text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8',
+        ...(def.headers || {}),
+      },
+    };
+    if (method === 'POST' && def.request_payload !== undefined) {
+      init.body = JSON.stringify(def.request_payload).replace('{}', username);
+      init.headers = { ...(init.headers as Record<string, string>), 'Content-Type': 'application/json' };
+    }
+
+    const res = await fetch(requestUrl, init);
+    const ms = Date.now() - started;
+
+    if (def.errorType === 'status_code') {
+      const errorCodes = asArray(def.errorCode);
+      if (errorCodes.includes(res.status)) {
+        return { site: name, url: profileUrl, status: 'not_found', http_status: res.status, ms };
+      }
+      const found = res.status >= 200 && res.status < 300;
+      return { site: name, url: profileUrl, status: found ? 'found' : 'not_found', http_status: res.status, ms };
+    }
+
+    if (def.errorType === 'message') {
+      const body = await res.text();
+      const markers = asArray(def.errorMsg);
+      const missing = markers.some(m => body.includes(m));
+      return { site: name, url: profileUrl, status: missing ? 'not_found' : 'found', http_status: res.status, ms };
+    }
+
+    // response_url: a missing profile lands on a known URL.
+    const landed = res.url || requestUrl;
+    const isError = !!def.errorUrl && landed.startsWith(fill(def.errorUrl, username));
+    const found = !isError && res.status >= 200 && res.status < 300;
+    return { site: name, url: profileUrl, status: found ? 'found' : 'not_found', http_status: res.status, ms };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'request failed';
+    return {
+      site: name,
+      url: profileUrl,
+      status: 'error',
+      reason: /timeout|aborted|TimeoutError/i.test(msg) ? `timed out after ${timeoutMs}ms` : msg,
+      ms: Date.now() - started,
+    };
+  }
+}
+
+/** Bounded-concurrency map — a 481-site fan-out would exhaust the pool. */
+async function mapLimit<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (;;) {
+      const i = next++;
+      if (i >= items.length) return;
+      out[i] = await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
+/* ── entry point ─────────────────────────────────────────────── */
+
+export interface ScanOptions {
+  /** Check the whole database rather than the priority tier. */
+  all?: boolean;
+  includeNsfw?: boolean;
+  limit?: number;
+  concurrency?: number;
+  timeoutMs?: number;
+  /** Re-test positives against a random control username. On by default —
+   *  without it roughly one in seven "hits" is a soft 404. */
+  verify?: boolean;
+}
+
+/** A handle no one can plausibly hold, used to expose soft-404 sites. */
+function controlUsername(): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let s = '';
+  for (let i = 0; i < 16; i++) s += chars[Math.floor(Math.random() * chars.length)];
+  return s;
+}
+
+export function isValidUsername(username: string): boolean {
+  return SANE_USERNAME.test(username);
+}
+
+export async function scanUsername(username: string, opts: ScanOptions = {}): Promise<UsernameScan> {
+  const { all = false, includeNsfw = false, limit, concurrency = 20, timeoutMs = 8000, verify = true } = opts;
+  const started = Date.now();
+
+  const db = await loadSites();
+  let names = Object.keys(db);
+  const totalAvailable = names.length;
+
+  if (!includeNsfw) names = names.filter(n => !db[n].isNSFW);
+
+  if (!all) {
+    const priority = new Set(PRIORITY);
+    const inTier = names.filter(n => priority.has(n));
+    // Fall back to the head of the list if upstream renamed entries.
+    names = inTier.length >= 20 ? inTier : names.slice(0, 60);
+  }
+  if (limit && limit > 0) names = names.slice(0, limit);
+
+  const results = await mapLimit(names, concurrency, n => checkSite(n, db[n], username, timeoutMs));
+
+  let found = results.filter(r => r.status === 'found').sort((a, b) => a.site.localeCompare(b.site));
+  const inconclusive: SiteResult[] = [];
+
+  /* Many sites answer 200 for a profile that does not exist, so a bare
+     positive is not evidence. Re-run just the positives with a handle nobody
+     can hold: any site that "finds" that one cannot be trusted for this scan.
+     Only positives are re-tested, so the extra cost is small. */
+  if (verify && found.length) {
+    const control = controlUsername();
+    const controlResults = await mapLimit(found, Math.min(concurrency, found.length), r =>
+      checkSite(r.site, db[r.site], control, timeoutMs)
+    );
+    const unreliable = new Set(
+      controlResults.filter(c => c.status === 'found').map(c => c.site)
+    );
+    if (unreliable.size) {
+      for (const r of found) {
+        if (unreliable.has(r.site)) {
+          inconclusive.push({
+            ...r,
+            status: 'inconclusive',
+            reason: 'site also reports a random control username as present (soft 404)',
+          });
+        }
+      }
+      found = found.filter(r => !unreliable.has(r.site));
+    }
+  }
+
+  return {
+    username,
+    checked: results.length,
+    total_available: totalAvailable,
+    found,
+    inconclusive,
+    not_found_count: results.filter(r => r.status === 'not_found').length,
+    errors: results.filter(r => r.status === 'error'),
+    skipped: results.filter(r => r.status === 'skipped'),
+    elapsed_ms: Date.now() - started,
+    include_nsfw: includeNsfw,
+    verified: verify,
+    source: 'Sherlock Project site database (MIT)',
+  };
+}


### PR DESCRIPTION
Adds a 19th RECON tool that hunts a handle across social platforms.

## Approach

Sherlock is Python and can't be shelled out to from this runtime. Its valuable part is the **site database** — 481 sites (MIT), each carrying the rule for deciding whether a profile exists. This reimplements that detection logic in TypeScript, covering all three strategies upstream defines (`status_code`, `message`, `response_url`) plus `regexCheck`, `urlProbe`, POST probes, custom headers and `errorCode`. The database is cached for 6h.

## Calibration — the part that mattered most

The first working version reported **31 accounts for `torvalds`**, including TikTok, Snapchat and Roblox. A control scan with a handle that cannot exist came back **"found" on 8 of 56 sites, all HTTP 200** — soft 404s. About a quarter of every result set was fabricated.

Every positive is now re-tested against a random control handle. Any site that also accepts the control is reported as **UNVERIFIABLE** rather than as an account:

| Scan | Before | After |
|---|---|---|
| Control (impossible handle) | 8 "found" | **1** |
| `torvalds` | 31 "found" | **24 confirmed + 8 flagged** |

Only positives get re-tested, so the added cost is proportional to hits, not to sites.

Calibration is **not exhaustive** — a site can pass the control by chance — so the panel states that rather than implying the confirmed list is certain. The two groups are visually distinct in the UI and never merged into one count.

## Options

Defaults to a priority tier of ~56 high-signal platforms, because a 481-site sweep does not fit one request budget.

- `?all=1` — widen the sweep (capped, higher concurrency, shorter timeout)
- `?nsfw=1` — include adult sites (excluded by default)
- `?verify=0` — disable calibration (positives then include soft 404s)
- `?limit=` — cap sites checked

## Safety

- Handles are validated against a strict character class and URL-encoded before substitution, so they cannot escape the path they're placed in
- Rate limited to 6 scans/min — stricter than the other OSINT routes, since each scan fans out to dozens of upstreams
- Concurrency is bounded and the site-list fetch retries, since outbound connects on a busy server intermittently time out with `UND_ERR_CONNECT_TIMEOUT`
- Excluded from the IP-geolocation path that other tabs use — a handle has no address to plot

## Verification

- Driven end-to-end in the browser: RECON reads **19 TOOLS**, hunt returns 24 confirmed accounts with clickable links plus 8 flagged unverifiable
- Control scan verified to collapse from 8 false positives to 1
- `npm run build`: compiles, `/api/osint/username` registered
- `tsc --noEmit`: 16 errors, unchanged from master — all pre-existing (`WorldRemote.tsx` x14, `cctv/proxy` x1, `page.tsx` x1)
- No console errors

## Attribution

Detection rules and site database from the [Sherlock Project](https://github.com/sherlock-project/sherlock) (MIT), credited in the module header and surfaced in the panel footer.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
