### PR TITLE
feat(route): rebuild the directions tool — better search, live tracking, multi-stop, alternatives, elevation

### DIFF
--- a/src/app/api/directions/route.test.ts
+++ b/src/app/api/directions/route.test.ts
@@ -4,6 +4,7 @@ import {
   valhallaManeuverKind,
   normalizeValhalla,
   normalizeValhallaAll,
+  buildCostingOptions,
   osrmInstruction,
   normalizeOsrm,
   type ValhallaResponse,
@@ -176,5 +177,20 @@ describe('normalizeValhallaAll', () => {
 
   it('returns nothing when there is no usable trip', () => {
     expect(normalizeValhallaAll({}, 'auto')).toEqual([]);
+  });
+});
+
+describe('buildCostingOptions', () => {
+  it('turns avoid flags into the engine 0..1 preferences', () => {
+    expect(buildCostingOptions('auto', { tolls: true, highways: true }))
+      .toEqual({ auto: { use_tolls: 0, use_highways: 0 } });
+  });
+
+  it('keys the options by the travel mode', () => {
+    expect(buildCostingOptions('bicycle', { ferries: true })).toEqual({ bicycle: { use_ferry: 0 } });
+  });
+
+  it('sends nothing when nothing is avoided', () => {
+    expect(buildCostingOptions('auto', {})).toEqual({});
   });
 });

--- a/src/app/api/directions/route.test.ts
+++ b/src/app/api/directions/route.test.ts
@@ -3,6 +3,7 @@ import {
   decodePolyline,
   valhallaManeuverKind,
   normalizeValhalla,
+  normalizeValhallaAll,
   osrmInstruction,
   normalizeOsrm,
   type ValhallaResponse,
@@ -155,5 +156,25 @@ describe('normalizeOsrm', () => {
   it('returns null without geometry', () => {
     expect(normalizeOsrm({}, 'auto')).toBeNull();
     expect(normalizeOsrm({ routes: [{ geometry: { coordinates: [] } }] }, 'auto')).toBeNull();
+  });
+});
+
+describe('normalizeValhallaAll', () => {
+  it('returns the primary route followed by each alternate', () => {
+    const withAlts = {
+      ...valhallaTrip,
+      alternates: [{ trip: valhallaTrip.trip }, { trip: valhallaTrip.trip }],
+    };
+    const all = normalizeValhallaAll(withAlts, 'auto');
+    expect(all).toHaveLength(3);
+    expect(all[0].steps).toHaveLength(3);
+  });
+
+  it('returns just the primary when the engine offers no alternative', () => {
+    expect(normalizeValhallaAll(valhallaTrip, 'auto')).toHaveLength(1);
+  });
+
+  it('returns nothing when there is no usable trip', () => {
+    expect(normalizeValhallaAll({}, 'auto')).toEqual([]);
   });
 });

--- a/src/app/api/directions/route.ts
+++ b/src/app/api/directions/route.ts
@@ -34,8 +34,14 @@ interface ValhallaLeg {
   shape?: string;
   maneuvers?: ValhallaManeuver[];
 }
+interface ValhallaTrip {
+  legs?: ValhallaLeg[];
+  summary?: { length?: number; time?: number };
+}
 export interface ValhallaResponse {
-  trip?: { legs?: ValhallaLeg[]; summary?: { length?: number; time?: number } };
+  trip?: ValhallaTrip;
+  /** Populated when `alternates` is requested and the network offers a choice. */
+  alternates?: Array<{ trip?: ValhallaTrip }>;
 }
 
 export interface OsrmStep {
@@ -120,7 +126,22 @@ export function valhallaManeuverKind(type: number): string {
 }
 
 export function normalizeValhalla(json: ValhallaResponse, mode: TravelMode): DirectionsResult | null {
-  const trip = json?.trip;
+  return normalizeValhallaTrip(json?.trip, mode);
+}
+
+/** Primary route plus any alternates the engine offered, best first. */
+export function normalizeValhallaAll(json: ValhallaResponse, mode: TravelMode): DirectionsResult[] {
+  const out: DirectionsResult[] = [];
+  const primary = normalizeValhallaTrip(json?.trip, mode);
+  if (primary) out.push(primary);
+  for (const alt of json?.alternates || []) {
+    const r = normalizeValhallaTrip(alt?.trip, mode);
+    if (r) out.push(r);
+  }
+  return out;
+}
+
+function normalizeValhallaTrip(trip: ValhallaTrip | undefined, mode: TravelMode): DirectionsResult | null {
   if (!trip || !Array.isArray(trip.legs) || trip.legs.length === 0) return null;
 
   const coordinates: [number, number][] = [];
@@ -231,29 +252,33 @@ async function tryValhalla(
   from: { lat: number; lng: number },
   to: { lat: number; lng: number },
   mode: TravelMode,
-): Promise<DirectionsResult | null> {
+): Promise<DirectionsResult[]> {
   const body = {
     locations: [
       { lat: from.lat, lon: from.lng },
       { lat: to.lat, lon: to.lng },
     ],
     costing: mode,
+    // Give the operator a choice the way a consumer mapping app does; the
+    // engine only returns these when the network genuinely offers one.
+    alternates: 2,
     directions_options: { units: 'kilometers' },
   };
   const url = `${VALHALLA}?json=${encodeURIComponent(JSON.stringify(body))}`;
-  return normalizeValhalla(await httpJson<ValhallaResponse>(url), mode);
+  return normalizeValhallaAll(await httpJson<ValhallaResponse>(url), mode);
 }
 
 async function tryOsrm(
   from: { lat: number; lng: number },
   to: { lat: number; lng: number },
   mode: TravelMode,
-): Promise<DirectionsResult | null> {
+): Promise<DirectionsResult[]> {
   // The public OSRM demo only carries the driving profile.
   const url =
     `${OSRM}/driving/${from.lng},${from.lat};${to.lng},${to.lat}` +
     `?steps=true&overview=full&geometries=geojson`;
-  return normalizeOsrm(await httpJson<OsrmResponse>(url), mode);
+  const r = normalizeOsrm(await httpJson<OsrmResponse>(url), mode);
+  return r ? [r] : [];
 }
 
 export async function GET(request: Request) {
@@ -274,34 +299,36 @@ export async function GET(request: Request) {
     // The public Valhalla demo intermittently refuses bursts, so give it one
     // retry before falling back — otherwise walking/cycling (which OSRM's demo
     // cannot serve) would fail on an entirely recoverable blip.
-    let result: DirectionsResult | null = null;
-    for (let attempt = 0; attempt < 2 && !result; attempt++) {
+    let routes: DirectionsResult[] = [];
+    for (let attempt = 0; attempt < 2 && routes.length === 0; attempt++) {
       if (attempt > 0) await new Promise((r) => setTimeout(r, 400));
       try {
-        result = await tryValhalla(from, to, mode);
+        routes = await tryValhalla(from, to, mode);
       } catch {
-        result = null;
+        routes = [];
       }
     }
 
     // OSRM has no walking/cycling profile on the demo server, so only fall back
     // for driving — a car route served for a walking request would be wrong.
-    if (!result && mode === 'auto') {
+    if (routes.length === 0 && mode === 'auto') {
       try {
-        result = await tryOsrm(from, to, mode);
+        routes = await tryOsrm(from, to, mode);
       } catch {
-        result = null;
+        routes = [];
       }
     }
 
-    if (!result) {
+    if (routes.length === 0) {
       return NextResponse.json(
         { error: 'No route found between those points' },
         { status: 502 },
       );
     }
 
-    return NextResponse.json(result, {
+    // `routes` is the full set, best first; the top-level fields mirror routes[0]
+    // so anything reading a single route still works.
+    return NextResponse.json({ ...routes[0], routes }, {
       headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
     });
   } catch (error) {

--- a/src/app/api/directions/route.ts
+++ b/src/app/api/directions/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { httpJson } from '@/lib/httpJson';
+import { httpJson, optional } from '@/lib/httpJson';
 
 export const maxDuration = 30;
 
@@ -17,7 +17,8 @@ export const maxDuration = 30;
  * normalised to the same shape so the client never branches on provider.
  */
 
-const VALHALLA = 'https://valhalla1.openstreetmap.de/route';
+const VALHALLA_BASE = 'https://valhalla1.openstreetmap.de';
+const VALHALLA = `${VALHALLA_BASE}/route`;
 const OSRM = 'https://router.project-osrm.org/route/v1';
 
 export type TravelMode = 'auto' | 'bicycle' | 'pedestrian';
@@ -36,7 +37,13 @@ interface ValhallaLeg {
 }
 interface ValhallaTrip {
   legs?: ValhallaLeg[];
-  summary?: { length?: number; time?: number };
+  summary?: {
+    length?: number;
+    time?: number;
+    has_highway?: boolean;
+    has_toll?: boolean;
+    has_ferry?: boolean;
+  };
 }
 export interface ValhallaResponse {
   trip?: ValhallaTrip;
@@ -67,6 +74,13 @@ export interface DirectionStep {
   type: string;
 }
 
+export interface ElevationPoint {
+  /** Metres travelled from the start of the route. */
+  distance: number;
+  /** Metres above sea level. */
+  height: number;
+}
+
 export interface DirectionsResult {
   provider: 'valhalla' | 'osrm';
   mode: TravelMode;
@@ -74,6 +88,21 @@ export interface DirectionsResult {
   duration: number;
   geometry: { type: 'LineString'; coordinates: [number, number][] };
   steps: DirectionStep[];
+  /** True when the engine reports the route uses a motorway / toll road. */
+  hasHighway?: boolean;
+  hasToll?: boolean;
+  hasFerry?: boolean;
+  /** Terrain profile — only requested for walking and cycling. */
+  elevation?: ElevationPoint[];
+  ascent?: number;
+  descent?: number;
+}
+
+/** What the operator asked the router to keep off the route. */
+export interface AvoidOptions {
+  tolls?: boolean;
+  highways?: boolean;
+  ferries?: boolean;
 }
 
 /**
@@ -173,6 +202,9 @@ function normalizeValhallaTrip(trip: ValhallaTrip | undefined, mode: TravelMode)
     duration: trip.summary?.time || 0,
     geometry: { type: 'LineString', coordinates },
     steps,
+    hasHighway: trip.summary?.has_highway,
+    hasToll: trip.summary?.has_toll,
+    hasFerry: trip.summary?.has_ferry,
   };
 }
 
@@ -248,17 +280,29 @@ function parsePoint(raw: string | null): { lat: number; lng: number } | null {
   return { lat: a, lng: b };
 }
 
+/**
+ * Valhalla expresses avoidance as a 0..1 preference rather than a hard ban, so
+ * 0 means "only if there is no other way" — which is the behaviour a user
+ * expects from an "avoid tolls" switch.
+ */
+export function buildCostingOptions(mode: TravelMode, avoid: AvoidOptions): Record<string, unknown> {
+  const o: Record<string, number> = {};
+  if (avoid.tolls) o.use_tolls = 0;
+  if (avoid.highways) o.use_highways = 0;
+  if (avoid.ferries) o.use_ferry = 0;
+  return Object.keys(o).length ? { [mode]: o } : {};
+}
+
 async function tryValhalla(
-  from: { lat: number; lng: number },
-  to: { lat: number; lng: number },
+  points: Array<{ lat: number; lng: number }>,
   mode: TravelMode,
+  avoid: AvoidOptions,
 ): Promise<DirectionsResult[]> {
+  const costingOptions = buildCostingOptions(mode, avoid);
   const body = {
-    locations: [
-      { lat: from.lat, lon: from.lng },
-      { lat: to.lat, lon: to.lng },
-    ],
+    locations: points.map((p) => ({ lat: p.lat, lon: p.lng })),
     costing: mode,
+    ...(Object.keys(costingOptions).length ? { costing_options: costingOptions } : {}),
     // Give the operator a choice the way a consumer mapping app does; the
     // engine only returns these when the network genuinely offers one.
     alternates: 2,
@@ -269,16 +313,55 @@ async function tryValhalla(
 }
 
 async function tryOsrm(
-  from: { lat: number; lng: number },
-  to: { lat: number; lng: number },
+  points: Array<{ lat: number; lng: number }>,
   mode: TravelMode,
 ): Promise<DirectionsResult[]> {
   // The public OSRM demo only carries the driving profile.
-  const url =
-    `${OSRM}/driving/${from.lng},${from.lat};${to.lng},${to.lat}` +
-    `?steps=true&overview=full&geometries=geojson`;
+  const coords = points.map((p) => `${p.lng},${p.lat}`).join(';');
+  const url = `${OSRM}/driving/${coords}?steps=true&overview=full&geometries=geojson`;
   const r = normalizeOsrm(await httpJson<OsrmResponse>(url), mode);
   return r ? [r] : [];
+}
+
+/**
+ * Terrain profile for a route, sampled along its shape.
+ *
+ * Only worth asking for on foot or by bike, where the climb is the thing that
+ * decides whether a route is actually viable — and it costs an extra upstream
+ * call, so driving skips it.
+ */
+async function fetchElevation(
+  coords: [number, number][],
+): Promise<{ elevation: ElevationPoint[]; ascent: number; descent: number } | null> {
+  // Valhalla caps the shape it will accept; ~120 samples describes the terrain
+  // without a huge request.
+  const MAX = 120;
+  const stride = Math.max(1, Math.ceil(coords.length / MAX));
+  const shape = coords.filter((_, i) => i % stride === 0).map(([lon, lat]) => ({ lat, lon }));
+  if (shape.length < 2) return null;
+
+  const url = `${VALHALLA_BASE}/height?json=${encodeURIComponent(JSON.stringify({ range: true, shape }))}`;
+  const json = await httpJson<{ range_height?: [number, number][] }>(url, { timeoutMs: 10000 });
+  const pairs = json?.range_height;
+  if (!Array.isArray(pairs) || pairs.length < 2) return null;
+
+  const elevation: ElevationPoint[] = [];
+  let ascent = 0;
+  let descent = 0;
+  let prev: number | null = null;
+  for (const [distance, height] of pairs) {
+    if (!Number.isFinite(distance) || !Number.isFinite(height)) continue;
+    elevation.push({ distance, height });
+    if (prev !== null) {
+      const d = height - prev;
+      // Ignore sub-metre wobble so SRTM noise doesn't inflate the totals.
+      if (d > 1) ascent += d;
+      else if (d < -1) descent += -d;
+    }
+    prev = height;
+  }
+  if (elevation.length < 2) return null;
+  return { elevation, ascent: Math.round(ascent), descent: Math.round(descent) };
 }
 
 export async function GET(request: Request) {
@@ -296,6 +379,21 @@ export async function GET(request: Request) {
       );
     }
 
+    // Intermediate stops, in order: ?via=lat,lng|lat,lng
+    const via = (searchParams.get('via') || '')
+      .split('|')
+      .map((s) => parsePoint(s))
+      .filter((p): p is { lat: number; lng: number } => p !== null);
+
+    const avoidParam = (searchParams.get('avoid') || '').split(',').map((s) => s.trim());
+    const avoid: AvoidOptions = {
+      tolls: avoidParam.includes('tolls'),
+      highways: avoidParam.includes('highways'),
+      ferries: avoidParam.includes('ferries'),
+    };
+
+    const points = [from, ...via, to];
+
     // The public Valhalla demo intermittently refuses bursts, so give it one
     // retry before falling back — otherwise walking/cycling (which OSRM's demo
     // cannot serve) would fail on an entirely recoverable blip.
@@ -303,7 +401,7 @@ export async function GET(request: Request) {
     for (let attempt = 0; attempt < 2 && routes.length === 0; attempt++) {
       if (attempt > 0) await new Promise((r) => setTimeout(r, 400));
       try {
-        routes = await tryValhalla(from, to, mode);
+        routes = await tryValhalla(points, mode, avoid);
       } catch {
         routes = [];
       }
@@ -313,7 +411,7 @@ export async function GET(request: Request) {
     // for driving — a car route served for a walking request would be wrong.
     if (routes.length === 0 && mode === 'auto') {
       try {
-        routes = await tryOsrm(from, to, mode);
+        routes = await tryOsrm(points, mode);
       } catch {
         routes = [];
       }
@@ -324,6 +422,12 @@ export async function GET(request: Request) {
         { error: 'No route found between those points' },
         { status: 502 },
       );
+    }
+
+    // Terrain matters on foot and by bike; skip the extra call when driving.
+    if (mode !== 'auto') {
+      const profile = await optional(fetchElevation(routes[0].geometry.coordinates));
+      if (profile) Object.assign(routes[0], profile);
     }
 
     // `routes` is the full set, best first; the top-level fields mirror routes[0]

--- a/src/app/api/geosearch/route.test.ts
+++ b/src/app/api/geosearch/route.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { classifyKind, normalizePhoton, normalizeNominatim, mergeResults, type GeoResult } from './route';
+
+describe('classifyKind', () => {
+  it('separates the kinds the UI gives distinct icons', () => {
+    expect(classifyKind('place', 'country')).toBe('country');
+    expect(classifyKind('place', 'state')).toBe('region');
+    expect(classifyKind('place', 'city')).toBe('city');
+    expect(classifyKind('highway', 'residential')).toBe('street');
+    expect(classifyKind('building', 'yes')).toBe('address');
+    expect(classifyKind('tourism', 'attraction')).toBe('poi');
+    expect(classifyKind('man_made', 'tower')).toBe('poi');
+  });
+
+  it('falls back to a generic place', () => {
+    expect(classifyKind(undefined, undefined)).toBe('place');
+    expect(classifyKind('something_odd', 'x')).toBe('place');
+  });
+});
+
+describe('normalizePhoton', () => {
+  const eiffel = {
+    geometry: { coordinates: [2.2945, 48.8584] as [number, number] },
+    properties: {
+      name: 'Eiffel Tower', street: 'Avenue Anatole France', housenumber: '5',
+      city: 'Paris', state: 'Île-de-France', country: 'France',
+      osm_key: 'man_made', osm_value: 'tower',
+    },
+  };
+
+  it('maps a POI, putting the street into the context line', () => {
+    expect(normalizePhoton(eiffel)).toEqual({
+      name: 'Eiffel Tower',
+      context: 'Avenue Anatole France 5, Paris, Île-de-France',
+      lat: 48.8584,
+      lng: 2.2945,
+      kind: 'poi',
+      source: 'photon',
+    });
+  });
+
+  it('uses the street as the name when a feature has none', () => {
+    const addr = {
+      geometry: { coordinates: [13.3777, 52.5163] as [number, number] },
+      properties: { street: 'Pariser Platz', housenumber: '1', city: 'Berlin', osm_key: 'building' },
+    };
+    expect(normalizePhoton(addr)?.name).toBe('Pariser Platz 1');
+  });
+
+  it('rejects features without usable geometry', () => {
+    expect(normalizePhoton({ properties: { name: 'X' } })).toBeNull();
+    expect(normalizePhoton({ geometry: { coordinates: [2.29] as unknown as [number, number] }, properties: {} })).toBeNull();
+  });
+});
+
+describe('normalizeNominatim', () => {
+  it('splits display_name into a name and a context line', () => {
+    const r = normalizeNominatim({
+      display_name: 'Brandenburger Tor, 1, Pariser Platz, Mitte, Berlin, Germany',
+      lat: '52.5163', lon: '13.3777', class: 'tourism', type: 'attraction',
+    })!;
+    expect(r.name).toBe('Brandenburger Tor');
+    expect(r.context).toBe('1, Pariser Platz, Mitte');
+    expect(r.kind).toBe('poi');
+    expect(r.source).toBe('nominatim');
+  });
+
+  it('rejects rows without coordinates', () => {
+    expect(normalizeNominatim({ display_name: 'X' })).toBeNull();
+  });
+});
+
+describe('mergeResults', () => {
+  const hit = (name: string, lat: number, lng: number, source: 'photon' | 'nominatim' = 'photon'): GeoResult =>
+    ({ name, context: '', lat, lng, kind: 'poi', source });
+
+  it('keeps the primary provider first', () => {
+    const merged = mergeResults([hit('A', 1, 1)], [hit('B', 2, 2, 'nominatim')]);
+    expect(merged.map((r) => r.name)).toEqual(['A', 'B']);
+  });
+
+  it('drops a duplicate that both providers returned', () => {
+    // same name, ~50 m apart — one place, two indexes
+    const merged = mergeResults([hit('Eiffel Tower', 48.8584, 2.2945)],
+      [hit('eiffel tower', 48.85845, 2.29455, 'nominatim')]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].source).toBe('photon');
+  });
+
+  it('keeps same-named places that are genuinely far apart', () => {
+    // Paris, France vs Paris, Texas
+    const merged = mergeResults([hit('Paris', 48.8566, 2.3522)],
+      [hit('Paris', 33.6609, -95.5555, 'nominatim')]);
+    expect(merged).toHaveLength(2);
+  });
+
+  // "heathrow": Photon ranks the Florida town first, Nominatim scores the
+  // London airport 0.606 against the town's 0.352.
+  it('promotes a globally prominent hit above the primary ordering', () => {
+    const florida = hit('Heathrow', 28.76, -81.37);
+    const airport: GeoResult = {
+      name: 'London Heathrow Airport', context: 'London', lat: 51.47, lng: -0.454,
+      kind: 'poi', source: 'nominatim', score: 0.606,
+    };
+    expect(mergeResults([florida], [airport])[0].name).toBe('London Heathrow Airport');
+  });
+
+  it('leaves ordering alone when nothing clears the prominence bar', () => {
+    const a = hit('A', 1, 1);
+    const weak: GeoResult = { name: 'B', context: '', lat: 2, lng: 2, kind: 'poi', source: 'nominatim', score: 0.31 };
+    expect(mergeResults([a], [weak]).map((r) => r.name)).toEqual(['A', 'B']);
+  });
+
+  it('respects the result limit', () => {
+    const many = Array.from({ length: 12 }, (_, i) => hit(`P${i}`, i, i));
+    expect(mergeResults(many, [], 8)).toHaveLength(8);
+  });
+});

--- a/src/app/api/geosearch/route.ts
+++ b/src/app/api/geosearch/route.ts
@@ -1,0 +1,194 @@
+import { NextResponse } from 'next/server';
+import { httpJson, optional } from '@/lib/httpJson';
+import { cachedSource } from '@/lib/sourceCache';
+
+export const maxDuration = 20;
+
+/**
+ * OSIRIS — Location search for the route planner.
+ *
+ * Nominatim alone was the problem: it is a *geocoder*, not a type-ahead index,
+ * so it needs near-complete input. Measured side by side, "eiffel tow" returns
+ * nothing from Nominatim and the correct Paris landmark from Photon; "sydny
+ * opera house" (typo) returns one weak hit vs six good ones.
+ *
+ * Photon is Komoot's autocomplete index over the same OSM data — prefix and
+ * fuzzy tolerant — so it leads. Nominatim still runs as a supplement because it
+ * resolves some structured/administrative phrasings Photon ranks poorly, and
+ * merging the two is what closes the "location is 100% missing" gap.
+ *
+ * Both are keyless OSM community services and both ask for an identifying
+ * User-Agent, which lib/httpJson supplies.
+ */
+
+const PHOTON = 'https://photon.komoot.io/api';
+const NOMINATIM = 'https://nominatim.openstreetmap.org/search';
+
+export interface GeoResult {
+  name: string;
+  context: string;
+  lat: number;
+  lng: number;
+  kind: string;
+  source: 'photon' | 'nominatim';
+  /** Nominatim importance, when the hit came from there. Ranking only. */
+  score?: number;
+}
+
+interface PhotonFeature {
+  geometry?: { coordinates?: [number, number] };
+  properties?: Record<string, string | undefined>;
+}
+
+interface NominatimRow {
+  display_name?: string;
+  lat?: string;
+  lon?: string;
+  class?: string;
+  type?: string;
+  name?: string;
+  importance?: number;
+}
+
+/**
+ * Nominatim's importance above which a hit is treated as globally prominent.
+ * Photon is the better prefix matcher but ranks purely lexically — searching
+ * "heathrow" puts Heathrow, Florida above London Heathrow Airport. Nominatim
+ * scores the airport 0.606 and the town 0.352, so this promotes the former
+ * without disturbing queries Nominatim can't answer at all.
+ */
+const PROMINENT = 0.5;
+
+/** Collapse OSM class/value pairs into the handful of kinds the UI icons. */
+export function classifyKind(key?: string, value?: string): string {
+  if (!key) return 'place';
+  if (key === 'place' && ['country'].includes(value || '')) return 'country';
+  if (key === 'place' && ['state', 'region', 'province', 'county'].includes(value || '')) return 'region';
+  if (key === 'place' && ['city', 'town', 'village', 'hamlet', 'municipality'].includes(value || '')) return 'city';
+  if (key === 'boundary') return 'region';
+  if (key === 'highway' || key === 'street') return 'street';
+  if (key === 'building' || key === 'address' || value === 'house') return 'address';
+  if (['amenity', 'tourism', 'shop', 'leisure', 'historic', 'office', 'railway', 'aeroway', 'natural', 'man_made'].includes(key)) {
+    return 'poi';
+  }
+  return 'place';
+}
+
+export function normalizePhoton(f: PhotonFeature): GeoResult | null {
+  const c = f?.geometry?.coordinates;
+  const p = f?.properties;
+  if (!c || c.length < 2 || !p) return null;
+  const [lng, lat] = c;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+
+  // Photon splits an address across name/housenumber/street
+  const street = [p.street, p.housenumber].filter(Boolean).join(' ');
+  const name = p.name || street || p.city || p.country || 'Unnamed place';
+  const context = [p.name && street ? street : null, p.district, p.city, p.state, p.country]
+    .filter(Boolean)
+    .filter((v, i, a) => a.indexOf(v) === i)
+    .slice(0, 3)
+    .join(', ');
+
+  return { name, context, lat, lng, kind: classifyKind(p.osm_key, p.osm_value), source: 'photon' };
+}
+
+export function normalizeNominatim(r: NominatimRow): GeoResult | null {
+  const lat = parseFloat(r?.lat || '');
+  const lng = parseFloat(r?.lon || '');
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+
+  const parts = (r.display_name || '').split(',').map((s) => s.trim()).filter(Boolean);
+  return {
+    name: r.name || parts[0] || 'Unnamed place',
+    context: parts.slice(1, 4).join(', '),
+    lat,
+    lng,
+    kind: classifyKind(r.class, r.type),
+    source: 'nominatim',
+    score: typeof r.importance === 'number' ? r.importance : undefined,
+  };
+}
+
+/** Roughly 100 m — close enough that two hits are the same place. */
+const DEDUPE_DEG = 0.001;
+
+/**
+ * Merge provider results, Photon first, dropping anything the other provider
+ * already covers at effectively the same coordinate with the same name.
+ */
+export function mergeResults(primary: GeoResult[], secondary: GeoResult[], limit = 8): GeoResult[] {
+  const out: GeoResult[] = [];
+
+  const isDuplicate = (r: GeoResult) =>
+    out.some(
+      (o) =>
+        Math.abs(o.lat - r.lat) < DEDUPE_DEG &&
+        Math.abs(o.lng - r.lng) < DEDUPE_DEG &&
+        o.name.toLowerCase() === r.name.toLowerCase(),
+    );
+
+  // A landmark the world knows leads, whichever index found it; everything else
+  // keeps Photon's ordering, which is what makes partial input work.
+  const prominent = secondary
+    .filter((r) => (r.score ?? 0) >= PROMINENT)
+    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+  const rest = secondary.filter((r) => (r.score ?? 0) < PROMINENT);
+
+  for (const r of [...prominent, ...primary, ...rest]) {
+    if (out.length >= limit) break;
+    if (!isDuplicate(r)) out.push(r);
+  }
+  return out;
+}
+
+async function searchPhoton(q: string, lat?: number, lng?: number): Promise<GeoResult[]> {
+  let url = `${PHOTON}/?q=${encodeURIComponent(q)}&limit=8&lang=en`;
+  // Bias toward what the operator is currently looking at
+  if (Number.isFinite(lat) && Number.isFinite(lng)) url += `&lat=${lat}&lon=${lng}`;
+  const json = await httpJson<{ features?: PhotonFeature[] }>(url, { timeoutMs: 8000 });
+  return (json.features || []).map(normalizePhoton).filter((r): r is GeoResult => r !== null);
+}
+
+async function searchNominatim(q: string): Promise<GeoResult[]> {
+  const url = `${NOMINATIM}?q=${encodeURIComponent(q)}&format=json&limit=6&addressdetails=0`;
+  const json = await httpJson<NominatimRow[]>(url, { timeoutMs: 8000 });
+  return (Array.isArray(json) ? json : []).map(normalizeNominatim).filter((r): r is GeoResult => r !== null);
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const q = (searchParams.get('q') || '').trim();
+    const lat = parseFloat(searchParams.get('lat') || '');
+    const lng = parseFloat(searchParams.get('lng') || '');
+
+    if (q.length < 2) return NextResponse.json({ results: [] });
+
+    // Bias is rounded so panning slightly still reuses the cached search.
+    const biasKey = Number.isFinite(lat) && Number.isFinite(lng)
+      ? `${lat.toFixed(1)},${lng.toFixed(1)}`
+      : 'global';
+    const key = `geosearch:${q.toLowerCase()}|${biasKey}`;
+
+    const results = await cachedSource<GeoResult>(
+      key,
+      async () => {
+        const [photon, nominatim] = await Promise.all([
+          optional(searchPhoton(q, lat, lng)),
+          optional(searchNominatim(q)),
+        ]);
+        return mergeResults(photon || [], nominatim || []);
+      },
+      10 * 60 * 1000,
+    )();
+
+    return NextResponse.json(
+      { results },
+      { headers: { 'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=1800' } },
+    );
+  } catch (error) {
+    console.error('[OSIRIS] Geosearch error:', error);
+    return NextResponse.json({ results: [], error: 'Search failed' }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import IntelFeed from '@/components/IntelFeed';
 import MarketsPanel from '@/components/MarketsPanel';
 import ScmPanel from '@/components/ScmPanel';
 import SearchBar from '@/components/SearchBar';
-import DirectionsBar, { type RouteResult } from '@/components/DirectionsBar';
+import DirectionsBar, { type RouteResult, type LiveLocation } from '@/components/DirectionsBar';
 import ScaleBar from '@/components/ScaleBar';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import SharePanel from '@/components/SharePanel';
@@ -111,8 +111,15 @@ export default function Dashboard() {
   const [showDesktopSearch, setShowDesktopSearch] = useState(false);
   const [showDirections, setShowDirections] = useState(false);
   const [activeRoute, setActiveRoute] = useState<
-    (RouteResult & { from: { lat: number; lng: number }; to: { lat: number; lng: number } }) | null
+    (RouteResult & {
+      from: { lat: number; lng: number };
+      to: { lat: number; lng: number };
+      alternates?: Array<{ type: 'LineString'; coordinates: [number, number][] }>;
+      activeSegment?: [number, number][] | null;
+    }) | null
   >(null);
+  const [liveLocation, setLiveLocation] = useState<LiveLocation | null>(null);
+  const [followUser, setFollowUser] = useState(false);
   const [showRemote, setShowRemote] = useState(false);
   const [showArcGIS, setShowArcGIS] = useState(false);
   const [arcgisLayers, setArcgisLayers] = useState<Array<{ id: string; title: string; url: string; geojson: any; color: string; visible: boolean; opacity: number }>>([]);
@@ -851,6 +858,8 @@ export default function Dashboard() {
           arcgisLayers={arcgisLayers.filter(l => l.visible).map(l => ({ id: l.id, title: l.title, geojson: l.geojson, color: l.color, opacity: l.opacity }))}
           onMapCenter={setMapCenter}
           route={activeRoute}
+          userLocation={liveLocation}
+          followUser={followUser}
         />
       </ErrorBoundary>
 
@@ -864,6 +873,9 @@ export default function Dashboard() {
             <DirectionsBar
               center={mapCenter ? { lat: mapCenter.lat, lng: mapCenter.lng } : null}
               onRoute={(r) => setActiveRoute(r)}
+              onLiveLocation={setLiveLocation}
+              onFollowChange={setFollowUser}
+              onActiveSegment={(seg) => setActiveRoute((r) => (r ? { ...r, activeSegment: seg } : r))}
               onLocate={(lat, lng, zoom) => setFlyToLocation({ lat, lng, zoom, ts: Date.now() })}
               onClose={() => { setShowDirections(false); setActiveRoute(null); }}
             />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -862,6 +862,7 @@ export default function Dashboard() {
         {showDirections && (
           <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }}>
             <DirectionsBar
+              center={mapCenter ? { lat: mapCenter.lat, lng: mapCenter.lng } : null}
               onRoute={(r) => setActiveRoute(r)}
               onLocate={(lat, lng, zoom) => setFlyToLocation({ lat, lng, zoom, ts: Date.now() })}
               onClose={() => { setShowDirections(false); setActiveRoute(null); }}

--- a/src/components/DirectionsBar.test.ts
+++ b/src/components/DirectionsBar.test.ts
@@ -3,8 +3,6 @@ import {
   formatDistance,
   formatDuration,
   viaRoad,
-  shortLabel,
-  isCoordLabel,
   type RouteStep,
 } from './DirectionsBar';
 
@@ -54,26 +52,5 @@ describe('viaRoad', () => {
     expect(viaRoad([step('Keep left to take the walkway.', 900)])).toBeNull();
     expect(viaRoad([step('Turn right.', 24), step('You have arrived.', 0)])).toBeNull();
     expect(viaRoad([])).toBeNull();
-  });
-});
-
-describe('isCoordLabel / shortLabel', () => {
-  it('recognises a lat,lng label', () => {
-    expect(isCoordLabel('52.51630, 13.37770')).toBe(true);
-    expect(isCoordLabel('-33.86, 151.21')).toBe(true);
-    expect(isCoordLabel('Pariser Platz, Berlin')).toBe(false);
-  });
-
-  // Regression: splitting a coordinate on its comma rendered it as two lines
-  // ("52.51630" over "13.37770"), which read as a mangled address.
-  it('never splits a coordinate label', () => {
-    expect(shortLabel('52.51630, 13.37770')).toBe('52.51630, 13.37770');
-  });
-
-  it('trims a long display_name to its two leading parts', () => {
-    expect(shortLabel('Brandenburger Tor, 1, Pariser Platz, Mitte, Berlin, 10117, Germany'))
-      .toBe('Brandenburger Tor, 1');
-    expect(shortLabel('Alexanderplatz, Berlin')).toBe('Alexanderplatz, Berlin');
-    expect(shortLabel('Berlin')).toBe('Berlin');
   });
 });

--- a/src/components/DirectionsBar.test.ts
+++ b/src/components/DirectionsBar.test.ts
@@ -5,6 +5,9 @@ import {
   viaRoad,
   arrivalTime,
   segmentBetween,
+  haversine,
+  nextManeuver,
+  elevationPath,
   type RouteStep,
 } from './DirectionsBar';
 
@@ -86,5 +89,70 @@ describe('segmentBetween', () => {
 
   it('copes with the endpoints arriving reversed', () => {
     expect(segmentBetween(line, [3, 3], [1, 1])).toEqual([[1, 1], [2, 2], [3, 3]]);
+  });
+});
+
+describe('haversine', () => {
+  it('measures a known distance', () => {
+    // Brandenburg Gate -> Reichstag, ~290 m
+    const d = haversine(52.5163, 13.3777, 52.5186, 13.3762);
+    expect(d).toBeGreaterThan(200);
+    expect(d).toBeLessThan(400);
+  });
+
+  it('is zero for the same point', () => {
+    expect(haversine(52.5163, 13.3777, 52.5163, 13.3777)).toBe(0);
+  });
+});
+
+describe('nextManeuver', () => {
+  // A straight west-to-east run; maneuvers sit on vertices along it.
+  const coords: [number, number][] = [
+    [13.3777, 52.5163], [13.3800, 52.5166], [13.3850, 52.5170],
+    [13.3990, 52.5195], [13.4132, 52.5219],
+  ];
+  const steps: RouteStep[] = [
+    { instruction: 'Depart', distance: 100, duration: 20, location: [13.3777, 52.5163], type: 'depart' },
+    { instruction: 'Turn right', distance: 500, duration: 90, location: [13.3850, 52.5170], type: 'right' },
+    { instruction: 'Arrive', distance: 0, duration: 0, location: [13.4132, 52.5219], type: 'arrive' },
+  ];
+
+  // The case nearest-maneuver gets wrong: past the depart point, the closest
+  // maneuver is still behind you.
+  it('reports the turn ahead, not the one just passed', () => {
+    const g = nextManeuver(steps, coords, 52.5166, 13.38)!;
+    expect(g.step.instruction).toBe('Turn right');
+    expect(g.distance).toBeGreaterThan(0);
+  });
+
+  it('advances once a maneuver is behind the current position', () => {
+    const g = nextManeuver(steps, coords, 52.5195, 13.399)!;
+    expect(g.step.instruction).toBe('Arrive');
+  });
+
+  it('falls back to the destination past the last maneuver', () => {
+    const g = nextManeuver(steps, coords, 52.5219, 13.4132)!;
+    expect(g.step.instruction).toBe('Arrive');
+  });
+
+  it('returns null without steps', () => {
+    expect(nextManeuver([], coords, 52.5, 13.4)).toBeNull();
+  });
+});
+
+describe('elevationPath', () => {
+  it('normalises points into the viewbox, flat ground included', () => {
+    const d = elevationPath([{ distance: 0, height: 10 }, { distance: 100, height: 20 }], 300, 40);
+    expect(d.startsWith('M0.0,40.0')).toBe(true);
+    expect(d).toContain('L300.0,0.0');
+  });
+
+  it('does not divide by zero when the route is level', () => {
+    const d = elevationPath([{ distance: 0, height: 5 }, { distance: 50, height: 5 }], 300, 40);
+    expect(d).not.toContain('NaN');
+  });
+
+  it('returns nothing for a single sample', () => {
+    expect(elevationPath([{ distance: 0, height: 1 }], 300, 40)).toBe('');
   });
 });

--- a/src/components/DirectionsBar.test.ts
+++ b/src/components/DirectionsBar.test.ts
@@ -3,6 +3,8 @@ import {
   formatDistance,
   formatDuration,
   viaRoad,
+  arrivalTime,
+  segmentBetween,
   type RouteStep,
 } from './DirectionsBar';
 
@@ -52,5 +54,37 @@ describe('viaRoad', () => {
     expect(viaRoad([step('Keep left to take the walkway.', 900)])).toBeNull();
     expect(viaRoad([step('Turn right.', 24), step('You have arrived.', 0)])).toBeNull();
     expect(viaRoad([])).toBeNull();
+  });
+});
+
+describe('arrivalTime', () => {
+  it('adds the trip duration to the clock', () => {
+    const at = arrivalTime(30 * 60, new Date('2026-01-01T12:00:00'));
+    expect(at).toMatch(/12:30|00:30/); // locale may render 12h or 24h
+  });
+
+  it('rolls past midnight', () => {
+    const at = arrivalTime(2 * 3600, new Date('2026-01-01T23:00:00'));
+    expect(at).toMatch(/01:00|1:00/);
+  });
+});
+
+describe('segmentBetween', () => {
+  const line: [number, number][] = [[0, 0], [1, 1], [2, 2], [3, 3], [4, 4]];
+
+  it('slices the stretch a step covers', () => {
+    expect(segmentBetween(line, [1, 1], [3, 3])).toEqual([[1, 1], [2, 2], [3, 3]]);
+  });
+
+  it('runs to the end of the route for the final step', () => {
+    expect(segmentBetween(line, [3, 3])).toEqual([[3, 3], [4, 4]]);
+  });
+
+  it('snaps to the nearest vertex when a step is slightly off the line', () => {
+    expect(segmentBetween(line, [1.02, 0.98], [2.01, 2.02])).toEqual([[1, 1], [2, 2]]);
+  });
+
+  it('copes with the endpoints arriving reversed', () => {
+    expect(segmentBetween(line, [3, 3], [1, 1])).toEqual([[1, 1], [2, 2], [3, 3]]);
   });
 });

--- a/src/components/DirectionsBar.tsx
+++ b/src/components/DirectionsBar.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import {
   X, Car, Footprints, Bike, ArrowUpDown, MapPin, Flag, Route,
   CornerUpRight, CornerUpLeft, ArrowUp, RotateCw, Merge, Search,
+  LocateFixed, Building2, Landmark, Globe2, Signpost, Home,
 } from 'lucide-react';
 
 /* ═══════════════════════════════════════════════════════════════
@@ -28,22 +29,30 @@ export interface RouteResult {
   steps: RouteStep[];
 }
 
+interface GeoHit {
+  name: string;
+  context: string;
+  lat: number;
+  lng: number;
+  kind: string;
+}
+
 interface Place {
   label: string;
   lat: number;
   lng: number;
+  /** Secondary line, e.g. "Avenue Anatole France, Paris, France". */
+  context?: string;
+  /** poi | address | street | city | region | country | coordinate | current */
+  kind?: string;
 }
 
 interface DirectionsBarProps {
   onRoute: (route: (RouteResult & { from: Place; to: Place }) | null) => void;
   onLocate?: (lat: number, lng: number, zoom?: number) => void;
   onClose?: () => void;
-}
-
-interface NominatimPlace {
-  display_name: string;
-  lat: string;
-  lon: string;
+  /** Current map centre — biases search toward what the operator is looking at. */
+  center?: { lat: number; lng: number } | null;
 }
 
 const MODES = [
@@ -78,19 +87,6 @@ export function viaRoad(steps: RouteStep[]): string | null {
   return best?.road ?? null;
 }
 
-/** A "lat, lng" label must never be split on its comma like an address. */
-export function isCoordLabel(label: string): boolean {
-  return /^-?\d+\.?\d*,\s*-?\d+\.?\d*$/.test(label.trim());
-}
-
-/** Shorten a Nominatim display_name to something readable in a narrow field. */
-export function shortLabel(displayName: string): string {
-  if (isCoordLabel(displayName)) return displayName.trim();
-  const parts = displayName.split(',').map((p) => p.trim()).filter(Boolean);
-  if (parts.length <= 2) return parts.join(', ');
-  return `${parts[0]}, ${parts[1]}`;
-}
-
 function StepIcon({ type }: { type: string }) {
   // Turns carry the actual navigational signal, so they get the accent colour;
   // start/finish are green/flagged; filler moves stay muted.
@@ -104,21 +100,40 @@ function StepIcon({ type }: { type: string }) {
   return <ArrowUp className={`${cls} text-[var(--text-muted)]`} />;
 }
 
+/** Icon for a search hit, so the list is scannable by type. */
+function KindIcon({ kind }: { kind?: string }) {
+  const cls = 'w-3 h-3 flex-shrink-0 mt-0.5';
+  if (kind === 'coordinate') return <MapPin className={`${cls} text-[var(--cyan-primary)]`} />;
+  if (kind === 'current') return <LocateFixed className={`${cls} text-[var(--alert-green)]`} />;
+  if (kind === 'country') return <Globe2 className={`${cls} text-[var(--gold-primary)]`} />;
+  if (kind === 'region' || kind === 'city') return <Landmark className={`${cls} text-[#FF9500]`} />;
+  if (kind === 'street') return <Signpost className={`${cls} text-[var(--text-secondary)]`} />;
+  if (kind === 'address') return <Home className={`${cls} text-[var(--text-secondary)]`} />;
+  if (kind === 'poi') return <Building2 className={`${cls} text-[var(--cyan-primary)]`} />;
+  return <Search className={`${cls} text-[var(--text-muted)]`} />;
+}
+
 /** Origin / destination field with Nominatim autocomplete. */
 function PlaceInput({
-  value, onChange, onPick, placeholder, autoFocus,
+  value, onChange, onPick, placeholder, autoFocus, biasLat, biasLng, onLocate, locating,
 }: {
   value: string;
   onChange: (v: string) => void;
   onPick: (p: Place) => void;
   placeholder: string;
   autoFocus?: boolean;
+  biasLat?: number;
+  biasLng?: number;
+  /** Present only on the origin field — fills it with the operator's position. */
+  onLocate?: () => void;
+  locating?: boolean;
 }) {
   const [results, setResults] = useState<Place[]>([]);
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
   const [idx, setIdx] = useState(-1);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abort = useRef<AbortController | null>(null);
   const box = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -139,7 +154,7 @@ function PlaceInput({
       const lat = parseFloat(coord[1]);
       const lng = parseFloat(coord[2]);
       if (lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180) {
-        setResults([{ label: `${lat.toFixed(5)}, ${lng.toFixed(5)}`, lat, lng }]);
+        setResults([{ label: `${lat.toFixed(5)}, ${lng.toFixed(5)}`, lat, lng, kind: 'coordinate', context: 'Coordinates' }]);
         setOpen(true);
         return;
       }
@@ -148,24 +163,35 @@ function PlaceInput({
     if (q.trim().length < 2) { setResults([]); setOpen(false); return; }
 
     timer.current = setTimeout(async () => {
+      // Abandon any in-flight lookup so a slow earlier keystroke can never
+      // overwrite the results for what the user has actually typed.
+      abort.current?.abort();
+      const ctrl = new AbortController();
+      abort.current = ctrl;
+
       setLoading(true);
       try {
+        const bias = biasLat !== undefined && biasLng !== undefined
+          ? `&lat=${biasLat}&lng=${biasLng}` : '';
         const res = await fetch(
-          `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&limit=6`,
-          { headers: { 'Accept-Language': 'en' } },
+          `/api/geosearch?q=${encodeURIComponent(q)}${bias}`,
+          { signal: ctrl.signal },
         );
-        const data: NominatimPlace[] = await res.json();
-        setResults(data.map((r) => ({
-          label: r.display_name, lat: parseFloat(r.lat), lng: parseFloat(r.lon),
+        const data: { results?: GeoHit[] } = await res.json();
+        if (ctrl.signal.aborted) return;
+        setResults((data.results || []).map((r) => ({
+          label: r.name, context: r.context, lat: r.lat, lng: r.lng, kind: r.kind,
         })));
         setOpen(true);
-      } catch { setResults([]); }
-      setLoading(false);
-    }, 320);
-  }, [onChange]);
+      } catch {
+        if (!ctrl.signal.aborted) setResults([]);
+      }
+      if (!ctrl.signal.aborted) setLoading(false);
+    }, 280);
+  }, [onChange, biasLat, biasLng]);
 
   const choose = (p: Place) => {
-    onChange(shortLabel(p.label));
+    onChange(p.label);
     onPick(p);
     setOpen(false);
     setResults([]);
@@ -198,7 +224,21 @@ function PlaceInput({
       />
 
       {loading && (
-        <span className="absolute right-0 top-1/2 -translate-y-1/2 w-2.5 h-2.5 rounded-full border border-[var(--gold-primary)] border-t-transparent animate-spin" />
+        <span className="absolute right-6 top-1/2 -translate-y-1/2 w-2.5 h-2.5 rounded-full border border-[var(--gold-primary)] border-t-transparent animate-spin" />
+      )}
+
+      {onLocate && (
+        <button
+          type="button"
+          onClick={onLocate}
+          disabled={locating}
+          title="Use my location"
+          aria-label="Use my location"
+          className="absolute right-0 top-1/2 -translate-y-1/2 p-1 rounded text-[var(--text-muted)]
+                     hover:text-[var(--alert-green)] hover:bg-[rgba(0,230,118,0.08)] transition-colors disabled:opacity-50"
+        >
+          <LocateFixed className={`w-3.5 h-3.5 ${locating ? 'animate-pulse text-[var(--alert-green)]' : ''}`} />
+        </button>
       )}
 
       {open && results.length > 0 && (
@@ -207,42 +247,33 @@ function PlaceInput({
                      border border-[var(--border-primary)] bg-[var(--bg-panel-solid)] max-h-[220px] overflow-y-auto styled-scrollbar"
           style={{ boxShadow: '0 16px 40px rgba(0,0,0,0.7)' }}
         >
-          {results.map((r, i) => {
-            const coord = isCoordLabel(r.label);
-            const parts = coord ? [r.label] : r.label.split(',').map((p) => p.trim());
-            return (
-              <button
-                key={i}
-                onClick={() => choose(r)}
-                onMouseEnter={() => setIdx(i)}
-                className={`w-full text-left px-2.5 py-2 flex items-start gap-2 transition-colors ${
-                  i === idx ? 'bg-[rgba(var(--gold-rgb),0.10)]' : 'hover:bg-[rgba(255,255,255,0.03)]'
-                }`}
-              >
-                {coord
-                  ? <MapPin className="w-3 h-3 text-[var(--cyan-primary)] flex-shrink-0 mt-0.5" />
-                  : <Search className="w-3 h-3 text-[var(--text-muted)] flex-shrink-0 mt-0.5" />}
-                <span className="min-w-0">
-                  <span className="block text-[10px] text-[var(--text-primary)] truncate tabular-nums">{parts[0]}</span>
-                  {parts.length > 1 && (
-                    <span className="block text-[9px] text-[var(--text-muted)] truncate">
-                      {parts.slice(1, 4).join(', ')}
-                    </span>
-                  )}
-                  {coord && (
-                    <span className="block text-[9px] text-[var(--text-muted)]">Coordinates</span>
-                  )}
+          {results.map((r, i) => (
+            <button
+              key={i}
+              onClick={() => choose(r)}
+              onMouseEnter={() => setIdx(i)}
+              className={`w-full text-left px-2.5 py-2 flex items-start gap-2 transition-colors ${
+                i === idx ? 'bg-[rgba(var(--gold-rgb),0.10)]' : 'hover:bg-[rgba(255,255,255,0.03)]'
+              }`}
+            >
+              <KindIcon kind={r.kind} />
+              <span className="min-w-0">
+                <span className={`block text-[10px] text-[var(--text-primary)] truncate ${r.kind === 'coordinate' ? 'tabular-nums' : ''}`}>
+                  {r.label}
                 </span>
-              </button>
-            );
-          })}
+                {r.context && (
+                  <span className="block text-[9px] text-[var(--text-muted)] truncate">{r.context}</span>
+                )}
+              </span>
+            </button>
+          ))}
         </div>
       )}
     </div>
   );
 }
 
-export default function DirectionsBar({ onRoute, onLocate, onClose }: DirectionsBarProps) {
+export default function DirectionsBar({ onRoute, onLocate, onClose, center = null }: DirectionsBarProps) {
   const [fromText, setFromText] = useState('');
   const [toText, setToText] = useState('');
   const [from, setFrom] = useState<Place | null>(null);
@@ -252,6 +283,8 @@ export default function DirectionsBar({ onRoute, onLocate, onClose }: Directions
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeStep, setActiveStep] = useState<number | null>(null);
+  const [locating, setLocating] = useState(false);
+  const [locateError, setLocateError] = useState<string | null>(null);
 
   const runRoute = useCallback(async (a: Place, b: Place, m: string) => {
     setLoading(true);
@@ -275,6 +308,56 @@ export default function DirectionsBar({ onRoute, onLocate, onClose }: Directions
     }
     setLoading(false);
   }, [onRoute]);
+
+  /**
+   * Fill the origin with wherever the operator is.
+   *
+   * Tries the browser first (precise, but needs permission and a secure
+   * context), then falls back to OSIRIS's existing IP geolocation, which needs
+   * neither — so this still does something useful when permission is denied.
+   */
+  const useMyLocation = useCallback(async () => {
+    setLocating(true);
+    setLocateError(null);
+
+    const apply = (lat: number, lng: number, label: string) => {
+      const place: Place = { label, lat, lng, kind: 'current' };
+      setFromText(label);
+      setFrom(place);
+      onLocate?.(lat, lng, 14);
+      if (to) runRoute(place, to, mode);
+    };
+
+    const browser = await new Promise<GeolocationPosition | null>((resolve) => {
+      if (typeof navigator === 'undefined' || !navigator.geolocation) return resolve(null);
+      navigator.geolocation.getCurrentPosition(
+        (pos) => resolve(pos),
+        () => resolve(null),
+        { enableHighAccuracy: true, timeout: 8000, maximumAge: 60000 },
+      );
+    });
+
+    if (browser) {
+      const { latitude, longitude } = browser.coords;
+      apply(latitude, longitude, 'My location');
+      setLocating(false);
+      return;
+    }
+
+    try {
+      const res = await fetch('/api/geo');
+      const d = await res.json();
+      if (d?.lat && d?.lon) {
+        apply(d.lat, d.lon, d.city ? `Near ${d.city}` : 'Approximate location');
+        setLocateError('Approximate — from network location');
+      } else {
+        setLocateError('Could not determine your location');
+      }
+    } catch {
+      setLocateError('Could not determine your location');
+    }
+    setLocating(false);
+  }, [to, mode, runRoute, onLocate]);
 
   const pickFrom = (p: Place) => { setFrom(p); if (to) runRoute(p, to, mode); };
   const pickTo = (p: Place) => { setTo(p); if (from) runRoute(from, p, mode); };
@@ -330,10 +413,13 @@ export default function DirectionsBar({ onRoute, onLocate, onClose }: Directions
           <PlaceInput
             value={fromText} onChange={setFromText} onPick={pickFrom}
             placeholder="Choose starting point" autoFocus
+            biasLat={center?.lat} biasLng={center?.lng}
+            onLocate={useMyLocation} locating={locating}
           />
           <PlaceInput
             value={toText} onChange={setToText} onPick={pickTo}
             placeholder="Choose destination"
+            biasLat={center?.lat} biasLng={center?.lng}
           />
         </div>
 
@@ -391,6 +477,10 @@ export default function DirectionsBar({ onRoute, onLocate, onClose }: Directions
               ))}
             </div>
           </div>
+        )}
+
+        {!loading && !error && locateError && (
+          <p className="px-3 pt-2 text-[9px] text-[var(--gold-primary)]">{locateError}</p>
         )}
 
         {!loading && error && (

--- a/src/components/DirectionsBar.tsx
+++ b/src/components/DirectionsBar.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import {
   X, Car, Footprints, Bike, ArrowUpDown, MapPin, Flag, Route,
   CornerUpRight, CornerUpLeft, ArrowUp, RotateCw, Merge, Search,
-  LocateFixed, Building2, Landmark, Globe2, Signpost, Home,
+  LocateFixed, Building2, Landmark, Globe2, Signpost, Home, Crosshair, Clock,
 } from 'lucide-react';
 
 /* ═══════════════════════════════════════════════════════════════
@@ -27,6 +27,15 @@ export interface RouteResult {
   duration: number;
   geometry: { type: 'LineString'; coordinates: [number, number][] };
   steps: RouteStep[];
+  /** All options the engine offered, best first. Present on the API response. */
+  routes?: RouteResult[];
+}
+
+export interface LiveLocation {
+  lat: number;
+  lng: number;
+  accuracy?: number;
+  heading?: number | null;
 }
 
 interface GeoHit {
@@ -48,11 +57,21 @@ interface Place {
 }
 
 interface DirectionsBarProps {
-  onRoute: (route: (RouteResult & { from: Place; to: Place }) | null) => void;
+  onRoute: (route: (RouteResult & {
+    from: Place;
+    to: Place;
+    alternates?: Array<{ type: 'LineString'; coordinates: [number, number][] }>;
+    activeSegment?: [number, number][] | null;
+  }) | null) => void;
   onLocate?: (lat: number, lng: number, zoom?: number) => void;
   onClose?: () => void;
   /** Current map centre — biases search toward what the operator is looking at. */
   center?: { lat: number; lng: number } | null;
+  /** Live position, when tracking is on, so the map can draw the dot. */
+  onLiveLocation?: (loc: LiveLocation | null) => void;
+  /** Selected step segment, for highlighting the leg on the map. */
+  onActiveSegment?: (seg: [number, number][] | null) => void;
+  onFollowChange?: (follow: boolean) => void;
 }
 
 const MODES = [
@@ -64,6 +83,35 @@ const MODES = [
 export function formatDistance(m: number): string {
   if (m < 1000) return `${Math.round(m)} m`;
   return `${(m / 1000).toFixed(m < 10000 ? 1 : 0)} km`;
+}
+
+/** Wall-clock arrival time for a trip of `seconds` starting now. */
+export function arrivalTime(seconds: number, now: Date = new Date()): string {
+  const at = new Date(now.getTime() + seconds * 1000);
+  return at.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+/**
+ * Slice the route geometry between two step positions, so selecting a step can
+ * highlight the leg it covers rather than just dropping a pin on its start.
+ */
+export function segmentBetween(
+  coords: [number, number][],
+  from: [number, number],
+  to?: [number, number],
+): [number, number][] {
+  const nearest = (t: [number, number]) => {
+    let best = 0;
+    let bestD = Infinity;
+    for (let i = 0; i < coords.length; i++) {
+      const d = (coords[i][0] - t[0]) ** 2 + (coords[i][1] - t[1]) ** 2;
+      if (d < bestD) { bestD = d; best = i; }
+    }
+    return best;
+  };
+  const a = nearest(from);
+  const b = to ? nearest(to) : coords.length - 1;
+  return coords.slice(Math.min(a, b), Math.max(a, b) + 1);
 }
 
 export function formatDuration(s: number): string {
@@ -115,7 +163,7 @@ function KindIcon({ kind }: { kind?: string }) {
 
 /** Origin / destination field with Nominatim autocomplete. */
 function PlaceInput({
-  value, onChange, onPick, placeholder, autoFocus, biasLat, biasLng, onLocate, locating,
+  value, onChange, onPick, placeholder, autoFocus, biasLat, biasLng, onLocate, locating, liveFix,
 }: {
   value: string;
   onChange: (v: string) => void;
@@ -127,6 +175,8 @@ function PlaceInput({
   /** Present only on the origin field — fills it with the operator's position. */
   onLocate?: () => void;
   locating?: boolean;
+  /** When a live fix exists, both fields offer it as the first choice. */
+  liveFix?: { lat: number; lng: number } | null;
 }) {
   const [results, setResults] = useState<Place[]>([]);
   const [loading, setLoading] = useState(false);
@@ -203,7 +253,7 @@ function PlaceInput({
         value={value}
         autoFocus={autoFocus}
         onChange={(e) => search(e.target.value)}
-        onFocus={() => results.length && setOpen(true)}
+        onFocus={() => (results.length || liveFix) && setOpen(true)}
         onKeyDown={(e) => {
           if (e.key === 'ArrowDown') { e.preventDefault(); setIdx((i) => Math.min(i + 1, results.length - 1)); }
           if (e.key === 'ArrowUp') { e.preventDefault(); setIdx((i) => Math.max(i - 1, 0)); }
@@ -241,12 +291,25 @@ function PlaceInput({
         </button>
       )}
 
-      {open && results.length > 0 && (
+      {open && (results.length > 0 || liveFix) && (
         <div
           className="absolute top-full left-0 right-0 mt-1 z-[10000] rounded-lg overflow-hidden
-                     border border-[var(--border-primary)] bg-[var(--bg-panel-solid)] max-h-[220px] overflow-y-auto styled-scrollbar"
+                     border border-[var(--border-primary)] bg-[var(--bg-panel-solid)] max-h-[240px] overflow-y-auto styled-scrollbar"
           style={{ boxShadow: '0 16px 40px rgba(0,0,0,0.7)' }}
         >
+          {liveFix && (
+            <button
+              onClick={() => choose({ label: 'Your location', lat: liveFix.lat, lng: liveFix.lng, kind: 'current', context: 'Live position' })}
+              className="w-full text-left px-2.5 py-2 flex items-start gap-2 transition-colors
+                         border-b border-[var(--border-secondary)] hover:bg-[rgba(0,230,118,0.08)]"
+            >
+              <KindIcon kind="current" />
+              <span className="min-w-0">
+                <span className="block text-[10px] text-[var(--alert-green)]">Your location</span>
+                <span className="block text-[9px] text-[var(--text-muted)]">Live position</span>
+              </span>
+            </button>
+          )}
           {results.map((r, i) => (
             <button
               key={i}
@@ -273,7 +336,7 @@ function PlaceInput({
   );
 }
 
-export default function DirectionsBar({ onRoute, onLocate, onClose, center = null }: DirectionsBarProps) {
+export default function DirectionsBar({ onRoute, onLocate, onClose, center = null, onLiveLocation, onActiveSegment, onFollowChange }: DirectionsBarProps) {
   const [fromText, setFromText] = useState('');
   const [toText, setToText] = useState('');
   const [from, setFrom] = useState<Place | null>(null);
@@ -285,6 +348,12 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
   const [activeStep, setActiveStep] = useState<number | null>(null);
   const [locating, setLocating] = useState(false);
   const [locateError, setLocateError] = useState<string | null>(null);
+  const [live, setLive] = useState<LiveLocation | null>(null);
+  const [tracking, setTracking] = useState(false);
+  const [follow, setFollow] = useState(false);
+  const [routes, setRoutes] = useState<RouteResult[]>([]);
+  const [chosen, setChosen] = useState(0);
+  const watchId = useRef<number | null>(null);
 
   const runRoute = useCallback(async (a: Place, b: Place, m: string) => {
     setLoading(true);
@@ -295,19 +364,68 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
       const data = await res.json();
       if (!res.ok || data.error) {
         setRoute(null);
+        setRoutes([]);
         onRoute(null);
         setError(data.error || 'No route found');
       } else {
-        setRoute(data);
-        onRoute({ ...data, from: a, to: b });
+        const all: RouteResult[] = data.routes?.length ? data.routes : [data];
+        setRoutes(all);
+        setChosen(0);
+        setRoute(all[0]);
+        onRoute({ ...all[0], from: a, to: b, alternates: all.slice(1).map((r) => r.geometry) });
       }
     } catch {
       setRoute(null);
+      setRoutes([]);
       onRoute(null);
       setError('Routing service unreachable');
     }
     setLoading(false);
   }, [onRoute]);
+
+  /** Continuous position updates — the moving dot, not a one-shot fix. */
+  const toggleTracking = useCallback(() => {
+    if (tracking) {
+      if (watchId.current !== null) navigator.geolocation.clearWatch(watchId.current);
+      watchId.current = null;
+      setTracking(false);
+      setFollow(false);
+      onFollowChange?.(false);
+      setLive(null);
+      onLiveLocation?.(null);
+      return;
+    }
+
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setLocateError('This browser has no geolocation');
+      return;
+    }
+
+    setLocateError(null);
+    watchId.current = navigator.geolocation.watchPosition(
+      (pos) => {
+        const loc: LiveLocation = {
+          lat: pos.coords.latitude,
+          lng: pos.coords.longitude,
+          accuracy: pos.coords.accuracy,
+          heading: pos.coords.heading,
+        };
+        setLive(loc);
+        onLiveLocation?.(loc);
+        setTracking(true);
+      },
+      () => {
+        setLocateError('Location permission denied — needs HTTPS or localhost');
+        setTracking(false);
+      },
+      { enableHighAccuracy: true, maximumAge: 5000, timeout: 15000 },
+    );
+    setTracking(true);
+  }, [tracking, onLiveLocation, onFollowChange]);
+
+  useEffect(() => () => {
+    if (watchId.current !== null) navigator.geolocation.clearWatch(watchId.current);
+  }, []);
 
   /**
    * Fill the origin with wherever the operator is.
@@ -386,6 +504,34 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
             {route.steps.length} steps
           </span>
         )}
+
+        <button
+          onClick={toggleTracking}
+          aria-pressed={tracking}
+          title={tracking ? 'Stop live tracking' : 'Track my location live'}
+          className={`p-1 rounded transition-colors ${
+            tracking
+              ? 'text-[#4285F4] bg-[rgba(66,133,244,0.14)]'
+              : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+          }`}
+        >
+          <Crosshair className={`w-3.5 h-3.5 ${tracking ? 'animate-pulse' : ''}`} />
+        </button>
+
+        {tracking && (
+          <button
+            onClick={() => { const n = !follow; setFollow(n); onFollowChange?.(n); }}
+            aria-pressed={follow}
+            title={follow ? 'Stop following' : 'Keep the map centred on me'}
+            className={`p-1 rounded transition-colors ${
+              follow
+                ? 'text-[var(--gold-primary)] bg-[rgba(var(--gold-rgb),0.14)]'
+                : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+            }`}
+          >
+            <LocateFixed className="w-3.5 h-3.5" />
+          </button>
+        )}
         {onClose && (
           <button
             onClick={onClose}
@@ -414,12 +560,12 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
             value={fromText} onChange={setFromText} onPick={pickFrom}
             placeholder="Choose starting point" autoFocus
             biasLat={center?.lat} biasLng={center?.lng}
-            onLocate={useMyLocation} locating={locating}
+            onLocate={useMyLocation} locating={locating} liveFix={live}
           />
           <PlaceInput
             value={toText} onChange={setToText} onPick={pickTo}
             placeholder="Choose destination"
-            biasLat={center?.lat} biasLng={center?.lng}
+            biasLat={center?.lat} biasLng={center?.lng} liveFix={live}
           />
         </div>
 
@@ -503,18 +649,64 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
         {!loading && route && (
           <>
             {/* summary */}
-            <div className="px-3 py-2.5 flex items-baseline justify-between gap-3 border-b border-[var(--border-secondary)]">
-              <div className="min-w-0">
-                <div className="text-[17px] leading-none text-[var(--gold-primary)] tabular-nums">
-                  {formatDuration(route.duration)}
+            <div className="px-3 py-2.5 border-b border-[var(--border-secondary)]">
+              <div className="flex items-baseline justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-[17px] leading-none text-[var(--gold-primary)] tabular-nums">
+                    {formatDuration(route.duration)}
+                  </div>
+                  {via && (
+                    <div className="text-[9px] text-[var(--text-muted)] truncate mt-1">via {via}</div>
+                  )}
                 </div>
-                {via && (
-                  <div className="text-[9px] text-[var(--text-muted)] truncate mt-1">via {via}</div>
-                )}
+                <div className="text-right flex-shrink-0">
+                  <div className="text-[11px] text-[var(--text-secondary)] tabular-nums">
+                    {formatDistance(route.distance)}
+                  </div>
+                  <div className="flex items-center gap-1 justify-end text-[9px] text-[var(--text-muted)] tabular-nums mt-1">
+                    <Clock className="w-2.5 h-2.5" />
+                    {arrivalTime(route.duration)}
+                  </div>
+                </div>
               </div>
-              <div className="text-[11px] text-[var(--text-secondary)] tabular-nums flex-shrink-0">
-                {formatDistance(route.distance)}
-              </div>
+
+              {routes.length > 1 && (
+                <div className="flex gap-1 mt-2.5" role="tablist" aria-label="Route options">
+                  {routes.map((r, i) => {
+                    const on = i === chosen;
+                    const slower = Math.round((r.duration - routes[0].duration) / 60);
+                    return (
+                      <button
+                        key={i}
+                        role="tab"
+                        aria-selected={on}
+                        onClick={() => {
+                          setChosen(i);
+                          setRoute(r);
+                          setActiveStep(null);
+                          onActiveSegment?.(null);
+                          if (from && to) {
+                            onRoute({
+                              ...r, from, to,
+                              alternates: routes.filter((_, j) => j !== i).map((x) => x.geometry),
+                            });
+                          }
+                        }}
+                        className={`flex-1 px-2 py-1.5 rounded-md border text-[9px] transition-all ${
+                          on
+                            ? 'border-[var(--border-active)] bg-[rgba(var(--gold-rgb),0.12)] text-[var(--gold-primary)]'
+                            : 'border-[var(--border-secondary)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+                        }`}
+                      >
+                        <span className="block tabular-nums">{formatDuration(r.duration)}</span>
+                        <span className="block text-[8px] opacity-70 tabular-nums">
+                          {i === 0 ? 'Fastest' : slower > 0 ? `+${slower} min` : formatDistance(r.distance)}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
 
             {/* steps */}
@@ -522,7 +714,13 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
               {route.steps.map((s, i) => (
                 <li key={i}>
                   <button
-                    onClick={() => { setActiveStep(i); onLocate?.(s.location[1], s.location[0], 17); }}
+                    onClick={() => {
+                      setActiveStep(i);
+                      onLocate?.(s.location[1], s.location[0], 17);
+                      onActiveSegment?.(
+                        segmentBetween(route.geometry.coordinates, s.location, route.steps[i + 1]?.location),
+                      );
+                    }}
                     className={`w-full text-left px-3 py-2 flex items-start gap-2.5 border-l-2 transition-colors ${
                       activeStep === i
                         ? 'border-[var(--gold-primary)] bg-[rgba(var(--gold-rgb),0.07)]'

--- a/src/components/DirectionsBar.tsx
+++ b/src/components/DirectionsBar.tsx
@@ -5,6 +5,7 @@ import {
   X, Car, Footprints, Bike, ArrowUpDown, MapPin, Flag, Route,
   CornerUpRight, CornerUpLeft, ArrowUp, RotateCw, Merge, Search,
   LocateFixed, Building2, Landmark, Globe2, Signpost, Home, Crosshair, Clock,
+  Plus, Trash2, SlidersHorizontal, Mountain, Navigation,
 } from 'lucide-react';
 
 /* ═══════════════════════════════════════════════════════════════
@@ -29,6 +30,12 @@ export interface RouteResult {
   steps: RouteStep[];
   /** All options the engine offered, best first. Present on the API response. */
   routes?: RouteResult[];
+  hasHighway?: boolean;
+  hasToll?: boolean;
+  hasFerry?: boolean;
+  elevation?: Array<{ distance: number; height: number }>;
+  ascent?: number;
+  descent?: number;
 }
 
 export interface LiveLocation {
@@ -83,6 +90,77 @@ const MODES = [
 export function formatDistance(m: number): string {
   if (m < 1000) return `${Math.round(m)} m`;
   return `${(m / 1000).toFixed(m < 10000 ? 1 : 0)} km`;
+}
+
+/** Metres between two WGS84 points. */
+export function haversine(aLat: number, aLng: number, bLat: number, bLng: number): number {
+  const R = 6371000;
+  const p = Math.PI / 180;
+  const dLat = (bLat - aLat) * p;
+  const dLng = (bLng - aLng) * p;
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(aLat * p) * Math.cos(bLat * p) * Math.sin(dLng / 2) ** 2;
+  return Math.round(2 * R * Math.asin(Math.sqrt(h)));
+}
+
+/** Index of the route vertex closest to a point. */
+function nearestVertex(coords: [number, number][], lat: number, lng: number): number {
+  let best = 0;
+  let bestD = Infinity;
+  for (let i = 0; i < coords.length; i++) {
+    const d = (coords[i][1] - lat) ** 2 + (coords[i][0] - lng) ** 2;
+    if (d < bestD) { bestD = d; best = i; }
+  }
+  return best;
+}
+
+/**
+ * The maneuver the operator is heading into.
+ *
+ * Nearest-maneuver is the wrong rule: 160 m past a depart point, the closest
+ * maneuver is still the one behind you. Progress along the route decides it —
+ * project the position onto the route line, then take the first maneuver that
+ * lies further along than that.
+ */
+export function nextManeuver(
+  steps: RouteStep[],
+  coords: [number, number][],
+  lat: number,
+  lng: number,
+): { step: RouteStep; index: number; distance: number } | null {
+  if (!steps.length) return null;
+  if (!coords.length) return { step: steps[0], index: 0, distance: haversine(lat, lng, steps[0].location[1], steps[0].location[0]) };
+
+  const here = nearestVertex(coords, lat, lng);
+  for (let i = 0; i < steps.length; i++) {
+    const at = nearestVertex(coords, steps[i].location[1], steps[i].location[0]);
+    if (at > here) {
+      return { step: steps[i], index: i, distance: haversine(lat, lng, steps[i].location[1], steps[i].location[0]) };
+    }
+  }
+  // Past the last maneuver — the destination is what remains.
+  const last = steps.length - 1;
+  return { step: steps[last], index: last, distance: haversine(lat, lng, steps[last].location[1], steps[last].location[0]) };
+}
+
+/** Build an SVG path for the elevation profile, normalised into a viewbox. */
+export function elevationPath(
+  points: Array<{ distance: number; height: number }>,
+  width: number,
+  height: number,
+): string {
+  if (points.length < 2) return '';
+  const maxD = points[points.length - 1].distance || 1;
+  const hs = points.map((p) => p.height);
+  const lo = Math.min(...hs);
+  const hi = Math.max(...hs);
+  const span = hi - lo || 1;
+  return points
+    .map((p, i) => {
+      const x = (p.distance / maxD) * width;
+      const y = height - ((p.height - lo) / span) * height;
+      return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
 }
 
 /** Wall-clock arrival time for a trip of `seconds` starting now. */
@@ -353,14 +431,29 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
   const [follow, setFollow] = useState(false);
   const [routes, setRoutes] = useState<RouteResult[]>([]);
   const [chosen, setChosen] = useState(0);
+  const [vias, setVias] = useState<Array<{ place: Place | null; text: string }>>([]);
+  const [avoid, setAvoid] = useState({ tolls: false, highways: false, ferries: false });
+  const [showOptions, setShowOptions] = useState(false);
   const watchId = useRef<number | null>(null);
 
-  const runRoute = useCallback(async (a: Place, b: Place, m: string) => {
+  const runRoute = useCallback(async (
+    a: Place,
+    b: Place,
+    m: string,
+    stops: Place[] = [],
+    av: { tolls: boolean; highways: boolean; ferries: boolean } = { tolls: false, highways: false, ferries: false },
+  ) => {
     setLoading(true);
     setError(null);
     setActiveStep(null);
     try {
-      const res = await fetch(`/api/directions?from=${a.lat},${a.lng}&to=${b.lat},${b.lng}&mode=${m}`);
+      const viaParam = stops.length
+        ? `&via=${stops.map((p) => `${p.lat},${p.lng}`).join('|')}` : '';
+      const avoidList = Object.entries(av).filter(([, on]) => on).map(([k]) => k);
+      const avoidParam = avoidList.length ? `&avoid=${avoidList.join(',')}` : '';
+      const res = await fetch(
+        `/api/directions?from=${a.lat},${a.lng}&to=${b.lat},${b.lng}&mode=${m}${viaParam}${avoidParam}`,
+      );
       const data = await res.json();
       if (!res.ok || data.error) {
         setRoute(null);
@@ -382,6 +475,12 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
     }
     setLoading(false);
   }, [onRoute]);
+
+  /** Current intermediate stops that actually resolved to a place. */
+  const stops = useCallback(
+    () => vias.map((v) => v.place).filter((p): p is Place => p !== null),
+    [vias],
+  );
 
   /** Continuous position updates — the moving dot, not a one-shot fix. */
   const toggleTracking = useCallback(() => {
@@ -443,7 +542,7 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
       setFromText(label);
       setFrom(place);
       onLocate?.(lat, lng, 14);
-      if (to) runRoute(place, to, mode);
+      if (to) runRoute(place, to, mode, stops(), avoid);
     };
 
     const browser = await new Promise<GeolocationPosition | null>((resolve) => {
@@ -475,20 +574,50 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
       setLocateError('Could not determine your location');
     }
     setLocating(false);
-  }, [to, mode, runRoute, onLocate]);
+  }, [to, mode, runRoute, onLocate, stops, avoid]);
 
-  const pickFrom = (p: Place) => { setFrom(p); if (to) runRoute(p, to, mode); };
-  const pickTo = (p: Place) => { setTo(p); if (from) runRoute(from, p, mode); };
-  const pickMode = (m: string) => { setMode(m); if (from && to) runRoute(from, to, m); };
+  const pickFrom = (p: Place) => { setFrom(p); if (to) runRoute(p, to, mode, stops(), avoid); };
+  const pickTo = (p: Place) => { setTo(p); if (from) runRoute(from, p, mode, stops(), avoid); };
+  const pickMode = (m: string) => { setMode(m); if (from && to) runRoute(from, to, m, stops(), avoid); };
+
+  const pickVia = (i: number, p: Place) => {
+    const next = vias.map((v, j) => (j === i ? { place: p, text: p.label } : v));
+    setVias(next);
+    const all = next.map((v) => v.place).filter((x): x is Place => x !== null);
+    if (from && to) runRoute(from, to, mode, all, avoid);
+  };
+
+  const removeVia = (i: number) => {
+    const next = vias.filter((_, j) => j !== i);
+    setVias(next);
+    const all = next.map((v) => v.place).filter((x): x is Place => x !== null);
+    if (from && to) runRoute(from, to, mode, all, avoid);
+  };
+
+  const toggleAvoid = (key: 'tolls' | 'highways' | 'ferries') => {
+    const next = { ...avoid, [key]: !avoid[key] };
+    setAvoid(next);
+    if (from && to) runRoute(from, to, mode, stops(), next);
+  };
 
   const swap = () => {
     setFrom(to); setTo(from);
     setFromText(toText); setToText(fromText);
-    if (from && to) runRoute(to, from, mode);
+    // Reverse the intermediate stops too, or the trip back visits them backwards.
+    const reversed = [...vias].reverse();
+    setVias(reversed);
+    if (from && to) {
+      runRoute(to, from, mode, reversed.map((v) => v.place).filter((x): x is Place => x !== null), avoid);
+    }
   };
 
   const via = route ? viaRoad(route.steps) : null;
   const ready = Boolean(from && to);
+  // While tracking, the useful thing is the turn you are approaching, not the
+  // whole list — recomputed from each position update.
+  const guidance = live && route
+    ? nextManeuver(route.steps, route.geometry.coordinates, live.lat, live.lng)
+    : null;
 
   return (
     <div
@@ -552,6 +681,12 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
             style={{ boxShadow: '0 0 8px rgba(0,230,118,0.6)' }}
           />
           <span className="flex-1 w-px my-1 bg-[repeating-linear-gradient(to_bottom,var(--text-muted)_0_2px,transparent_2px_5px)]" />
+          {vias.map((_, i) => (
+            <span key={i} className="contents">
+              <span className="w-1.5 h-1.5 bg-[var(--cyan-primary)] flex-shrink-0 rotate-45" />
+              <span className="flex-1 w-px my-1 bg-[repeating-linear-gradient(to_bottom,var(--text-muted)_0_2px,transparent_2px_5px)]" />
+            </span>
+          ))}
           <MapPin className="w-3 h-3 text-[var(--alert-red)] flex-shrink-0" />
         </div>
 
@@ -562,6 +697,24 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
             biasLat={center?.lat} biasLng={center?.lng}
             onLocate={useMyLocation} locating={locating} liveFix={live}
           />
+          {vias.map((v, i) => (
+            <div key={i} className="flex items-center gap-1">
+              <PlaceInput
+                value={v.text}
+                onChange={(t) => setVias((prev) => prev.map((x, j) => (j === i ? { ...x, text: t } : x)))}
+                onPick={(p) => pickVia(i, p)}
+                placeholder={`Stop ${i + 1}`}
+                biasLat={center?.lat} biasLng={center?.lng} liveFix={live}
+              />
+              <button
+                onClick={() => removeVia(i)}
+                aria-label={`Remove stop ${i + 1}`}
+                className="p-1 text-[var(--text-muted)] hover:text-[var(--alert-red)] transition-colors flex-shrink-0"
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
+            </div>
+          ))}
           <PlaceInput
             value={toText} onChange={setToText} onPick={pickTo}
             placeholder="Choose destination"
@@ -580,11 +733,11 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
       </div>
 
       {/* ── travel mode ── */}
-      <div className="px-3 pb-2.5">
+      <div className="px-3 pb-2.5 flex items-center gap-1.5">
         <div
           role="tablist"
           aria-label="Travel mode"
-          className="flex p-0.5 rounded-lg border border-[var(--border-secondary)] bg-[rgba(0,0,0,0.35)]"
+          className="flex-1 flex p-0.5 rounded-lg border border-[var(--border-secondary)] bg-[rgba(0,0,0,0.35)]"
         >
           {MODES.map(({ id, label, Icon }) => {
             const on = mode === id;
@@ -606,7 +759,49 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
             );
           })}
         </div>
+
+        <button
+          onClick={() => setVias((v) => [...v, { place: null, text: '' }])}
+          title="Add a stop"
+          aria-label="Add a stop"
+          className="p-1.5 rounded-md text-[var(--text-muted)] hover:text-[var(--cyan-primary)]
+                     hover:bg-[rgba(var(--cyan-rgb),0.08)] transition-colors flex-shrink-0"
+        >
+          <Plus className="w-3.5 h-3.5" />
+        </button>
+        <button
+          onClick={() => setShowOptions((o) => !o)}
+          aria-pressed={showOptions}
+          title="Route options"
+          aria-label="Route options"
+          className={`p-1.5 rounded-md transition-colors flex-shrink-0 ${
+            showOptions || avoid.tolls || avoid.highways || avoid.ferries
+              ? 'text-[var(--gold-primary)] bg-[rgba(var(--gold-rgb),0.1)]'
+              : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+          }`}
+        >
+          <SlidersHorizontal className="w-3.5 h-3.5" />
+        </button>
       </div>
+
+      {showOptions && (
+        <div className="px-3 pb-2.5 flex gap-1.5">
+          {(['tolls', 'highways', 'ferries'] as const).map((k) => (
+            <button
+              key={k}
+              onClick={() => toggleAvoid(k)}
+              aria-pressed={avoid[k]}
+              className={`flex-1 py-1.5 rounded-md border text-[9px] capitalize transition-all ${
+                avoid[k]
+                  ? 'border-[var(--border-active)] bg-[rgba(var(--gold-rgb),0.12)] text-[var(--gold-primary)]'
+                  : 'border-[var(--border-secondary)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+              }`}
+            >
+              Avoid {k}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* ── result region ── */}
       <div className="min-h-0 flex-1 overflow-y-auto styled-scrollbar border-t border-[var(--border-secondary)]">
@@ -648,6 +843,24 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
 
         {!loading && route && (
           <>
+            {guidance && (
+              <div className="px-3 py-2.5 border-b border-[var(--border-secondary)] bg-[rgba(66,133,244,0.07)]">
+                <div className="flex items-center gap-1.5 mb-1.5">
+                  <Navigation className="w-2.5 h-2.5 text-[#4285F4]" />
+                  <span className="text-[8px] uppercase tracking-[0.15em] text-[#4285F4]">Next turn</span>
+                </div>
+                <div className="flex items-start gap-2.5">
+                  <span className="mt-0.5 flex-shrink-0"><StepIcon type={guidance.step.type} /></span>
+                  <span className="flex-1 min-w-0 text-[11px] text-[var(--text-primary)] leading-snug">
+                    {guidance.step.instruction}
+                  </span>
+                  <span className="text-[13px] text-[var(--gold-primary)] tabular-nums flex-shrink-0">
+                    {formatDistance(guidance.distance)}
+                  </span>
+                </div>
+              </div>
+            )}
+
             {/* summary */}
             <div className="px-3 py-2.5 border-b border-[var(--border-secondary)]">
               <div className="flex items-baseline justify-between gap-3">
@@ -669,6 +882,38 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
                   </div>
                 </div>
               </div>
+
+              {(route.hasToll || route.hasHighway || route.hasFerry) && (
+                <div className="flex gap-1.5 mt-2">
+                  {route.hasToll && <span className="px-1.5 py-0.5 rounded text-[8px] uppercase tracking-wider border border-[var(--border-secondary)] text-[var(--alert-orange)]">Toll</span>}
+                  {route.hasHighway && <span className="px-1.5 py-0.5 rounded text-[8px] uppercase tracking-wider border border-[var(--border-secondary)] text-[var(--text-muted)]">Motorway</span>}
+                  {route.hasFerry && <span className="px-1.5 py-0.5 rounded text-[8px] uppercase tracking-wider border border-[var(--border-secondary)] text-[var(--cyan-primary)]">Ferry</span>}
+                </div>
+              )}
+
+              {route.elevation && route.elevation.length > 1 && (
+                <div className="mt-2.5">
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="flex items-center gap-1 text-[8px] uppercase tracking-[0.15em] text-[var(--text-muted)]">
+                      <Mountain className="w-2.5 h-2.5" /> Elevation
+                    </span>
+                    <span className="text-[9px] text-[var(--text-secondary)] tabular-nums">
+                      ↑{route.ascent ?? 0} m · ↓{route.descent ?? 0} m
+                    </span>
+                  </div>
+                  <svg viewBox="0 0 300 40" className="w-full h-10" preserveAspectRatio="none" aria-hidden="true">
+                    <path
+                      d={`${elevationPath(route.elevation, 300, 38)} L300,40 L0,40 Z`}
+                      fill="rgba(0,229,255,0.12)"
+                    />
+                    <path
+                      d={elevationPath(route.elevation, 300, 38)}
+                      fill="none" stroke="var(--cyan-primary)" strokeWidth="1.2"
+                      vectorEffect="non-scaling-stroke"
+                    />
+                  </svg>
+                </div>
+              )}
 
               {routes.length > 1 && (
                 <div className="flex gap-1 mt-2.5" role="tablist" aria-label="Route options">

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -28,7 +28,15 @@ interface OsirisMapProps {
     geometry: { type: 'LineString'; coordinates: [number, number][] };
     from: { lat: number; lng: number };
     to: { lat: number; lng: number };
+    /** Unselected alternatives, drawn dimmed behind the active line. */
+    alternates?: Array<{ type: 'LineString'; coordinates: [number, number][] }>;
+    /** Highlighted portion for the step the operator has selected. */
+    activeSegment?: [number, number][] | null;
   } | null;
+  /** Live position from the browser — drawn as a pulsing dot with accuracy ring. */
+  userLocation?: { lat: number; lng: number; accuracy?: number; heading?: number | null } | null;
+  /** Keep the camera centred on userLocation as it moves. */
+  followUser?: boolean;
 }
 
 function computeSolarTerminator(): [number, number][] {
@@ -53,7 +61,7 @@ function computeSolarTerminator(): [number, number][] {
 
 const EMPTY_FC = { type: 'FeatureCollection' as const, features: [] };
 
-function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null }: OsirisMapProps) {
+function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null, userLocation = null, followUser = false }: OsirisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -2220,38 +2228,51 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     const map = mapRef.current;
 
     const SRC = 'directions-route';
+    const SRC_ALT = 'directions-alternates';
+    const SRC_ACTIVE = 'directions-active-step';
     const SRC_ENDS = 'directions-endpoints';
-    const IDS = ['directions-line-casing', 'directions-line', 'directions-endpoint-halo', 'directions-endpoint'];
+    const IDS = [
+      'directions-alt-line', 'directions-line-casing', 'directions-line',
+      'directions-active-line', 'directions-endpoint-halo', 'directions-endpoint',
+    ];
 
     const teardown = () => {
       IDS.forEach(id => { if (map.getLayer(id)) map.removeLayer(id); });
-      if (map.getSource(SRC)) map.removeSource(SRC);
-      if (map.getSource(SRC_ENDS)) map.removeSource(SRC_ENDS);
+      [SRC, SRC_ALT, SRC_ACTIVE, SRC_ENDS].forEach(id => { if (map.getSource(id)) map.removeSource(id); });
     };
 
-    if (!route?.geometry?.coordinates?.length) {
-      teardown();
-      return;
+    if (!route?.geometry?.coordinates?.length) { teardown(); return; }
+
+    const fc = (features: GeoJSON.Feature[]) => ({ type: 'FeatureCollection' as const, features });
+    const line = (coords: [number, number][]): GeoJSON.Feature => ({
+      type: 'Feature', properties: {},
+      geometry: { type: 'LineString', coordinates: coords },
+    });
+    const setData = (id: string, data: unknown) => {
+      if (!map.getSource(id)) map.addSource(id, { type: 'geojson', data: data as never });
+      else (map.getSource(id) as maplibregl.GeoJSONSource).setData(data as never);
+    };
+
+    setData(SRC, fc([line(route.geometry.coordinates)]));
+    setData(SRC_ALT, fc((route.alternates || []).map(a => line(a.coordinates))));
+    setData(SRC_ACTIVE, fc(route.activeSegment?.length ? [line(route.activeSegment)] : []));
+    setData(SRC_ENDS, fc([
+      { type: 'Feature', properties: { kind: 'origin' }, geometry: { type: 'Point', coordinates: [route.from.lng, route.from.lat] } },
+      { type: 'Feature', properties: { kind: 'destination' }, geometry: { type: 'Point', coordinates: [route.to.lng, route.to.lat] } },
+    ]));
+
+    // Alternatives sit underneath, muted, so the chosen line stays unambiguous.
+    if (!map.getLayer('directions-alt-line')) {
+      map.addLayer({
+        id: 'directions-alt-line', type: 'line', source: SRC_ALT,
+        layout: { 'line-cap': 'round', 'line-join': 'round' },
+        paint: {
+          'line-color': '#5C6470',
+          'line-width': ['interpolate', ['linear'], ['zoom'], 5, 2.5, 14, 5],
+          'line-opacity': 0.55,
+        },
+      });
     }
-
-    const lineFC = {
-      type: 'FeatureCollection' as const,
-      features: [{ type: 'Feature' as const, properties: {}, geometry: route.geometry }],
-    };
-    const endsFC = {
-      type: 'FeatureCollection' as const,
-      features: [
-        { type: 'Feature' as const, properties: { kind: 'origin' }, geometry: { type: 'Point' as const, coordinates: [route.from.lng, route.from.lat] } },
-        { type: 'Feature' as const, properties: { kind: 'destination' }, geometry: { type: 'Point' as const, coordinates: [route.to.lng, route.to.lat] } },
-      ],
-    };
-
-    if (!map.getSource(SRC)) map.addSource(SRC, { type: 'geojson', data: lineFC as any });
-    else (map.getSource(SRC) as maplibregl.GeoJSONSource).setData(lineFC as any);
-
-    if (!map.getSource(SRC_ENDS)) map.addSource(SRC_ENDS, { type: 'geojson', data: endsFC as any });
-    else (map.getSource(SRC_ENDS) as maplibregl.GeoJSONSource).setData(endsFC as any);
-
     if (!map.getLayer('directions-line-casing')) {
       map.addLayer({
         id: 'directions-line-casing', type: 'line', source: SRC,
@@ -2266,6 +2287,17 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         paint: {
           'line-color': '#00E5FF',
           'line-width': ['interpolate', ['linear'], ['zoom'], 5, 2.5, 14, 6],
+          'line-opacity': 0.95,
+        },
+      });
+    }
+    if (!map.getLayer('directions-active-line')) {
+      map.addLayer({
+        id: 'directions-active-line', type: 'line', source: SRC_ACTIVE,
+        layout: { 'line-cap': 'round', 'line-join': 'round' },
+        paint: {
+          'line-color': '#D4AF37',
+          'line-width': ['interpolate', ['linear'], ['zoom'], 5, 4, 14, 9],
           'line-opacity': 0.95,
         },
       });
@@ -2291,8 +2323,16 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         },
       });
     }
+  }, [mapReady, route]);
 
-    // Frame the whole route
+  // ── ROUTE FRAMING ──
+  // Kept apart from drawing so picking a step or an alternative redraws without
+  // yanking the camera back out to the whole route.
+  const routeFrameKey = route
+    ? `${route.from.lat},${route.from.lng},${route.to.lat},${route.to.lng},${route.geometry.coordinates.length}`
+    : null;
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !route?.geometry?.coordinates?.length) return;
     const coords = route.geometry.coordinates;
     let [west, south, east, north] = [coords[0][0], coords[0][1], coords[0][0], coords[0][1]];
     for (const [lng, lat] of coords) {
@@ -2301,8 +2341,96 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       if (lat < south) south = lat;
       if (lat > north) north = lat;
     }
-    map.fitBounds([[west, south], [east, north]], { padding: 90, duration: 900, maxZoom: 15 });
-  }, [mapReady, route]);
+    mapRef.current.fitBounds([[west, south], [east, north]], { padding: 90, duration: 900, maxZoom: 15 });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapReady, routeFrameKey]);
+
+  // ── LIVE USER LOCATION ──
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    const map = mapRef.current;
+
+    const SRC = 'user-location';
+    const SRC_ACC = 'user-location-accuracy';
+    const IDS = ['user-accuracy-fill', 'user-accuracy-line', 'user-dot-pulse', 'user-dot', 'user-dot-core'];
+
+    if (!userLocation) {
+      IDS.forEach(id => { if (map.getLayer(id)) map.removeLayer(id); });
+      [SRC, SRC_ACC].forEach(id => { if (map.getSource(id)) map.removeSource(id); });
+      return;
+    }
+
+    const { lat, lng, accuracy } = userLocation;
+
+    // Accuracy is a real-world radius, so it must be a polygon in degrees
+    // rather than a fixed pixel circle — it has to shrink as you zoom out.
+    const ring: [number, number][] = [];
+    const r = Math.min(Math.max(accuracy ?? 0, 0), 5000);
+    if (r > 0) {
+      const dLat = r / 111320;
+      const dLng = r / (111320 * Math.cos((lat * Math.PI) / 180) || 1);
+      for (let i = 0; i <= 64; i++) {
+        const t = (i / 64) * 2 * Math.PI;
+        ring.push([lng + dLng * Math.cos(t), lat + dLat * Math.sin(t)]);
+      }
+    }
+
+    const point = {
+      type: 'FeatureCollection',
+      features: [{ type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [lng, lat] } }],
+    };
+    const accFc = {
+      type: 'FeatureCollection',
+      features: ring.length
+        ? [{ type: 'Feature', properties: {}, geometry: { type: 'Polygon', coordinates: [ring] } }]
+        : [],
+    };
+
+    if (!map.getSource(SRC)) map.addSource(SRC, { type: 'geojson', data: point as never });
+    else (map.getSource(SRC) as maplibregl.GeoJSONSource).setData(point as never);
+    if (!map.getSource(SRC_ACC)) map.addSource(SRC_ACC, { type: 'geojson', data: accFc as never });
+    else (map.getSource(SRC_ACC) as maplibregl.GeoJSONSource).setData(accFc as never);
+
+    if (!map.getLayer('user-accuracy-fill')) {
+      map.addLayer({ id: 'user-accuracy-fill', type: 'fill', source: SRC_ACC, paint: { 'fill-color': '#4285F4', 'fill-opacity': 0.12 } });
+    }
+    if (!map.getLayer('user-accuracy-line')) {
+      map.addLayer({ id: 'user-accuracy-line', type: 'line', source: SRC_ACC, paint: { 'line-color': '#4285F4', 'line-width': 1, 'line-opacity': 0.35 } });
+    }
+    if (!map.getLayer('user-dot-pulse')) {
+      map.addLayer({ id: 'user-dot-pulse', type: 'circle', source: SRC, paint: { 'circle-radius': 8, 'circle-color': '#4285F4', 'circle-opacity': 0.35 } });
+    }
+    if (!map.getLayer('user-dot')) {
+      map.addLayer({ id: 'user-dot', type: 'circle', source: SRC, paint: { 'circle-radius': 7, 'circle-color': '#FFFFFF' } });
+    }
+    if (!map.getLayer('user-dot-core')) {
+      map.addLayer({ id: 'user-dot-core', type: 'circle', source: SRC, paint: { 'circle-radius': 5, 'circle-color': '#4285F4' } });
+    }
+  }, [mapReady, userLocation]);
+
+  // Pulse the halo. rAF-driven, so it stops when the tab is backgrounded.
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !userLocation) return;
+    const map = mapRef.current;
+    let raf = 0;
+    const started = performance.now();
+    const tick = (now: number) => {
+      if (map.getLayer('user-dot-pulse')) {
+        const t = ((now - started) % 2000) / 2000;
+        map.setPaintProperty('user-dot-pulse', 'circle-radius', 8 + t * 22);
+        map.setPaintProperty('user-dot-pulse', 'circle-opacity', 0.35 * (1 - t));
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [mapReady, userLocation]);
+
+  // ── FOLLOW MODE ──
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !followUser || !userLocation) return;
+    mapRef.current.easeTo({ center: [userLocation.lng, userLocation.lat], duration: 700 });
+  }, [mapReady, followUser, userLocation]);
 
   // ── ARCGIS LAYERS ──
   useEffect(() => {


### PR DESCRIPTION
Brings the route planner up to consumer-mapping-app standard. Three commits, each a distinct concern.

---

## 1 · Location search — the "locations are missing" bug

Nominatim is a *geocoder*, not a type-ahead index, so it needs near-complete input. Measured side by side:

| Query | Nominatim | Now |
|---|---:|---:|
| `eiffel tow` | **0** | 7 |
| `sydny opera house` (typo) | 1 | 8 |
| `shibuya cross` | 2 | 7 |
| `10117 Berlin` | 2 | 8 |

New `/api/geosearch` leads with **Photon** (Komoot's autocomplete index over the same OSM data — prefix and typo tolerant) and keeps Nominatim as a supplement, merged and de-duplicated by name + proximity.

Photon ranks lexically though, so `heathrow` returned *Heathrow, Florida* above London Heathrow Airport. Nominatim publishes an importance score — **0.606** for the airport against **0.352** for the town — so hits clearing 0.5 are promoted. That fixes the airport *without* disturbing queries Nominatim can't answer at all, which is the case a prominence rule could easily break; there's a test pinning both sides.

Results are biased toward the current map centre, so `hauptbahnhof` resolves to Berlin when you're looking at Berlin rather than to Halle. Search moved server-side so both providers can be merged, the identifying User-Agent both OSM services ask for is sent, and results cache for 10 min (repeat query 0.24s).

## 2 · Live location

`watchPosition`, not a one-shot fix. The map draws a white-ringed blue dot, an accuracy circle and a halo pulsing on a rAF loop (so it stops when the tab is backgrounded rather than burning a timer).

The accuracy ring is a **polygon computed in degrees**, not a fixed pixel radius — it represents metres on the ground, so it has to shrink as you zoom out or it lies about precision.

A follow toggle keeps the camera on the dot, and once a fix exists **"Your location" is pinned as the first entry in both fields**. The one-shot locate button falls back to OSIRIS's existing IP geolocation when permission is denied, labelled *"Approximate — from network location"* rather than pretending to be a fix.

## 3 · Route alternatives, ETA, multi-stop, avoid, guidance, elevation

- **Alternatives** — Valhalla returns them when the network offers a real choice (none for a 2 km hop, three for Berlin→Frankfurt). Shown as tabs (`Fastest` / `+20 min`); unselected lines draw muted underneath the active one. The API returns the full set best-first, with top-level fields still mirroring `routes[0]` so single-route readers are unaffected.
- **Arrival ETA** as a clock time, next to the duration.
- **Multi-stop** via `?via=lat,lng|lat,lng`. Swapping origin/destination reverses the stops too, or the return trip visits them backwards.
- **Avoid tolls / motorways / ferries** — Valhalla treats avoidance as a 0..1 preference, not a hard ban, so these map to `use_tolls`/`use_highways`/`use_ferry = 0`. Berlin→Frankfurt: 546km/5.5h → **595km/11.9h** with motorways off, `has_highway=false`. Summary carries toll/motorway/ferry badges so the trade-off is visible.
- **Live turn guidance** — the maneuver being approached plus distance to it, recomputed per position fix.
- **Elevation profile** for walking and cycling, from Valhalla's `/height`, with total ascent/descent. Driving skips it (extra upstream call, and the climb only decides viability on foot or by bike).
- Selecting a step highlights the stretch of road it covers, and camera framing moved to its own effect so picking a step or an alternative no longer yanks the view back out.

---

## Two bugs caught by tests, worth reading

**Live guidance picked the nearest maneuver.** Wrong rule: 160 m past a depart point the closest maneuver is still *behind* you, so it kept announcing "Depart". It now projects the position onto the route line and takes the first maneuver further along than that.

**The redesigned suggestion list split labels on commas**, which mangled coordinate entries into `52.51630` over `13.37770` — reading as a broken address. Both have regression tests.

## Verification

- **96 tests pass** (37 new across search merging/ranking, guidance, elevation, costing options, alternatives and the two regressions above). Production build compiles.
- Verified through the real UI, and confirmed via the network log that the client actually sends `via=…` and `avoid=highways` rather than trusting the buttons looked right.
- Lint clean on every file I own. `OsirisMap` sits at 129 pre-existing errors, down from 133 — the route-layer rewrite removed some `any`.

## For a reviewer

- **I could not visually confirm two things.** The browser pane used for verification doesn't composite frames — screenshots time out and canvas readback returns a blank buffer. The **blue location dot** and the **elevation graph** are verified through props and DOM text, but nobody has actually looked at them yet. Everything else was exercised end-to-end.
- **Browser geolocation needs HTTPS or localhost**, so live tracking is refused over plain-HTTP LAN/Tailscale; the one-shot button still falls back to IP.
- Alternatives only appear when the road network genuinely offers a choice — a short urban hop legitimately returns one route.
- `page.tsx` reports the same pre-existing lint errors before and after these changes; none added.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
