### PR TITLE
fix(markets): stop dropping instruments when a refresh partly fails

### DIFF
--- a/src/app/api/markets/route.test.ts
+++ b/src/app/api/markets/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { fetchQuote, groupQuotes, type Quote } from './route';
+import { fetchQuote, fetchAllQuotes, groupQuotes, type Quote } from './route';
 
 const TICKER = { symbol: 'LMT', name: 'LMT', group: 'stocks' };
 
@@ -108,6 +108,38 @@ describe('fetchQuote', () => {
   it('swallows a network failure', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
     expect(await fetchQuote(TICKER)).toBeNull();
+  });
+});
+
+/* These share the route's module-level last-good cache, so they run in order:
+   the first populates it, the second depends on it being warm. */
+describe('fetchAllQuotes', () => {
+  /** Answer normally, except for symbols the caller wants to fail. */
+  function mockUpstream(failing: string[] = []) {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      const symbol = decodeURIComponent(new URL(url).pathname.split('/').pop() || '');
+      if (failing.includes(symbol)) throw new Error('upstream down');
+      return chartResponse({ price: 100, closes: [90, 100] });
+    }));
+  }
+
+  it('returns instruments in the declared order, not the order they answered', async () => {
+    mockUpstream();
+    const quotes = await fetchAllQuotes();
+    const indices = quotes.filter(q => q.group === 'indices').map(q => q.name);
+    expect(indices).toEqual(['S&P 500', 'Nasdaq 100', 'VIX', 'Dollar Index', 'US 10Y']);
+  });
+
+  /* The bug this guards: the workers start on the first five tickers — which
+     are the five indices — so they raced cold connections together and failed
+     as a group. Dropping them emptied the whole INDICES tab. */
+  it('keeps the last good value for a symbol that fails this refresh', async () => {
+    mockUpstream(['ES=F', '^VIX']);
+    const quotes = await fetchAllQuotes();
+    const names = quotes.filter(q => q.group === 'indices').map(q => q.name);
+    expect(names).toContain('S&P 500');
+    expect(names).toContain('VIX');
+    expect(quotes).toHaveLength(28);
   });
 });
 

--- a/src/app/api/markets/route.ts
+++ b/src/app/api/markets/route.ts
@@ -133,20 +133,49 @@ export async function fetchQuote(t: { symbol: string; name: string; group: strin
  */
 const CONCURRENCY = 5;
 
-/** All instruments in one pass. A symbol that fails is simply absent. */
-async function fetchAllQuotes(): Promise<Quote[]> {
-  const out: Quote[] = [];
-  let next = 0;
+/**
+ * The last good quote for each symbol.
+ *
+ * A refresh that loses some symbols used to drop them from the payload
+ * entirely, which empties a whole tab: the workers start on the first five
+ * tickers, those are the five indices, and they race cold connections
+ * together — so INDICES was the group that kept vanishing. Holding the
+ * previous value per symbol means a transient miss costs freshness rather
+ * than the instrument.
+ */
+const lastGood = new Map<string, Quote>();
 
+/** Run `fetchQuote` over a list with a bounded number of requests in flight. */
+async function fetchBatch(tickers: typeof TICKERS, into: Map<string, Quote>): Promise<void> {
+  let next = 0;
   const worker = async () => {
-    while (next < TICKERS.length) {
-      const quote = await fetchQuote(TICKERS[next++]);
-      if (quote) out.push(quote);
+    while (next < tickers.length) {
+      const ticker = tickers[next++];
+      const quote = await fetchQuote(ticker);
+      if (quote) into.set(ticker.symbol, quote);
     }
   };
-
   await Promise.all(Array.from({ length: CONCURRENCY }, worker));
-  return out;
+}
+
+/**
+ * All instruments in one pass, with a second go at whatever missed. The retry
+ * runs against connections the first pass has already opened, which is exactly
+ * what the symbols unlucky enough to be first in the list need.
+ */
+export async function fetchAllQuotes(): Promise<Quote[]> {
+  const fresh = new Map<string, Quote>();
+
+  await fetchBatch(TICKERS, fresh);
+
+  const missed = TICKERS.filter(t => !fresh.has(t.symbol));
+  if (missed.length) await fetchBatch(missed, fresh);
+
+  for (const [symbol, quote] of fresh) lastGood.set(symbol, quote);
+
+  return TICKERS
+    .map(t => fresh.get(t.symbol) || lastGood.get(t.symbol))
+    .filter((q): q is Quote => q !== undefined);
 }
 
 /**


### PR DESCRIPTION
Follow-up to #273. Reported as "many of the charts are not pulling up".

## The charts were fine

All **28 symbols × all 7 ranges = 196 combinations** return data from `/api/markets/history`, with zero empties. The problem was upstream of the chart: **the rows were missing**, so there was nothing to click.

`INDICES` rendered with no count at all and breadth read "of 23" instead of 28 — the five indices had vanished from the payload. Consecutive refreshes gave **23, 23, 28**: instruments blinking in and out.

## Two defects, both from the bounded fan-out added in #273

**1. A partial failure deleted instruments.** The worker pool walks the ticker list in order, so the first five requests are *exactly* the five indices. They race cold connections together, and when that opening burst hits the connect timeout they fail as a group. `fetchAllQuotes` returned only what succeeded, and `cachedSource` treats just an empty array as a failed refresh — so a partial result (23 of 28) overwrote the good cached 28 and emptied the whole tab.

**2. Rows were emitted in response-completion order**, which reshuffles on every refresh. Beyond the visual churn, a refresh landing between reading a row and clicking it opens a different instrument's chart.

## Fix

- **Retry whatever missed**, against connections the first pass has already opened — which is precisely what the symbols unlucky enough to be first in the list need.
- **Hold the last good value per symbol**, so a transient miss costs freshness rather than the instrument.
- **Emit in declared order**, so the list never reshuffles.

## Verification

- Six consecutive refreshes: 28 every time, `indices:5` every time.
- **Soak test across six real cache expiries** (65s apart, each past the 60s TTL so every pass forced a live upstream fetch): 28 instruments on all six passes. Same check before the fix: 23 / 23 / 28.
- Key ordering confirmed stable across refreshes.
- Panel shows `INDICES 5` and breadth "of 28"; `^VIX` opens correctly (O 15.40 H 15.72 L 15.10 C 15.46) and switching straight from `^VIX` to `DX-Y.NYB` works.
- **186 tests pass** (2 new). The second new test only passes via the last-good fallback — its mock fails those symbols on both the initial pass and the retry. `eslint` clean on both files.

## Reviewer note

The two new tests share the route's module-level last-good cache, so they are order-dependent: the first populates it, the second depends on it being warm. That is called out in a comment above the block, but it is the kind of coupling worth a second opinion.

Generated with [SIMPLIFAI](https://Simplifai-1.com)
