### PR TITLE
feat(mobile): put directions in reach on a phone

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1183,7 +1183,9 @@ export default function Dashboard() {
       </motion.div>
 
       {/* ── MOBILE: Compact top status ── */}
-      {isMobile && (
+      {/* The route planner claims the top of a phone screen; leaving this in
+          place would put the support badge underneath the destination field. */}
+      {isMobile && !showDirections && !navSession && (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 2.5 }} className="absolute top-3 right-3 z-[200] pointer-events-auto flex items-center gap-2">
           <TokenPanel />
           <a href='https://ko-fi.com/M8D41ZYW4Z' target='_blank' rel='noopener noreferrer' className="glass-panel px-2 py-1 flex items-center gap-1.5 text-[7px] font-mono tracking-widest hover:opacity-80 transition-opacity border-[var(--gold-primary)]/40 bg-[var(--gold-primary)]/10">
@@ -1436,14 +1438,45 @@ export default function Dashboard() {
                 { id: 'intel' as const, icon: Newspaper, label: 'INTEL' },
                 { id: 'recon' as const, icon: Radar, label: 'RECON' },
                 { id: 'search' as const, icon: Search, label: 'SEARCH' },
+                // Routing was reachable only from the desktop tool rail, so a
+                // phone could not open it at all. It sits next to SEARCH
+                // because both answer "take me somewhere".
+                { id: 'route' as const, icon: Route, label: 'ROUTE' },
                 { id: 'remote' as const, icon: Bluetooth, label: 'REMOTE' },
-              ].map(tab => (
-                <button key={tab.id} onClick={() => setMobilePanel(mobilePanel === tab.id ? null : tab.id)}
-                  className={`mobile-nav-btn ${mobilePanel === tab.id ? 'active' : ''}`}>
-                  <tab.icon className={`w-4 h-4 ${tab.id === 'recon' ? 'text-[var(--cyan-primary)]' : ''}`} />
-                  <span className={tab.id === 'recon' ? 'text-[var(--cyan-primary)]' : ''}>{tab.label}</span>
-                </button>
-              ))}
+              ].map(tab => {
+                // Routing opens the planner at the top of the screen rather than
+                // the bottom drawer — it needs the room above the keyboard, and
+                // guidance has to stay readable while you drive.
+                const isRoute = tab.id === 'route';
+                const active = isRoute ? showDirections || Boolean(navSession) : mobilePanel === tab.id;
+                return (
+                  <button
+                    key={tab.id}
+                    onClick={() => {
+                      if (isRoute) {
+                        // Mid-drive this must not touch anything: closing the
+                        // planner clears the active route, which would take the
+                        // line off the map underneath a driver. Guidance is
+                        // ended from the navigation view's own exit.
+                        if (navSession) return;
+                        setMobilePanel(null);
+                        setShowDirections((open) => {
+                          if (open) setActiveRoute(null);
+                          return !open;
+                        });
+                        return;
+                      }
+                      setMobilePanel(mobilePanel === tab.id ? null : tab.id);
+                    }}
+                    aria-pressed={active}
+                    disabled={isRoute && Boolean(navSession)}
+                    className={`mobile-nav-btn ${active ? 'active' : ''}`}
+                  >
+                    <tab.icon className={`w-4 h-4 ${tab.id === 'recon' ? 'text-[var(--cyan-primary)]' : ''}`} />
+                    <span className={tab.id === 'recon' ? 'text-[var(--cyan-primary)]' : ''}>{tab.label}</span>
+                  </button>
+                );
+              })}
             </div>
           </div>
 


### PR DESCRIPTION
Routing shipped in #266 and #267 with exactly one entry point: the desktop tool rail. That rail is not rendered below 768px. So a phone could open every other tool from the bottom nav — layers, markets, intel, recon, search, remote — and had no way at all to reach the one tool most worth having on a phone.

## The change

**ROUTE joins the bottom nav, between SEARCH and REMOTE.** Both answer *"take me somewhere"*, so they belong next to each other.

It opens the planner at the **top** of the screen rather than in the bottom drawer the other six tabs share. That is deliberate, not an inconsistency: routing needs the room above the keyboard, and turn-by-turn guidance has to stay readable while you drive. The planner already had mobile positioning (`top-3`, centred, `min(92vw, 372px)`) — it just had no way to be opened.

Three details that fall out of putting it there:

- Tapping ROUTE dismisses any drawer that was up, so the two don't compete for the screen.
- The compact mobile top status steps aside while the planner is open, otherwise the support badge sits underneath the destination field.
- **While a navigation session is running, the tab reads as active but does nothing.** Closing the planner clears the active route — a driver tapping it would have watched their route come off the map mid-journey. Guidance is ended from the navigation view's own exit.

## Verification

Measured in the DOM at a 375×812 viewport. I could not capture a screenshot — the preview pane stopped compositing frames partway through — so this is geometry rather than pixels:

| check | result |
|---|---|
| tab count / width at 375px | 7 tabs, **52.7px each**, no overflow |
| planner box | **x=15, w=345** — centred, even margins |
| clearance | planner bottom 230px vs nav top 769px |
| ROUTE toggle | opens/closes planner, `aria-pressed` tracks state |
| drawer interaction | opening ROUTE clears `mobilePanel` |
| top status | hidden while open, restored on close |
| desktop at 1280px | rail Directions still visible, no mobile nav rendered |

162 tests pass, `next build` clean, lint unchanged at 92 problems before and after.

## Worth an eye before merge

Seven tabs at 6px labels is the tight part. The numbers say it fits without overflow, but how it *reads* at that density — and whether ROUTE sits well beside SEARCH — is a judgement a screenshot would have settled and I could not take one.

Generated with [SIMPLIFAI](https://Simplifai-1.com)