### PR TITLE
feat(flights): real airframe identity, actual flown tracks, and multi-aircraft watch

### DIFF
--- a/src/app/api/aircraft/route.test.ts
+++ b/src/app/api/aircraft/route.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { shardFor, downsample, parseTrace } from './route';
+
+describe('shardFor', () => {
+  it('uses the last two hex characters, as readsb shards them', () => {
+    expect(shardFor('ae291a')).toBe('1a');
+    expect(shardFor('ab6fdd')).toBe('dd');
+    expect(shardFor('a0e250')).toBe('50');
+  });
+
+  it('normalises case and whitespace', () => {
+    expect(shardFor(' AE291A ')).toBe('1a');
+  });
+});
+
+describe('downsample', () => {
+  it('leaves a short track untouched', () => {
+    expect(downsample([1, 2, 3], 10)).toEqual([1, 2, 3]);
+  });
+
+  it('thins to the cap', () => {
+    expect(downsample(Array.from({ length: 5000 }, (_, i) => i), 700)).toHaveLength(700);
+  });
+
+  // The path has to still start and end where the aircraft did.
+  it('keeps the first and last point', () => {
+    const src = Array.from({ length: 1000 }, (_, i) => i);
+    const out = downsample(src, 50);
+    expect(out[0]).toBe(0);
+    expect(out.at(-1)).toBe(999);
+  });
+
+  it('stays in order', () => {
+    const out = downsample(Array.from({ length: 500 }, (_, i) => i), 40);
+    expect([...out].sort((a, b) => a - b)).toEqual(out);
+  });
+});
+
+describe('parseTrace', () => {
+  // Shape of a readsb trace row: [Δt, lat, lon, alt, gs, track, flags]
+  const trace = {
+    icao: 'AE291A',
+    r: '6043 ',
+    t: 'H60',
+    desc: 'Sikorsky MH-60T Jayhawk',
+    trace: [
+      [0, 57.737091, -152.509017, -150, 28.3, 227.9, 5],
+      [10, 57.74, -152.5, 500, 90, 220, 5],
+      [20, 57.75, -152.4, 'ground', 0, 0, 5],
+    ],
+  };
+
+  it('extracts identity, trimming the source whitespace', () => {
+    const p = parseTrace(trace);
+    expect(p.icao24).toBe('ae291a');
+    expect(p.registration).toBe('6043');
+    expect(p.typeCode).toBe('H60');
+    expect(p.model).toBe('Sikorsky MH-60T Jayhawk');
+  });
+
+  it('emits the flown path as [lng, lat], oldest first', () => {
+    const p = parseTrace(trace);
+    expect(p.track[0]).toEqual([-152.509017, 57.737091]);
+    expect(p.points).toBe(3);
+  });
+
+  it('keeps altitudes aligned with the track, nulling non-numeric ones', () => {
+    const p = parseTrace(trace);
+    expect(p.altitudes).toEqual([-150, 500, null]);
+    expect(p.altitudes).toHaveLength(p.track.length);
+  });
+
+  it('drops rows with no usable position', () => {
+    const p = parseTrace({
+      ...trace,
+      trace: [[0, null, null, 100], [1, 57.7, -152.5, 200], [2, 'x', 'y', 300]] as never,
+    });
+    expect(p.points).toBe(1);
+  });
+
+  it('thins a long trace but preserves its endpoints', () => {
+    const long = Array.from({ length: 3000 }, (_, i) => [i, 50 + i / 10000, 10 + i / 10000, 1000]);
+    const p = parseTrace({ ...trace, trace: long as never }, 700);
+    expect(p.points).toBe(700);
+    expect(p.track[0]).toEqual([10, 50]);
+    expect(p.track.at(-1)![1]).toBeCloseTo(50 + 2999 / 10000, 6);
+  });
+
+  it('survives an empty or missing trace', () => {
+    expect(parseTrace({}).points).toBe(0);
+    expect(parseTrace({ trace: [] }).track).toEqual([]);
+  });
+});

--- a/src/app/api/aircraft/route.ts
+++ b/src/app/api/aircraft/route.ts
@@ -1,0 +1,173 @@
+import { NextResponse } from 'next/server';
+import { httpJson, optional } from '@/lib/httpJson';
+import { cachedSource } from '@/lib/sourceCache';
+
+export const maxDuration = 20;
+
+/**
+ * OSIRIS — Aircraft identity and flown track.
+ *
+ * The live feed only carries what the transponder broadcasts, so `model` came
+ * through as "Unknown" for most airliners and as a bare ICAO type code ("H60")
+ * for the rest. And the route line was drawn straight between two airports,
+ * which is not the path the aircraft actually flew — an orbit or a hold showed
+ * as a straight line to the destination.
+ *
+ * adsb.lol publishes readsb trace files that answer both at once: the real
+ * flown track, plus the aircraft's registration, type code and full model name.
+ * adsbdb fills in the registered operator, which the traces do not carry.
+ */
+
+const TRACE_BASE = 'https://adsb.lol/data/traces';
+const ADSBDB = 'https://api.adsbdb.com/v0/aircraft';
+
+export interface AircraftDetail {
+  icao24: string;
+  registration: string | null;
+  typeCode: string | null;
+  /** Full human model, e.g. "BOEING 737-800" or "Sikorsky MH-60T Jayhawk". */
+  model: string | null;
+  operator: string | null;
+  /** Actual flown path as [lng, lat], oldest first. */
+  track: [number, number][];
+  /** Altitude in feet at each track point, aligned by index. */
+  altitudes: (number | null)[];
+  points: number;
+  source: string;
+}
+
+/** readsb shards traces by the last two characters of the hex address. */
+export function shardFor(icao24: string): string {
+  return icao24.trim().toLowerCase().slice(-2);
+}
+
+interface TraceFile {
+  icao?: string;
+  r?: string;
+  t?: string;
+  desc?: string;
+  ownOp?: string;
+  timestamp?: number;
+  /** [Δseconds, lat, lon, altitude, groundSpeed, track, flags, …] */
+  trace?: Array<Array<number | string | null>>;
+}
+
+/**
+ * Thin a track to at most `max` points, always keeping the first and last so
+ * the path still starts and ends where the aircraft did. A 5,000-point trace
+ * is ~120 KB and renders no better than a few hundred at map scale.
+ */
+export function downsample<T>(points: T[], max: number): T[] {
+  if (points.length <= max) return points;
+  const step = (points.length - 1) / (max - 1);
+  const out: T[] = [];
+  for (let i = 0; i < max; i++) out.push(points[Math.round(i * step)]);
+  return out;
+}
+
+/** Pull identity and the flown path out of a readsb trace file. */
+export function parseTrace(json: TraceFile, maxPoints = 700): Omit<AircraftDetail, 'operator' | 'source'> {
+  const track: [number, number][] = [];
+  const altitudes: (number | null)[] = [];
+
+  for (const row of json?.trace || []) {
+    const lat = row?.[1];
+    const lng = row?.[2];
+    if (typeof lat !== 'number' || typeof lng !== 'number') continue;
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+    track.push([lng, lat]);
+    // Altitude is feet, or the string "ground".
+    const alt = row?.[3];
+    altitudes.push(typeof alt === 'number' ? alt : null);
+  }
+
+  const idx = track.map((_, i) => i);
+  const keep = downsample(idx, maxPoints);
+
+  return {
+    icao24: (json?.icao || '').toLowerCase(),
+    registration: json?.r?.trim() || null,
+    typeCode: json?.t?.trim() || null,
+    model: json?.desc?.trim() || null,
+    track: keep.map((i) => track[i]),
+    altitudes: keep.map((i) => altitudes[i]),
+    points: keep.length,
+  };
+}
+
+interface AdsbdbResponse {
+  response?: {
+    aircraft?: {
+      manufacturer?: string;
+      type?: string;
+      registered_owner?: string;
+      registration?: string;
+      icao_type?: string;
+    };
+  };
+}
+
+async function fetchTrace(icao24: string, full: boolean): Promise<TraceFile> {
+  const kind = full ? 'full' : 'recent';
+  const url = `${TRACE_BASE}/${shardFor(icao24)}/trace_${kind}_${icao24.toLowerCase()}.json`;
+  return httpJson<TraceFile>(url, { timeoutMs: 12000 });
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const icao24 = (searchParams.get('icao24') || '').trim().toLowerCase();
+    const full = searchParams.get('detail') !== 'recent';
+
+    if (!/^[0-9a-f]{6}$/.test(icao24)) {
+      return NextResponse.json({ error: 'icao24 must be a 6-character hex address' }, { status: 400 });
+    }
+
+    const detail = await cachedSource<AircraftDetail>(
+      `aircraft:${icao24}:${full ? 'full' : 'recent'}`,
+      async () => {
+        const [trace, db] = await Promise.all([
+          optional(fetchTrace(icao24, full)),
+          optional(httpJson<AdsbdbResponse>(`${ADSBDB}/${icao24}`, { timeoutMs: 8000 })),
+        ]);
+
+        const ac = db?.response?.aircraft;
+        const parsed = trace ? parseTrace(trace) : null;
+
+        // Neither source knew this airframe.
+        if (!parsed && !ac) return [];
+
+        const model = parsed?.model
+          || (ac?.manufacturer && ac?.type ? `${ac.manufacturer} ${ac.type}` : null)
+          || ac?.type
+          || null;
+
+        return [{
+          icao24,
+          registration: parsed?.registration || ac?.registration || null,
+          typeCode: parsed?.typeCode || ac?.icao_type || null,
+          model,
+          operator: ac?.registered_owner || null,
+          track: parsed?.track || [],
+          altitudes: parsed?.altitudes || [],
+          points: parsed?.points || 0,
+          source: parsed ? 'adsb.lol' : 'adsbdb',
+        }];
+      },
+      // Identity is effectively static; the track only matters for the current
+      // leg, so a couple of minutes keeps the line fresh without hammering.
+      2 * 60 * 1000,
+    )();
+
+    if (!detail.length) {
+      return NextResponse.json({ error: 'Aircraft not found', icao24 }, { status: 404 });
+    }
+
+    return NextResponse.json(detail[0], {
+      headers: { 'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=600' },
+    });
+  } catch (error) {
+    console.error('[OSIRIS] Aircraft lookup error:', error);
+    return NextResponse.json({ error: 'Aircraft lookup failed' }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import ScmPanel from '@/components/ScmPanel';
 import SearchBar from '@/components/SearchBar';
 import DirectionsBar, { type RouteResult, type LiveLocation } from '@/components/DirectionsBar';
 import NavigationView from '@/components/NavigationView';
+import FlightWatchPanel, { type WatchedFlight, type FlightTelemetry, type AircraftDetail } from '@/components/FlightWatchPanel';
 import type { NavProgress } from '@/lib/navigation';
 import ScaleBar from '@/components/ScaleBar';
 import ErrorBoundary from '@/components/ErrorBoundary';
@@ -126,6 +127,54 @@ export default function Dashboard() {
     { route: RouteResult; label: string; key: number } | null
   >(null);
   const [navProgress, setNavProgress] = useState<NavProgress | null>(null);
+  const [watchedFlights, setWatchedFlights] = useState<WatchedFlight[]>([]);
+  const [aircraftTracks, setAircraftTracks] = useState<Record<string, [number, number][]>>({});
+
+  // The popup lives in raw map HTML, so it hands aircraft over through a global.
+  useEffect(() => {
+    (window as unknown as { osirisWatchFlight?: (f: WatchedFlight) => void }).osirisWatchFlight = (f) => {
+      if (!f?.icao24) return;
+      setWatchedFlights((prev) =>
+        prev.some((w) => w.icao24 === f.icao24) ? prev : [...prev, f].slice(-6));
+    };
+  }, []);
+
+  const removeWatched = useCallback((icao24: string) => {
+    setWatchedFlights((prev) => prev.filter((w) => w.icao24 !== icao24));
+    setAircraftTracks((prev) => {
+      const next = { ...prev };
+      delete next[icao24];
+      return next;
+    });
+  }, []);
+
+  const handleAircraftDetail = useCallback((icao24: string, detail: AircraftDetail | null) => {
+    setAircraftTracks((prev) =>
+      detail?.track?.length ? { ...prev, [icao24]: detail.track } : prev);
+  }, []);
+
+  // Telemetry for watched aircraft, refreshed from whatever the feed last gave us.
+  const watchTelemetry = useMemo(() => {
+    const out: Record<string, FlightTelemetry> = {};
+    if (!watchedFlights.length) return out;
+    const buckets = [
+      data?.commercial_flights, data?.private_flights,
+      data?.private_jets, data?.military_flights,
+    ];
+    const wanted = new Set(watchedFlights.map((w) => w.icao24));
+    for (const bucket of buckets) {
+      for (const f of bucket || []) {
+        if (f?.icao24 && wanted.has(f.icao24)) {
+          out[f.icao24] = {
+            lat: f.lat, lng: f.lng, alt: f.alt,
+            speed_knots: f.speed_knots, heading: f.heading,
+            grounded: f.grounded, squawk: f.squawk,
+          };
+        }
+      }
+    }
+    return out;
+  }, [watchedFlights, data]);
 
   // A navigation session owns its own position watch. The planner's watch dies
   // with the planner when guidance takes over the panel, so guidance cannot
@@ -890,6 +939,7 @@ export default function Dashboard() {
           }
           followUser={followUser}
           navigating={Boolean(navSession)}
+          aircraftTracks={aircraftTracks}
         />
       </ErrorBoundary>
 
@@ -952,6 +1002,24 @@ export default function Dashboard() {
         )}
       </div>
 
+
+      {/* ── FLIGHT WATCH ── */}
+      {watchedFlights.length > 0 && (
+        <motion.div
+          initial={{ opacity: 0, x: -16 }} animate={{ opacity: 1, x: 0 }}
+          className="absolute top-3 z-[380] w-[min(92vw,290px)] pointer-events-auto
+                     max-h-[calc(100vh-180px)] overflow-y-auto styled-scrollbar"
+          style={{ left: isMobile ? '12px' : '120px' }}
+        >
+          <FlightWatchPanel
+            watched={watchedFlights}
+            telemetry={watchTelemetry}
+            onRemove={removeWatched}
+            onLocate={(lat, lng) => setFlyToLocation({ lat, lng, zoom: 8, ts: Date.now() })}
+            onDetail={handleAircraftDetail}
+          />
+        </motion.div>
+      )}
 
       {/* ── MAP VIEW CONTROLS ── */}
       <motion.div

--- a/src/components/FlightWatchPanel.test.ts
+++ b/src/components/FlightWatchPanel.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { toFeet, formatAlt } from './FlightWatchPanel';
+
+describe('toFeet', () => {
+  // The feed reports metres; aviation reads feet, rounded to the nearest 25.
+  it('converts metres to feet at a 25 ft granularity', () => {
+    expect(toFeet(0)).toBe(0);
+    expect(toFeet(1000)).toBe(3275);
+    expect(toFeet(10668)).toBe(35000);
+  });
+});
+
+describe('formatAlt', () => {
+  it('renders thousands separated', () => {
+    expect(formatAlt(10668)).toBe('35,000 ft');
+  });
+
+  it('says Ground rather than an altitude when the aircraft is down', () => {
+    expect(formatAlt(0, true)).toBe('Ground');
+    expect(formatAlt(12, true)).toBe('Ground');
+  });
+
+  it('falls back to a dash when altitude is missing or unusable', () => {
+    expect(formatAlt(undefined)).toBe('—');
+    expect(formatAlt(NaN)).toBe('—');
+  });
+});

--- a/src/components/FlightWatchPanel.tsx
+++ b/src/components/FlightWatchPanel.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { X, Plane, Gauge, ArrowUp, Radio, Crosshair, Loader2 } from 'lucide-react';
+
+/* ═══════════════════════════════════════════════════════════════
+   OSIRIS — Flight Watch
+   Pin several aircraft and follow them side by side
+   ═══════════════════════════════════════════════════════════════ */
+
+export interface WatchedFlight {
+  icao24: string;
+  callsign: string;
+  category?: string;
+}
+
+/** Live telemetry, refreshed from the flights feed. */
+export interface FlightTelemetry {
+  lat: number;
+  lng: number;
+  alt: number;
+  speed_knots: number;
+  heading: number;
+  grounded?: boolean;
+  squawk?: string;
+}
+
+export interface AircraftDetail {
+  icao24: string;
+  registration: string | null;
+  typeCode: string | null;
+  model: string | null;
+  operator: string | null;
+  track: [number, number][];
+  points: number;
+}
+
+interface FlightWatchPanelProps {
+  watched: WatchedFlight[];
+  /** Current telemetry keyed by icao24, from the live feed. */
+  telemetry: Record<string, FlightTelemetry>;
+  onRemove: (icao24: string) => void;
+  onLocate: (lat: number, lng: number) => void;
+  /** Resolved identity + flown track, so the map can draw each path. */
+  onDetail: (icao24: string, detail: AircraftDetail | null) => void;
+}
+
+/** Feet is what aviation actually uses; the feed reports metres. */
+export function toFeet(metres: number): number {
+  return Math.round((metres * 3.28084) / 25) * 25;
+}
+
+export function formatAlt(metres: number | undefined, grounded?: boolean): string {
+  if (grounded) return 'Ground';
+  if (typeof metres !== 'number' || !Number.isFinite(metres)) return '—';
+  return `${toFeet(metres).toLocaleString()} ft`;
+}
+
+function Row({ flight, telem, onRemove, onLocate, onDetail }: {
+  flight: WatchedFlight;
+  telem?: FlightTelemetry;
+  onRemove: (icao24: string) => void;
+  onLocate: (lat: number, lng: number) => void;
+  onDetail: (icao24: string, d: AircraftDetail | null) => void;
+}) {
+  const [detail, setDetail] = useState<AircraftDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/aircraft?icao24=${flight.icao24}`)
+      .then(async (r) => {
+        const d = r.ok ? await r.json() : null;
+        if (cancelled) return;
+        setDetail(d && !d.error ? d : null);
+        setLoading(false);
+        onDetail(flight.icao24, d && !d.error ? d : null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setLoading(false);
+        onDetail(flight.icao24, null);
+      });
+    return () => { cancelled = true; };
+  }, [flight.icao24, onDetail]);
+
+  return (
+    <div className="glass-panel overflow-hidden" style={{ boxShadow: '0 12px 32px rgba(0,0,0,0.6)' }}>
+      <header className="flex items-center gap-2 px-2.5 h-8 border-b border-[var(--border-secondary)]">
+        <Plane className="w-3 h-3 text-[var(--cyan-primary)] flex-shrink-0" />
+        <span className="text-[11px] text-[var(--text-primary)] tracking-wide truncate">
+          {flight.callsign || flight.icao24.toUpperCase()}
+        </span>
+        <span className="text-[8px] text-[var(--text-muted)] tabular-nums ml-auto flex-shrink-0">
+          {flight.icao24.toUpperCase()}
+        </span>
+        {telem && (
+          <button
+            onClick={() => onLocate(telem.lat, telem.lng)}
+            title="Centre on this aircraft"
+            className="p-0.5 text-[var(--text-muted)] hover:text-[var(--cyan-primary)] transition-colors"
+          >
+            <Crosshair className="w-3 h-3" />
+          </button>
+        )}
+        <button
+          onClick={() => onRemove(flight.icao24)}
+          title="Stop watching"
+          aria-label={`Stop watching ${flight.callsign || flight.icao24}`}
+          className="p-0.5 text-[var(--text-muted)] hover:text-[var(--alert-red)] transition-colors"
+        >
+          <X className="w-3 h-3" />
+        </button>
+      </header>
+
+      <div className="px-2.5 py-2">
+        {loading ? (
+          <div className="flex items-center gap-1.5 text-[9px] text-[var(--text-muted)]">
+            <Loader2 className="w-3 h-3 animate-spin" /> Identifying airframe…
+          </div>
+        ) : (
+          <>
+            <div className="text-[10px] text-[var(--text-primary)] leading-snug">
+              {detail?.model || 'Unidentified type'}
+            </div>
+            <div className="flex flex-wrap gap-x-2.5 gap-y-0.5 mt-0.5 text-[8px] text-[var(--text-muted)]">
+              {detail?.registration && <span className="tabular-nums">{detail.registration}</span>}
+              {detail?.typeCode && <span>{detail.typeCode}</span>}
+              {detail?.operator && <span className="truncate max-w-[170px]">{detail.operator}</span>}
+            </div>
+          </>
+        )}
+
+        <div className="grid grid-cols-3 gap-1.5 mt-2">
+          <div className="flex items-center gap-1">
+            <ArrowUp className="w-2.5 h-2.5 text-[var(--text-muted)] flex-shrink-0" />
+            <span className="text-[9px] text-[var(--text-secondary)] tabular-nums truncate">
+              {formatAlt(telem?.alt, telem?.grounded)}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Gauge className="w-2.5 h-2.5 text-[var(--text-muted)] flex-shrink-0" />
+            <span className="text-[9px] text-[var(--text-secondary)] tabular-nums truncate">
+              {telem ? `${Math.round(telem.speed_knots)} kt` : '—'}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Radio className="w-2.5 h-2.5 text-[var(--text-muted)] flex-shrink-0" />
+            <span className="text-[9px] text-[var(--text-secondary)] tabular-nums truncate">
+              {telem?.squawk || '—'}
+            </span>
+          </div>
+        </div>
+
+        {detail && detail.points > 0 && (
+          <div className="mt-1.5 text-[8px] text-[var(--text-muted)] tabular-nums">
+            {detail.points} flown track points
+          </div>
+        )}
+        {!telem && (
+          <div className="mt-1.5 text-[8px] text-[var(--alert-orange)]">
+            No longer in the live feed
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function FlightWatchPanel({
+  watched, telemetry, onRemove, onLocate, onDetail,
+}: FlightWatchPanelProps) {
+  if (watched.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {watched.map((f) => (
+        <Row
+          key={f.icao24}
+          flight={f}
+          telem={telemetry[f.icao24]}
+          onRemove={onRemove}
+          onLocate={onLocate}
+          onDetail={onDetail}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -39,6 +39,8 @@ interface OsirisMapProps {
   followUser?: boolean;
   /** Live navigation: tighter zoom and the map turned to face travel direction. */
   navigating?: boolean;
+  /** Flown tracks for watched aircraft, keyed by icao24. */
+  aircraftTracks?: Record<string, [number, number][]>;
 }
 
 function computeSolarTerminator(): [number, number][] {
@@ -63,7 +65,7 @@ function computeSolarTerminator(): [number, number][] {
 
 const EMPTY_FC = { type: 'FeatureCollection' as const, features: [] };
 
-function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null, userLocation = null, followUser = false, navigating = false }: OsirisMapProps) {
+function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null, userLocation = null, followUser = false, navigating = false, aircraftTracks = {} }: OsirisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -872,7 +874,11 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
             <div><span style="color:#5C5A54;font-size:9px;">REG</span><br/><span style="color:#B0BEC5;">${htmlEsc(p.registration||'—')}</span></div>
             <div><span style="color:#5C5A54;font-size:9px;">POS</span><br/><span style="color:#B0BEC5;">${coords[1].toFixed(2)},${coords[0].toFixed(2)}</span></div>
           </div>
-          <div id="${routeLoadingId}" style="margin-top:10px;padding:6px;border-top:1px solid rgba(255,255,255,0.06);text-align:center;">
+          <div id="ac-${idSafe(p.icao24||'')}" style="margin-top:8px;padding-top:8px;border-top:1px solid rgba(255,255,255,0.06);">
+            <span style="color:#5C5A54;font-size:9px;letter-spacing:0.1em;">IDENTIFYING AIRFRAME…</span>
+          </div>
+          <button onclick="window.osirisWatchFlight && window.osirisWatchFlight({ icao24: '${idSafe(p.icao24||'')}', callsign: '${idSafe(cs)}' })" style="width:100%;margin-top:8px;padding:6px 12px;background:rgba(0,229,255,0.10);border:1px solid rgba(0,229,255,0.35);color:#7FE9FF;font-family:'JetBrains Mono',monospace;font-size:9px;font-weight:bold;letter-spacing:0.1em;border-radius:4px;cursor:pointer;">+ WATCH THIS AIRCRAFT</button>
+          <div id="${routeLoadingId}" style="margin-top:8px;padding:6px;border-top:1px solid rgba(255,255,255,0.06);text-align:center;">
             <span style="color:#5C5A54;font-size:9px;letter-spacing:0.1em;">RESOLVING ROUTE…</span>
           </div>
           <div style="margin-top:8px;display:flex;gap:4px;flex-wrap:wrap;">
@@ -891,6 +897,26 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
               clearFlightRoute(true);
             }
           });
+        }
+
+        // The transponder only reports a type code (often nothing at all), so
+        // resolve the real manufacturer/model and registration out of band.
+        if (p.icao24) {
+          fetch(`/api/aircraft?icao24=${encodeURIComponent(p.icao24)}`)
+            .then(r => (r.ok ? r.json() : null))
+            .then((d) => {
+              const el = document.getElementById(`ac-${p.icao24}`);
+              if (!el || !d || d.error) {
+                if (el) el.innerHTML = '<span style="color:#5C5A54;font-size:9px;">AIRFRAME NOT IN REGISTRY</span>';
+                return;
+              }
+              const bits = [d.registration, d.typeCode, d.operator].filter(Boolean)
+                .map((x: string) => htmlEsc(String(x))).join(' · ');
+              el.innerHTML =
+                `<div style="color:#E8E6E0;font-size:11px;line-height:1.35;">${htmlEsc(d.model || 'Unidentified type')}</div>` +
+                (bits ? `<div style="color:#78909C;font-size:9px;margin-top:2px;">${bits}</div>` : '');
+            })
+            .catch(() => {});
         }
 
         // Fetch route data and draw on map
@@ -2453,6 +2479,58 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     if (!mapReady || !mapRef.current || navigating) return;
     mapRef.current.easeTo({ pitch: 0, bearing: 0, duration: 600 });
   }, [mapReady, navigating]);
+
+  // ── WATCHED AIRCRAFT FLOWN TRACKS ──
+  // The straight airport-to-airport line was never the path flown: an orbit,
+  // a hold or a diversion all rendered as a direct line to the destination.
+  // These are the actual reported positions.
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    const map = mapRef.current;
+    const SRC = 'aircraft-tracks';
+    const IDS = ['aircraft-track-casing', 'aircraft-track-line'];
+
+    const features = Object.entries(aircraftTracks)
+      .filter(([, t]) => Array.isArray(t) && t.length > 1)
+      .map(([icao24, t]) => ({
+        type: 'Feature' as const,
+        properties: { icao24 },
+        geometry: { type: 'LineString' as const, coordinates: t },
+      }));
+
+    if (features.length === 0) {
+      IDS.forEach((id) => { if (map.getLayer(id)) map.removeLayer(id); });
+      if (map.getSource(SRC)) map.removeSource(SRC);
+      return;
+    }
+
+    const fc = { type: 'FeatureCollection' as const, features };
+    if (!map.getSource(SRC)) map.addSource(SRC, { type: 'geojson', data: fc as never });
+    else (map.getSource(SRC) as maplibregl.GeoJSONSource).setData(fc as never);
+
+    if (!map.getLayer('aircraft-track-casing')) {
+      map.addLayer({
+        id: 'aircraft-track-casing', type: 'line', source: SRC,
+        layout: { 'line-cap': 'round', 'line-join': 'round' },
+        paint: {
+          'line-color': '#001014',
+          'line-width': ['interpolate', ['linear'], ['zoom'], 2, 3, 8, 6],
+          'line-opacity': 0.7,
+        },
+      });
+    }
+    if (!map.getLayer('aircraft-track-line')) {
+      map.addLayer({
+        id: 'aircraft-track-line', type: 'line', source: SRC,
+        layout: { 'line-cap': 'round', 'line-join': 'round' },
+        paint: {
+          'line-color': '#FFB300',
+          'line-width': ['interpolate', ['linear'], ['zoom'], 2, 1.4, 8, 3],
+          'line-opacity': 0.9,
+        },
+      });
+    }
+  }, [mapReady, aircraftTracks]);
 
   // ── ARCGIS LAYERS ──
   useEffect(() => {

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -211,9 +211,6 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       sources.forEach(s => map.addSource(s, { type: 'geojson', data: EMPTY_FC }));
 
       // ── FLIGHT ROUTE VISUALIZATION SOURCES & LAYERS ──
-      map.addSource('active-flight-route', { type: 'geojson', data: EMPTY_FC });
-      map.addSource('active-flight-endpoints', { type: 'geojson', data: EMPTY_FC });
-      map.addSource('active-flight-progress', { type: 'geojson', data: EMPTY_FC });
 
       // Warning icon generator (parameterized — eliminates 3x copy-paste)
       const createWarningIcon = (id: string, color: string) => {
@@ -670,48 +667,6 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         'text-offset': [0, 1.2], 'text-allow-overlap': false,
       }, paint: { 'text-color': ['match', ['get','type'], 'military','#D32F2F', 'tanker','#E65100', 'cargo','#26C6DA', '#B0BEC5'], 'text-halo-color': '#000', 'text-halo-width': 1 }});
 
-      // ── FLIGHT ROUTE LAYERS ── added last so they render ON TOP of everything
-      // Gold glow under the route line
-      map.addLayer({ id: 'flight-route-glow', type: 'line', source: 'active-flight-route', paint: {
-        'line-color': '#D4AF37',
-        'line-width': 12,
-        'line-opacity': 0.15,
-        'line-blur': 6,
-      }});
-      // Main dotted route line — gold
-      map.addLayer({ id: 'flight-route-line', type: 'line', source: 'active-flight-route', paint: {
-        'line-color': '#D4AF37',
-        'line-width': 2,
-        'line-opacity': 0.8,
-        'line-dasharray': [2, 3],
-      }});
-      // Endpoint glow — soft ring behind the dot so airports are unmistakable
-      map.addLayer({ id: 'flight-endpoint-glow', type: 'circle', source: 'active-flight-endpoints', paint: {
-        'circle-radius': 14,
-        'circle-color': '#D4AF37',
-        'circle-opacity': 0.15,
-        'circle-blur': 1,
-      }});
-      // Endpoint dots — solid white with dark stroke, positioned right on the airport
-      map.addLayer({ id: 'flight-endpoint-dots', type: 'circle', source: 'active-flight-endpoints', paint: {
-        'circle-radius': 6,
-        'circle-color': '#ffffff',
-        'circle-opacity': 0.95,
-        'circle-stroke-width': 2,
-        'circle-stroke-color': '#D4AF37',
-      }});
-      // Endpoint labels — airport code below the dot
-      map.addLayer({ id: 'flight-endpoint-labels', type: 'symbol', source: 'active-flight-endpoints', layout: {
-        'text-field': ['get', 'label'],
-        'text-size': 11,
-        'text-font': ['Open Sans Bold'],
-        'text-offset': [0, 1.8],
-        'text-allow-overlap': true,
-      }, paint: {
-        'text-color': '#D4AF37',
-        'text-halo-color': '#0C0E1A',
-        'text-halo-width': 1.5,
-      }});
 
       setMapReady(true);
     });
@@ -742,100 +697,6 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     const urlSafe = (s: any): string => { const u = String(s ?? ''); return /^https?:\/\//i.test(u) ? u : '#'; };
     const colorSafe = (s: any): string => /^#[0-9a-fA-F]{3,8}$/.test(String(s ?? '')) ? String(s) : '#aaa';
 
-    // ── FLIGHT ROUTE STATE ──
-    // Track whether a flight route is actively being drawn to prevent race conditions
-    let activeRouteClickId: string | null = null;
-
-    // ── HELPER: Clear active flight route ──
-    const clearFlightRoute = (force = false) => {
-      // Don't clear if a new route is being drawn (prevents popup-close race)
-      if (!force && activeRouteClickId) return;
-      try {
-        const routeSrc = map.getSource('active-flight-route') as any;
-        const endpointSrc = map.getSource('active-flight-endpoints') as any;
-        const progressSrc = map.getSource('active-flight-progress') as any;
-        if (routeSrc) routeSrc.setData(EMPTY_FC);
-        if (endpointSrc) endpointSrc.setData(EMPTY_FC);
-        if (progressSrc) progressSrc.setData(EMPTY_FC);
-      } catch (err) {
-        console.warn('[OSIRIS] clearFlightRoute error:', err);
-      }
-    };
-
-    // ── HELPER: Draw flight route on map ──
-    const drawFlightRoute = (routeData: any, currentCoords: [number, number]) => {
-      if (!routeData.found) return;
-      const { origin, destination, arc } = routeData;
-      console.log('[OSIRIS] Drawing route:', origin.iata, '→', destination.iata, '| arc points:', arc?.length);
-
-      // Build all GeoJSON data objects first, then set them in rapid succession
-      const lineFC = {
-        type: 'FeatureCollection' as const,
-        features: [{ type: 'Feature' as const, geometry: { type: 'LineString' as const, coordinates: arc }, properties: {} }],
-      };
-      const endpointFC = {
-        type: 'FeatureCollection' as const,
-        features: [
-          { type: 'Feature' as const, geometry: { type: 'Point' as const, coordinates: [origin.lng, origin.lat] }, properties: { label: origin.iata || origin.icao } },
-          { type: 'Feature' as const, geometry: { type: 'Point' as const, coordinates: [destination.lng, destination.lat] }, properties: { label: destination.iata || destination.icao } },
-        ],
-      };
-
-      try {
-        const rSrc = map.getSource('active-flight-route') as any;
-        const eSrc = map.getSource('active-flight-endpoints') as any;
-        if (rSrc) rSrc.setData(lineFC);
-        if (eSrc) eSrc.setData(endpointFC);
-      } catch (err) {
-        console.error('[OSIRIS] drawFlightRoute error:', err);
-      }
-    };
-
-    // ── HELPER: Draw heading-based projected trajectory (fallback) ──
-    const drawProjectedTrajectory = (coords: [number, number], heading: number, speedKnots: number) => {
-      const lng = coords[0], lat = coords[1];
-      const speed = speedKnots > 50 ? speedKnots : 400;
-      // Project ~2 hours ahead and ~30 min behind based on heading
-      const projDistKm = speed * 1.852 * 2; // 2 hours forward
-      const backDistKm = speed * 1.852 * 0.5; // 30 min backward
-      const hdgRad = (heading || 0) * Math.PI / 180;
-      const degPerKm = 1 / 111.32;
-
-      const fwdLat = lat + Math.cos(hdgRad) * projDistKm * degPerKm;
-      const fwdLng = lng + Math.sin(hdgRad) * projDistKm * degPerKm / Math.cos(lat * Math.PI / 180);
-      const backLat = lat - Math.cos(hdgRad) * backDistKm * degPerKm;
-      const backLng = lng - Math.sin(hdgRad) * backDistKm * degPerKm / Math.cos(lat * Math.PI / 180);
-
-      try {
-        const routeSrc = map.getSource('active-flight-route') as any;
-        if (routeSrc) {
-          routeSrc.setData({
-            type: 'FeatureCollection',
-            features: [{
-              type: 'Feature',
-              geometry: { type: 'LineString', coordinates: [[backLng, backLat], [lng, lat], [fwdLng, fwdLat]] },
-              properties: {},
-            }],
-          });
-        }
-        // Show current position marker
-        const progressSrc = map.getSource('active-flight-progress') as any;
-        if (progressSrc) {
-          progressSrc.setData({
-            type: 'FeatureCollection',
-            features: [{
-              type: 'Feature',
-              geometry: { type: 'Point', coordinates: coords },
-              properties: {},
-            }],
-          });
-        }
-      } catch (err) {
-        console.warn('[OSIRIS] drawProjectedTrajectory error:', err);
-      }
-    };
-
-    // ── HELPER: Format time for display ──
     const formatTime = (iso: string | null) => {
       if (!iso) return '—';
       try {
@@ -851,13 +712,6 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         const p = e.features[0].properties as any;
         const coords = (e.features[0].geometry as any).coordinates;
         const cs = (p.callsign||'').trim();
-
-        // Generate a unique ID for this click to prevent race conditions
-        const clickId = `${cs}-${Date.now()}`;
-        activeRouteClickId = clickId;
-
-        // Clear any previous route before drawing new one
-        clearFlightRoute(true);
 
         // Show initial popup immediately (without route data)
         const routeLoadingId = `route-info-${Date.now()}`;
@@ -889,16 +743,6 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
           <button onclick="window.openOsirisIntel({ callsign: '${idSafe(cs)}', icao24: '${idSafe(p.icao24||'')}', model: '${idSafe(p.model||'')}', registration: '${idSafe(p.registration||'')}' })" style="width:100%;margin-top:6px;padding:5px 12px;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.12);color:#B0BEC5;font-family:'JetBrains Mono',monospace;font-size:9px;font-weight:bold;letter-spacing:0.1em;border-radius:4px;cursor:pointer;">DEEP DIVE INTEL</button>
         </div>`);
 
-        // Bind popup close to clear route (must be done AFTER popup is created)
-        if (popupRef.current) {
-          popupRef.current.on('close', () => {
-            if (activeRouteClickId === clickId) {
-              activeRouteClickId = null;
-              clearFlightRoute(true);
-            }
-          });
-        }
-
         // The transponder only reports a type code (often nothing at all), so
         // resolve the real manufacturer/model and registration out of band.
         if (p.icao24) {
@@ -919,7 +763,9 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
             .catch(() => {});
         }
 
-        // Fetch route data and draw on map
+        // Resolve origin/destination for the readout only. The line this used
+        // to draw was a straight hop between two airports, which is not the
+        // path flown — watched aircraft draw their real reported track instead.
         const cleanCallsign = cs.replace(/\s+/g, '');
         const routeParams = new URLSearchParams({
           callsign: cleanCallsign,
@@ -931,59 +777,37 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         fetch(`/api/flight-route?${routeParams}`)
           .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
           .then(routeData => {
-            if (activeRouteClickId !== clickId) return;
-
-            if (routeData.found && routeData.arc && routeData.arc.length > 1) {
-              drawFlightRoute(routeData, coords);
-
-              const el = document.getElementById(routeLoadingId);
-              if (el) {
-                const depTime = formatTime(routeData.departureTime);
-                const arrTime = formatTime(routeData.arrivalTime);
-                const pct = Math.round((routeData.progress || 0) * 100);
-                const distKm = routeData.totalDistanceKm || 0;
-                el.innerHTML = `
-                  <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px;">
-                    <div><span style="color:#5C5A54;font-size:8px;">FROM</span><br/><span style="color:#E8E6E0;font-size:13px;font-weight:700;">${htmlEsc(routeData.origin.iata || routeData.origin.icao)}</span> <span style="color:#5C5A54;font-size:9px;">${htmlEsc(routeData.origin.city)}</span></div>
-                    <span style="color:#5C5A54;font-size:11px;">→</span>
-                    <div style="text-align:right;"><span style="color:#5C5A54;font-size:8px;">TO</span><br/><span style="color:#E8E6E0;font-size:13px;font-weight:700;">${htmlEsc(routeData.destination.iata || routeData.destination.icao)}</span> <span style="color:#5C5A54;font-size:9px;">${htmlEsc(routeData.destination.city)}</span></div>
-                  </div>
-                  <div style="height:2px;background:rgba(255,255,255,0.06);border-radius:1px;margin:6px 0;"><div style="width:${pct}%;height:100%;background:rgba(255,255,255,0.35);border-radius:1px;"></div></div>
-                  <div style="display:flex;justify-content:space-between;font-size:10px;color:#78909C;">
-                    <span>DEP ${depTime}</span>
-                    <span>${pct}% · ${distKm.toLocaleString()}km</span>
-                    <span>ARR ${arrTime}</span>
-                  </div>
-                `;
-              }
+            const el = document.getElementById(routeLoadingId);
+            if (!el) return;
+            if (routeData.found && routeData.origin && routeData.destination) {
+              const depTime = formatTime(routeData.departureTime);
+              const arrTime = formatTime(routeData.arrivalTime);
+              const pct = Math.round((routeData.progress || 0) * 100);
+              const distKm = routeData.totalDistanceKm || 0;
+              el.innerHTML = `
+                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px;">
+                  <div><span style="color:#5C5A54;font-size:8px;">FROM</span><br/><span style="color:#E8E6E0;font-size:13px;font-weight:700;">${htmlEsc(routeData.origin.iata || routeData.origin.icao)}</span> <span style="color:#5C5A54;font-size:9px;">${htmlEsc(routeData.origin.city)}</span></div>
+                  <span style="color:#5C5A54;font-size:11px;">&rarr;</span>
+                  <div style="text-align:right;"><span style="color:#5C5A54;font-size:8px;">TO</span><br/><span style="color:#E8E6E0;font-size:13px;font-weight:700;">${htmlEsc(routeData.destination.iata || routeData.destination.icao)}</span> <span style="color:#5C5A54;font-size:9px;">${htmlEsc(routeData.destination.city)}</span></div>
+                </div>
+                <div style="height:2px;background:rgba(255,255,255,0.06);border-radius:1px;margin:6px 0;"><div style="width:${pct}%;height:100%;background:rgba(255,255,255,0.35);border-radius:1px;"></div></div>
+                <div style="display:flex;justify-content:space-between;font-size:10px;color:#78909C;">
+                  <span>DEP ${depTime}</span>
+                  <span>${pct}% &middot; ${distKm.toLocaleString()}km</span>
+                  <span>ARR ${arrTime}</span>
+                </div>
+              `;
             } else {
-              drawProjectedTrajectory(coords, p.heading || 0, p.speed_knots || 0);
-              const el = document.getElementById(routeLoadingId);
-              if (el) el.innerHTML = `<span style="color:#5C5A54;font-size:9px;">HDG ${Math.round(p.heading||0)}° — ROUTE UNAVAILABLE</span>`;
+              el.innerHTML = `<span style="color:#5C5A54;font-size:9px;">NO SCHEDULED ROUTE</span>`;
             }
           })
-          .catch((err) => {
-            console.warn('[OSIRIS] Route fetch error:', err);
-            if (activeRouteClickId !== clickId) return;
-            drawProjectedTrajectory(coords, p.heading || 0, p.speed_knots || 0);
+          .catch(() => {
             const el = document.getElementById(routeLoadingId);
-            if (el) el.innerHTML = `<span style="color:#5C5A54;font-size:9px;">HDG ${Math.round(p.heading||0)}° — ROUTE TIMEOUT</span>`;
+            if (el) el.innerHTML = `<span style="color:#5C5A54;font-size:9px;">ROUTE UNAVAILABLE</span>`;
           });
       });
       map.on('mouseenter', layer, () => { map.getCanvas().style.cursor = 'pointer'; });
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
-    });
-
-    // ── Clear flight route when clicking on empty map area ──
-    map.on('click', (e) => {
-      // Only clear if no flight feature was clicked
-      const flLayers = ['fl-commercial','fl-private','fl-jets','fl-military'].filter(id => map.getLayer(id));
-      if (flLayers.length === 0) return;
-      const hitFeatures = map.queryRenderedFeatures(e.point, { layers: flLayers });
-      if (!hitFeatures || hitFeatures.length === 0) {
-        activeRouteClickId = null;
-        clearFlightRoute(true);
-      }
     });
 
     // ── CCTV (opens CameraViewer panel) ──

--- a/src/lib/httpJson.ts
+++ b/src/lib/httpJson.ts
@@ -1,4 +1,6 @@
 import https from 'https';
+import zlib from 'zlib';
+import type { Readable } from 'stream';
 
 /**
  * OSIRIS — JSON fetch over Node's https client.
@@ -32,10 +34,20 @@ export function httpJson<T>(
           reject(new Error(`HTTP ${res.statusCode}`));
           return;
         }
+        // Some hosts serve pre-compressed static JSON and set Content-Encoding
+        // regardless of what we asked for — adsb.lol's trace files do exactly
+        // that — so decode by the header rather than by what we requested.
+        const encoding = (res.headers['content-encoding'] || '').toLowerCase();
+        let stream: Readable = res;
+        if (encoding === 'gzip') stream = res.pipe(zlib.createGunzip());
+        else if (encoding === 'deflate') stream = res.pipe(zlib.createInflate());
+        else if (encoding === 'br') stream = res.pipe(zlib.createBrotliDecompress());
+
         let body = '';
-        res.setEncoding('utf8');
-        res.on('data', (chunk) => { body += chunk; });
-        res.on('end', () => {
+        stream.setEncoding('utf8');
+        stream.on('data', (chunk: string) => { body += chunk; });
+        stream.on('error', reject);
+        stream.on('end', () => {
           try { resolve(JSON.parse(body) as T); } catch (e) { reject(e); }
         });
       },


### PR DESCRIPTION
Three problems with the aircraft layer, all rooted in the same gap: the live feed only carries what the transponder broadcasts.

## 1 · The routes were wrong because the line was synthetic

The drawn line was a **straight hop between two airports**. That is not the path flown — an orbit, a hold or a diversion all rendered as a direct line to the destination. When no route resolved at all, it fell back to *projecting a line forward from the current heading*: a guess, drawn as if it were data.

`adsb.lol` publishes readsb trace files carrying the aircraft's **actual reported positions**. Watched aircraft now draw that instead — 700 points, thinned server-side from up to 5,000 while keeping the endpoints, since a 120 KB trace renders no better than a few hundred points at map scale.

The second commit removes the old pipeline entirely (−202 lines): the three sources, the five layers, `drawFlightRoute`, `drawProjectedTrajectory`, `clearFlightRoute`, and the `activeRouteClickId` race guard that existed only to manage them.

**The origin→destination readout stays.** It is separately sourced and correct — re-verified live, `AAL2042` resolves `KSFO → KPHX` — so the popup keeps FROM/TO, progress and times. Only the drawing is gone.

## 2 · Exact aircraft model

`model` arrived as `"Unknown"` for most airliners and a bare ICAO type code (`"H60"`) for the rest, so the popup could not say what it was looking at. New `/api/aircraft` resolves the airframe out of band:

| hex | model | reg | operator |
|---|---|---|---|
| `ae291a` | Sikorsky MH-60T Jayhawk | 6043 | United States Coast Guard |
| `ab6fdd` | BOEING 737-800 | N836NN | American Airlines |
| `c0797b` | AIRBUS A220-300 | C-GUAC | Air Canada |

The trace files carry model, registration and type code; `adsbdb` adds the registered operator, which the traces don't have. The popup resolves this after opening rather than blocking on it.

## 3 · Watching several at once

Up to six aircraft pin as stacked cards, each with model, registration, operator, live altitude (converted to feet, which is what aviation reads), speed and squawk — refreshed from the feed, with a crosshair to recentre and an X to drop it. Cards say **"No longer in the live feed"** when an aircraft drops out, rather than freezing on stale numbers.

## The bug underneath

Identity resolved but tracks came back **empty**. `adsb.lol` serves pre-compressed static JSON and sets `Content-Encoding: gzip` regardless of what the client asked for, so every trace fetch silently failed to parse. `lib/httpJson` now decodes gzip/deflate/br, which also hardens every other caller of that helper.

## Verification

- **131 tests pass** (16 new: shard derivation, downsampling that preserves endpoints, trace parsing with altitude alignment, feet conversion).
- Production build compiles; lint clean on new files. `OsirisMap` errors drop **129 → 121** — the removal took some `any` with it.
- Exercised in the browser: two aircraft watched simultaneously, 700 track points each reaching the map layer, **zero console errors**.
- The removal was verified **against the compiled bundle**, not just the diff: `flight-route-glow`, `flight-route-line`, `flight-endpoint-dots` and `active-flight-route` appear in 0 files, while `aircraft-track-line` is present.

## For a reviewer

- **The track lines are visually unverified.** The browser pane used for testing doesn't composite frames — screenshots time out and canvas readback returns a blank buffer — so the amber tracks are confirmed through the map's props and the bundle, not by eye.
- Route *resolution* was never broken and is untouched. Callsigns that return "not found" are GA and private flights with no scheduled route — correct behaviour, not a bug.
- Tracks are fetched per watched aircraft and cached for 2 minutes; identity is effectively static, the track only matters for the current leg.
- The watch list caps at six, and the popup hands aircraft over through a `window` global because that popup is raw map HTML rather than React.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
