### PR TITLE
feat(markets): rebuild the markets panel — live data, candlestick charts, scrollable fullscreen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "framer-motion": "^12.38.0",
         "google-libphonenumber": "^3.2.44",
         "hls.js": "^1.6.16",
+        "lightweight-charts": "^5.2.0",
         "lucide-react": "^1.14.0",
         "maplibre-gl": "^5.24.0",
         "next": "16.2.6",
@@ -5032,6 +5033,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6575,6 +6582,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightweight-charts": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.2.0.tgz",
+      "integrity": "sha512-ey3Vas8UhV06ni+LT9TA1nEe4y8So4Mi6CL/oarNHFMyTktz/xy8e8+oh04Q//eO3t6etvFXgayz2fClyFQb5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "framer-motion": "^12.38.0",
     "google-libphonenumber": "^3.2.44",
     "hls.js": "^1.6.16",
+    "lightweight-charts": "^5.2.0",
     "lucide-react": "^1.14.0",
     "maplibre-gl": "^5.24.0",
     "next": "16.2.6",

--- a/src/app/api/ai/overview/route.ts
+++ b/src/app/api/ai/overview/route.ts
@@ -84,7 +84,7 @@ function digestMarkets(payload: any): Digest {
     facts.push('No live market instruments available in the current feed.');
   }
 
-  const btc = markets?.crypto?.BTC || markets?.crypto?.bitcoin;
+  const btc = markets?.crypto?.Bitcoin || markets?.crypto?.BTC || markets?.crypto?.bitcoin;
   const btcPct = num(btc?.change_percent);
   if (btcPct !== null) {
     facts.push(`Bitcoin ${btcPct >= 0 ? 'up' : 'down'} ${btcPct.toFixed(2)}% at $${num(btc?.price)?.toLocaleString() ?? '—'}.`);

--- a/src/app/api/markets/history/route.test.ts
+++ b/src/app/api/markets/history/route.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { parseCandles } from './route';
+
+/** A chart result shaped the way Yahoo returns it. */
+function result(over: Record<string, unknown> = {}) {
+  return {
+    timestamp: [100, 200, 300],
+    indicators: {
+      quote: [{
+        open: [1, 2, 3],
+        high: [2, 3, 4],
+        low: [0.5, 1.5, 2.5],
+        close: [1.5, 2.5, 3.5],
+        volume: [10, 20, 30],
+      }],
+    },
+    ...over,
+  };
+}
+
+describe('parseCandles', () => {
+  it('maps a clean series into candles', () => {
+    const out = parseCandles(result());
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual({ time: 100, open: 1, high: 2, low: 0.5, close: 1.5, volume: 10 });
+  });
+
+  // A bar missing any leg cannot be drawn, and interpolating one would be
+  // inventing a price that never traded.
+  it('drops a bar with a null leg rather than guessing it', () => {
+    const out = parseCandles(result({
+      indicators: { quote: [{ open: [1, null, 3], high: [2, 3, 4], low: [0.5, 1.5, 2.5], close: [1.5, 2.5, 3.5], volume: [10, 20, 30] }] },
+    }));
+    expect(out.map(c => c.time)).toEqual([100, 300]);
+  });
+
+  it('keeps a bar whose volume is missing, defaulting it to zero', () => {
+    const out = parseCandles(result({
+      indicators: { quote: [{ open: [1], high: [2], low: [0.5], close: [1.5], volume: [null] }] },
+      timestamp: [100],
+    }));
+    expect(out).toHaveLength(1);
+    expect(out[0].volume).toBe(0);
+  });
+
+  it('returns nothing when the payload has no series', () => {
+    expect(parseCandles(null)).toEqual([]);
+    expect(parseCandles({})).toEqual([]);
+    expect(parseCandles({ timestamp: [1, 2] })).toEqual([]);
+  });
+
+  it('ignores a bar with a non-finite timestamp', () => {
+    const out = parseCandles(result({ timestamp: [100, null, 300] }));
+    expect(out.map(c => c.time)).toEqual([100, 300]);
+  });
+});

--- a/src/app/api/markets/history/route.test.ts
+++ b/src/app/api/markets/history/route.test.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect } from 'vitest';
-import { parseCandles } from './route';
+import { parseCandles, RANGES } from './route';
+
+describe('RANGES', () => {
+  /* The whole reason the route stopped upper-casing its query parameter:
+     case-folding would turn one-minute bars into one-month bars. */
+  it('keeps one-minute and one-month as separate ranges', () => {
+    expect(RANGES['1m'].interval).toBe('1m');
+    expect(RANGES['1M'].interval).toBe('1d');
+    expect(RANGES['1m']).not.toEqual(RANGES['1M']);
+  });
+
+  it('serves every intraday range at a sub-daily bar size', () => {
+    for (const key of ['1m', '15m', '24H', '1W']) {
+      expect(RANGES[key].interval).toMatch(/m$/);
+    }
+  });
+
+  it('offers the ranges the selector renders', () => {
+    expect(Object.keys(RANGES)).toEqual(['1m', '15m', '24H', '1W', '1M', '6M', '1Y']);
+  });
+});
 
 /** A chart result shaped the way Yahoo returns it. */
 function result(over: Record<string, unknown> = {}) {

--- a/src/app/api/markets/history/route.ts
+++ b/src/app/api/markets/history/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * OSIRIS — Instrument price history.
+ *
+ * OHLC candles for one symbol, for the chart in the markets panel. Each range
+ * carries its own interval: a day at 5-minute bars, a year at weekly ones, so
+ * every window comes back at a resolution that is worth drawing.
+ */
+
+/** Ranges the client may ask for, and the bar size each is served at. */
+const RANGES: Record<string, { interval: string; range: string }> = {
+  '1D': { interval: '5m', range: '1d' },
+  '1W': { interval: '30m', range: '5d' },
+  '1M': { interval: '1d', range: '1mo' },
+  '6M': { interval: '1d', range: '6mo' },
+  '1Y': { interval: '1wk', range: '1y' },
+};
+
+export interface Candle {
+  /** Epoch seconds — what lightweight-charts expects for an intraday scale. */
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+const UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+/**
+ * Yahoo pads its series with nulls wherever a bar has no trade. A candle with
+ * a missing leg cannot be drawn, so drop it rather than invent a value.
+ */
+export function parseCandles(result: unknown): Candle[] {
+  const r = result as {
+    timestamp?: number[];
+    indicators?: { quote?: Array<{ open?: (number | null)[]; high?: (number | null)[]; low?: (number | null)[]; close?: (number | null)[]; volume?: (number | null)[] }> };
+  } | null;
+
+  const stamps = r?.timestamp;
+  const q = r?.indicators?.quote?.[0];
+  if (!Array.isArray(stamps) || !q) return [];
+
+  const out: Candle[] = [];
+  for (let i = 0; i < stamps.length; i++) {
+    const [o, h, l, c] = [q.open?.[i], q.high?.[i], q.low?.[i], q.close?.[i]];
+    if (![o, h, l, c].every(v => Number.isFinite(v))) continue;
+    if (!Number.isFinite(stamps[i])) continue;
+    out.push({
+      time: stamps[i],
+      open: o as number,
+      high: h as number,
+      low: l as number,
+      close: c as number,
+      volume: Number.isFinite(q.volume?.[i]) ? (q.volume![i] as number) : 0,
+    });
+  }
+  return out;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const symbol = searchParams.get('symbol')?.trim();
+  const rangeKey = (searchParams.get('range') || '1M').toUpperCase();
+
+  if (!symbol) {
+    return NextResponse.json({ error: 'symbol required' }, { status: 400 });
+  }
+  const spec = RANGES[rangeKey];
+  if (!spec) {
+    return NextResponse.json({ error: `range must be one of ${Object.keys(RANGES).join(', ')}` }, { status: 400 });
+  }
+
+  try {
+    const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=${spec.interval}&range=${spec.range}`;
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(9000),
+      headers: { 'User-Agent': UA, Accept: 'application/json' },
+    });
+    if (!res.ok) {
+      return NextResponse.json({ error: `upstream ${res.status}`, candles: [] }, { status: 502 });
+    }
+
+    const result = (await res.json())?.chart?.result?.[0];
+    const candles = parseCandles(result);
+
+    return NextResponse.json({
+      symbol,
+      range: rangeKey,
+      interval: spec.interval,
+      currency: result?.meta?.currency || 'USD',
+      candles,
+    }, {
+      // Intraday bars go stale fast; a minute of edge caching still absorbs
+      // the clicking-through-ranges burst.
+      headers: { 'Cache-Control': 'public, max-age=60' },
+    });
+  } catch (error) {
+    console.error('Markets history error:', error);
+    return NextResponse.json({ error: 'Failed', candles: [] }, { status: 500 });
+  }
+}

--- a/src/app/api/markets/history/route.ts
+++ b/src/app/api/markets/history/route.ts
@@ -8,9 +8,17 @@ import { NextResponse } from 'next/server';
  * every window comes back at a resolution that is worth drawing.
  */
 
-/** Ranges the client may ask for, and the bar size each is served at. */
-const RANGES: Record<string, { interval: string; range: string }> = {
-  '1D': { interval: '5m', range: '1d' },
+/**
+ * Ranges the client may ask for, and the bar size each is served at.
+ *
+ * Case matters, and deliberately so: `1m` is one-minute bars while `1M` is one
+ * month, the same convention the trading tools use. Do not case-fold the query
+ * parameter — it would collapse the two.
+ */
+export const RANGES: Record<string, { interval: string; range: string }> = {
+  '1m': { interval: '1m', range: '1d' },
+  '15m': { interval: '15m', range: '2d' },
+  '24H': { interval: '5m', range: '1d' },
   '1W': { interval: '30m', range: '5d' },
   '1M': { interval: '1d', range: '1mo' },
   '6M': { interval: '1d', range: '6mo' },
@@ -63,7 +71,7 @@ export function parseCandles(result: unknown): Candle[] {
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const symbol = searchParams.get('symbol')?.trim();
-  const rangeKey = (searchParams.get('range') || '1M').toUpperCase();
+  const rangeKey = searchParams.get('range') || '1M';
 
   if (!symbol) {
     return NextResponse.json({ error: 'symbol required' }, { status: 400 });

--- a/src/app/api/markets/route.test.ts
+++ b/src/app/api/markets/route.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchQuote, groupQuotes, type Quote } from './route';
+
+const TICKER = { symbol: 'LMT', name: 'LMT', group: 'stocks' };
+
+/** A trimmed v8 chart response — only the fields the parser reads. */
+function chartResponse(over: {
+  price?: number | null;
+  prevClose?: number | null;
+  closes?: (number | null)[];
+  period?: { start: number; end: number } | null;
+} = {}) {
+  const {
+    price = 100,
+    prevClose = 80,
+    closes = [80, 90, 100],
+    period = { start: 0, end: 4102444800 }, // wide-open window
+  } = over;
+  return {
+    ok: true,
+    json: async () => ({
+      chart: {
+        result: [{
+          meta: {
+            regularMarketPrice: price,
+            chartPreviousClose: prevClose,
+            currency: 'USD',
+            ...(period ? { currentTradingPeriod: { regular: period } } : {}),
+          },
+          indicators: { quote: [{ close: closes }] },
+        }],
+      },
+    }),
+  };
+}
+
+function mockFetch(res: unknown) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(res));
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('fetchQuote', () => {
+  it('derives the percentage move from the previous close', async () => {
+    mockFetch(chartResponse({ price: 110, closes: [50, 100, 110] }));
+    const q = await fetchQuote(TICKER);
+    expect(q?.change_percent).toBe(10);
+    expect(q?.up).toBe(true);
+  });
+
+  it('marks a decline as down', async () => {
+    mockFetch(chartResponse({ price: 90, closes: [50, 100, 90] }));
+    const q = await fetchQuote(TICKER);
+    expect(q?.change_percent).toBe(-10);
+    expect(q?.up).toBe(false);
+  });
+
+  /* The regression that made every instrument look like a runaway gainer:
+     over a one-month range chartPreviousClose predates the whole series, so
+     using it reported the month's move as the day's. */
+  it('measures against yesterday, not the start of the month', async () => {
+    mockFetch(chartResponse({ price: 110, prevClose: 55, closes: [55, 100, 110] }));
+    expect((await fetchQuote(TICKER))?.change_percent).toBe(10);
+  });
+
+  it('falls back to chartPreviousClose when the series is too short', async () => {
+    mockFetch(chartResponse({ price: 110, prevClose: 100, closes: [110] }));
+    expect((await fetchQuote(TICKER))?.change_percent).toBe(10);
+  });
+
+  it('drops the nulls Yahoo leaves in the close series', async () => {
+    mockFetch(chartResponse({ closes: [10, null, 12, null, 14] }));
+    expect((await fetchQuote(TICKER))?.spark).toEqual([10, 12, 14]);
+  });
+
+  // A zero previous close would make the percentage infinite.
+  it('returns null rather than dividing by a zero previous close', async () => {
+    mockFetch(chartResponse({ prevClose: 0, closes: [100] }));
+    expect(await fetchQuote(TICKER)).toBeNull();
+  });
+
+  it('returns null when the price is missing', async () => {
+    mockFetch(chartResponse({ price: null }));
+    expect(await fetchQuote(TICKER)).toBeNull();
+  });
+
+  it('reports the session closed when now sits outside the trading window', async () => {
+    mockFetch(chartResponse({ period: { start: 0, end: 1 } }));
+    expect((await fetchQuote(TICKER))?.market_open).toBe(false);
+  });
+
+  it('reports the session open inside the trading window', async () => {
+    mockFetch(chartResponse());
+    expect((await fetchQuote(TICKER))?.market_open).toBe(true);
+  });
+
+  // No window at all is not evidence that trading is live.
+  it('treats a missing trading period as closed', async () => {
+    mockFetch(chartResponse({ period: null }));
+    expect((await fetchQuote(TICKER))?.market_open).toBe(false);
+  });
+
+  it('returns null on a non-ok response instead of throwing', async () => {
+    mockFetch({ ok: false, json: async () => ({}) });
+    expect(await fetchQuote(TICKER)).toBeNull();
+  });
+
+  it('swallows a network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    expect(await fetchQuote(TICKER)).toBeNull();
+  });
+});
+
+describe('groupQuotes', () => {
+  const quote = (name: string, group: string): Quote => ({
+    group, name, symbol: name, price: 1, change_percent: 0, up: true,
+    spark: [], currency: 'USD', market_open: true,
+  });
+
+  it('files each quote under its section, keyed by display name', () => {
+    const out = groupQuotes([quote('Gold', 'commodities'), quote('LMT', 'stocks')]);
+    expect(out.commodities.Gold.symbol).toBe('Gold');
+    expect(out.stocks.LMT.symbol).toBe('LMT');
+  });
+
+  // The panel iterates a fixed tab list, so every section must exist even
+  // when its instruments all failed to load.
+  it('always returns every section', () => {
+    expect(Object.keys(groupQuotes([])).sort())
+      .toEqual(['commodities', 'crypto', 'fx', 'indices', 'oil', 'stocks']);
+  });
+});

--- a/src/app/api/markets/route.ts
+++ b/src/app/api/markets/route.ts
@@ -1,178 +1,197 @@
 
 import { NextResponse } from 'next/server';
+import { cachedSource } from '@/lib/sourceCache';
 
 /**
  * OSIRIS — Financial Markets & Commodities API
- * Defense stocks, oil, gold, silver, natural gas, wheat, crypto
- * Multiple source fallback: Yahoo Finance → Google Finance scraping → static estimates
+ *
+ * Indices, rates, FX, defense equities, energy, commodities and crypto, all
+ * from Yahoo's v8 chart endpoint. One request per symbol buys the last close,
+ * a month of daily closes for the sparkline, and the session window — so the
+ * panel can show a trend and say whether the market is actually open.
+ *
+ * The old v6 quote fallback was removed: Yahoo decommissioned it and it 404s
+ * on every call, so it only ever added a round-trip to a failing request.
  */
 
-const DEFENSE_STOCKS = ['RTX', 'LMT', 'NOC', 'GD', 'BA', 'PLTR'];
-const OIL_TICKERS = ['CL=F', 'BZ=F'];
-const COMMODITY_TICKERS = ['GC=F', 'SI=F', 'HG=F', 'NG=F', 'ZW=F', 'ZC=F'];
-const CRYPTO_TICKERS = ['BTC-USD', 'ETH-USD'];
-const INDEX_TICKERS = ['ES=F', 'NQ=F'];
+export interface Quote {
+  group: string;
+  name: string;
+  symbol: string;
+  price: number;
+  change_percent: number;
+  up: boolean;
+  /** Daily closes, oldest first — enough to draw a one-month sparkline. */
+  spark: number[];
+  currency: string;
+  market_open: boolean;
+}
 
-// Yahoo Finance v8 chart API
-async function fetchYahoo(symbol: string): Promise<any | null> {
+/** Display name and section for every instrument we track. */
+const TICKERS: Array<{ symbol: string; name: string; group: string }> = [
+  { symbol: 'ES=F', name: 'S&P 500', group: 'indices' },
+  { symbol: 'NQ=F', name: 'Nasdaq 100', group: 'indices' },
+  { symbol: '^VIX', name: 'VIX', group: 'indices' },
+  { symbol: 'DX-Y.NYB', name: 'Dollar Index', group: 'indices' },
+  { symbol: '^TNX', name: 'US 10Y', group: 'indices' },
+
+  { symbol: 'RTX', name: 'RTX', group: 'stocks' },
+  { symbol: 'LMT', name: 'LMT', group: 'stocks' },
+  { symbol: 'NOC', name: 'NOC', group: 'stocks' },
+  { symbol: 'GD', name: 'GD', group: 'stocks' },
+  { symbol: 'BA', name: 'BA', group: 'stocks' },
+  { symbol: 'LHX', name: 'LHX', group: 'stocks' },
+  { symbol: 'PLTR', name: 'PLTR', group: 'stocks' },
+
+  { symbol: 'CL=F', name: 'WTI Crude', group: 'oil' },
+  { symbol: 'BZ=F', name: 'Brent Crude', group: 'oil' },
+  { symbol: 'NG=F', name: 'Natural Gas', group: 'oil' },
+
+  { symbol: 'GC=F', name: 'Gold', group: 'commodities' },
+  { symbol: 'SI=F', name: 'Silver', group: 'commodities' },
+  { symbol: 'HG=F', name: 'Copper', group: 'commodities' },
+  { symbol: 'ZW=F', name: 'Wheat', group: 'commodities' },
+  { symbol: 'ZC=F', name: 'Corn', group: 'commodities' },
+
+  { symbol: 'BTC-USD', name: 'Bitcoin', group: 'crypto' },
+  { symbol: 'ETH-USD', name: 'Ethereum', group: 'crypto' },
+  { symbol: 'SOL-USD', name: 'Solana', group: 'crypto' },
+  { symbol: 'XRP-USD', name: 'XRP', group: 'crypto' },
+
+  { symbol: 'EURUSD=X', name: 'EUR/USD', group: 'fx' },
+  { symbol: 'USDJPY=X', name: 'USD/JPY', group: 'fx' },
+  { symbol: 'GBPUSD=X', name: 'GBP/USD', group: 'fx' },
+  { symbol: 'USDCNY=X', name: 'USD/CNY', group: 'fx' },
+];
+
+const UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+/** Round to 2dp without dragging in floating-point tails. */
+function r2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export async function fetchQuote(t: { symbol: string; name: string; group: string }): Promise<Quote | null> {
   try {
-    const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=1d&range=2d`;
+    const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(t.symbol)}?interval=1d&range=1mo`;
     const res = await fetch(url, {
       signal: AbortSignal.timeout(8000),
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-        'Accept': 'application/json',
-      },
+      headers: { 'User-Agent': UA, Accept: 'application/json' },
     });
     if (!res.ok) return null;
-    const data = await res.json();
-    const result = data.chart?.result?.[0];
-    if (!result) return null;
-    const meta = result.meta;
-    const closes = result.indicators?.quote?.[0]?.close || [];
-    const currentPrice = meta.regularMarketPrice || closes[closes.length - 1];
-    const prevClose = meta.chartPreviousClose || closes[0];
-    if (!currentPrice || !prevClose) return null;
-    const changePercent = ((currentPrice - prevClose) / prevClose) * 100;
+
+    const result = (await res.json())?.chart?.result?.[0];
+    const meta = result?.meta;
+    if (!meta) return null;
+
+    const price = meta.regularMarketPrice;
+    if (!Number.isFinite(price)) return null;
+
+    // Yahoo leaves nulls in the close series for non-trading days; a sparkline
+    // only needs the shape, so drop them rather than trying to interpolate.
+    const spark: number[] = (result.indicators?.quote?.[0]?.close || [])
+      .filter((c: unknown): c is number => Number.isFinite(c))
+      .map((c: number) => r2(c));
+
+    /* Over a one-month range `chartPreviousClose` is the close before the whole
+       month, which would report a monthly move as if it were today's. The last
+       entry in the series is the current session, so the one before it is the
+       previous close. */
+    const prevClose = spark.length >= 2 ? spark[spark.length - 2] : meta.chartPreviousClose;
+    if (!Number.isFinite(prevClose) || prevClose === 0) return null;
+
+    const changePercent = ((price - prevClose) / prevClose) * 100;
+
+    // The session window Yahoo reports for this exchange. Crypto trades around
+    // the clock and reports a full-day window, so this comes out open for it.
+    const period = meta.currentTradingPeriod?.regular;
+    const nowSec = Date.now() / 1000;
+    const marketOpen = Number.isFinite(period?.start) && Number.isFinite(period?.end)
+      ? nowSec >= period.start && nowSec <= period.end
+      : false;
+
     return {
-      price: Math.round(currentPrice * 100) / 100,
-      change_percent: Math.round(changePercent * 100) / 100,
+      group: t.group,
+      name: t.name,
+      symbol: t.symbol,
+      price: r2(price),
+      change_percent: r2(changePercent),
       up: changePercent >= 0,
+      spark,
+      currency: meta.currency || 'USD',
+      market_open: marketOpen,
     };
   } catch { return null; }
 }
 
-// Yahoo Finance v6 quote API (alternative endpoint)
-async function fetchYahooV6(symbol: string): Promise<any | null> {
+/** All instruments in one pass. A symbol that fails is simply absent. */
+async function fetchAllQuotes(): Promise<Quote[]> {
+  const results = await Promise.all(TICKERS.map(fetchQuote));
+  return results.filter((q): q is Quote => q !== null);
+}
+
+/**
+ * 60s TTL. The client polls far less often than that; the cache is here so a
+ * burst of viewers shares one upstream pass, and — more importantly — so a
+ * failed refresh keeps serving the last good prices instead of blanking the
+ * whole panel, which is what used to happen on a cold start.
+ */
+const getQuotes = cachedSource<Quote>('markets', fetchAllQuotes, 60_000);
+
+/** Chokepoint risk that has a direct read-through to the instruments above. */
+async function fetchScmAlerts(origin: string): Promise<string[]> {
+  const alerts: string[] = [];
   try {
-    const url = `https://query2.finance.yahoo.com/v6/finance/quote?symbols=${encodeURIComponent(symbol)}`;
-    const res = await fetch(url, {
-      signal: AbortSignal.timeout(8000),
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
-      },
-    });
-    if (!res.ok) return null;
-    const data = await res.json();
-    const q = data.quoteResponse?.result?.[0];
-    if (!q) return null;
-    return {
-      price: Math.round((q.regularMarketPrice || 0) * 100) / 100,
-      change_percent: Math.round((q.regularMarketChangePercent || 0) * 100) / 100,
-      up: (q.regularMarketChangePercent || 0) >= 0,
+    const res = await fetch(`${origin}/api/maritime`, { signal: AbortSignal.timeout(3000) });
+    if (!res.ok) return alerts;
+    const chokepoints = (await res.json())?.chokepoints || [];
+
+    const atRisk = (name: string) => {
+      const c = chokepoints.find((x: { name?: string; risk?: string }) => x.name === name);
+      return c && (c.risk === 'CRITICAL' || c.risk === 'HIGH') ? c.risk : null;
     };
-  } catch { return null; }
+
+    const hormuz = atRisk('Strait of Hormuz');
+    const suez = atRisk('Suez Canal');
+    const panama = atRisk('Panama Canal');
+    if (hormuz) alerts.push(`🚨 HORMUZ ${hormuz}: High risk of WTI/Brent Crude price spike due to congestion.`);
+    if (suez) alerts.push(`🚨 SUEZ ${suez}: Potential supply chain delays impacting European markets and Energy.`);
+    if (panama) alerts.push(`🚨 PANAMA ${panama}: LNG and Agriculture (Corn/Wheat) shipment delays expected.`);
+  } catch {
+    // Maritime unreachable — the market data still stands on its own.
+  }
+  return alerts;
 }
 
-// Fetch from CoinGecko for crypto (free, no key)
-async function fetchCoinGecko(): Promise<Record<string, any>> {
+/** Fold the flat quote list back into the per-section shape the UI reads. */
+export function groupQuotes(quotes: Quote[]): Record<string, Record<string, Quote>> {
+  const out: Record<string, Record<string, Quote>> = {
+    indices: {}, stocks: {}, oil: {}, commodities: {}, crypto: {}, fx: {},
+  };
+  for (const q of quotes) {
+    (out[q.group] ||= {})[q.name] = q;
+  }
+  return out;
+}
+
+export async function GET(request: Request) {
   try {
-    const res = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum&vs_currencies=usd&include_24hr_change=true', {
-      signal: AbortSignal.timeout(8000),
-    });
-    if (!res.ok) return {};
-    const data = await res.json();
-    const result: Record<string, any> = {};
-    if (data.bitcoin) {
-      result['Bitcoin'] = {
-        price: Math.round(data.bitcoin.usd * 100) / 100,
-        change_percent: Math.round((data.bitcoin.usd_24h_change || 0) * 100) / 100,
-        up: (data.bitcoin.usd_24h_change || 0) >= 0,
-      };
-    }
-    if (data.ethereum) {
-      result['Ethereum'] = {
-        price: Math.round(data.ethereum.usd * 100) / 100,
-        change_percent: Math.round((data.ethereum.usd_24h_change || 0) * 100) / 100,
-        up: (data.ethereum.usd_24h_change || 0) >= 0,
-      };
-    }
-    return result;
-  } catch { return {}; }
-}
-
-async function fetchQuote(symbol: string): Promise<any | null> {
-  // Try Yahoo v8 first, then v6
-  let result = await fetchYahoo(symbol);
-  if (!result) result = await fetchYahooV6(symbol);
-  return result;
-}
-
-const COMMODITY_NAMES: Record<string, string> = {
-  'GC=F': 'Gold', 'SI=F': 'Silver', 'HG=F': 'Copper',
-  'NG=F': 'Natural Gas', 'ZW=F': 'Wheat', 'ZC=F': 'Corn',
-};
-const OIL_NAMES: Record<string, string> = { 'CL=F': 'WTI Crude', 'BZ=F': 'Brent Crude' };
-const CRYPTO_NAMES: Record<string, string> = { 'BTC-USD': 'Bitcoin', 'ETH-USD': 'Ethereum' };
-const INDEX_NAMES: Record<string, string> = { 'ES=F': 'S&P 500', 'NQ=F': 'Nasdaq 100' };
-
-export async function GET() {
-  try {
-    // Fetch all in parallel
-    const [stockResults, oilResults, commodityResults, yahooResults, indexResults, cgCrypto] = await Promise.all([
-      Promise.all(DEFENSE_STOCKS.map(async t => ({ symbol: t, data: await fetchQuote(t) }))),
-      Promise.all(OIL_TICKERS.map(async t => ({ symbol: t, data: await fetchQuote(t) }))),
-      Promise.all(COMMODITY_TICKERS.map(async t => ({ symbol: t, data: await fetchQuote(t) }))),
-      Promise.all(CRYPTO_TICKERS.map(async t => ({ symbol: t, data: await fetchQuote(t) }))),
-      Promise.all(INDEX_TICKERS.map(async t => ({ symbol: t, data: await fetchQuote(t) }))),
-      fetchCoinGecko(), // CoinGecko as crypto fallback
-    ]);
-
-    const stocks: Record<string, any> = {};
-    for (const { symbol, data } of stockResults) { if (data) stocks[symbol] = data; }
-
-    const oil: Record<string, any> = {};
-    for (const { symbol, data } of oilResults) { if (data) oil[OIL_NAMES[symbol] || symbol] = data; }
-
-    const commodities: Record<string, any> = {};
-    for (const { symbol, data } of commodityResults) { if (data) commodities[COMMODITY_NAMES[symbol] || symbol] = data; }
-
-    // Crypto: prefer Yahoo, fallback to CoinGecko
-    const crypto: Record<string, any> = {};
-    for (const { symbol, data } of yahooResults) { if (data) crypto[CRYPTO_NAMES[symbol] || symbol] = data; }
-    // Fill gaps with CoinGecko
-    for (const [name, data] of Object.entries(cgCrypto)) {
-      if (!crypto[name]) crypto[name] = data;
-    }
-
-    const indices: Record<string, any> = {};
-    for (const { symbol, data } of indexResults) { if (data) indices[INDEX_NAMES[symbol] || symbol] = data; }
-
-    // --- SCM Integration: Chokepoint-Commodity Correlation ---
-    const scm_alerts: string[] = [];
-    try {
-      const maritimeRes = await fetch('http://127.0.0.1:3000/api/maritime', { signal: AbortSignal.timeout(3000) });
-      if (maritimeRes.ok) {
-        const maritimeData = await maritimeRes.json();
-        const chokepoints = maritimeData.chokepoints || [];
-        
-        const hormuz = chokepoints.find((c: any) => c.name === 'Strait of Hormuz');
-        const suez = chokepoints.find((c: any) => c.name === 'Suez Canal');
-        const panama = chokepoints.find((c: any) => c.name === 'Panama Canal');
-
-        if (hormuz && (hormuz.risk === 'CRITICAL' || hormuz.risk === 'HIGH')) {
-          scm_alerts.push(`🚨 HORMUZ ${hormuz.risk}: High risk of WTI/Brent Crude price spike due to congestion.`);
-        }
-        if (suez && (suez.risk === 'CRITICAL' || suez.risk === 'HIGH')) {
-          scm_alerts.push(`🚨 SUEZ ${suez.risk}: Potential supply chain delays impacting European markets and Energy.`);
-        }
-        if (panama && (panama.risk === 'CRITICAL' || panama.risk === 'HIGH')) {
-          scm_alerts.push(`🚨 PANAMA ${panama.risk}: LNG and Agriculture (Corn/Wheat) shipment delays expected.`);
-        }
-      }
-    } catch (e) {
-      // Ignore if maritime is unreachable
-    }
+    const origin = new URL(request.url).origin;
+    const [quotes, scm_alerts] = await Promise.all([getQuotes(), fetchScmAlerts(origin)]);
 
     return NextResponse.json({
-      stocks, oil, commodities, crypto, indices, scm_alerts,
+      ...groupQuotes(quotes),
+      scm_alerts,
+      count: quotes.length,
       timestamp: new Date().toISOString(),
     }, {
       headers: { 'Cache-Control': 'no-store' }, // Prevent caching so alerts update real-time
     });
   } catch (error) {
     console.error('Markets fetch error:', error);
-    return NextResponse.json({ stocks: {}, oil: {}, commodities: {}, crypto: {}, indices: {}, scm_alerts: [], error: 'Failed' }, { status: 500 });
+    return NextResponse.json(
+      { ...groupQuotes([]), scm_alerts: [], count: 0, error: 'Failed' },
+      { status: 500 },
+    );
   }
 }
-

--- a/src/app/api/markets/route.ts
+++ b/src/app/api/markets/route.ts
@@ -124,10 +124,29 @@ export async function fetchQuote(t: { symbol: string; name: string; group: strin
   } catch { return null; }
 }
 
+/**
+ * Yahoo is one host, and firing every symbol at it at once is the access
+ * pattern upstreams throttle first — enough in-flight connections and requests
+ * start hanging until they time out, which loses the whole refresh. A small
+ * number of workers walking the list keeps the fan-out civil and still
+ * finishes well inside a request.
+ */
+const CONCURRENCY = 5;
+
 /** All instruments in one pass. A symbol that fails is simply absent. */
 async function fetchAllQuotes(): Promise<Quote[]> {
-  const results = await Promise.all(TICKERS.map(fetchQuote));
-  return results.filter((q): q is Quote => q !== null);
+  const out: Quote[] = [];
+  let next = 0;
+
+  const worker = async () => {
+    while (next < TICKERS.length) {
+      const quote = await fetchQuote(TICKERS[next++]);
+      if (quote) out.push(quote);
+    }
+  };
+
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+  return out;
 }
 
 /**

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -460,7 +460,17 @@ export default function Dashboard() {
     const eqTransform = (data: any) => ({ earthquakes: (data.features || []).map((f: any) => ({ id: f.id, lat: f.geometry?.coordinates?.[1] || 0, lng: f.geometry?.coordinates?.[0] || 0, depth: f.geometry?.coordinates?.[2] || 0, magnitude: f.properties?.mag, place: f.properties?.place, time: f.properties?.time, url: f.properties?.url, tsunami: f.properties?.tsunami, type: f.properties?.type, felt: f.properties?.felt, alert: f.properties?.alert })) });
     fetchEndpoint(eqUrl, eqTransform);
     fetchEndpoint('/api/news');
-    const marketTimer = setTimeout(() => fetchEndpoint('/api/markets', d => ({ markets: d })), 800);
+    /* A cold start can time out every upstream quote and return an all-empty
+       feed. Waiting a full poll interval to find out leaves the panel blank for
+       15 minutes, so retry a few times up-front until instruments actually land. */
+    const marketRetries: ReturnType<typeof setTimeout>[] = [];
+    const loadMarkets = async (attempt = 0) => {
+      await fetchEndpoint('/api/markets', d => ({ markets: d }));
+      if ((dataRef.current.markets?.count || 0) === 0 && attempt < 3) {
+        marketRetries.push(setTimeout(() => loadMarkets(attempt + 1), 15000));
+      }
+    };
+    const marketTimer = setTimeout(() => loadMarkets(), 800);
 
     // Priority 2: Space Weather (needed for MarketsPanel)
     const spaceTimer = setTimeout(async () => {
@@ -478,6 +488,7 @@ export default function Dashboard() {
     ];
     return () => {
       clearTimeout(marketTimer);
+      marketRetries.forEach(clearTimeout);
       clearTimeout(spaceTimer);
       intervals.forEach(clearInterval);
     };

--- a/src/components/MarketChart.tsx
+++ b/src/components/MarketChart.tsx
@@ -20,11 +20,16 @@ interface MarketChartProps {
   large?: boolean;
 }
 
-const RANGES = ['1D', '1W', '1M', '6M', '1Y'] as const;
+/* Lowercase m is minutes, uppercase M is months — the convention every
+   trading tool uses, and what the API's range keys mean. */
+const RANGES = ['1m', '15m', '24H', '1W', '1M', '6M', '1Y'] as const;
 type Range = typeof RANGES[number];
 
 /** Bars finer than a day need the clock on the axis, not just the date. */
-const INTRADAY: Record<Range, boolean> = { '1D': true, '1W': true, '1M': false, '6M': false, '1Y': false };
+const INTRADAY: Record<Range, boolean> = {
+  '1m': true, '15m': true, '24H': true, '1W': true,
+  '1M': false, '6M': false, '1Y': false,
+};
 
 const UP = '#26A69A';
 const DOWN = '#D32F2F';
@@ -217,11 +222,12 @@ export default function MarketChart({ symbol, name, onClose, large = false }: Ma
       </div>
 
       {/* Window extremes + range selector */}
-      <div className="flex items-center justify-between mt-1.5">
+      <div className="flex items-center justify-between gap-2 mt-1.5 flex-wrap">
         <div className="text-[8px] font-mono text-[var(--text-muted)] tabular-nums">
           {high !== null && low !== null && <>H {priceFormat(high)} · L {priceFormat(low)}</>}
         </div>
-        <div className="flex gap-0.5">
+        {/* Seven ranges will not fit one line in the docked panel — let them wrap. */}
+        <div className="flex gap-0.5 flex-wrap justify-end">
           {RANGES.map(r => (
             <button
               key={r}

--- a/src/components/MarketChart.tsx
+++ b/src/components/MarketChart.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  createChart, CandlestickSeries, HistogramSeries,
+  type IChartApi, type ISeriesApi, type UTCTimestamp,
+} from 'lightweight-charts';
+import { X, Loader2, AlertTriangle } from 'lucide-react';
+
+interface Candle {
+  time: number;
+  open: number; high: number; low: number; close: number; volume: number;
+}
+
+interface MarketChartProps {
+  symbol: string;
+  name: string;
+  onClose: () => void;
+  /** Taller layout for the maximized panel, where there is room for it. */
+  large?: boolean;
+}
+
+const RANGES = ['1D', '1W', '1M', '6M', '1Y'] as const;
+type Range = typeof RANGES[number];
+
+/** Bars finer than a day need the clock on the axis, not just the date. */
+const INTRADAY: Record<Range, boolean> = { '1D': true, '1W': true, '1M': false, '6M': false, '1Y': false };
+
+const UP = '#26A69A';
+const DOWN = '#D32F2F';
+const GRID = 'rgba(255,255,255,0.04)';
+const AXIS = 'rgba(255,255,255,0.12)';
+
+/** Prices here span FX pairs to Bitcoin — pick the precision from the value. */
+function priceFormat(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 1000) return v.toLocaleString(undefined, { maximumFractionDigits: 0 });
+  if (abs >= 1) return v.toFixed(2);
+  return v.toFixed(4);
+}
+
+function formatVolume(v: number): string {
+  if (v >= 1e9) return `${(v / 1e9).toFixed(1)}B`;
+  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+  if (v >= 1e3) return `${(v / 1e3).toFixed(1)}K`;
+  return String(v);
+}
+
+export default function MarketChart({ symbol, name, onClose, large = false }: MarketChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const candleRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+  const volumeRef = useRef<ISeriesApi<'Histogram'> | null>(null);
+
+  const [range, setRange] = useState<Range>('1M');
+  /* Keyed by the request it answers, so status is derived rather than set on
+     the way in — a synchronous setState in the effect body would cascade. */
+  const [result, setResult] = useState<{ key: string; rows: Candle[] | null }>({ key: '', rows: null });
+  /** Whatever the crosshair is currently over — falls back to the last bar. */
+  const [hover, setHover] = useState<Candle | null>(null);
+
+  const height = large ? 420 : 200;
+
+  // ── Chart instance. Built once; data and axis formatting are applied later
+  //    so that changing range never tears down the canvas.
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const chart = createChart(containerRef.current, {
+      // The library measures the container itself. Sizing the canvases by
+      // hand left their bitmaps at the 300x150 default — laid out, but never
+      // painted.
+      autoSize: true,
+      layout: {
+        background: { color: 'transparent' },
+        textColor: '#78909C',
+        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+        fontSize: 9,
+      },
+      grid: { vertLines: { color: GRID }, horzLines: { color: GRID } },
+      rightPriceScale: { borderColor: AXIS, scaleMargins: { top: 0.1, bottom: 0.26 } },
+      timeScale: { borderColor: AXIS, secondsVisible: false },
+      crosshair: {
+        vertLine: { color: 'rgba(212,175,55,0.4)', labelBackgroundColor: '#D4AF37' },
+        horzLine: { color: 'rgba(212,175,55,0.4)', labelBackgroundColor: '#D4AF37' },
+      },
+      handleScale: { axisPressedMouseMove: false },
+    });
+
+    const candleSeries = chart.addSeries(CandlestickSeries, {
+      upColor: UP, downColor: DOWN,
+      wickUpColor: UP, wickDownColor: DOWN,
+      borderVisible: false,
+    });
+
+    // Volume sits in the bottom quarter, on its own invisible scale so it
+    // never distorts the price axis.
+    const volumeSeries = chart.addSeries(HistogramSeries, {
+      priceFormat: { type: 'volume' },
+      priceScaleId: 'vol',
+    });
+    chart.priceScale('vol').applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
+
+    chart.subscribeCrosshairMove((param) => {
+      const d = param.seriesData.get(candleSeries) as Candle | undefined;
+      setHover(d && param.time ? { ...d, time: param.time as number, volume: d.volume ?? 0 } : null);
+    });
+
+    chartRef.current = chart;
+    candleRef.current = candleSeries;
+    volumeRef.current = volumeSeries;
+
+    return () => { chart.remove(); chartRef.current = null; };
+  }, []);
+
+  // Only intraday bars need the clock on the axis. Applied separately so
+  // switching range never tears down the canvas.
+  useEffect(() => {
+    chartRef.current?.timeScale().applyOptions({ timeVisible: INTRADAY[range] });
+  }, [range]);
+
+  const requestKey = `${symbol}|${range}`;
+  const status: 'loading' | 'ready' | 'error' =
+    result.key !== requestKey ? 'loading' : result.rows === null ? 'error' : 'ready';
+  const candles = useMemo(
+    () => (result.key === requestKey && result.rows ? result.rows : []),
+    [result, requestKey],
+  );
+
+  // ── Data ──
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`/api/markets/history?symbol=${encodeURIComponent(symbol)}&range=${range}`)
+      .then(r => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+      .then((d) => {
+        if (cancelled) return;
+        const rows: Candle[] = d.candles || [];
+        setResult({ key: `${symbol}|${range}`, rows: rows.length ? rows : null });
+      })
+      .catch(() => { if (!cancelled) setResult({ key: `${symbol}|${range}`, rows: null }); });
+
+    return () => { cancelled = true; };
+  }, [symbol, range]);
+
+  // Push data once both the series and the rows exist.
+  useEffect(() => {
+    if (status !== 'ready' || !candleRef.current || !volumeRef.current) return;
+
+    candleRef.current.setData(candles.map(c => ({
+      time: c.time as UTCTimestamp,
+      open: c.open, high: c.high, low: c.low, close: c.close,
+    })));
+
+    volumeRef.current.setData(candles.map(c => ({
+      time: c.time as UTCTimestamp,
+      value: c.volume,
+      color: c.close >= c.open ? 'rgba(38,166,154,0.28)' : 'rgba(211,47,47,0.28)',
+    })));
+
+    chartRef.current?.timeScale().fitContent();
+  }, [candles, status]);
+
+  // ── Range summary: first open to last close across the window shown ──
+  const last = candles[candles.length - 1];
+  const first = candles[0];
+  const rangeChange = first && last ? ((last.close - first.open) / first.open) * 100 : null;
+  const shown = hover || last;
+  const high = candles.length ? Math.max(...candles.map(c => c.high)) : null;
+  const low = candles.length ? Math.min(...candles.map(c => c.low)) : null;
+
+  return (
+    <div className="rounded-lg border border-[var(--border-primary)] bg-black/30 p-2">
+      {/* Identity + range performance */}
+      <div className="flex items-start justify-between mb-1.5">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="text-[11px] font-mono font-bold text-[var(--text-primary)] truncate">{name}</span>
+            <span className="text-[8px] font-mono text-[var(--text-muted)]">{symbol}</span>
+          </div>
+          {rangeChange !== null && (
+            <div className="text-[9px] font-mono tabular-nums" style={{ color: rangeChange >= 0 ? UP : DOWN }}>
+              {rangeChange >= 0 ? '+' : ''}{rangeChange.toFixed(2)}% over {range}
+            </div>
+          )}
+        </div>
+        <button onClick={onClose} className="text-[var(--text-muted)] hover:text-white transition-colors shrink-0" title="Close chart">
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* OHLC readout — tracks the crosshair, resting on the latest bar */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mb-1 text-[8px] font-mono tabular-nums">
+        {shown ? (
+          <>
+            <span className="text-[var(--text-muted)]">O <span className="text-[var(--text-secondary)]">{priceFormat(shown.open)}</span></span>
+            <span className="text-[var(--text-muted)]">H <span style={{ color: UP }}>{priceFormat(shown.high)}</span></span>
+            <span className="text-[var(--text-muted)]">L <span style={{ color: DOWN }}>{priceFormat(shown.low)}</span></span>
+            <span className="text-[var(--text-muted)]">C <span className="text-[var(--text-primary)] font-bold">{priceFormat(shown.close)}</span></span>
+            {shown.volume > 0 && <span className="text-[var(--text-muted)]">V <span className="text-[var(--text-secondary)]">{formatVolume(shown.volume)}</span></span>}
+          </>
+        ) : <span className="text-[var(--text-muted)]">—</span>}
+      </div>
+
+      {/* Canvas, with loading and failure drawn over the same box so the
+          panel never changes height while a range is fetching. */}
+      <div className="relative" style={{ height }}>
+        <div ref={containerRef} className="w-full" style={{ height }} />
+
+        {status !== 'ready' && (
+          <div className="absolute inset-0 flex items-center justify-center gap-1.5 bg-black/40 text-[9px] font-mono text-[var(--text-muted)]">
+            {status === 'loading'
+              ? <><Loader2 className="w-3 h-3 animate-spin" /> LOADING {range}</>
+              : <><AlertTriangle className="w-3 h-3" /> NO {range} DATA FOR {symbol}</>}
+          </div>
+        )}
+      </div>
+
+      {/* Window extremes + range selector */}
+      <div className="flex items-center justify-between mt-1.5">
+        <div className="text-[8px] font-mono text-[var(--text-muted)] tabular-nums">
+          {high !== null && low !== null && <>H {priceFormat(high)} · L {priceFormat(low)}</>}
+        </div>
+        <div className="flex gap-0.5">
+          {RANGES.map(r => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`px-1.5 py-0.5 rounded text-[8px] font-mono tracking-wider transition-all ${
+                range === r
+                  ? 'bg-[var(--hover-accent)] text-[var(--gold-primary)] border border-[var(--border-primary)]'
+                  : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)] border border-transparent'
+              }`}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MarketsPanel.tsx
+++ b/src/components/MarketsPanel.tsx
@@ -139,6 +139,19 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
+  // Fullscreen covers the map, so Escape has to get you out of it — closing
+  // the chart first, since that is the nearer thing to dismiss.
+  useEffect(() => {
+    if (!maximized) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (selected) setSelected(null);
+      else setMaximized(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [maximized, selected]);
+
   /** Every instrument across every section — the basis for the breadth line. */
   const allQuotes = useMemo<Quote[]>(
     () => SECTIONS.flatMap(s => Object.values<Quote>(markets[s.key] || {})).filter(q => Number.isFinite(q?.change_percent)),
@@ -162,8 +175,133 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
   const feedLoaded = Boolean(markets.timestamp || markets.error);
   const sessionOpen = rows.some(q => q.market_open);
 
+  /* The blocks below are shared by both layouts. Docked stacks them in one
+     column; fullscreen splits them across two, so they carry no margins of
+     their own — the container that places them owns the spacing. */
+
+  const breadthBlock = breadth && (
+    <div className="px-2 py-1.5 rounded-lg border border-[var(--border-primary)] bg-white/[0.02]">
+      <div className="flex items-center justify-between">
+        <span className="text-[8px] font-mono tracking-widest text-[var(--text-muted)]">BREADTH</span>
+        <span className="text-[9px] font-mono tabular-nums">
+          <span style={{ color: GREEN }}>{breadth.up}▲</span>
+          <span className="text-[var(--text-muted)]"> / </span>
+          <span style={{ color: RED }}>{breadth.down}▼</span>
+          <span className="text-[var(--text-muted)]"> of {breadth.total}</span>
+        </span>
+      </div>
+      <div className="mt-1.5 h-1 rounded-full overflow-hidden bg-[var(--alert-red)]/30">
+        <div className="h-full rounded-full" style={{ width: `${(breadth.up / breadth.total) * 100}%`, background: GREEN }} />
+      </div>
+      <div className="mt-1.5 flex items-center justify-between text-[8px] font-mono">
+        <span style={{ color: GREEN }}>▲ {breadth.top.name} +{breadth.top.change_percent.toFixed(2)}%</span>
+        <span style={{ color: RED }}>▼ {breadth.worst.name} {breadth.worst.change_percent.toFixed(2)}%</span>
+      </div>
+    </div>
+  );
+
+  const spaceBlock = spaceWeather && (
+    <div className="p-2 rounded-lg border" style={{ borderColor: `${spaceWeather.storm_color}33`, background: `${spaceWeather.storm_color}08` }}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <Zap className="w-3 h-3" style={{ color: spaceWeather.storm_color }} />
+          <span className="text-[10px] font-mono tracking-widest text-[var(--text-muted)]">SPACE WEATHER</span>
+        </div>
+        <span className="text-[10px] font-mono font-bold" style={{ color: spaceWeather.storm_color }}>
+          Kp {spaceWeather.kp_index} — {spaceWeather.storm_level}
+        </span>
+      </div>
+      {spaceWeather.solar_flares?.length > 0 && (
+        <div className="mt-1 text-[8px] font-mono text-[var(--text-muted)]">
+          Latest flare: {spaceWeather.solar_flares[0].class}
+        </div>
+      )}
+    </div>
+  );
+
+  const aiBlock = <AiOverview mode="markets" payload={{ markets, spaceWeather }} accent="#D4AF37" />;
+
+  const scmBlock = markets.scm_alerts && markets.scm_alerts.length > 0 && (
+    <div className="space-y-1">
+      {markets.scm_alerts.map((alert: string, i: number) => (
+        <div key={i} className="px-2 py-1.5 rounded border border-[#FF9500] bg-[#FF9500]/10 text-[#FF9500] text-[9px] font-mono leading-tight shadow-[0_0_8px_rgba(255,149,0,0.15)]">
+          {alert}
+        </div>
+      ))}
+    </div>
+  );
+
+  const chartBlock = selected && (
+    <MarketChart
+      symbol={selected.symbol}
+      name={selected.name}
+      large={maximized}
+      onClose={() => setSelected(null)}
+    />
+  );
+
+  const tabsBar = (
+    <div className="flex gap-0.5 overflow-x-auto styled-scrollbar">
+      {SECTIONS.map(s => {
+        const Icon = s.icon;
+        const count = Object.keys(markets[s.key] || {}).length;
+        return (
+          <button key={s.key} onClick={() => setActiveSection(s.key)}
+            className={`flex items-center gap-1 px-2.5 py-1.5 rounded text-[9px] font-mono tracking-wider whitespace-nowrap transition-all ${activeSection === s.key ? 'bg-[var(--hover-accent)] text-[var(--gold-primary)] border border-[var(--border-primary)]' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)] border border-transparent'}`}>
+            <Icon className="w-3 h-3" />
+            {s.label}
+            {count > 0 && <span className="text-[var(--text-muted)]">{count}</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  const listHeader = rows.length > 0 && (
+    <div className="flex items-center justify-between px-2 py-1 shrink-0">
+      <span className="flex items-center gap-1 text-[8px] font-mono tracking-widest text-[var(--text-muted)]">
+        <span className="w-1 h-1 rounded-full" style={{ background: sessionOpen ? GREEN : 'var(--text-muted)' }} />
+        {sessionOpen ? 'SESSION OPEN' : 'SESSION CLOSED'}
+      </span>
+      <button
+        onClick={() => setSortByMove(v => !v)}
+        className={`flex items-center gap-1 text-[8px] font-mono tracking-widest transition-colors ${sortByMove ? 'text-[var(--gold-primary)]' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'}`}
+        title={sortByMove ? 'Listed by biggest move' : 'Listed in feed order'}
+      >
+        <ArrowUpDown className="w-2.5 h-2.5" />
+        {sortByMove ? 'BY MOVE' : 'DEFAULT'}
+      </button>
+    </div>
+  );
+
+  const listRows = (
+    <>
+      {rows.map(q => (
+        <Ticker
+          key={q.symbol || q.name}
+          quote={q}
+          active={selected?.symbol === q.symbol}
+          onSelect={() => setSelected(
+            selected?.symbol === q.symbol ? null : { symbol: q.symbol, name: q.name },
+          )}
+        />
+      ))}
+
+      {rows.length === 0 && (
+        feedLoaded ? (
+          <div className="flex items-center justify-center gap-1.5 py-3 text-[9px] font-mono text-[var(--text-muted)]">
+            <AlertTriangle className="w-3 h-3" />
+            {activeSection.toUpperCase()} FEED UNAVAILABLE — RETRYING
+          </div>
+        ) : (
+          <div className="text-center py-3 text-[10px] font-mono text-[var(--text-muted)]">Loading {activeSection}...</div>
+        )
+      )}
+    </>
+  );
+
   const content = (
-    <motion.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} transition={{ delay: 0.6, duration: 0.6 }} className={`glass-panel p-3 pointer-events-auto transition-all duration-300 flex flex-col ${maximized ? 'fixed inset-4 z-[9999] bg-[#0a0a09]/95 backdrop-blur-3xl' : ''}`}>
+    <motion.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} transition={{ delay: 0.6, duration: 0.6 }} className={`glass-panel p-3 pointer-events-auto transition-all duration-300 flex flex-col ${maximized ? 'fixed inset-3 z-[9999] bg-[#0a0a09]/95 backdrop-blur-3xl' : ''}`}>
       {/* Header controls sit side by side, not nested — a button inside a
           button is invalid HTML and React fails hydration on it. */}
       <div className="flex items-center justify-between w-full mb-2">
@@ -184,135 +322,64 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
         </div>
       </div>
 
+      {/* Fades rather than animating height. Fullscreen makes this a flex child
+          and docked lets it size to content; animating height across that
+          switch stranded it at 0 with the content spilling out of the panel.
+          The key remounts it per mode so the chart re-measures at the new size. */}
       <AnimatePresence>
         {expanded && (
-          <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} transition={{ duration: 0.2 }} className={maximized ? 'flex-1 min-h-0 flex flex-col' : ''}>
-            {/* Breadth — the one-line answer to "what is the tape doing" */}
-            {breadth && (
-              <div className="mb-2 px-2 py-1.5 rounded-lg border border-[var(--border-primary)] bg-white/[0.02]">
-                <div className="flex items-center justify-between">
-                  <span className="text-[8px] font-mono tracking-widest text-[var(--text-muted)]">BREADTH</span>
-                  <span className="text-[9px] font-mono tabular-nums">
-                    <span style={{ color: GREEN }}>{breadth.up}▲</span>
-                    <span className="text-[var(--text-muted)]"> / </span>
-                    <span style={{ color: RED }}>{breadth.down}▼</span>
-                    <span className="text-[var(--text-muted)]"> of {breadth.total}</span>
-                  </span>
+          <motion.div
+            key={maximized ? 'fullscreen' : 'docked'}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className={maximized ? 'flex-1 min-h-0 flex flex-col' : ''}
+          >
+            {maximized ? (
+              /* Fullscreen: context and chart on the left, the list beside it.
+                 Each column scrolls on its own, so a long list never pushes the
+                 chart off-screen and the panel itself never overflows. Below
+                 lg the columns stack and the whole body scrolls instead. */
+              <div className="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_340px] gap-3 overflow-y-auto lg:overflow-hidden styled-scrollbar">
+                <div className="min-h-0 lg:overflow-y-auto styled-scrollbar space-y-2 lg:pr-1">
+                  {chartBlock}
+                  {breadthBlock}
+                  {scmBlock}
+                  {spaceBlock}
+                  {aiBlock}
                 </div>
-                <div className="mt-1.5 h-1 rounded-full overflow-hidden bg-[var(--alert-red)]/30">
-                  <div className="h-full rounded-full" style={{ width: `${(breadth.up / breadth.total) * 100}%`, background: GREEN }} />
+
+                <div className="min-h-0 flex flex-col lg:border-l lg:border-[var(--border-primary)] lg:pl-3">
+                  <div className="shrink-0 space-y-2">
+                    {tabsBar}
+                    {listHeader}
+                  </div>
+                  <div className="flex-1 min-h-0 overflow-y-auto styled-scrollbar space-y-0.5">
+                    {listRows}
+                  </div>
                 </div>
-                <div className="mt-1.5 flex items-center justify-between text-[8px] font-mono">
-                  <span style={{ color: GREEN }}>▲ {breadth.top.name} +{breadth.top.change_percent.toFixed(2)}%</span>
-                  <span style={{ color: RED }}>▼ {breadth.worst.name} {breadth.worst.change_percent.toFixed(2)}%</span>
+              </div>
+            ) : (
+              /* Docked: one scroll region for the whole body, capped to the
+                 viewport. With a chart open the content is taller than the
+                 screen, and nested scrollers here would mean choosing which
+                 one you meant to scroll. */
+              <div className="space-y-2 overflow-y-auto styled-scrollbar max-h-[calc(100vh-9rem)] pr-0.5">
+                {breadthBlock}
+                {spaceBlock}
+                {aiBlock}
+                {tabsBar}
+                {scmBlock}
+                {chartBlock}
+                <div>
+                  {listHeader}
+                  <div className="space-y-0.5">
+                    {listRows}
+                  </div>
                 </div>
               </div>
             )}
-
-            {/* Space Weather Banner */}
-            {spaceWeather && (
-              <div className="mb-2 p-2 rounded-lg border" style={{ borderColor: `${spaceWeather.storm_color}33`, background: `${spaceWeather.storm_color}08` }}>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-1.5">
-                    <Zap className="w-3 h-3" style={{ color: spaceWeather.storm_color }} />
-                    <span className="text-[10px] font-mono tracking-widest text-[var(--text-muted)]">SPACE WEATHER</span>
-                  </div>
-                  <span className="text-[10px] font-mono font-bold" style={{ color: spaceWeather.storm_color }}>
-                    Kp {spaceWeather.kp_index} — {spaceWeather.storm_level}
-                  </span>
-                </div>
-                {spaceWeather.solar_flares?.length > 0 && (
-                  <div className="mt-1 text-[8px] font-mono text-[var(--text-muted)]">
-                    Latest flare: {spaceWeather.solar_flares[0].class}
-                  </div>
-                )}
-              </div>
-            )}
-
-            {/* One-click AI overview of the current market picture */}
-            <div className="mb-2">
-              <AiOverview mode="markets" payload={{ markets, spaceWeather }} accent="#D4AF37" />
-            </div>
-
-            {/* Section Tabs — icons instead of emojis */}
-            <div className="flex gap-0.5 mb-2 overflow-x-auto">
-              {SECTIONS.map(s => {
-                const Icon = s.icon;
-                return (
-                  <button key={s.key} onClick={() => setActiveSection(s.key)}
-                    className={`flex items-center gap-1 px-2.5 py-1.5 rounded text-[9px] font-mono tracking-wider whitespace-nowrap transition-all ${activeSection === s.key ? 'bg-[var(--hover-accent)] text-[var(--gold-primary)] border border-[var(--border-primary)]' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)] border border-transparent'}`}>
-                    <Icon className="w-3 h-3" />
-                    {s.label}
-                  </button>
-                );
-              })}
-            </div>
-
-            {/* SCM Alerts from Markets API */}
-            {markets.scm_alerts && markets.scm_alerts.length > 0 && (
-              <div className="mb-2 space-y-1">
-                {markets.scm_alerts.map((alert: string, i: number) => (
-                  <div key={i} className="px-2 py-1.5 rounded border border-[#FF9500] bg-[#FF9500]/10 text-[#FF9500] text-[9px] font-mono leading-tight shadow-[0_0_8px_rgba(255,149,0,0.15)]">
-                    {alert}
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Chart for the selected instrument, above the list it came from */}
-            {selected && (
-              <div className="mb-2">
-                <MarketChart
-                  symbol={selected.symbol}
-                  name={selected.name}
-                  large={maximized}
-                  onClose={() => setSelected(null)}
-                />
-              </div>
-            )}
-
-            {/* Session state + sort control */}
-            {rows.length > 0 && (
-              <div className="flex items-center justify-between px-2 mb-0.5">
-                <span className="flex items-center gap-1 text-[8px] font-mono tracking-widest text-[var(--text-muted)]">
-                  <span className="w-1 h-1 rounded-full" style={{ background: sessionOpen ? GREEN : 'var(--text-muted)' }} />
-                  {sessionOpen ? 'SESSION OPEN' : 'SESSION CLOSED'}
-                </span>
-                <button
-                  onClick={() => setSortByMove(v => !v)}
-                  className={`flex items-center gap-1 text-[8px] font-mono tracking-widest transition-colors ${sortByMove ? 'text-[var(--gold-primary)]' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'}`}
-                  title={sortByMove ? 'Listed by biggest move' : 'Listed in feed order'}
-                >
-                  <ArrowUpDown className="w-2.5 h-2.5" />
-                  {sortByMove ? 'BY MOVE' : 'DEFAULT'}
-                </button>
-              </div>
-            )}
-
-            {/* Ticker List */}
-            <div className={`space-y-0.5 overflow-y-auto styled-scrollbar mt-1 ${maximized ? 'flex-1 min-h-0' : 'max-h-[280px]'}`}>
-              {rows.map(q => (
-                <Ticker
-                  key={q.symbol || q.name}
-                  quote={q}
-                  active={selected?.symbol === q.symbol}
-                  onSelect={() => setSelected(
-                    selected?.symbol === q.symbol ? null : { symbol: q.symbol, name: q.name },
-                  )}
-                />
-              ))}
-
-              {rows.length === 0 && (
-                feedLoaded ? (
-                  <div className="flex items-center justify-center gap-1.5 py-3 text-[9px] font-mono text-[var(--text-muted)]">
-                    <AlertTriangle className="w-3 h-3" />
-                    {activeSection.toUpperCase()} FEED UNAVAILABLE — RETRYING
-                  </div>
-                ) : (
-                  <div className="text-center py-3 text-[10px] font-mono text-[var(--text-muted)]">Loading {activeSection}...</div>
-                )
-              )}
-            </div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/MarketsPanel.tsx
+++ b/src/components/MarketsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
+import dynamic from 'next/dynamic';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   TrendingUp, TrendingDown, ChevronDown, ChevronUp, BarChart3,
@@ -9,6 +10,10 @@ import {
   DollarSign, ArrowUpDown, AlertTriangle,
 } from 'lucide-react';
 import AiOverview from './AiOverview';
+
+// Canvas charting has no business in the server bundle, and it only mounts
+// once a ticker is actually opened.
+const MarketChart = dynamic(() => import('./MarketChart'), { ssr: false });
 
 interface Quote {
   name: string;
@@ -70,10 +75,13 @@ function Sparkline({ points, up }: { points: number[]; up: boolean }) {
   );
 }
 
-function Ticker({ quote }: { quote: Quote }) {
+function Ticker({ quote, active, onSelect }: { quote: Quote; active: boolean; onSelect: () => void }) {
   const d = quote;
   return (
-    <div className="flex items-center justify-between gap-2 py-1.5 px-2 rounded hover:bg-[var(--hover-accent)] transition-colors">
+    <button
+      onClick={onSelect}
+      title={`${d.name} — open chart`}
+      className={`w-full flex items-center justify-between gap-2 py-1.5 px-2 rounded transition-colors ${active ? 'bg-[var(--hover-accent)] border border-[var(--border-primary)]' : 'border border-transparent hover:bg-[var(--hover-accent)]'}`}>
       <div className="min-w-0 flex-1">
         <div className="text-[10px] font-mono text-[var(--text-secondary)] tracking-wide truncate">{d.name}</div>
         {d.symbol && d.symbol !== d.name && (
@@ -95,7 +103,7 @@ function Ticker({ quote }: { quote: Quote }) {
           {d.change_percent > 0 ? '+' : ''}{d.change_percent?.toFixed(2)}%
         </span>
       </div>
-    </div>
+    </button>
   );
 }
 
@@ -121,6 +129,8 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
   const [maximized, setMaximized] = useState(false);
   const [activeSection, setActiveSection] = useState('stocks');
   const [sortByMove, setSortByMove] = useState(false);
+  /** The instrument whose chart is open, if any. */
+  const [selected, setSelected] = useState<{ symbol: string; name: string } | null>(null);
   // Memoised so the derived lists below don't recompute on every render.
   const markets = useMemo(() => data.markets || {}, [data.markets]);
   const age = useFeedAge(markets.timestamp);
@@ -249,6 +259,18 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
               </div>
             )}
 
+            {/* Chart for the selected instrument, above the list it came from */}
+            {selected && (
+              <div className="mb-2">
+                <MarketChart
+                  symbol={selected.symbol}
+                  name={selected.name}
+                  large={maximized}
+                  onClose={() => setSelected(null)}
+                />
+              </div>
+            )}
+
             {/* Session state + sort control */}
             {rows.length > 0 && (
               <div className="flex items-center justify-between px-2 mb-0.5">
@@ -269,7 +291,16 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
 
             {/* Ticker List */}
             <div className={`space-y-0.5 overflow-y-auto styled-scrollbar mt-1 ${maximized ? 'flex-1 min-h-0' : 'max-h-[280px]'}`}>
-              {rows.map(q => <Ticker key={q.symbol || q.name} quote={q} />)}
+              {rows.map(q => (
+                <Ticker
+                  key={q.symbol || q.name}
+                  quote={q}
+                  active={selected?.symbol === q.symbol}
+                  onSelect={() => setSelected(
+                    selected?.symbol === q.symbol ? null : { symbol: q.symbol, name: q.name },
+                  )}
+                />
+              ))}
 
               {rows.length === 0 && (
                 feedLoaded ? (

--- a/src/components/MarketsPanel.tsx
+++ b/src/components/MarketsPanel.tsx
@@ -1,13 +1,25 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   TrendingUp, TrendingDown, ChevronDown, ChevronUp, BarChart3,
-  Zap, Shield, Droplets, Gem, Bitcoin, LineChart, Maximize2, Minimize2
+  Zap, Shield, Droplets, Gem, Bitcoin, LineChart, Maximize2, Minimize2,
+  DollarSign, ArrowUpDown, AlertTriangle,
 } from 'lucide-react';
 import AiOverview from './AiOverview';
+
+interface Quote {
+  name: string;
+  symbol: string;
+  price: number;
+  change_percent: number;
+  up: boolean;
+  spark?: number[];
+  currency?: string;
+  market_open?: boolean;
+}
 
 interface MarketsPanelProps { data: any; spaceWeather?: any; }
 
@@ -17,18 +29,68 @@ const SECTIONS = [
   { key: 'oil', label: 'ENERGY', icon: Droplets },
   { key: 'commodities', label: 'COMMODITIES', icon: Gem },
   { key: 'crypto', label: 'CRYPTO', icon: Bitcoin },
+  { key: 'fx', label: 'FX', icon: DollarSign },
 ];
 
-function Ticker({ name, data: d }: { name: string; data: any }) {
-  if (!d) return null;
+const GREEN = 'var(--alert-green)';
+const RED = 'var(--alert-red)';
+
+/** Prices span 0.9 (FX) to 100,000 (BTC) — one formatter can't serve both. */
+function formatPrice(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 10000) return `${(v / 1000).toFixed(1)}K`;
+  if (abs >= 100) return v.toFixed(2);
+  if (abs >= 1) return v.toFixed(2);
+  return v.toFixed(4);
+}
+
+/**
+ * A month of closes as a single path. Drawn in the direction colour so the
+ * trend and the day's move read as one thing rather than two competing signals.
+ */
+function Sparkline({ points, up }: { points: number[]; up: boolean }) {
+  const W = 46, H = 14;
+  const path = useMemo(() => {
+    if (points.length < 2) return null;
+    const min = Math.min(...points);
+    const max = Math.max(...points);
+    const span = max - min || 1; // a flat line would divide by zero
+    const step = W / (points.length - 1);
+    return points
+      .map((p, i) => `${i === 0 ? 'M' : 'L'}${(i * step).toFixed(1)},${(H - ((p - min) / span) * H).toFixed(1)}`)
+      .join(' ');
+  }, [points]);
+
+  if (!path) return <div style={{ width: W, height: H }} />;
+
   return (
-    <div className="flex items-center justify-between py-1.5 px-2 rounded hover:bg-[var(--hover-accent)] transition-colors">
-      <span className="text-[10px] font-mono text-[var(--text-secondary)] tracking-wide">{name}</span>
-      <div className="flex items-center gap-2">
+    <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} className="overflow-visible shrink-0" aria-hidden="true">
+      <path d={path} fill="none" stroke={up ? GREEN : RED} strokeWidth="1" strokeLinejoin="round" strokeLinecap="round" opacity="0.75" />
+    </svg>
+  );
+}
+
+function Ticker({ quote }: { quote: Quote }) {
+  const d = quote;
+  return (
+    <div className="flex items-center justify-between gap-2 py-1.5 px-2 rounded hover:bg-[var(--hover-accent)] transition-colors">
+      <div className="min-w-0 flex-1">
+        <div className="text-[10px] font-mono text-[var(--text-secondary)] tracking-wide truncate">{d.name}</div>
+        {d.symbol && d.symbol !== d.name && (
+          <div className="text-[8px] font-mono text-[var(--text-muted)] truncate">{d.symbol}</div>
+        )}
+      </div>
+
+      <Sparkline points={d.spark || []} up={d.up} />
+
+      <div className="flex flex-col items-end shrink-0 w-[86px]">
         <span className="text-[11px] font-mono font-bold text-[var(--text-primary)] tabular-nums">
-          {d.price >= 1000 ? `${(d.price / 1000).toFixed(1)}K` : d.price?.toFixed(2)}
+          {formatPrice(d.price)}
         </span>
-        <span className={`text-[9px] font-mono font-bold flex items-center gap-0.5 ${d.up ? 'text-[var(--alert-green)]' : 'text-[var(--alert-red)]'}`}>
+        <span
+          className="text-[9px] font-mono font-bold flex items-center gap-0.5 tabular-nums"
+          style={{ color: d.up ? GREEN : RED }}
+        >
           {d.up ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
           {d.change_percent > 0 ? '+' : ''}{d.change_percent?.toFixed(2)}%
         </span>
@@ -37,36 +99,106 @@ function Ticker({ name, data: d }: { name: string; data: any }) {
   );
 }
 
+/** How long ago the feed was built, so a frozen panel is visibly frozen. */
+function useFeedAge(timestamp?: string): string | null {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(t);
+  }, []);
+
+  if (!timestamp) return null;
+  const ms = now - new Date(timestamp).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return null;
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  return `${Math.floor(mins / 60)}h ago`;
+}
+
 export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) {
   const [expanded, setExpanded] = useState(true);
   const [maximized, setMaximized] = useState(false);
   const [activeSection, setActiveSection] = useState('stocks');
-  const markets = data.markets || {};
+  const [sortByMove, setSortByMove] = useState(false);
+  // Memoised so the derived lists below don't recompute on every render.
+  const markets = useMemo(() => data.markets || {}, [data.markets]);
+  const age = useFeedAge(markets.timestamp);
 
   // Ensure portal only renders on client
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
+  /** Every instrument across every section — the basis for the breadth line. */
+  const allQuotes = useMemo<Quote[]>(
+    () => SECTIONS.flatMap(s => Object.values<Quote>(markets[s.key] || {})).filter(q => Number.isFinite(q?.change_percent)),
+    [markets],
+  );
+
+  const breadth = useMemo(() => {
+    if (!allQuotes.length) return null;
+    const up = allQuotes.filter(q => q.change_percent > 0).length;
+    const sorted = [...allQuotes].sort((a, b) => b.change_percent - a.change_percent);
+    return { up, down: allQuotes.length - up, total: allQuotes.length, top: sorted[0], worst: sorted[sorted.length - 1] };
+  }, [allQuotes]);
+
+  const rows = useMemo<Quote[]>(() => {
+    const list = Object.values<Quote>(markets[activeSection] || {});
+    return sortByMove ? [...list].sort((a, b) => b.change_percent - a.change_percent) : list;
+  }, [markets, activeSection, sortByMove]);
+
+  // A section with no rows means the upstream refresh failed — say so, rather
+  // than showing a "Loading…" that never resolves until the next 15m poll.
+  const feedLoaded = Boolean(markets.timestamp || markets.error);
+  const sessionOpen = rows.some(q => q.market_open);
+
   const content = (
     <motion.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} transition={{ delay: 0.6, duration: 0.6 }} className={`glass-panel p-3 pointer-events-auto transition-all duration-300 flex flex-col ${maximized ? 'fixed inset-4 z-[9999] bg-[#0a0a09]/95 backdrop-blur-3xl' : ''}`}>
-      <button onClick={() => setExpanded(!expanded)} className="flex items-center justify-between w-full mb-2">
-        <div className="flex items-center gap-2">
+      {/* Header controls sit side by side, not nested — a button inside a
+          button is invalid HTML and React fails hydration on it. */}
+      <div className="flex items-center justify-between w-full mb-2">
+        <button onClick={() => setExpanded(!expanded)} className="flex items-center gap-2">
           <BarChart3 className="w-3.5 h-3.5 text-[var(--gold-primary)]" />
           <span className="hud-text text-[12px] text-[var(--text-primary)]">MARKETS & INTEL</span>
           <span className="gotham-tag gotham-tag--low" style={{ fontSize: '7px', padding: '1px 4px' }}>LIVE</span>
-        </div>
+        </button>
         <div className="flex items-center gap-2">
+          {age && <span className="text-[8px] font-mono text-[var(--text-muted)]">{age}</span>}
           <div className="w-1.5 h-1.5 rounded-full bg-[var(--alert-green)] animate-osiris-pulse" />
-          <button onClick={(e) => { e.stopPropagation(); setMaximized(!maximized); if (!expanded && !maximized) setExpanded(true); }} className="hover:text-white transition-colors" title={maximized ? "Restore" : "Maximize"}>
+          <button onClick={() => { setMaximized(!maximized); if (!expanded && !maximized) setExpanded(true); }} className="hover:text-white transition-colors" title={maximized ? "Restore" : "Maximize"}>
             {maximized ? <Minimize2 className="w-3.5 h-3.5 text-[var(--text-muted)]" /> : <Maximize2 className="w-3.5 h-3.5 text-[var(--text-muted)]" />}
           </button>
-          {expanded ? <ChevronUp className="w-3.5 h-3.5 text-[var(--text-muted)]" /> : <ChevronDown className="w-3.5 h-3.5 text-[var(--text-muted)]" />}
+          <button onClick={() => setExpanded(!expanded)} title={expanded ? 'Collapse' : 'Expand'}>
+            {expanded ? <ChevronUp className="w-3.5 h-3.5 text-[var(--text-muted)]" /> : <ChevronDown className="w-3.5 h-3.5 text-[var(--text-muted)]" />}
+          </button>
         </div>
-      </button>
+      </div>
 
       <AnimatePresence>
         {expanded && (
-          <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} transition={{ duration: 0.2 }}>
+          <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} transition={{ duration: 0.2 }} className={maximized ? 'flex-1 min-h-0 flex flex-col' : ''}>
+            {/* Breadth — the one-line answer to "what is the tape doing" */}
+            {breadth && (
+              <div className="mb-2 px-2 py-1.5 rounded-lg border border-[var(--border-primary)] bg-white/[0.02]">
+                <div className="flex items-center justify-between">
+                  <span className="text-[8px] font-mono tracking-widest text-[var(--text-muted)]">BREADTH</span>
+                  <span className="text-[9px] font-mono tabular-nums">
+                    <span style={{ color: GREEN }}>{breadth.up}▲</span>
+                    <span className="text-[var(--text-muted)]"> / </span>
+                    <span style={{ color: RED }}>{breadth.down}▼</span>
+                    <span className="text-[var(--text-muted)]"> of {breadth.total}</span>
+                  </span>
+                </div>
+                <div className="mt-1.5 h-1 rounded-full overflow-hidden bg-[var(--alert-red)]/30">
+                  <div className="h-full rounded-full" style={{ width: `${(breadth.up / breadth.total) * 100}%`, background: GREEN }} />
+                </div>
+                <div className="mt-1.5 flex items-center justify-between text-[8px] font-mono">
+                  <span style={{ color: GREEN }}>▲ {breadth.top.name} +{breadth.top.change_percent.toFixed(2)}%</span>
+                  <span style={{ color: RED }}>▼ {breadth.worst.name} {breadth.worst.change_percent.toFixed(2)}%</span>
+                </div>
+              </div>
+            )}
+
             {/* Space Weather Banner */}
             {spaceWeather && (
               <div className="mb-2 p-2 rounded-lg border" style={{ borderColor: `${spaceWeather.storm_color}33`, background: `${spaceWeather.storm_color}08` }}>
@@ -117,13 +249,37 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
               </div>
             )}
 
+            {/* Session state + sort control */}
+            {rows.length > 0 && (
+              <div className="flex items-center justify-between px-2 mb-0.5">
+                <span className="flex items-center gap-1 text-[8px] font-mono tracking-widest text-[var(--text-muted)]">
+                  <span className="w-1 h-1 rounded-full" style={{ background: sessionOpen ? GREEN : 'var(--text-muted)' }} />
+                  {sessionOpen ? 'SESSION OPEN' : 'SESSION CLOSED'}
+                </span>
+                <button
+                  onClick={() => setSortByMove(v => !v)}
+                  className={`flex items-center gap-1 text-[8px] font-mono tracking-widest transition-colors ${sortByMove ? 'text-[var(--gold-primary)]' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'}`}
+                  title={sortByMove ? 'Listed by biggest move' : 'Listed in feed order'}
+                >
+                  <ArrowUpDown className="w-2.5 h-2.5" />
+                  {sortByMove ? 'BY MOVE' : 'DEFAULT'}
+                </button>
+              </div>
+            )}
+
             {/* Ticker List */}
-            <div className="space-y-0.5 overflow-y-auto styled-scrollbar mt-2">
-              {markets[activeSection] && Object.entries(markets[activeSection]).map(([name, d]) => (
-                <Ticker key={name} name={name} data={d} />
-              ))}
-              {(!markets[activeSection] || Object.keys(markets[activeSection]).length === 0) && (
-                <div className="text-center py-3 text-[10px] font-mono text-[var(--text-muted)]">Loading {activeSection}...</div>
+            <div className={`space-y-0.5 overflow-y-auto styled-scrollbar mt-1 ${maximized ? 'flex-1 min-h-0' : 'max-h-[280px]'}`}>
+              {rows.map(q => <Ticker key={q.symbol || q.name} quote={q} />)}
+
+              {rows.length === 0 && (
+                feedLoaded ? (
+                  <div className="flex items-center justify-center gap-1.5 py-3 text-[9px] font-mono text-[var(--text-muted)]">
+                    <AlertTriangle className="w-3 h-3" />
+                    {activeSection.toUpperCase()} FEED UNAVAILABLE — RETRYING
+                  </div>
+                ) : (
+                  <div className="text-center py-3 text-[10px] font-mono text-[var(--text-muted)]">Loading {activeSection}...</div>
+                )
               )}
             </div>
           </motion.div>


### PR DESCRIPTION
Rebuilds the markets panel on the right rail across three commits: fix the data, add real charts, then make fullscreen usable.

## 1. The data was broken

- **It went blank and stayed blank.** On a cold start every upstream quote raced an 8s timeout, the route returned an all-empty payload, and the client waited a full **15-minute** poll before retrying — so the panel showed `Loading indices…` indefinitely.
- **`fetchYahooV6` was dead code that cost a round-trip.** Yahoo decommissioned the v6 quote endpoint; it returns `404` on every call, so the "fallback" only slowed requests that had already failed.

Now: one source (v8 chart), `range=1mo` per symbol so each row gets **a month of daily closes** at no extra request cost, session state read from Yahoo's trading window, and the whole thing wrapped in the existing `cachedSource` helper (60s TTL) for in-flight dedup and **stale-on-error** — a failed refresh keeps serving the last good prices instead of blanking.

Coverage 18 → **28 instruments across 6 tabs**: added VIX, Dollar Index, US 10Y, LHX, natural gas, SOL, XRP, and an **FX** section. The fan-out is bounded to 5 in flight rather than firing all 28 at one host, which is the access pattern upstreams throttle first. `fetchScmAlerts` derives its origin from the request instead of a hardcoded `http://127.0.0.1:3000`.

**Bug caught during verification:** switching to `range=1mo` silently broke the percentages — over a one-month range `chartPreviousClose` predates the whole series, so a **monthly** move was displayed as the day's (LMT showed **+15.07%** against a true **+2.40%**). Change is now measured against the previous daily close, with a regression test pinning it.

**Cold start:** the client retries up to 3 times at 15s when the payload lands empty, and an empty section reads `FEED UNAVAILABLE — RETRYING` instead of a `Loading…` that never resolves.

## 2. Real charts

Sparklines show a shape, not what a price did. Clicking any row opens a proper chart for that instrument.

- **`/api/markets/history`** — OHLC + volume for one symbol, resolution per range. Bars with a missing leg are dropped rather than interpolated: a candle nobody traded shouldn't be drawn.
- **`MarketChart`** — `lightweight-charts` (TradingView, ~45KB, canvas), dynamically imported so it stays out of the server bundle and only loads when a row is opened. Candlesticks + volume on its own scale, crosshair-driven OHLC/volume readout, range performance, window high/low.
- **Ranges: `1m` `15m` `24H` `1W` `1M` `6M` `1Y`.** Case is load-bearing — `1m` is one-minute bars, `1M` is one month — so the route no longer upper-cases its range parameter, which would have collapsed the two. Pinned with a test.

Note `24H` is a true ~24 hours for crypto and FX (BTC 246 bars/20.4h, EUR/USD 258/21.4h); for equities it's the latest **session** (~6.5h), since stock markets aren't open 24 hours.

## 3. Fullscreen that scrolls

Fullscreen stacked everything in one column and only the ticker list could scroll, so opening a chart squeezed the list to nothing and the rest had nowhere to go.

Now two columns — chart and context left, instruments right — **each scrolling independently**, stacking into a single scrolling body below `lg`. Escape closes the chart, then leaves fullscreen. Tabs carry instrument counts.

**Two more bugs fixed in passing:**
- Docked mode with a chart open was **877px tall on a 790px screen**, running off-screen. It's now one scroll region capped to the viewport — nested scrollers would mean guessing which one you meant to scroll.
- Leaving fullscreen stranded the panel body at inline `height: 0px` while holding 503px of content, spilling it outside the glass panel. Cause was framer-motion animating height across the docked↔fullscreen layout switch; the body now fades instead.

## Drive-by fixes in the same surface

- `digestMarkets` looked up crypto as `markets.crypto.BTC`, but the feed keys it `Bitcoin` — Bitcoin never reached the AI overview.
- The panel header nested a `<button>` inside a `<button>` — invalid HTML that threw a React **hydration error** on every load.

## Verification

- **184 tests pass** / 5 skipped (22 new across the quote parser, candle parser and range map). `eslint` clean on all new files; remaining hits in `MarketsPanel` sit on pre-existing lines (`data: any` props, the portal-mount effect).
- Live on localhost: 28 instruments across all six tabs with plausible daily moves; all seven chart ranges return real bars (1m→389 over 6.5h, 1M→21 daily, 1Y→53 weekly); tab switching, sort toggle, breadth, Escape, and the maximize→restore cycle all verified against the DOM.
- **The cold-start path was verified end-to-end**: the panel showed `FEED UNAVAILABLE — RETRYING`, then filled itself in from the retry with no reload.
- Fullscreen columns confirmed scrolling independently (left 308px, right 21px of scroll at a constrained viewport) with no page overflow; single-column stacking confirmed below `lg`.

## Not verified — needs a human eye

I could not confirm the **painted candle pixels**. The verification browser doesn't composite, so `requestAnimationFrame` never fires, and lightweight-charts sizes and paints its canvases inside a rAF pass — every canvas reads back empty regardless of correctness. Data, DOM, layout, sizing and interaction are confirmed; the rendered candles are not.

## Environment note (not a code issue)

While testing, outbound `fetch` from the dev server began failing with `UND_ERR_CONNECT_TIMEOUT` to **every** host, while an identical fetch from a plain Node process on the same machine connected in 29ms. The dev server process had grown to ~3,800 handles / 1.7 GB RSS — the app's continuous feed polling exhausts sockets over a few hours. A restart clears it. Unrelated to this PR, but it will keep biting during long dev sessions.

Generated with [SIMPLIFAI](https://Simplifai-1.com)
