### PR TITLE
feat(nav): live turn-by-turn navigation with voice guidance and rerouting

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,8 @@ import MarketsPanel from '@/components/MarketsPanel';
 import ScmPanel from '@/components/ScmPanel';
 import SearchBar from '@/components/SearchBar';
 import DirectionsBar, { type RouteResult, type LiveLocation } from '@/components/DirectionsBar';
+import NavigationView from '@/components/NavigationView';
+import type { NavProgress } from '@/lib/navigation';
 import ScaleBar from '@/components/ScaleBar';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import SharePanel from '@/components/SharePanel';
@@ -120,6 +122,29 @@ export default function Dashboard() {
   >(null);
   const [liveLocation, setLiveLocation] = useState<LiveLocation | null>(null);
   const [followUser, setFollowUser] = useState(false);
+  const [navSession, setNavSession] = useState<
+    { route: RouteResult; label: string; key: number } | null
+  >(null);
+  const [navProgress, setNavProgress] = useState<NavProgress | null>(null);
+
+  // A navigation session owns its own position watch. The planner's watch dies
+  // with the planner when guidance takes over the panel, so guidance cannot
+  // depend on it — without this the banner sits on "waiting for a fix" forever.
+  useEffect(() => {
+    if (!navSession) return;
+    if (typeof navigator === 'undefined' || !navigator.geolocation) return;
+    const id = navigator.geolocation.watchPosition(
+      (pos) => setLiveLocation({
+        lat: pos.coords.latitude,
+        lng: pos.coords.longitude,
+        accuracy: pos.coords.accuracy,
+        heading: pos.coords.heading,
+      }),
+      () => { /* the view already explains the HTTPS requirement */ },
+      { enableHighAccuracy: true, maximumAge: 2000, timeout: 15000 },
+    );
+    return () => navigator.geolocation.clearWatch(id);
+  }, [navSession]);
   const [showRemote, setShowRemote] = useState(false);
   const [showArcGIS, setShowArcGIS] = useState(false);
   const [arcgisLayers, setArcgisLayers] = useState<Array<{ id: string; title: string; url: string; geojson: any; color: string; visible: boolean; opacity: number }>>([]);
@@ -858,8 +883,13 @@ export default function Dashboard() {
           arcgisLayers={arcgisLayers.filter(l => l.visible).map(l => ({ id: l.id, title: l.title, geojson: l.geojson, color: l.color, opacity: l.opacity }))}
           onMapCenter={setMapCenter}
           route={activeRoute}
-          userLocation={liveLocation}
+          userLocation={
+            navSession && navProgress
+              ? { lat: navProgress.snapped[1], lng: navProgress.snapped[0], accuracy: liveLocation?.accuracy, heading: liveLocation?.heading }
+              : liveLocation
+          }
           followUser={followUser}
+          navigating={Boolean(navSession)}
         />
       </ErrorBoundary>
 
@@ -868,14 +898,53 @@ export default function Dashboard() {
         className="absolute top-3 z-[400] w-[min(92vw,372px)] pointer-events-auto"
         style={isMobile ? { left: '50%', transform: 'translateX(-50%)' } : { right: '56px' }}
       >
-        {showDirections && (
+        {navSession ? (
           <motion.div initial={{ opacity: 0, y: -12 }} animate={{ opacity: 1, y: 0 }}>
+            <NavigationView
+              key={navSession.key}
+              route={navSession.route}
+              destinationLabel={navSession.label}
+              fix={liveLocation}
+              onProgress={setNavProgress}
+              onExit={() => { setNavSession(null); setNavProgress(null); setFollowUser(false); }}
+              onReroute={async (fromPt) => {
+                // Re-plan from where the driver actually is, to the same destination.
+                const dest = navSession.route.geometry.coordinates.at(-1)!;
+                try {
+                  const res = await fetch(
+                    `/api/directions?from=${fromPt.lat},${fromPt.lng}&to=${dest[1]},${dest[0]}&mode=auto`,
+                  );
+                  const data = await res.json();
+                  if (res.ok && !data.error) {
+                    setNavSession((n) => (n ? { ...n, route: data, key: Date.now() } : n));
+                    setActiveRoute({ ...data, from: fromPt, to: { lat: dest[1], lng: dest[0] } });
+                  }
+                } catch { /* keep the old route rather than dropping guidance */ }
+              }}
+            />
+          </motion.div>
+        ) : null}
+
+        {/* The planner stays mounted underneath a running session: unmounting it
+            would discard the route you are driving, so ending guidance would
+            drop you into an empty form instead of back onto your route. */}
+        {showDirections && (
+          <motion.div
+            initial={{ opacity: 0, y: -12 }}
+            animate={{ opacity: navSession ? 0 : 1, y: 0 }}
+            className={navSession ? 'pointer-events-none h-0 overflow-hidden' : ''}
+            aria-hidden={Boolean(navSession)}
+          >
             <DirectionsBar
               center={mapCenter ? { lat: mapCenter.lat, lng: mapCenter.lng } : null}
               onRoute={(r) => setActiveRoute(r)}
               onLiveLocation={setLiveLocation}
               onFollowChange={setFollowUser}
               onActiveSegment={(seg) => setActiveRoute((r) => (r ? { ...r, activeSegment: seg } : r))}
+              onStartNavigation={(r, label) => {
+                setNavSession({ route: r, label, key: Date.now() });
+                setFollowUser(true);
+              }}
               onLocate={(lat, lng, zoom) => setFlyToLocation({ lat, lng, zoom, ts: Date.now() })}
               onClose={() => { setShowDirections(false); setActiveRoute(null); }}
             />
@@ -1087,7 +1156,7 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowDirections(!showDirections); if (showDirections) { setActiveRoute(null); setRouteSeed(null); } setShowDesktopSearch(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDirections ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Directions — turn-by-turn routing">
+          <button onClick={() => { setShowDirections(!showDirections); if (showDirections) { setActiveRoute(null); } setShowDesktopSearch(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDirections ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Directions — turn-by-turn routing">
             <Route className={`w-4 h-4 ${showDirections ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ROUTE</span>

--- a/src/components/DirectionsBar.tsx
+++ b/src/components/DirectionsBar.tsx
@@ -5,7 +5,7 @@ import {
   X, Car, Footprints, Bike, ArrowUpDown, MapPin, Flag, Route,
   CornerUpRight, CornerUpLeft, ArrowUp, RotateCw, Merge, Search,
   LocateFixed, Building2, Landmark, Globe2, Signpost, Home, Crosshair, Clock,
-  Plus, Trash2, SlidersHorizontal, Mountain, Navigation,
+  Plus, Trash2, SlidersHorizontal, Mountain, Navigation, Play,
 } from 'lucide-react';
 
 /* ═══════════════════════════════════════════════════════════════
@@ -79,6 +79,8 @@ interface DirectionsBarProps {
   /** Selected step segment, for highlighting the leg on the map. */
   onActiveSegment?: (seg: [number, number][] | null) => void;
   onFollowChange?: (follow: boolean) => void;
+  /** Hand the chosen route to the parent to drive live navigation. */
+  onStartNavigation?: (route: RouteResult, destinationLabel: string) => void;
 }
 
 const MODES = [
@@ -414,7 +416,7 @@ function PlaceInput({
   );
 }
 
-export default function DirectionsBar({ onRoute, onLocate, onClose, center = null, onLiveLocation, onActiveSegment, onFollowChange }: DirectionsBarProps) {
+export default function DirectionsBar({ onRoute, onLocate, onClose, center = null, onLiveLocation, onActiveSegment, onFollowChange, onStartNavigation }: DirectionsBarProps) {
   const [fromText, setFromText] = useState('');
   const [toText, setToText] = useState('');
   const [from, setFrom] = useState<Place | null>(null);
@@ -913,6 +915,19 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
                     />
                   </svg>
                 </div>
+              )}
+
+              {onStartNavigation && (
+                <button
+                  onClick={() => onStartNavigation(route, to?.label || 'your destination')}
+                  className="w-full mt-2.5 flex items-center justify-center gap-2 py-2 rounded-lg
+                             bg-[rgba(66,133,244,0.16)] border border-[rgba(66,133,244,0.45)]
+                             text-[#7BAAF7] text-[11px] tracking-wide
+                             hover:bg-[rgba(66,133,244,0.24)] transition-colors"
+                >
+                  <Play className="w-3.5 h-3.5" />
+                  Start navigation
+                </button>
               )}
 
               {routes.length > 1 && (

--- a/src/components/NavigationView.tsx
+++ b/src/components/NavigationView.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import {
+  X, Volume2, VolumeX, CornerUpRight, CornerUpLeft, ArrowUp, RotateCw,
+  Merge, Flag, MapPin, AlertTriangle, Loader2,
+} from 'lucide-react';
+import {
+  cumulativeDistances, stepPositions, computeProgress, shouldAnnounce, announcementText,
+  type NavStep, type NavFix, type NavProgress,
+} from '@/lib/navigation';
+
+/* ═══════════════════════════════════════════════════════════════
+   OSIRIS — Live Navigation
+   Turn-by-turn guidance driven by the device's own position feed
+   ═══════════════════════════════════════════════════════════════ */
+
+export interface NavRoute {
+  distance: number;
+  duration: number;
+  geometry: { type: 'LineString'; coordinates: [number, number][] };
+  steps: NavStep[];
+}
+
+interface NavigationViewProps {
+  route: NavRoute;
+  destinationLabel: string;
+  /** Position feed; the parent owns the geolocation watch. */
+  fix: NavFix | null;
+  onExit: () => void;
+  /** Ask the parent to recompute the route from the current position. */
+  onReroute: (from: { lat: number; lng: number }) => void;
+  /** Snapped position + progress, so the map can follow and draw. */
+  onProgress?: (p: NavProgress | null) => void;
+}
+
+function ManeuverIcon({ type, className }: { type: string; className?: string }) {
+  const c = className ?? 'w-8 h-8';
+  if (type === 'arrive') return <Flag className={`${c} text-[var(--alert-green)]`} />;
+  if (type === 'depart') return <MapPin className={`${c} text-[var(--alert-green)]`} />;
+  if (type === 'roundabout') return <RotateCw className={`${c} text-white`} />;
+  if (type === 'merge') return <Merge className={`${c} text-white`} />;
+  if (type.includes('right')) return <CornerUpRight className={`${c} text-white`} />;
+  if (type.includes('left')) return <CornerUpLeft className={`${c} text-white`} />;
+  return <ArrowUp className={`${c} text-white`} />;
+}
+
+/** Guidance distances read better rounded than exact. */
+export function navDistance(m: number): string {
+  if (m < 20) return 'Now';
+  if (m < 1000) return `${Math.round(m / 10) * 10} m`;
+  return `${(m / 1000).toFixed(1)} km`;
+}
+
+export function navDuration(s: number): string {
+  const mins = Math.max(1, Math.round(s / 60));
+  if (mins < 60) return `${mins} min`;
+  return `${Math.floor(mins / 60)} hr ${mins % 60} min`;
+}
+
+export default function NavigationView({
+  route, destinationLabel, fix, onExit, onReroute, onProgress,
+}: NavigationViewProps) {
+  const [muted, setMuted] = useState(false);
+  const [rerouting, setRerouting] = useState(false);
+  // Coarse clock for the arrival time — reading Date.now() during render is
+  // impure, and the ETA does not need to tick faster than this anyway.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 15000);
+    return () => clearInterval(id);
+  }, []);
+
+  const spoken = useRef<Record<number, number>>({});
+  const offRouteSince = useRef<number | null>(null);
+  const wakeLock = useRef<WakeLockSentinel | null>(null);
+
+  // Derived once per route rather than on every position update. The parent
+  // keys this component by route, so a recalculated route remounts it and the
+  // spoken/off-route bookkeeping resets without a state write in an effect.
+  const geometry = route.geometry.coordinates;
+  const cumulative = useMemo(() => cumulativeDistances(geometry), [geometry]);
+  const stepAlong = useMemo(
+    () => stepPositions(geometry, route.steps, cumulative),
+    [geometry, route.steps, cumulative],
+  );
+
+  // Progress is derived from the current fix, not stored — deriving it keeps
+  // the render a pure function of props and avoids a state write per fix.
+  const progress = useMemo<NavProgress | null>(
+    () => (fix && geometry.length
+      ? computeProgress(geometry, route.steps, stepAlong, route.duration, fix, cumulative)
+      : null),
+    [fix, geometry, route.steps, stepAlong, route.duration, cumulative],
+  );
+
+  const speak = useCallback((text: string) => {
+    if (muted || typeof window === 'undefined' || !window.speechSynthesis) return;
+    const u = new SpeechSynthesisUtterance(text);
+    u.rate = 1.05;
+    u.lang = 'en-US';
+    window.speechSynthesis.speak(u);
+  }, [muted]);
+
+  // ── the guidance loop: side effects only ──
+  useEffect(() => {
+    const p = progress;
+    if (!p || !fix) return;
+
+    onProgress?.(p);
+
+    if (p.arrived) {
+      if (!spoken.current[-1]) {
+        spoken.current[-1] = 1;
+        speak('You have arrived at your destination.');
+      }
+      return;
+    }
+
+    // Only reroute once the driver has been off-line for a few seconds — a
+    // single noisy fix beside a building should not tear up the route.
+    if (p.offRoute) {
+      if (offRouteSince.current === null) offRouteSince.current = Date.now();
+      else if (Date.now() - offRouteSince.current > 6000 && !rerouting) {
+        setRerouting(true);
+        speak('Recalculating.');
+        onReroute({ lat: fix.lat, lng: fix.lng });
+      }
+      return;
+    }
+    offRouteSince.current = null;
+
+    const step = route.steps[p.stepIndex];
+    if (!step) return;
+    const band = shouldAnnounce(p.stepIndex, p.distanceToStep, spoken.current);
+    if (band !== null) {
+      spoken.current[p.stepIndex] = band;
+      speak(announcementText(step.instruction, band));
+    }
+  }, [progress, fix, route.steps, speak, onReroute, onProgress, rerouting]);
+
+  // Keep the display awake — a navigation view that sleeps mid-junction is useless.
+  useEffect(() => {
+    let cancelled = false;
+    const nav = navigator as Navigator & { wakeLock?: { request: (t: 'screen') => Promise<WakeLockSentinel> } };
+    nav.wakeLock?.request('screen').then((s) => {
+      if (cancelled) { s.release().catch(() => {}); return; }
+      wakeLock.current = s;
+    }).catch(() => {});
+    return () => {
+      cancelled = true;
+      wakeLock.current?.release().catch(() => {});
+      wakeLock.current = null;
+    };
+  }, []);
+
+  // Never leave a half-spoken instruction behind on exit.
+  useEffect(() => () => { window.speechSynthesis?.cancel(); }, []);
+
+  const step = progress ? route.steps[progress.stepIndex] : route.steps[0];
+  const arrived = progress?.arrived ?? false;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {/* ── maneuver banner ── */}
+      <div
+        className="glass-panel overflow-hidden !border-[var(--border-active)]"
+        style={{ boxShadow: '0 18px 56px rgba(0,0,0,0.75)' }}
+      >
+        <div className={`px-4 py-3 flex items-center gap-4 ${arrived ? 'bg-[rgba(0,230,118,0.10)]' : 'bg-[rgba(66,133,244,0.10)]'}`}>
+          {arrived
+            ? <Flag className="w-8 h-8 text-[var(--alert-green)] flex-shrink-0" />
+            : <ManeuverIcon type={step?.type ?? 'straight'} />}
+
+          <div className="flex-1 min-w-0">
+            {!arrived && progress && (
+              <div className="text-[22px] leading-none text-[var(--gold-primary)] tabular-nums mb-1">
+                {navDistance(progress.distanceToStep)}
+              </div>
+            )}
+            <div className={`text-[12px] leading-snug ${arrived ? 'text-[var(--alert-green)]' : 'text-[var(--text-primary)]'}`}>
+              {arrived ? `You have arrived at ${destinationLabel}` : step?.instruction ?? 'Starting…'}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1 flex-shrink-0">
+            <button
+              onClick={() => { setMuted((m) => !m); window.speechSynthesis?.cancel(); }}
+              aria-pressed={muted}
+              title={muted ? 'Unmute voice guidance' : 'Mute voice guidance'}
+              className="p-1.5 rounded-md text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+            >
+              {muted ? <VolumeX className="w-4 h-4" /> : <Volume2 className="w-4 h-4" />}
+            </button>
+            <button
+              onClick={onExit}
+              title="End navigation"
+              aria-label="End navigation"
+              className="p-1.5 rounded-md text-[var(--text-muted)] hover:text-[var(--alert-red)] transition-colors"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* progress along the route */}
+        <div className="h-[3px] bg-[rgba(255,255,255,0.06)]">
+          <div
+            className="h-full bg-[var(--gold-primary)] transition-[width] duration-700"
+            style={{ width: `${Math.round((progress?.fraction ?? 0) * 100)}%` }}
+          />
+        </div>
+
+        {/* ── trip status ── */}
+        <div className="px-4 py-2.5 flex items-center justify-between gap-3">
+          {rerouting ? (
+            <span className="flex items-center gap-2 text-[10px] text-[var(--alert-orange)]">
+              <Loader2 className="w-3 h-3 animate-spin" /> Recalculating route…
+            </span>
+          ) : progress?.offRoute ? (
+            <span className="flex items-center gap-2 text-[10px] text-[var(--alert-orange)]">
+              <AlertTriangle className="w-3 h-3" /> Off route
+            </span>
+          ) : (
+            <span className="text-[10px] text-[var(--text-muted)] truncate">
+              to {destinationLabel}
+            </span>
+          )}
+
+          {progress && !arrived && (
+            <span className="flex items-baseline gap-2.5 flex-shrink-0 tabular-nums">
+              <span className="text-[13px] text-[var(--text-primary)]">{navDuration(progress.durationRemaining)}</span>
+              <span className="text-[10px] text-[var(--text-secondary)]">{navDistance(progress.distanceRemaining)}</span>
+              <span className="text-[10px] text-[var(--text-muted)]">
+                {new Date(now + progress.durationRemaining * 1000)
+                  .toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+              </span>
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* ── the turn after this one ── */}
+      {progress && !arrived && route.steps[progress.stepIndex + 1] && (
+        <div className="glass-panel px-4 py-2 flex items-center gap-3">
+          <span className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-muted)] flex-shrink-0">Then</span>
+          <ManeuverIcon type={route.steps[progress.stepIndex + 1].type} className="w-4 h-4" />
+          <span className="text-[10px] text-[var(--text-secondary)] truncate">
+            {route.steps[progress.stepIndex + 1].instruction}
+          </span>
+        </div>
+      )}
+
+      {!fix && (
+        <div className="glass-panel px-4 py-2 text-[10px] text-[var(--alert-orange)]">
+          Waiting for a position fix… navigation needs HTTPS or localhost.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -37,6 +37,8 @@ interface OsirisMapProps {
   userLocation?: { lat: number; lng: number; accuracy?: number; heading?: number | null } | null;
   /** Keep the camera centred on userLocation as it moves. */
   followUser?: boolean;
+  /** Live navigation: tighter zoom and the map turned to face travel direction. */
+  navigating?: boolean;
 }
 
 function computeSolarTerminator(): [number, number][] {
@@ -61,7 +63,7 @@ function computeSolarTerminator(): [number, number][] {
 
 const EMPTY_FC = { type: 'FeatureCollection' as const, features: [] };
 
-function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null, userLocation = null, followUser = false }: OsirisMapProps) {
+function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null, userLocation = null, followUser = false, navigating = false }: OsirisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -2429,8 +2431,28 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   // ── FOLLOW MODE ──
   useEffect(() => {
     if (!mapReady || !mapRef.current || !followUser || !userLocation) return;
-    mapRef.current.easeTo({ center: [userLocation.lng, userLocation.lat], duration: 700 });
-  }, [mapReady, followUser, userLocation]);
+    // While navigating, sit close in and rotate the map so travel direction is
+    // "up" — reading a turn off a north-locked map at speed does not work.
+    mapRef.current.easeTo({
+      center: [userLocation.lng, userLocation.lat],
+      ...(navigating
+        ? {
+            zoom: Math.max(mapRef.current.getZoom(), 16.5),
+            pitch: 50,
+            ...(typeof userLocation.heading === 'number' && !Number.isNaN(userLocation.heading)
+              ? { bearing: userLocation.heading }
+              : {}),
+          }
+        : {}),
+      duration: 700,
+    });
+  }, [mapReady, followUser, userLocation, navigating]);
+
+  // Restore a plain north-up view when guidance ends.
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || navigating) return;
+    mapRef.current.easeTo({ pitch: 0, bearing: 0, duration: 600 });
+  }, [mapReady, navigating]);
 
   // ── ARCGIS LAYERS ──
   useEffect(() => {

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import {
+  distanceM,
+  cumulativeDistances,
+  snapToRoute,
+  stepPositions,
+  computeProgress,
+  announcementBand,
+  announcementText,
+  shouldAnnounce,
+  OFF_ROUTE_M,
+  type NavStep,
+} from './navigation';
+
+// A ~1 km straight run east along a constant latitude, sparsely sampled.
+const line: [number, number][] = [
+  [13.3777, 52.5163],
+  [13.3850, 52.5163],
+  [13.3924, 52.5163],
+];
+
+const steps: NavStep[] = [
+  { instruction: 'Drive east.', distance: 500, duration: 60, location: [13.3777, 52.5163], type: 'depart' },
+  { instruction: 'Turn right onto Friedrichstraße.', distance: 500, duration: 60, location: [13.385, 52.5163], type: 'right' },
+  { instruction: 'You have arrived.', distance: 0, duration: 0, location: [13.3924, 52.5163], type: 'arrive' },
+];
+
+describe('distanceM', () => {
+  it('measures a known short distance', () => {
+    // 0.0073° of longitude at 52.5°N is roughly 495 m
+    const d = distanceM(52.5163, 13.3777, 52.5163, 13.385);
+    expect(d).toBeGreaterThan(400);
+    expect(d).toBeLessThan(600);
+  });
+
+  it('is zero for the same point', () => {
+    expect(distanceM(52.5163, 13.3777, 52.5163, 13.3777)).toBe(0);
+  });
+});
+
+describe('cumulativeDistances', () => {
+  it('accumulates monotonically from zero', () => {
+    const cum = cumulativeDistances(line);
+    expect(cum[0]).toBe(0);
+    expect(cum[1]).toBeGreaterThan(0);
+    expect(cum[2]).toBeGreaterThan(cum[1]);
+  });
+});
+
+describe('snapToRoute', () => {
+  // The reason this projects onto segments rather than vertices: mid-segment,
+  // the nearest vertex can be hundreds of metres away while deviation is ~0.
+  it('reports near-zero deviation mid-segment, far from any vertex', () => {
+    const snap = snapToRoute(line, 52.5163, 13.3813);
+    expect(snap.deviation).toBeLessThan(5);
+    expect(snap.along).toBeGreaterThan(200);
+  });
+
+  it('measures perpendicular offset when off the line', () => {
+    // ~0.0009° of latitude ≈ 100 m north of the route
+    const snap = snapToRoute(line, 52.5172, 13.3813);
+    expect(snap.deviation).toBeGreaterThan(70);
+    expect(snap.deviation).toBeLessThan(130);
+  });
+
+  it('clamps to the ends rather than extrapolating past them', () => {
+    const before = snapToRoute(line, 52.5163, 13.3700);
+    expect(before.along).toBe(0);
+  });
+
+  it('handles degenerate routes', () => {
+    expect(snapToRoute([], 52.5, 13.4).along).toBe(0);
+    expect(snapToRoute([[13.3777, 52.5163]], 52.5163, 13.3777).deviation).toBe(0);
+  });
+});
+
+describe('computeProgress', () => {
+  const along = stepPositions(line, steps);
+  const total = cumulativeDistances(line).at(-1)!;
+
+  it('targets the maneuver ahead and counts down to it', () => {
+    const p = computeProgress(line, steps, along, 120, { lat: 52.5163, lng: 13.3800 });
+    expect(steps[p.stepIndex].instruction).toContain('Turn right');
+    expect(p.distanceToStep).toBeGreaterThan(0);
+    expect(p.distanceToStep).toBeLessThan(400);
+  });
+
+  it('shrinks the remaining distance and time as it advances', () => {
+    const early = computeProgress(line, steps, along, 120, { lat: 52.5163, lng: 13.3790 });
+    const later = computeProgress(line, steps, along, 120, { lat: 52.5163, lng: 13.3900 });
+    expect(later.distanceRemaining).toBeLessThan(early.distanceRemaining);
+    expect(later.durationRemaining).toBeLessThan(early.durationRemaining);
+    expect(later.fraction).toBeGreaterThan(early.fraction);
+  });
+
+  it('flags off-route past the deviation threshold, not before', () => {
+    const on = computeProgress(line, steps, along, 120, { lat: 52.5163, lng: 13.3813 });
+    expect(on.offRoute).toBe(false);
+    const off = computeProgress(line, steps, along, 120, { lat: 52.5200, lng: 13.3813 });
+    expect(off.deviation).toBeGreaterThan(OFF_ROUTE_M);
+    expect(off.offRoute).toBe(true);
+  });
+
+  it('declares arrival at the destination', () => {
+    const p = computeProgress(line, steps, along, 120, { lat: 52.5163, lng: 13.3924 });
+    expect(p.arrived).toBe(true);
+    expect(p.distanceRemaining).toBeLessThan(30);
+  });
+
+  it('does not declare arrival mid-route', () => {
+    expect(computeProgress(line, steps, along, 120, { lat: 52.5163, lng: 13.3800 }).arrived).toBe(false);
+  });
+
+  it('caps fraction at 1 rather than overshooting past the end', () => {
+    const p = computeProgress(line, steps, along, 120, { lat: 52.5163, lng: 13.4000 });
+    expect(p.fraction).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('announcements', () => {
+  it('picks the nearest band the distance has entered', () => {
+    expect(announcementBand(1500)).toBeNull();
+    expect(announcementBand(900)).toBe(1000);
+    expect(announcementBand(380)).toBe(400);
+    expect(announcementBand(20)).toBe(30);
+  });
+
+  it('phrases the call differently far out versus at the junction', () => {
+    expect(announcementText('Turn right onto Main St.', 400)).toBe('In 400 meters, turn right onto Main St');
+    expect(announcementText('Turn right onto Main St.', 30)).toBe('Turn right onto Main St');
+    expect(announcementText('Turn left.', 1000)).toBe('In 1 kilometer, turn left');
+  });
+
+  it('speaks once per band and never repeats it', () => {
+    const spoken: Record<number, number> = {};
+    const first = shouldAnnounce(1, 900, spoken);
+    expect(first).toBe(1000);
+    spoken[1] = first!;
+    expect(shouldAnnounce(1, 850, spoken)).toBeNull();
+  });
+
+  it('speaks again once a nearer band is crossed', () => {
+    const spoken: Record<number, number> = { 1: 1000 };
+    expect(shouldAnnounce(1, 380, spoken)).toBe(400);
+  });
+
+  it('keeps each step independent', () => {
+    const spoken: Record<number, number> = { 1: 30 };
+    expect(shouldAnnounce(2, 900, spoken)).toBe(1000);
+  });
+
+  it('stays quiet while the maneuver is still far off', () => {
+    expect(shouldAnnounce(0, 5000, {})).toBeNull();
+  });
+});

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,215 @@
+/**
+ * OSIRIS — live navigation engine.
+ *
+ * Pure geometry and state transitions for turn-by-turn guidance, kept out of
+ * the component so the parts that decide "where am I on this route, what do I
+ * say next, and have I gone wrong" can be tested without a browser or a GPS.
+ *
+ * Everything works in metres via a local equirectangular approximation, which
+ * is accurate well past the scale of a single road segment.
+ */
+
+export interface NavStep {
+  instruction: string;
+  distance: number;
+  duration: number;
+  location: [number, number]; // [lng, lat]
+  type: string;
+}
+
+export interface NavFix {
+  lat: number;
+  lng: number;
+  heading?: number | null;
+  speed?: number | null;
+}
+
+export interface NavProgress {
+  /** Index of the maneuver being approached. */
+  stepIndex: number;
+  /** Metres to that maneuver, measured along the route. */
+  distanceToStep: number;
+  /** Metres from here to the destination, along the route. */
+  distanceRemaining: number;
+  /** Seconds remaining, scaled from the route's own estimate. */
+  durationRemaining: number;
+  /** Perpendicular metres between the fix and the route line. */
+  deviation: number;
+  offRoute: boolean;
+  arrived: boolean;
+  /** The fix projected onto the route — what the map should draw. */
+  snapped: [number, number];
+  /** Fraction of the route completed, 0..1. */
+  fraction: number;
+}
+
+const R = 6371000;
+
+/** Local metres-per-degree, valid near `lat`. */
+function scale(lat: number): { mx: number; my: number } {
+  const p = Math.PI / 180;
+  return { mx: Math.cos(lat * p) * R * p, my: R * p };
+}
+
+export function distanceM(aLat: number, aLng: number, bLat: number, bLng: number): number {
+  const { mx, my } = scale((aLat + bLat) / 2);
+  const dx = (bLng - aLng) * mx;
+  const dy = (bLat - aLat) * my;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/** Along-route distance at every vertex, so progress is a lookup not a scan. */
+export function cumulativeDistances(coords: [number, number][]): number[] {
+  const out = new Array(coords.length).fill(0);
+  for (let i = 1; i < coords.length; i++) {
+    out[i] = out[i - 1] + distanceM(coords[i - 1][1], coords[i - 1][0], coords[i][1], coords[i][0]);
+  }
+  return out;
+}
+
+/**
+ * Project a fix onto the route.
+ *
+ * Perpendicular distance to the nearest *segment*, not the nearest vertex —
+ * on a long straight with sparse vertices, vertex distance would report you
+ * hundreds of metres off-route while you sit exactly on the line.
+ */
+export function snapToRoute(
+  coords: [number, number][],
+  lat: number,
+  lng: number,
+  /** Precomputed cumulative distances; pass them in a navigation loop. */
+  cum?: number[],
+): { index: number; deviation: number; along: number; point: [number, number] } {
+  if (coords.length === 0) return { index: 0, deviation: 0, along: 0, point: [lng, lat] };
+  if (coords.length === 1) {
+    return { index: 0, deviation: distanceM(lat, lng, coords[0][1], coords[0][0]), along: 0, point: coords[0] };
+  }
+
+  const { mx, my } = scale(lat);
+  const px = lng * mx;
+  const py = lat * my;
+
+  let best = { index: 0, deviation: Infinity, t: 0 };
+  for (let i = 0; i < coords.length - 1; i++) {
+    const ax = coords[i][0] * mx, ay = coords[i][1] * my;
+    const bx = coords[i + 1][0] * mx, by = coords[i + 1][1] * my;
+    const vx = bx - ax, vy = by - ay;
+    const len2 = vx * vx + vy * vy;
+    const t = len2 === 0 ? 0 : Math.max(0, Math.min(1, ((px - ax) * vx + (py - ay) * vy) / len2));
+    const cx = ax + t * vx, cy = ay + t * vy;
+    const d = Math.hypot(px - cx, py - cy);
+    if (d < best.deviation) best = { index: i, deviation: d, t };
+  }
+
+  const a = coords[best.index];
+  const b = coords[best.index + 1];
+  const point: [number, number] = [
+    a[0] + (b[0] - a[0]) * best.t,
+    a[1] + (b[1] - a[1]) * best.t,
+  ];
+  const c = cum ?? cumulativeDistances(coords);
+  const segLen = c[best.index + 1] - c[best.index];
+  return { index: best.index, deviation: best.deviation, along: c[best.index] + segLen * best.t, point };
+}
+
+/** Along-route position of each maneuver, so steps can be compared to progress. */
+export function stepPositions(coords: [number, number][], steps: NavStep[], cum?: number[]): number[] {
+  const c = cum ?? cumulativeDistances(coords);
+  return steps.map((s) => snapToRoute(coords, s.location[1], s.location[0], c).along);
+}
+
+/** Beyond this from the line, treat the driver as having left the route. */
+export const OFF_ROUTE_M = 45;
+/** Within this of the destination, the trip is done. */
+export const ARRIVAL_M = 30;
+
+export function computeProgress(
+  coords: [number, number][],
+  steps: NavStep[],
+  stepAlong: number[],
+  totalDuration: number,
+  fix: NavFix,
+  /**
+   * Precomputed cumulative distances. The navigation loop runs on every
+   * position fix, and rebuilding this for a route with thousands of vertices
+   * each time is wasted work — the caller memoises it per route.
+   */
+  cum?: number[],
+): NavProgress {
+  const c = cum ?? cumulativeDistances(coords);
+  const snap = snapToRoute(coords, fix.lat, fix.lng, c);
+  const total = c[c.length - 1] || 0;
+  const remaining = Math.max(0, total - snap.along);
+
+  // First maneuver still ahead of us; falls back to the last one at the end.
+  let stepIndex = stepAlong.findIndex((a) => a > snap.along + 1);
+  if (stepIndex === -1) stepIndex = Math.max(0, steps.length - 1);
+
+  const distanceToStep = Math.max(0, (stepAlong[stepIndex] ?? total) - snap.along);
+  const fraction = total > 0 ? Math.min(1, snap.along / total) : 0;
+
+  const destination = coords[coords.length - 1];
+  const toDestination = distanceM(fix.lat, fix.lng, destination[1], destination[0]);
+
+  return {
+    stepIndex,
+    distanceToStep,
+    distanceRemaining: remaining,
+    // Scale the engine's own estimate by what's left rather than inventing a speed.
+    durationRemaining: total > 0 ? Math.round(totalDuration * (remaining / total)) : 0,
+    deviation: snap.deviation,
+    offRoute: snap.deviation > OFF_ROUTE_M,
+    arrived: toDestination <= ARRIVAL_M || remaining <= ARRIVAL_M,
+    snapped: snap.point,
+    fraction,
+  };
+}
+
+/**
+ * Distance bands at which a maneuver is announced, far to near.
+ *
+ * Matching how a driver actually needs it: early warning to change lane, a
+ * reminder, then the call at the junction itself.
+ */
+export const ANNOUNCE_BANDS = [1000, 400, 150, 30] as const;
+
+/**
+ * The tightest band the distance has entered, or null if nothing to say yet.
+ *
+ * Tightest, not widest: at 380 m the driver is inside both the 1 km and the
+ * 400 m band, and the useful call is "in 400 meters" — announcing the kilometre
+ * again would be stale by the time it finished speaking.
+ */
+export function announcementBand(distance: number): number | null {
+  let match: number | null = null;
+  for (const b of ANNOUNCE_BANDS) {
+    if (distance <= b && (match === null || b < match)) match = b;
+  }
+  return match;
+}
+
+/** Spoken phrasing for a maneuver at a given band. */
+export function announcementText(instruction: string, band: number): string {
+  const clean = instruction.replace(/\.$/, '');
+  if (band <= 30) return clean;
+  if (band < 1000) return `In ${band} meters, ${clean.charAt(0).toLowerCase()}${clean.slice(1)}`;
+  return `In 1 kilometer, ${clean.charAt(0).toLowerCase()}${clean.slice(1)}`;
+}
+
+/**
+ * Decide whether to speak, given what has already been said for this step.
+ * Returns the band to record, or null to stay quiet.
+ */
+export function shouldAnnounce(
+  stepIndex: number,
+  distance: number,
+  spoken: Record<number, number>,
+): number | null {
+  const band = announcementBand(distance);
+  if (band === null) return null;
+  const last = spoken[stepIndex];
+  // Bands descend, so only speak when we've crossed into a nearer one.
+  if (last !== undefined && last <= band) return null;
+  return band;
+}


### PR DESCRIPTION
"Start navigation" on a planned route hands over to a guidance view driven by the device's own position feed, running until arrival.

## The engine — `src/lib/navigation.ts`

Kept out of the component so the parts that decide *where am I, what do I say next, and have I gone wrong* are testable without a browser or a GPS.

**Position is projected onto the nearest route _segment_, not the nearest vertex.** This matters: on a long straight with sparse geometry, vertex distance reports the driver hundreds of metres off-route while they sit exactly on the line — which would trigger a reroute on a road they never left. There's a test pinning near-zero deviation mid-segment, far from any vertex.

Remaining time scales the engine's own estimate by the fraction left rather than inventing a speed from GPS noise.

## Guidance

- **Voice** at 1 km / 400 m / 150 m / at-the-junction, each spoken once per maneuver, with a mute toggle.
- **Off-route** is only acted on after **six continuous seconds**, so a single fix bouncing off a building doesn't tear up the route. Then it says "Recalculating" and re-plans from the current position.
- Arrival detection, a **"Then"** preview of the following turn, progress bar, live ETA.
- **Wake Lock** keeps the screen on — a navigation view that sleeps mid-junction is useless.

## Map

While guiding, the camera sits closer, pitches, and rotates to the direction of travel — reading a turn off a north-locked map at speed doesn't work. It follows the **snapped** position rather than the raw fix, so the marker tracks the road instead of jittering beside it. North-up is restored on exit.

## Bugs this surfaced

**The position feed died the moment navigation started.** The geolocation watch lived inside the planner, which unmounts when guidance takes over the panel — so the fix source disappeared exactly when navigation needed it, and the banner sat on "waiting for a fix" forever. The page owns the watch for a session now.

**Exiting navigation dumped you into an empty form.** Unmounting the planner discarded the route being driven. It stays mounted and hidden; exiting returns you to your intact route with both fields preserved.

**A crash already on `master`:** #264 removed `setRouteSeed` but left a call to it in the tool-rail button, so clicking ROUTE to close directions throws a `ReferenceError`. `typescript.ignoreBuildErrors` hid it from CI. Fixed here since it's in the feature this PR touches.

**Caught by a test before it shipped:** the announcement band picked the *widest* band entered rather than the tightest, so at 380 m it would still announce "in 1 kilometer" — stale before the sentence finished speaking.

## Verification

Drove a full simulated trip along real route geometry:

```
  0: Now      | Turn left to stay on Pariser Platz.
 40: 1.8 km   | Turn right onto Alexanderstraße/B 2/B 5.
 80: 1.1 km   | Turn right onto Alexanderstraße/B 2/B 5.
120: 210 m    | Turn right onto Alexanderstraße/B 2/B 5.
     arrived  | You have arrived
```

Spoken output captured in order: *"In 1 kilometer, turn right onto Alexanderstraße/B 2/B 5"* → *"In 400 meters, …"* → *"Turn right onto Alexanderstraße/B 2/B 5"* → *"You have arrived at your destination."*

Off-route was exercised by holding ~250 m off the line: it spoke "Recalculating" and produced a fresh route from the deviated position (new first instruction, new 7 min / 2.5 km summary).

**115 tests pass** (19 new covering segment projection, progress, off-route thresholds, arrival, and the announcement state machine). Lint clean on all files this PR owns. Production build compiles.

## For a reviewer

- **Verified with a scripted position feed, not a real GPS.** The geometry and state machine are exercised end-to-end, but nobody has driven this with an actual device.
- **The map camera is visually unverified.** The browser pane used for testing doesn't composite frames — screenshots time out and canvas readback returns a blank buffer — so the pitched/rotated navigation view and the snapped marker are confirmed through props only.
- Browser geolocation requires HTTPS or localhost; over plain-HTTP LAN/Tailscale the feed is refused and the view says so explicitly rather than failing silently.
- Reroute currently re-plans with `mode=auto`; carrying the original travel mode through is a small follow-up.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
