### PR TITLE
fix(flights): read a flight's airports off its track, not the schedule

### DIFF
--- a/src/app/api/aircraft/route.test.ts
+++ b/src/app/api/aircraft/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { shardFor, downsample, parseTrace, currentLeg } from './route';
+import { shardFor, downsample, parseTrace, currentLeg, legEndpoints } from './route';
+import { nearestAirport } from '@/lib/airports';
 
 describe('shardFor', () => {
   it('uses the last two hex characters, as readsb shards them', () => {
@@ -135,6 +136,88 @@ describe('currentLeg', () => {
 
   it('copes with an empty trace', () => {
     expect(currentLeg([])).toEqual([]);
+  });
+});
+
+describe('nearestAirport', () => {
+  it('names the airport under a runway position', () => {
+    expect(nearestAirport(33.4373, -112.0078)?.iata).toBe('PHX');
+  });
+
+  it('returns nothing over open ground', () => {
+    expect(nearestAirport(39.5, -99.5)).toBeNull();   // rural Kansas
+    expect(nearestAirport(0, -140)).toBeNull();        // mid-Pacific
+  });
+
+  it('does not let longitude convergence pull in a distant airport', () => {
+    // 0.5° of longitude at 60°N is ~28 km, not the ~56 km it is at the equator.
+    expect(nearestAirport(59.9139, 10.7522 + 0.5, 20)).toBeNull();
+  });
+
+  it('ignores a nonsense position', () => {
+    expect(nearestAirport(NaN, NaN)).toBeNull();
+  });
+});
+
+describe('legEndpoints', () => {
+  const PHX: [number, number] = [-112.0078, 33.4373];
+  const LAX: [number, number] = [-118.4081, 33.9425];
+  const OPEN: [number, number] = [-105, 35];
+
+  it('names the departure when the leg starts low over an airport', () => {
+    const { departure } = legEndpoints([PHX, OPEN, LAX], [900, 34000, 31000], false);
+    expect(departure?.iata).toBe('PHX');
+  });
+
+  // Coverage that begins at cruise says nothing about where the flight started;
+  // the schedule's guess is what produced lines to airports it never saw.
+  it('refuses a departure when the leg was picked up in the cruise', () => {
+    const { departure } = legEndpoints([PHX, OPEN, LAX], [35000, 34000, 31000], false);
+    expect(departure).toBeNull();
+  });
+
+  it('names the arrival once the trace ends on the ground', () => {
+    const { arrival } = legEndpoints([PHX, OPEN, LAX], [900, 34000, 200], true);
+    expect(arrival?.iata).toBe('LAX');
+  });
+
+  it('leaves the arrival unknown while still airborne', () => {
+    expect(legEndpoints([PHX, OPEN, LAX], [900, 34000, 31000], false).arrival).toBeNull();
+  });
+
+  it('treats a ground first sample as a departure, not a missing altitude', () => {
+    expect(legEndpoints([PHX, OPEN], [null, 30000], false).departure?.iata).toBe('PHX');
+  });
+
+  it('finds nothing for a leg that starts and ends away from any airport', () => {
+    expect(legEndpoints([OPEN, [-104, 36]], [900, 900], true)).toEqual({ departure: null, arrival: null });
+  });
+
+  it('ignores a track too short to have endpoints', () => {
+    expect(legEndpoints([PHX], [900], true)).toEqual({ departure: null, arrival: null });
+  });
+});
+
+describe('parseTrace endpoints', () => {
+  const phx = (t: number, alt: number | string) => [t, 33.4373, -112.0078, alt, 0, 0];
+
+  it('reports the airport a parsed leg left and landed at', () => {
+    const p = parseTrace({
+      trace: [
+        ...Array.from({ length: 5 }, (_, i) => phx(i, 'ground')),
+        [10, 33.4373, -112.0078, 800, 150, 0],
+        [20, 34, -115, 34000, 450, 270],
+        [30, 33.9425, -118.4081, 600, 150, 270],
+        ...Array.from({ length: 5 }, (_, i) => [40 + i, 33.9425, -118.4081, 'ground', 0, 0]),
+      ] as never,
+    });
+    expect(p.departure?.iata).toBe('PHX');
+    expect(p.arrival?.iata).toBe('LAX');
+  });
+
+  it('leaves both unknown for a trace with no usable positions', () => {
+    expect(parseTrace({}).departure).toBeNull();
+    expect(parseTrace({}).arrival).toBeNull();
   });
 });
 

--- a/src/app/api/aircraft/route.test.ts
+++ b/src/app/api/aircraft/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { shardFor, downsample, parseTrace } from './route';
+import { shardFor, downsample, parseTrace, currentLeg } from './route';
 
 describe('shardFor', () => {
   it('uses the last two hex characters, as readsb shards them', () => {
@@ -59,13 +59,13 @@ describe('parseTrace', () => {
   });
 
   it('emits the flown path as [lng, lat], oldest first', () => {
-    const p = parseTrace(trace);
+    const p = parseTrace(trace, 700, false);
     expect(p.track[0]).toEqual([-152.509017, 57.737091]);
     expect(p.points).toBe(3);
   });
 
   it('keeps altitudes aligned with the track, nulling non-numeric ones', () => {
-    const p = parseTrace(trace);
+    const p = parseTrace(trace, 700, false);
     expect(p.altitudes).toEqual([-150, 500, null]);
     expect(p.altitudes).toHaveLength(p.track.length);
   });
@@ -89,5 +89,67 @@ describe('parseTrace', () => {
   it('survives an empty or missing trace', () => {
     expect(parseTrace({}).points).toBe(0);
     expect(parseTrace({ trace: [] }).track).toEqual([]);
+  });
+});
+
+describe('currentLeg', () => {
+  const air = (t: number, lat: number, alt: number) => [t, lat, 10, alt, 400, 90];
+  const gnd = (t: number, lat: number) => [t, lat, 10, 'ground', 0, 90];
+
+  // A 24h trace is five or six flights; drawn whole it reads as random lines.
+  it('keeps only the flight after the last real stop', () => {
+    const rows = [
+      ...Array.from({ length: 5 }, (_, i) => air(i, 40 + i, 30000)),   // earlier flight
+      ...Array.from({ length: 6 }, (_, i) => gnd(10 + i, 45)),          // parked
+      ...Array.from({ length: 4 }, (_, i) => air(20 + i, 50 + i, 32000)), // current flight
+    ];
+    const leg = currentLeg(rows);
+    expect(leg).toHaveLength(4);
+    expect(leg[0][1]).toBe(50);
+  });
+
+  it('ignores a brief ground blip rather than splitting on it', () => {
+    const rows = [
+      ...Array.from({ length: 4 }, (_, i) => air(i, 40 + i, 30000)),
+      gnd(10, 44),                                                     // single spurious sample
+      ...Array.from({ length: 4 }, (_, i) => air(20 + i, 45 + i, 31000)),
+    ];
+    expect(currentLeg(rows).length).toBeGreaterThan(4);
+  });
+
+  it('returns the last completed flight when the aircraft is parked now', () => {
+    const rows = [
+      ...Array.from({ length: 6 }, (_, i) => gnd(i, 30)),
+      ...Array.from({ length: 5 }, (_, i) => air(10 + i, 40 + i, 30000)),
+      ...Array.from({ length: 6 }, (_, i) => gnd(20 + i, 45)),          // landed, parked
+    ];
+    const leg = currentLeg(rows);
+    expect(leg.every((r) => r[3] !== 'ground')).toBe(true);
+    expect(leg).toHaveLength(5);
+  });
+
+  it('treats a trace with no ground reports as a single leg', () => {
+    const rows = Array.from({ length: 10 }, (_, i) => air(i, 40 + i, 35000));
+    expect(currentLeg(rows)).toHaveLength(10);
+  });
+
+  it('copes with an empty trace', () => {
+    expect(currentLeg([])).toEqual([]);
+  });
+});
+
+describe('parseTrace leg trimming', () => {
+  const rows = [
+    ...Array.from({ length: 4 }, (_, i) => [i, 40 + i, 10, 30000]),
+    ...Array.from({ length: 6 }, (_, i) => [10 + i, 45, 10, 'ground']),
+    ...Array.from({ length: 3 }, (_, i) => [20 + i, 50 + i, 10, 32000]),
+  ];
+
+  it('draws only the current flight by default', () => {
+    expect(parseTrace({ trace: rows as never }).points).toBe(3);
+  });
+
+  it('can still return the whole history on request', () => {
+    expect(parseTrace({ trace: rows as never }, 700, false).points).toBe(13);
   });
 });

--- a/src/app/api/aircraft/route.ts
+++ b/src/app/api/aircraft/route.ts
@@ -53,6 +53,47 @@ interface TraceFile {
 }
 
 /**
+ * Keep only the leg the aircraft is currently flying.
+ *
+ * A full trace covers 24 hours, which for an airliner is five or six separate
+ * flights strung end to end — drawn as one polyline it reads as random lines
+ * criss-crossing the country. Ground reports delimit the legs, so walk back
+ * from the newest point: skip time parked, take the airborne run, and stop at
+ * the previous stint on the ground.
+ */
+export function currentLeg(
+  rows: Array<Array<number | string | null>>,
+  /** Ground samples in a row before it counts as a real stop, not a blip. */
+  minGroundRun = 4,
+): Array<Array<number | string | null>> {
+  if (rows.length === 0) return rows;
+  const isGround = (r: Array<number | string | null>) => r?.[3] === 'ground';
+
+  let i = rows.length - 1;
+  while (i >= 0 && isGround(rows[i])) i--;   // currently parked? rewind to the flight
+  if (i < 0) return rows.slice(-2);          // never left the ground in this window
+  const end = i;
+
+  // Scanning backwards, remember where each ground run *ends* (its newest
+  // sample) — the leg resumes there, not at the point the run was confirmed.
+  let run = 0;
+  let runNewest = -1;
+  let start = 0;
+  while (i >= 0) {
+    if (isGround(rows[i])) {
+      if (run === 0) runNewest = i;
+      if (++run >= minGroundRun) { start = runNewest + 1; break; }
+    } else {
+      run = 0;
+    }
+    i--;
+  }
+  const leg = rows.slice(start, end + 1);
+  // A trace with no ground reports at all is one continuous leg.
+  return leg.length > 1 ? leg : rows;
+}
+
+/**
  * Thin a track to at most `max` points, always keeping the first and last so
  * the path still starts and ends where the aircraft did. A 5,000-point trace
  * is ~120 KB and renders no better than a few hundred at map scale.
@@ -66,11 +107,17 @@ export function downsample<T>(points: T[], max: number): T[] {
 }
 
 /** Pull identity and the flown path out of a readsb trace file. */
-export function parseTrace(json: TraceFile, maxPoints = 700): Omit<AircraftDetail, 'operator' | 'source'> {
+export function parseTrace(
+  json: TraceFile,
+  maxPoints = 700,
+  /** Draw only the flight in progress; the full history is rarely meaningful. */
+  legOnly = true,
+): Omit<AircraftDetail, 'operator' | 'source'> {
   const track: [number, number][] = [];
   const altitudes: (number | null)[] = [];
 
-  for (const row of json?.trace || []) {
+  const rows = legOnly ? currentLeg(json?.trace || []) : (json?.trace || []);
+  for (const row of rows) {
     const lat = row?.[1];
     const lng = row?.[2];
     if (typeof lat !== 'number' || typeof lng !== 'number') continue;
@@ -118,13 +165,15 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const icao24 = (searchParams.get('icao24') || '').trim().toLowerCase();
     const full = searchParams.get('detail') !== 'recent';
+    // ?legs=all draws the whole 24h history instead of just this flight.
+    const legOnly = searchParams.get('legs') !== 'all';
 
     if (!/^[0-9a-f]{6}$/.test(icao24)) {
       return NextResponse.json({ error: 'icao24 must be a 6-character hex address' }, { status: 400 });
     }
 
     const detail = await cachedSource<AircraftDetail>(
-      `aircraft:${icao24}:${full ? 'full' : 'recent'}`,
+      `aircraft:${icao24}:${full ? 'full' : 'recent'}:${legOnly ? 'leg' : 'all'}`,
       async () => {
         const [trace, db] = await Promise.all([
           optional(fetchTrace(icao24, full)),
@@ -132,7 +181,7 @@ export async function GET(request: Request) {
         ]);
 
         const ac = db?.response?.aircraft;
-        const parsed = trace ? parseTrace(trace) : null;
+        const parsed = trace ? parseTrace(trace, 700, legOnly) : null;
 
         // Neither source knew this airframe.
         if (!parsed && !ac) return [];

--- a/src/app/api/aircraft/route.ts
+++ b/src/app/api/aircraft/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { httpJson, optional } from '@/lib/httpJson';
 import { cachedSource } from '@/lib/sourceCache';
+import { nearestAirport, type Airport } from '@/lib/airports';
 
 export const maxDuration = 20;
 
@@ -33,6 +34,10 @@ export interface AircraftDetail {
   /** Altitude in feet at each track point, aligned by index. */
   altitudes: (number | null)[];
   points: number;
+  /** Airport this leg was seen to leave, read off the track. Null if unknown. */
+  departure: Airport | null;
+  /** Airport this leg was seen to land at. Null while still airborne. */
+  arrival: Airport | null;
   source: string;
 }
 
@@ -93,6 +98,39 @@ export function currentLeg(
   return leg.length > 1 ? leg : rows;
 }
 
+/** Above this, the leg was picked up in the cruise, not seen to depart. */
+const DEPARTURE_CEILING_FT = 10_000;
+
+/**
+ * Name the airports a leg was *observed* to use.
+ *
+ * Schedule lookups are keyed by callsign and hand back whichever leg of the
+ * aircraft's day the database happens to hold — measured against the flown
+ * track, the origin they claim is typically over a thousand kilometres out,
+ * which is what turned the drawn route into lines to nowhere. The track knows
+ * better: a leg that begins low over an airport began *at* that airport, and
+ * one whose trace ends in ground reports has landed at the airport under it.
+ *
+ * Anything else stays null. An aircraft first seen at cruise has no knowable
+ * origin, and one still airborne has no knowable destination.
+ */
+export function legEndpoints(
+  track: [number, number][],
+  altitudes: (number | null)[],
+  landed: boolean,
+): { departure: Airport | null; arrival: Airport | null } {
+  if (track.length < 2) return { departure: null, arrival: null };
+
+  const firstAlt = altitudes[0];
+  const lowStart = firstAlt === null || (typeof firstAlt === 'number' && firstAlt <= DEPARTURE_CEILING_FT);
+  const departure = lowStart ? nearestAirport(track[0][1], track[0][0]) : null;
+
+  const last = track[track.length - 1];
+  const arrival = landed ? nearestAirport(last[1], last[0]) : null;
+
+  return { departure, arrival };
+}
+
 /**
  * Thin a track to at most `max` points, always keeping the first and last so
  * the path still starts and ends where the aircraft did. A 5,000-point trace
@@ -131,6 +169,11 @@ export function parseTrace(
   const idx = track.map((_, i) => i);
   const keep = downsample(idx, maxPoints);
 
+  // Trailing ground reports are trimmed off the leg, so the landing has to be
+  // read from the untrimmed trace.
+  const raw = json?.trace || [];
+  const landed = raw.length > 0 && raw[raw.length - 1]?.[3] === 'ground';
+
   return {
     icao24: (json?.icao || '').toLowerCase(),
     registration: json?.r?.trim() || null,
@@ -139,6 +182,7 @@ export function parseTrace(
     track: keep.map((i) => track[i]),
     altitudes: keep.map((i) => altitudes[i]),
     points: keep.length,
+    ...legEndpoints(track, altitudes, landed),
   };
 }
 
@@ -200,6 +244,8 @@ export async function GET(request: Request) {
           track: parsed?.track || [],
           altitudes: parsed?.altitudes || [],
           points: parsed?.points || 0,
+          departure: parsed?.departure || null,
+          arrival: parsed?.arrival || null,
           source: parsed ? 'adsb.lol' : 'adsbdb',
         }];
       },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -130,6 +130,7 @@ export default function Dashboard() {
   const [watchedFlights, setWatchedFlights] = useState<WatchedFlight[]>([]);
   const [aircraftTracks, setAircraftTracks] = useState<Record<string, [number, number][]>>({});
   const [aircraftAirports, setAircraftAirports] = useState<Record<string, Airport[]>>({});
+  const [aircraftPending, setAircraftPending] = useState<Record<string, [number, number][]>>({});
 
   // The popup lives in raw map HTML, so it hands aircraft over through a global.
   useEffect(() => {
@@ -152,6 +153,11 @@ export default function Dashboard() {
       delete next[icao24];
       return next;
     });
+    setAircraftPending((prev) => {
+      const next = { ...prev };
+      delete next[icao24];
+      return next;
+    });
   }, []);
 
   const handleAircraftDetail = useCallback((icao24: string, detail: AircraftDetail | null) => {
@@ -161,6 +167,22 @@ export default function Dashboard() {
     const ports = [detail?.origin, detail?.destination]
       .filter((a): a is Airport => Boolean(a && Number.isFinite(a.lat) && Number.isFinite(a.lng)));
     setAircraftAirports((prev) => (ports.length ? { ...prev, [icao24]: ports } : prev));
+
+    // The origin is read off the track, so it already sits on the first fix and
+    // needs nothing drawn to reach it. The destination is still ahead of the
+    // aircraft — a dashed run from the last fix says so without pretending to
+    // know the path it will take.
+    const track = detail?.track || [];
+    const dest = detail?.destination;
+    setAircraftPending((prev) => {
+      if (track.length < 2 || !dest || detail?.arrival) {
+        if (!(icao24 in prev)) return prev;
+        const next = { ...prev };
+        delete next[icao24];
+        return next;
+      }
+      return { ...prev, [icao24]: [track[track.length - 1], [dest.lng, dest.lat]] };
+    });
   }, []);
 
   // Telemetry for watched aircraft, refreshed from whatever the feed last gave us.
@@ -951,6 +973,7 @@ export default function Dashboard() {
           navigating={Boolean(navSession)}
           aircraftTracks={aircraftTracks}
           aircraftAirports={aircraftAirports}
+          aircraftPending={aircraftPending}
         />
       </ErrorBoundary>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import ScmPanel from '@/components/ScmPanel';
 import SearchBar from '@/components/SearchBar';
 import DirectionsBar, { type RouteResult, type LiveLocation } from '@/components/DirectionsBar';
 import NavigationView from '@/components/NavigationView';
-import FlightWatchPanel, { type WatchedFlight, type FlightTelemetry, type AircraftDetail } from '@/components/FlightWatchPanel';
+import FlightWatchPanel, { type WatchedFlight, type FlightTelemetry, type AircraftDetail, type Airport } from '@/components/FlightWatchPanel';
 import type { NavProgress } from '@/lib/navigation';
 import ScaleBar from '@/components/ScaleBar';
 import ErrorBoundary from '@/components/ErrorBoundary';
@@ -129,6 +129,7 @@ export default function Dashboard() {
   const [navProgress, setNavProgress] = useState<NavProgress | null>(null);
   const [watchedFlights, setWatchedFlights] = useState<WatchedFlight[]>([]);
   const [aircraftTracks, setAircraftTracks] = useState<Record<string, [number, number][]>>({});
+  const [aircraftAirports, setAircraftAirports] = useState<Record<string, Airport[]>>({});
 
   // The popup lives in raw map HTML, so it hands aircraft over through a global.
   useEffect(() => {
@@ -146,11 +147,20 @@ export default function Dashboard() {
       delete next[icao24];
       return next;
     });
+    setAircraftAirports((prev) => {
+      const next = { ...prev };
+      delete next[icao24];
+      return next;
+    });
   }, []);
 
   const handleAircraftDetail = useCallback((icao24: string, detail: AircraftDetail | null) => {
     setAircraftTracks((prev) =>
       detail?.track?.length ? { ...prev, [icao24]: detail.track } : prev);
+
+    const ports = [detail?.origin, detail?.destination]
+      .filter((a): a is Airport => Boolean(a && Number.isFinite(a.lat) && Number.isFinite(a.lng)));
+    setAircraftAirports((prev) => (ports.length ? { ...prev, [icao24]: ports } : prev));
   }, []);
 
   // Telemetry for watched aircraft, refreshed from whatever the feed last gave us.
@@ -940,6 +950,7 @@ export default function Dashboard() {
           followUser={followUser}
           navigating={Boolean(navSession)}
           aircraftTracks={aircraftTracks}
+          aircraftAirports={aircraftAirports}
         />
       </ErrorBoundary>
 

--- a/src/components/FlightWatchPanel.test.ts
+++ b/src/components/FlightWatchPanel.test.ts
@@ -1,27 +1,141 @@
 import { describe, it, expect } from 'vitest';
-import { toFeet, formatAlt } from './FlightWatchPanel';
+import {
+  toFeet,
+  formatAlt,
+  greatCircleKm,
+  onCorridor,
+  resolveEndpoints,
+  type Airport,
+  type AircraftDetail,
+} from './FlightWatchPanel';
 
-describe('toFeet', () => {
-  // The feed reports metres; aviation reads feet, rounded to the nearest 25.
-  it('converts metres to feet at a 25 ft granularity', () => {
-    expect(toFeet(0)).toBe(0);
-    expect(toFeet(1000)).toBe(3275);
-    expect(toFeet(10668)).toBe(35000);
+const ap = (icao: string, iata: string, lat: number, lng: number): Airport =>
+  ({ icao, iata, lat, lng });
+
+const CLT = ap('KCLT', 'CLT', 35.2140, -80.9431);
+const DTW = ap('KDTW', 'DTW', 42.2124, -83.3534);
+const FLL = ap('KFLL', 'FLL', 26.0742, -80.1506);
+const MUC = ap('EDDM', 'MUC', 48.3538, 11.7861);
+const SLC = ap('KSLC', 'SLC', 40.7884, -111.9778);
+const CLE = ap('KCLE', 'CLE', 41.4117, -81.8498);
+
+const detail = (over: Partial<AircraftDetail>): AircraftDetail => ({
+  icao24: 'a0e250',
+  registration: 'N123AA',
+  typeCode: 'B738',
+  model: 'BOEING 737-800',
+  operator: 'American Airlines',
+  track: [[-83.35, 42.21], [-81.5, 33.0]],
+  points: 2,
+  ...over,
+});
+
+describe('toFeet / formatAlt', () => {
+  it('converts metres to feet, rounded to the nearest 25', () => {
+    expect(toFeet(10000)).toBe(32800);
+    expect(toFeet(1)).toBe(0);
+  });
+
+  it('says Ground rather than an altitude when the aircraft is on it', () => {
+    expect(formatAlt(0, true)).toBe('Ground');
+  });
+
+  it('falls back for a missing or unusable altitude', () => {
+    expect(formatAlt(undefined)).toBe('—');
+    expect(formatAlt(NaN)).toBe('—');
   });
 });
 
-describe('formatAlt', () => {
-  it('renders thousands separated', () => {
-    expect(formatAlt(10668)).toBe('35,000 ft');
+describe('greatCircleKm', () => {
+  it('measures a known leg', () => {
+    // DTW–FLL is about 1,800 km.
+    expect(greatCircleKm([-83.3534, 42.2124], [-80.1506, 26.0742])).toBeGreaterThan(1750);
+    expect(greatCircleKm([-83.3534, 42.2124], [-80.1506, 26.0742])).toBeLessThan(1870);
   });
 
-  it('says Ground rather than an altitude when the aircraft is down', () => {
-    expect(formatAlt(0, true)).toBe('Ground');
-    expect(formatAlt(12, true)).toBe('Ground');
+  it('is zero for a point against itself', () => {
+    expect(greatCircleKm([10, 50], [10, 50])).toBe(0);
+  });
+});
+
+describe('onCorridor', () => {
+  it('accepts an aircraft partway along the route', () => {
+    expect(onCorridor([-81.7, 34.1], DTW, FLL)).toBe(true);
   });
 
-  it('falls back to a dash when altitude is missing or unusable', () => {
-    expect(formatAlt(undefined)).toBe('—');
-    expect(formatAlt(NaN)).toBe('—');
+  it('rejects one nowhere near it', () => {
+    // Salt Lake City is not on the way from Cleveland to Detroit.
+    expect(onCorridor([-111.98, 40.79], CLE, DTW)).toBe(false);
+  });
+
+  it('tolerates the vectoring that dominates a short hop', () => {
+    // 60 km off a 150 km route is normal departure routing, not a wrong leg.
+    expect(onCorridor([-82.6, 42.4], CLE, DTW)).toBe(true);
+  });
+});
+
+describe('resolveEndpoints', () => {
+  it('uses the observed departure as the origin, not the schedule', () => {
+    const { origin } = resolveEndpoints(
+      detail({ departure: DTW }),
+      { found: true, origin: MUC, destination: CLT },
+    );
+    expect(origin?.iata).toBe('DTW');
+  });
+
+  it('takes the schedule destination when the schedule origin matches what was seen', () => {
+    const { origin, destination } = resolveEndpoints(
+      detail({ departure: DTW }),
+      { found: true, origin: DTW, destination: FLL },
+    );
+    expect(origin?.iata).toBe('DTW');
+    expect(destination?.iata).toBe('FLL');
+  });
+
+  // The failure the user saw: a dot thousands of km from the track, joined to
+  // it by a straight line the aircraft never flew.
+  it('drops the destination when the schedule describes a different leg', () => {
+    const { origin, destination } = resolveEndpoints(
+      detail({ departure: SLC }),
+      { found: true, origin: CLE, destination: DTW },
+    );
+    expect(origin?.iata).toBe('SLC');
+    expect(destination).toBeNull();
+  });
+
+  it('falls back to the corridor test when the departure was never seen', () => {
+    const onRoute = resolveEndpoints(
+      detail({ departure: null, track: [[-81.7, 34.1]] }),
+      { found: true, origin: DTW, destination: FLL },
+    );
+    expect(onRoute.destination?.iata).toBe('FLL');
+
+    const offRoute = resolveEndpoints(
+      detail({ departure: null, track: [[-111.98, 40.79]] }),
+      { found: true, origin: CLE, destination: DTW },
+    );
+    expect(offRoute.destination).toBeNull();
+  });
+
+  it('prefers the observed arrival over anything the schedule claims', () => {
+    const { origin, destination } = resolveEndpoints(
+      detail({ departure: DTW, arrival: CLT }),
+      { found: true, origin: DTW, destination: FLL },
+    );
+    expect(origin?.iata).toBe('DTW');
+    expect(destination?.iata).toBe('CLT');
+  });
+
+  it('reports nothing at all when there is no track and no schedule', () => {
+    expect(resolveEndpoints(detail({ track: [], points: 0 }), null))
+      .toEqual({ origin: null, destination: null });
+  });
+
+  it('ignores a schedule lookup that found nothing', () => {
+    const { destination } = resolveEndpoints(
+      detail({ departure: DTW }),
+      { found: false, origin: DTW, destination: FLL },
+    );
+    expect(destination).toBeNull();
   });
 });

--- a/src/components/FlightWatchPanel.tsx
+++ b/src/components/FlightWatchPanel.tsx
@@ -41,9 +41,87 @@ export interface AircraftDetail {
   operator: string | null;
   track: [number, number][];
   points: number;
-  /** Scheduled endpoints, so the map can pin the airports it flies between. */
+  /** Airports read off the track: where this leg was seen to leave and land. */
+  departure?: Airport | null;
+  arrival?: Airport | null;
+  /** Endpoints the map should pin — observed where possible, schedule where not. */
   origin?: Airport | null;
   destination?: Airport | null;
+}
+
+/** Schedule lookup result from /api/flight-route. */
+export interface ScheduledRoute {
+  found?: boolean;
+  origin?: Airport | null;
+  destination?: Airport | null;
+}
+
+const R_KM = 6371;
+
+export function greatCircleKm(a: [number, number], b: [number, number]): number {
+  const t = Math.PI / 180;
+  const dLat = (b[1] - a[1]) * t;
+  const dLng = (b[0] - a[0]) * t;
+  const h = Math.sin(dLat / 2) ** 2
+    + Math.cos(a[1] * t) * Math.cos(b[1] * t) * Math.sin(dLng / 2) ** 2;
+  return 2 * R_KM * Math.asin(Math.sqrt(h));
+}
+
+const sameAirport = (a: Airport, b: Airport) =>
+  a.icao === b.icao || (Boolean(a.iata) && a.iata === b.iata);
+
+/**
+ * Is the aircraft actually inside the corridor between these two airports?
+ *
+ * Flying O→D means the legs either side of you add up to about the whole trip.
+ * A wrong-leg schedule fails loudly — one sampled aircraft measured 32× the
+ * direct distance out of its supposed corridor.
+ */
+export function onCorridor(here: [number, number], origin: Airport, destination: Airport): boolean {
+  const direct = greatCircleKm([origin.lng, origin.lat], [destination.lng, destination.lat]);
+  const detour = greatCircleKm([origin.lng, origin.lat], here)
+    + greatCircleKm(here, [destination.lng, destination.lat]);
+  // Short hops spend a bigger share of the trip on departure and arrival
+  // vectoring, so allow a fixed slice of slack on top of the proportional one.
+  return detour <= direct * 1.15 + 150;
+}
+
+/**
+ * Decide which airports are safe to put on the map.
+ *
+ * Schedule lookups are keyed by callsign, and across a live sample they named
+ * the wrong leg of the aircraft's day about four times in five — origins over
+ * a thousand kilometres from where the track began. Drawn, that is a dot in
+ * open country with a straight line to nowhere, which is exactly what this
+ * used to look like.
+ *
+ * So the track leads and the schedule corroborates: the departure the aircraft
+ * was seen to make is the origin, and the schedule's destination is only
+ * accepted when its origin agrees with that departure. With no observed
+ * departure to check against — coverage that began mid-ocean — the corridor
+ * test stands in. Failing both, nothing is drawn.
+ */
+export function resolveEndpoints(
+  ac: AircraftDetail,
+  schedule: ScheduledRoute | null,
+): { origin: Airport | null; destination: Airport | null } {
+  const observedDep = ac.departure || null;
+  const observedArr = ac.arrival || null;
+  const sched = schedule?.found ? schedule : null;
+  const here = ac.track.length ? ac.track[ac.track.length - 1] : null;
+
+  // Already landed: both ends were watched happening, nothing to corroborate.
+  if (observedDep && observedArr) return { origin: observedDep, destination: observedArr };
+
+  let destination: Airport | null = observedArr;
+  if (!destination && sched?.origin && sched?.destination && here) {
+    const corroborated = observedDep
+      ? sameAirport(observedDep, sched.origin)
+      : onCorridor(here, sched.origin, sched.destination);
+    if (corroborated) destination = sched.destination;
+  }
+
+  return { origin: observedDep, destination };
 }
 
 interface FlightWatchPanelProps {
@@ -95,11 +173,7 @@ function Row({ flight, telem, onRemove, onLocate, onDetail }: {
       if (cancelled) return;
       const base = ac && !ac.error ? (ac as AircraftDetail) : null;
       const merged: AircraftDetail | null = base
-        ? {
-            ...base,
-            origin: route?.found ? route.origin : null,
-            destination: route?.found ? route.destination : null,
-          }
+        ? { ...base, ...resolveEndpoints(base, route as ScheduledRoute | null) }
         : null;
       setDetail(merged);
       setLoading(false);
@@ -177,14 +251,19 @@ function Row({ flight, telem, onRemove, onLocate, onDetail }: {
           </div>
         </div>
 
-        {detail?.origin && detail?.destination && (
+        {(detail?.origin || detail?.destination) && (
           <div className="flex items-center gap-1.5 mt-2 pt-1.5 border-t border-[var(--border-secondary)]">
             <span className="text-[10px] text-[var(--text-primary)] tabular-nums">
-              {detail.origin.iata || detail.origin.icao}
+              {detail.origin ? detail.origin.iata || detail.origin.icao : '····'}
             </span>
             <span className="text-[9px] text-[var(--text-muted)]">&rarr;</span>
             <span className="text-[10px] text-[var(--text-primary)] tabular-nums">
-              {detail.destination.iata || detail.destination.icao}
+              {detail.destination ? detail.destination.iata || detail.destination.icao : '····'}
+            </span>
+            {/* An unconfirmed destination is a schedule claim, not something the
+                aircraft was seen to do — say so rather than imply certainty. */}
+            <span className="text-[8px] text-[var(--text-muted)] ml-auto">
+              {detail.arrival ? 'landed' : detail.destination ? 'scheduled' : 'destination unknown'}
             </span>
           </div>
         )}

--- a/src/components/FlightWatchPanel.tsx
+++ b/src/components/FlightWatchPanel.tsx
@@ -25,6 +25,14 @@ export interface FlightTelemetry {
   squawk?: string;
 }
 
+export interface Airport {
+  icao: string;
+  iata?: string;
+  city?: string;
+  lat: number;
+  lng: number;
+}
+
 export interface AircraftDetail {
   icao24: string;
   registration: string | null;
@@ -33,6 +41,9 @@ export interface AircraftDetail {
   operator: string | null;
   track: [number, number][];
   points: number;
+  /** Scheduled endpoints, so the map can pin the airports it flies between. */
+  origin?: Airport | null;
+  destination?: Airport | null;
 }
 
 interface FlightWatchPanelProps {
@@ -68,21 +79,35 @@ function Row({ flight, telem, onRemove, onLocate, onDetail }: {
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`/api/aircraft?icao24=${flight.icao24}`)
-      .then(async (r) => {
-        const d = r.ok ? await r.json() : null;
-        if (cancelled) return;
-        setDetail(d && !d.error ? d : null);
-        setLoading(false);
-        onDetail(flight.icao24, d && !d.error ? d : null);
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setLoading(false);
-        onDetail(flight.icao24, null);
-      });
+    const cs = (flight.callsign || '').replace(/\s+/g, '');
+
+    // Airframe and scheduled route come from different places: the trace files
+    // know what the aircraft is and where it has been, the route lookup knows
+    // which airports it is booked between.
+    Promise.all([
+      fetch(`/api/aircraft?icao24=${flight.icao24}`)
+        .then((r) => (r.ok ? r.json() : null)).catch(() => null),
+      cs
+        ? fetch(`/api/flight-route?callsign=${encodeURIComponent(cs)}&icao24=${flight.icao24}`)
+            .then((r) => (r.ok ? r.json() : null)).catch(() => null)
+        : Promise.resolve(null),
+    ]).then(([ac, route]) => {
+      if (cancelled) return;
+      const base = ac && !ac.error ? (ac as AircraftDetail) : null;
+      const merged: AircraftDetail | null = base
+        ? {
+            ...base,
+            origin: route?.found ? route.origin : null,
+            destination: route?.found ? route.destination : null,
+          }
+        : null;
+      setDetail(merged);
+      setLoading(false);
+      onDetail(flight.icao24, merged);
+    });
+
     return () => { cancelled = true; };
-  }, [flight.icao24, onDetail]);
+  }, [flight.icao24, flight.callsign, onDetail]);
 
   return (
     <div className="glass-panel overflow-hidden" style={{ boxShadow: '0 12px 32px rgba(0,0,0,0.6)' }}>
@@ -152,9 +177,21 @@ function Row({ flight, telem, onRemove, onLocate, onDetail }: {
           </div>
         </div>
 
+        {detail?.origin && detail?.destination && (
+          <div className="flex items-center gap-1.5 mt-2 pt-1.5 border-t border-[var(--border-secondary)]">
+            <span className="text-[10px] text-[var(--text-primary)] tabular-nums">
+              {detail.origin.iata || detail.origin.icao}
+            </span>
+            <span className="text-[9px] text-[var(--text-muted)]">&rarr;</span>
+            <span className="text-[10px] text-[var(--text-primary)] tabular-nums">
+              {detail.destination.iata || detail.destination.icao}
+            </span>
+          </div>
+        )}
+
         {detail && detail.points > 0 && (
           <div className="mt-1.5 text-[8px] text-[var(--text-muted)] tabular-nums">
-            {detail.points} flown track points
+            {detail.points} points this leg
           </div>
         )}
         {!telem && (

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -41,8 +41,10 @@ interface OsirisMapProps {
   navigating?: boolean;
   /** Flown tracks for watched aircraft, keyed by icao24. */
   aircraftTracks?: Record<string, [number, number][]>;
-  /** Scheduled airports for watched aircraft, keyed by icao24. */
+  /** Corroborated endpoint airports for watched aircraft, keyed by icao24. */
   aircraftAirports?: Record<string, Array<{ icao: string; iata?: string; city?: string; lat: number; lng: number }>>;
+  /** Aircraft position to its destination — the leg still to fly, drawn dashed. */
+  aircraftPending?: Record<string, [number, number][]>;
 }
 
 function computeSolarTerminator(): [number, number][] {
@@ -67,7 +69,7 @@ function computeSolarTerminator(): [number, number][] {
 
 const EMPTY_FC = { type: 'FeatureCollection' as const, features: [] };
 
-function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null, userLocation = null, followUser = false, navigating = false, aircraftTracks = {}, aircraftAirports = {} }: OsirisMapProps) {
+function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null, userLocation = null, followUser = false, navigating = false, aircraftTracks = {}, aircraftAirports = {}, aircraftPending = {} }: OsirisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -2316,8 +2318,20 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     const SRC = 'aircraft-tracks';
     const IDS = ['aircraft-track-casing', 'aircraft-track-line'];
 
+    // An aircraft taxiing produces a few hundred samples inside a few hundred
+    // metres — at map scale that is a meaningless squiggle, so require the leg
+    // to actually cover ground before drawing it.
+    const spansGround = (t: [number, number][]) => {
+      let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+      for (const [x, y] of t) {
+        if (x < minX) minX = x; if (x > maxX) maxX = x;
+        if (y < minY) minY = y; if (y > maxY) maxY = y;
+      }
+      return Math.max(maxX - minX, maxY - minY) > 0.05; // ≈5 km
+    };
+
     const features = Object.entries(aircraftTracks)
-      .filter(([, t]) => Array.isArray(t) && t.length > 1)
+      .filter(([, t]) => Array.isArray(t) && t.length > 1 && spansGround(t))
       .map(([icao24, t]) => ({
         type: 'Feature' as const,
         properties: { icao24 },
@@ -2331,7 +2345,8 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     }
 
     const fc = { type: 'FeatureCollection' as const, features };
-    if (!map.getSource(SRC)) map.addSource(SRC, { type: 'geojson', data: fc as never });
+    // lineMetrics is what makes line-progress — and so the gradient — available.
+    if (!map.getSource(SRC)) map.addSource(SRC, { type: 'geojson', lineMetrics: true, data: fc as never });
     else (map.getSource(SRC) as maplibregl.GeoJSONSource).setData(fc as never);
 
     if (!map.getLayer('aircraft-track-casing')) {
@@ -2350,17 +2365,65 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         id: 'aircraft-track-line', type: 'line', source: SRC,
         layout: { 'line-cap': 'round', 'line-join': 'round' },
         paint: {
-          'line-color': '#FFB300',
+          // Faint where the leg began, bright at the aircraft — the line reads
+          // as a direction of travel rather than a stroke someone drew.
+          'line-gradient': [
+            'interpolate', ['linear'], ['line-progress'],
+            0, 'rgba(255,179,0,0.18)',
+            0.6, 'rgba(255,193,7,0.6)',
+            1, '#FFD54F',
+          ],
           'line-width': ['interpolate', ['linear'], ['zoom'], 2, 1.4, 8, 3],
-          'line-opacity': 0.9,
         },
       });
     }
   }, [mapReady, aircraftTracks]);
 
+  // ── REMAINING LEG ──
+  // Dashed, because it is where the aircraft is booked to go, not where it has
+  // been — the solid track is the part that actually happened.
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    const map = mapRef.current;
+    const SRC = 'aircraft-pending';
+    const ID = 'aircraft-pending-line';
+
+    const features = Object.entries(aircraftPending)
+      .filter(([, t]) => Array.isArray(t) && t.length > 1)
+      .map(([icao24, pts]) => ({
+        type: 'Feature' as const,
+        properties: { icao24 },
+        geometry: { type: 'LineString' as const, coordinates: pts },
+      }));
+
+    if (features.length === 0) {
+      if (map.getLayer(ID)) map.removeLayer(ID);
+      if (map.getSource(SRC)) map.removeSource(SRC);
+      return;
+    }
+
+    const fc = { type: 'FeatureCollection' as const, features };
+    if (!map.getSource(SRC)) map.addSource(SRC, { type: 'geojson', data: fc as never });
+    else (map.getSource(SRC) as maplibregl.GeoJSONSource).setData(fc as never);
+
+    if (!map.getLayer(ID)) {
+      map.addLayer({
+        id: ID, type: 'line', source: SRC,
+        layout: { 'line-cap': 'round', 'line-join': 'round' },
+        paint: {
+          'line-color': '#FFB300',
+          'line-width': ['interpolate', ['linear'], ['zoom'], 2, 1, 8, 2],
+          'line-opacity': 0.45,
+          'line-dasharray': [2, 3],
+        },
+      });
+    }
+  }, [mapReady, aircraftPending]);
+
   // ── AIRPORTS FOR WATCHED AIRCRAFT ──
   // A bare track is hard to read: it shows where the aircraft went without
-  // saying between what. Pinning the scheduled endpoints gives the line ends.
+  // saying between what. These are the endpoints that survived corroboration
+  // against the track, so each dot lands on the line rather than beside it.
   useEffect(() => {
     if (!mapReady || !mapRef.current) return;
     const map = mapRef.current;

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -41,6 +41,8 @@ interface OsirisMapProps {
   navigating?: boolean;
   /** Flown tracks for watched aircraft, keyed by icao24. */
   aircraftTracks?: Record<string, [number, number][]>;
+  /** Scheduled airports for watched aircraft, keyed by icao24. */
+  aircraftAirports?: Record<string, Array<{ icao: string; iata?: string; city?: string; lat: number; lng: number }>>;
 }
 
 function computeSolarTerminator(): [number, number][] {
@@ -65,7 +67,7 @@ function computeSolarTerminator(): [number, number][] {
 
 const EMPTY_FC = { type: 'FeatureCollection' as const, features: [] };
 
-function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null, userLocation = null, followUser = false, navigating = false, aircraftTracks = {} }: OsirisMapProps) {
+function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null, userLocation = null, followUser = false, navigating = false, aircraftTracks = {}, aircraftAirports = {} }: OsirisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -2355,6 +2357,71 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       });
     }
   }, [mapReady, aircraftTracks]);
+
+  // ── AIRPORTS FOR WATCHED AIRCRAFT ──
+  // A bare track is hard to read: it shows where the aircraft went without
+  // saying between what. Pinning the scheduled endpoints gives the line ends.
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    const map = mapRef.current;
+    const SRC = 'watched-airports';
+    const IDS = ['watched-airport-glow', 'watched-airport-dot', 'watched-airport-label'];
+
+    // The same airport can serve several watched aircraft — draw it once.
+    const seen = new Set<string>();
+    const features = Object.values(aircraftAirports).flat()
+      .filter((a) => {
+        if (!a || seen.has(a.icao)) return false;
+        seen.add(a.icao);
+        return true;
+      })
+      .map((a) => ({
+        type: 'Feature' as const,
+        properties: { label: a.iata || a.icao, city: a.city || '' },
+        geometry: { type: 'Point' as const, coordinates: [a.lng, a.lat] },
+      }));
+
+    if (features.length === 0) {
+      IDS.forEach((id) => { if (map.getLayer(id)) map.removeLayer(id); });
+      if (map.getSource(SRC)) map.removeSource(SRC);
+      return;
+    }
+
+    const fc = { type: 'FeatureCollection' as const, features };
+    if (!map.getSource(SRC)) map.addSource(SRC, { type: 'geojson', data: fc as never });
+    else (map.getSource(SRC) as maplibregl.GeoJSONSource).setData(fc as never);
+
+    if (!map.getLayer('watched-airport-glow')) {
+      map.addLayer({
+        id: 'watched-airport-glow', type: 'circle', source: SRC,
+        paint: { 'circle-radius': 13, 'circle-color': '#FFB300', 'circle-opacity': 0.16, 'circle-blur': 0.8 },
+      });
+    }
+    if (!map.getLayer('watched-airport-dot')) {
+      map.addLayer({
+        id: 'watched-airport-dot', type: 'circle', source: SRC,
+        paint: {
+          'circle-radius': 5,
+          'circle-color': '#FFFFFF',
+          'circle-stroke-width': 2,
+          'circle-stroke-color': '#FFB300',
+        },
+      });
+    }
+    if (!map.getLayer('watched-airport-label')) {
+      map.addLayer({
+        id: 'watched-airport-label', type: 'symbol', source: SRC,
+        layout: {
+          'text-field': ['get', 'label'],
+          'text-size': 11,
+          'text-font': ['Open Sans Bold'],
+          'text-offset': [0, 1.6],
+          'text-allow-overlap': true,
+        },
+        paint: { 'text-color': '#FFB300', 'text-halo-color': '#0C0E1A', 'text-halo-width': 1.5 },
+      });
+    }
+  }, [mapReady, aircraftAirports]);
 
   // ── ARCGIS LAYERS ──
   useEffect(() => {

--- a/src/lib/airports.ts
+++ b/src/lib/airports.ts
@@ -525,4 +525,30 @@ export function getAllAirports(): Airport[] {
   return Object.values(AIRPORTS_BY_ICAO);
 }
 
+/**
+ * The airport closest to a position, or null if none is within `maxKm`.
+ *
+ * Used to name the airport a flown leg actually started from. Schedule data is
+ * keyed by callsign and routinely returns a different leg of the aircraft's
+ * day, so the departure is read back off the track instead of trusted.
+ */
+export function nearestAirport(lat: number, lng: number, maxKm = 25): Airport | null {
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  let best: Airport | null = null;
+  let bestKm = maxKm;
+  // A degree of longitude shrinks toward the poles; without this an airport
+  // 25 km away at 60°N measures as 12 km and the wrong one wins.
+  const lngScale = Math.cos((lat * Math.PI) / 180);
+  for (const ap of Object.values(AIRPORTS_BY_ICAO)) {
+    const dy = (ap.lat - lat) * 111.32;
+    const dx = (ap.lng - lng) * 111.32 * lngScale;
+    const d = Math.hypot(dx, dy);
+    if (d < bestKm) {
+      bestKm = d;
+      best = ap;
+    }
+  }
+  return best;
+}
+
 export { AIRPORTS_BY_ICAO, AIRPORTS_BY_IATA };


### PR DESCRIPTION
The airport dots added in #268 landed nowhere near the lines they were meant to anchor. This fixes the cause: the schedule lookup they came from is usually describing a different flight.

## The measurement

I sampled 30 live airliners and compared the callsign schedule lookup's claimed route against the track the aircraft had actually flown.

**The schedule named the wrong leg of the aircraft's day four times in five.**

| callsign | schedule said | leg actually began at | origin off by |
|---|---|---|---|
| `SKW4105` | CLE → DTW | Salt Lake City | 2,512 km |
| `AAL717` | MUC → CLT | Seattle | 8,477 km |
| `SWA3616` | MCO → ALB | San Jose | 3,888 km |
| `DAL1075` | SFO → ATL | Boston | 4,341 km |

`SKW4105` was thirty-two times its own route length off corridor. Drawn, that is a dot in open country joined to the aircraft by a straight line it never flew — which is what the map was showing. Across the sample the median picture was **87% inferred geometry**.

## The fix — the track leads, the schedule corroborates

The trace already answers this. A leg that starts low over an airport started *at* that airport; one whose trace ends in ground reports has landed under them.

- **`/api/aircraft` now returns `departure` and `arrival`**, derived from the track via a new `nearestAirport()` in `src/lib/airports.ts`. A leg first seen above 10,000 ft has no knowable origin and reports none, rather than guessing.
- **The observed departure becomes the origin outright.** It sits on the first fix by construction — measured at 1–2 km across live samples, against the 1,000–8,000 km the schedule was producing.
- **The schedule is demoted to corroboration.** Its destination is drawn only when its origin agrees with the departure that was actually seen. With no observed departure to check against — coverage that began mid-ocean — a corridor test stands in: flying O→D means the legs either side of you add up to about the whole trip.
- **Failing both, nothing is drawn** and the card reads *destination unknown*. An observed arrival always wins over a schedule claim.

## Rendering

- Flown track fades in at the departure and brightens to the aircraft (`line-gradient` over `line-progress`), so the line carries a direction rather than reading as a stroke someone drew.
- The leg still to fly runs dashed from the aircraft to its destination. The origin stub is gone — the origin is on the track now, so there was nothing left to bridge.
- Tracks spanning under ~5 km are suppressed; that is an aircraft taxiing, not a journey.

Every dot now sits on an end of a line.

## Verification

Checked on the real map, not just in props — the watch panel, both layer effects, and the reconciliation were exercised end to end on localhost with live aircraft.

- 24 new tests (162 total, 12 files) covering `nearestAirport`, `legEndpoints`, `onCorridor` and `resolveEndpoints`, including the exact failure above: a schedule describing a different leg is rejected.
- `next build` clean; no new lint or typecheck findings (231 pre-existing problems in the touched files, unchanged).

## Tradeoff worth flagging

Roughly a quarter of watched flights now get a corroborated destination; the rest say *destination unknown*. That is the price of not inventing one. The corroboration threshold is a single call in `resolveEndpoints` if you'd rather trade accuracy for coverage.

Generated with [SIMPLIFAI](https://Simplifai-1.com)