### PR TITLE
feat(cctv): add Lithuania — 304 Via Lietuva national-road cameras

### DIFF
--- a/src/app/api/cctv/lithuania.test.ts
+++ b/src/app/api/cctv/lithuania.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { indexVkrCoords, parseLithuania, fetchLithuaniaCameras } from './lithuania';
+
+const NOW = 1786114800000; // 2026-08-07T15:00:00Z — fixed so staleness is deterministic
+
+/** One VKR layer feature, shaped as `?lks=false` returns it (WGS84, lat first). */
+function feature(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '72',
+    name: 'Vilnius A1 10,04',
+    details: true,
+    icon: '15',
+    points: [{ min: 9, max: 99, point: [54.7268, 25.2043] }],
+    ...overrides,
+  };
+}
+const layer = (...features: unknown[]) => [{ layer: 'VKR', name: 'Vaizdo kameros', features }];
+
+/** One camera-info-table entry. */
+function entry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 72,
+    name: 'Vilnius A1 10,04',
+    roadName: 'Vilnius–Kaunas–Klaipėda',
+    roadNr: 'A1',
+    date: NOW - 60_000, // one minute old
+    image: 'https://eismoinfo.lt/eismoinfo-backend/image-provider/camera/last?id=72',
+    x: 576154,
+    y: 6056867,
+    km: 10.04,
+    ...overrides,
+  };
+}
+
+describe('indexVkrCoords', () => {
+  it('indexes features by id, coercing numeric ids to strings', () => {
+    const idx = indexVkrCoords(layer(feature(), feature({ id: 8 })));
+    expect(idx.get('72')).toEqual([54.7268, 25.2043]);
+    expect(idx.get('8')).toEqual([54.7268, 25.2043]);
+  });
+
+  it('returns an empty index for malformed payloads', () => {
+    expect(indexVkrCoords(null).size).toBe(0);
+    expect(indexVkrCoords({}).size).toBe(0);
+    expect(indexVkrCoords(layer(feature({ points: [] }))).size).toBe(0);
+    expect(indexVkrCoords(layer(feature({ points: [{ point: ['a', 'b'] }] }))).size).toBe(0);
+  });
+});
+
+describe('parseLithuania', () => {
+  it('joins the layer and the table into one camera', () => {
+    expect(parseLithuania(layer(feature()), [entry()], NOW)[0]).toEqual({
+      id: 'lt-72',
+      lat: 54.7268,
+      lng: 25.2043,
+      name: 'Vilnius A1 10,04 (A1 Vilnius–Kaunas–Klaipėda)',
+      city: 'Vilnius',
+      country: 'Lithuania',
+      feed_url:
+        '/api/cctv/proxy?url=https%3A%2F%2Feismoinfo.lt%2Feismoinfo-backend%2Fimage-provider%2Fcamera%2Flast%3Fid%3D72',
+      stream_type: 'jpg',
+      external_url: 'https://eismoinfo.lt/#!/vkr/72',
+      source: 'Via Lietuva',
+    });
+  });
+
+  it('routes the feed through the proxy with the ?id= preserved', () => {
+    const [cam] = parseLithuania(layer(feature()), [entry()], NOW);
+    expect(cam.feed_url).toMatch(/^\/api\/cctv\/proxy\?url=/);
+    const inner = decodeURIComponent(cam.feed_url!.replace('/api/cctv/proxy?url=', ''));
+    expect(inner).toBe('https://eismoinfo.lt/eismoinfo-backend/image-provider/camera/last?id=72');
+  });
+
+  it('derives the city by trimming the road number and km suffix', () => {
+    const cases: Array<[string, string, string]> = [
+      ['Vilnius A1 10,04', 'A1', 'Vilnius'],
+      ['Šilagalys į Panevėžį A8 7,57', 'A8', 'Šilagalys į Panevėžį'],
+      ['Didžiulio ež. A1 19,42', 'A1', 'Didžiulio ež.'],
+      ['Pabradė 102 41,46', '102', 'Pabradė'],
+    ];
+    for (const [name, roadNr, city] of cases) {
+      const cams = parseLithuania(layer(feature({ name })), [entry({ name, roadNr })], NOW);
+      expect(cams[0].city).toBe(city);
+    }
+  });
+
+  it('falls back to Lithuania when no place can be recovered', () => {
+    const cams = parseLithuania(layer(feature()), [entry({ name: 'A1', roadNr: 'A1' })], NOW);
+    expect(cams[0].city).toBe('Lithuania');
+  });
+
+  it('drops table entries with no matching coordinates in the layer', () => {
+    expect(parseLithuania(layer(feature({ id: '999' })), [entry()], NOW)).toEqual([]);
+    expect(parseLithuania([], [entry()], NOW)).toEqual([]);
+  });
+
+  it('drops frames older than six hours, and entries with no timestamp', () => {
+    const stale = entry({ date: NOW - 7 * 60 * 60 * 1000 });
+    const fresh = entry({ date: NOW - 5 * 60 * 60 * 1000 });
+    expect(parseLithuania(layer(feature()), [stale], NOW)).toEqual([]);
+    expect(parseLithuania(layer(feature()), [fresh], NOW)).toHaveLength(1);
+    expect(parseLithuania(layer(feature()), [entry({ date: undefined })], NOW)).toEqual([]);
+  });
+
+  it('drops coordinates outside the Lithuanian bounding box', () => {
+    // London — well outside Lithuania
+    const bad = layer(feature({ points: [{ point: [51.5072, -0.1276] }] }));
+    expect(parseLithuania(bad, [entry()], NOW)).toEqual([]);
+  });
+
+  it('de-duplicates repeated ids', () => {
+    expect(parseLithuania(layer(feature()), [entry(), entry()], NOW)).toHaveLength(1);
+  });
+
+  it('returns an empty list for malformed payloads', () => {
+    expect(parseLithuania(layer(feature()), null, NOW)).toEqual([]);
+    expect(parseLithuania(null, [entry()], NOW)).toEqual([]);
+  });
+});
+
+// Live integration test — opt in with RUN_LIVE_TESTS=1 (hits the real eismoinfo endpoints).
+const liveIt = process.env.RUN_LIVE_TESTS === '1' ? it : it.skip;
+
+describe('fetchLithuaniaCameras (live)', () => {
+  liveIt('fetches well-formed Lithuanian cameras', async () => {
+    const cams = await fetchLithuaniaCameras();
+    expect(cams.length).toBeGreaterThan(200);
+    expect(new Set(cams.map((c) => c.id)).size).toBe(cams.length);
+
+    for (const cam of cams) {
+      expect(cam.country).toBe('Lithuania');
+      expect(cam.source).toBe('Via Lietuva');
+      expect(cam.stream_type).toBe('jpg');
+      expect(cam.feed_url).toMatch(
+        /^\/api\/cctv\/proxy\?url=https%3A%2F%2Feismoinfo\.lt%2F[\w%.-]+%3Fid%3D\d+$/,
+      );
+      expect(cam.lat).toBeGreaterThan(53.8);
+      expect(cam.lat).toBeLessThan(56.5);
+      expect(cam.lng).toBeGreaterThan(20.9);
+      expect(cam.lng).toBeLessThan(26.9);
+    }
+  });
+});

--- a/src/app/api/cctv/lithuania.ts
+++ b/src/app/api/cctv/lithuania.ts
@@ -1,0 +1,165 @@
+import type { CctvCamera } from './types';
+import { stealthFetch } from '@/lib/stealthFetch';
+import { cachedSource } from '@/lib/sourceCache';
+
+/**
+ * OSIRIS — Lithuania CCTV Cameras (Via Lietuva / eismoinfo.lt)
+ * Sources: https://eismoinfo.lt/eismoinfo-backend/layer-static-features/VKR?lks=false
+ *          https://eismoinfo.lt/eismoinfo-backend/camera-info-table
+ * ~300 national-road cameras — NO API KEY NEEDED.
+ *
+ * Neither endpoint is sufficient alone, so the two are joined on camera id:
+ *   • VKR layer      — coordinates, but no road metadata and no frame timestamp.
+ *   • camera-info-table — road/km metadata and a `date` for the newest frame,
+ *                      but coordinates only in LKS-94 grid (EPSG:3346).
+ *
+ * `?lks=false` is what makes this cheap: it flips the VKR layer from LKS-94 to
+ * WGS84, so no reprojection is needed. Dropping it silently yields grid metres.
+ *
+ * The table is the driver, not the layer: the layer carries ~13 ids that are no
+ * longer served (their image endpoint 500s), and the table is exactly the live
+ * subset. Frames older than MAX_FRAME_AGE_MS are dropped on top of that, so a
+ * camera that has quietly frozen doesn't get presented as a live feed.
+ *
+ * Attribution: eismoinfo.lt's terms permit reuse provided "Via Lietuva" or
+ * eismoinfo.lt is named as the source — hence `source: 'Via Lietuva'`.
+ */
+
+const FEATURES_URL = 'https://eismoinfo.lt/eismoinfo-backend/layer-static-features/VKR?lks=false';
+const TABLE_URL = 'https://eismoinfo.lt/eismoinfo-backend/camera-info-table';
+const IMAGE_BASE = 'https://eismoinfo.lt/eismoinfo-backend/image-provider/camera/last';
+const VIEW_BASE = 'https://eismoinfo.lt/#!/vkr';
+
+/** Lithuania bounding box, padded slightly past the border. */
+const LT_BOUNDS = { minLat: 53.8, maxLat: 56.5, minLng: 20.9, maxLng: 26.9 };
+
+/** Cameras refresh every ~10 min; anything this stale has stopped publishing. */
+const MAX_FRAME_AGE_MS = 6 * 60 * 60 * 1000;
+
+interface VkrPoint {
+  point?: [number, number];
+}
+interface VkrFeature {
+  id?: string | number;
+  name?: string;
+  points?: VkrPoint[];
+}
+interface VkrLayer {
+  layer?: string;
+  features?: VkrFeature[];
+}
+interface TableEntry {
+  id?: string | number;
+  name?: string;
+  roadName?: string;
+  roadNr?: string;
+  date?: number;
+  km?: number;
+}
+
+/**
+ * Camera names read "<place> <roadNr> <km>" ("Šilagalys į Panevėžį A8 7,57").
+ * Trim from the road number back to recover the place on its own.
+ */
+function placeFrom(name: string, roadNr: string): string {
+  const cut = roadNr ? name.lastIndexOf(roadNr) : -1;
+  const head = cut >= 0 ? name.slice(0, cut) : name.replace(/\s+[A-Za-z]*\d[\d,.]*\s*$/, '');
+  return head.trim().replace(/[\s,–-]+$/, '') || 'Lithuania';
+}
+
+/** Index the VKR layer by camera id → [lat, lng]. Exported for tests. */
+export function indexVkrCoords(features: unknown): Map<string, [number, number]> {
+  const coords = new Map<string, [number, number]>();
+  if (!Array.isArray(features)) return coords;
+
+  for (const layer of features as VkrLayer[]) {
+    for (const feature of layer?.features ?? []) {
+      const id = feature?.id != null ? String(feature.id) : '';
+      const point = feature?.points?.[0]?.point;
+      if (!id || !Array.isArray(point)) continue;
+
+      const [lat, lng] = point;
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+      coords.set(id, [lat, lng]);
+    }
+  }
+
+  return coords;
+}
+
+/** Join the VKR layer and the camera table into cameras. Exported for tests. */
+export function parseLithuania(
+  features: unknown,
+  table: unknown,
+  now: number = Date.now(),
+): CctvCamera[] {
+  if (!Array.isArray(table)) return [];
+
+  const coords = indexVkrCoords(features);
+  const cams: CctvCamera[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of table as TableEntry[]) {
+    const id = entry?.id != null ? String(entry.id) : '';
+    if (!id || seen.has(id)) continue;
+
+    const point = coords.get(id);
+    if (!point) continue; // no coordinates in the VKR layer — unplottable
+
+    const [lat, lng] = point;
+    if (lat < LT_BOUNDS.minLat || lat > LT_BOUNDS.maxLat) continue;
+    if (lng < LT_BOUNDS.minLng || lng > LT_BOUNDS.maxLng) continue;
+
+    // A missing timestamp is treated as stale — better absent than frozen.
+    const date = typeof entry.date === 'number' ? entry.date : 0;
+    if (now - date > MAX_FRAME_AGE_MS) continue;
+
+    seen.add(id);
+
+    const name = (entry.name ?? '').trim() || `Via Lietuva Camera ${id}`;
+    const roadNr = (entry.roadNr ?? '').trim();
+    const roadName = (entry.roadName ?? '').trim();
+
+    cams.push({
+      id: `lt-${id}`,
+      lat,
+      lng,
+      name: roadName && roadNr ? `${name} (${roadNr} ${roadName})` : name,
+      city: placeFrom(name, roadNr),
+      country: 'Lithuania',
+      // Proxied: eismoinfo 403s any request carrying a foreign Referer, which
+      // every browser <img> sends. The proxy re-issues it with an on-site
+      // Referer. Built from the id rather than echoed from upstream, since the
+      // URL reaches the client and the `?id=` must survive intact
+      // (normalizeFeedUrl would strip it, breaking every frame).
+      feed_url: `/api/cctv/proxy?url=${encodeURIComponent(`${IMAGE_BASE}?id=${id}`)}`,
+      stream_type: 'jpg',
+      external_url: `${VIEW_BASE}/${encodeURIComponent(id)}`,
+      source: 'Via Lietuva',
+    });
+  }
+
+  return cams;
+}
+
+async function getJson(url: string, label: string): Promise<unknown> {
+  const res = await stealthFetch(url, {
+    signal: AbortSignal.timeout(15000),
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) throw new Error(`${label} HTTP ${res.status}`);
+  return res.json();
+}
+
+async function loadLithuaniaCameras(): Promise<CctvCamera[]> {
+  const [features, table] = await Promise.all([
+    getJson(FEATURES_URL, 'eismoinfo VKR'),
+    getJson(TABLE_URL, 'eismoinfo camera-info-table'),
+  ]);
+
+  const cams = parseLithuania(features, table);
+  console.log(`[OSIRIS] Lithuania cameras — Via Lietuva: ${cams.length}`);
+  return cams;
+}
+
+export const fetchLithuaniaCameras = cachedSource('lithuania', loadLithuaniaCameras);

--- a/src/app/api/cctv/proxy/route.ts
+++ b/src/app/api/cctv/proxy/route.ts
@@ -16,6 +16,7 @@ const ALLOWED_HOSTS = [
   's3-eu-west-1.amazonaws.com',
   'voyage.aprr.fr',
   'thb.gov.tw',
+  'eismoinfo.lt',
 ];
 
 // THB servers send non-standard HTTP headers that Node's strict parser rejects.

--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -26,6 +26,7 @@ import { fetchIcelandCameras } from './iceland';
 import { fetchTaiwanCameras } from './taiwan';
 import { fetchAsiaLiveCameras } from './asia-live';
 import { fetchNewZealandCameras } from './newzealand';
+import { fetchLithuaniaCameras } from './lithuania';
 import { fetchOregonCameras } from './oregon';
 import { fetchMichiganCameras } from './michigan';
 import {
@@ -452,6 +453,7 @@ const REGION_FETCHERS: Record<string, () => Promise<any[]>> = {
   'taiwan': fetchTaiwanCameras,
   'asia-live': fetchAsiaLiveCameras,
   'newzealand': fetchNewZealandCameras,
+  'lithuania': fetchLithuaniaCameras,
   'oregon': fetchOregonCameras,
   'michigan': fetchMichiganCameras,
   'latam-live': fetchLatamLiveCameras,
@@ -493,9 +495,10 @@ function getRegionsForBounds(lat: number, lng: number, radius: number): string[]
   const inSpain = lat > 27 && lat < 43.8 && lng > -18.2 && lng < 4.4;
   const inPoland = lat > 49.0 && lat < 55.0 && lng > 14.1 && lng < 24.1;
   const inFinland = lat > 59.5 && lat < 70.1 && lng > 20 && lng < 31.6;
+  const inLithuania = lat > 53.8 && lat < 56.5 && lng > 20.9 && lng < 26.9;
   const inIceland = lat > 63.0 && lat < 67.0 && lng > -25.0 && lng < -13.0;
   const inBalkans = inBulgaria || inGreece || inSerbia || inMacedonia || inRomania || inTurkey;
-  const inWesternEurope = inItaly || inCzechia || inSlovakia || inGermany || inFrance || inSpain || inPoland || inFinland || inIceland;
+  const inWesternEurope = inItaly || inCzechia || inSlovakia || inGermany || inFrance || inSpain || inPoland || inFinland || inIceland || inLithuania;
 
   if (lat > 35 && lat < 72 && lng > -11 && lng < 40 && !inBalkans && !inWesternEurope) {
     regions.push('europe');
@@ -515,6 +518,7 @@ function getRegionsForBounds(lat: number, lng: number, radius: number): string[]
   if (inPoland) regions.push('poland');
   if (inFinland) regions.push('finland');
   if (inIceland) regions.push('iceland');
+  if (inLithuania) regions.push('lithuania');
 
   // Middle East
   const inMiddleEast = lat > 29 && lat < 34.5 && lng > 34 && lng < 36.5;


### PR DESCRIPTION
Adds Lithuanian cctv: ~304 national-road cameras from Via Lietuva (eismoinfo.lt).

The source needs two endpoints joined on camera id — one has coordinates, the other has road metadata and a frame timestamp. Note `?lks=false` on the layer URL: without it you get LKS-94 grid metres instead of WGS84.

Only cameras present in the live table are included, and frames older than 6 hours are dropped, so stalled cameras don't show up as live feeds.

Feeds route through `/api/cctv/proxy` — eismoinfo returns 403 for requests with a foreign Referer. Added `eismoinfo.lt` to `ALLOWED_HOSTS`.

Licence: [eismoinfo's terms](https://eismoinfo.lt/#!/termsofuse) allow reuse as long as Via Lietuva or eismoinfo.lt is credited as the source ("...tik nurodant „Via Lietuva" įmonę arba interneto svetainę eismoinfo.lt kaip informacijos šaltinį"), which `source: 'Via Lietuva'` covers.