### PR TITLE
feat(cctv): live cameras for Bangkok and the Thai islands

### DIFF
--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -24,6 +24,7 @@ import { fetchHongKongCameras } from './hongkong';
 import { fetchUtahCameras } from './utah';
 import { fetchIcelandCameras } from './iceland';
 import { fetchTaiwanCameras } from './taiwan';
+import { fetchThailandCameras } from './thailand';
 import { fetchAsiaLiveCameras } from './asia-live';
 import { fetchNewZealandCameras } from './newzealand';
 import { fetchOregonCameras } from './oregon';
@@ -450,6 +451,7 @@ const REGION_FETCHERS: Record<string, () => Promise<any[]>> = {
   'utah': fetchUtahCameras,
   'iceland': fetchIcelandCameras,
   'taiwan': fetchTaiwanCameras,
+  'thailand': fetchThailandCameras,
   'asia-live': fetchAsiaLiveCameras,
   'newzealand': fetchNewZealandCameras,
   'oregon': fetchOregonCameras,
@@ -528,6 +530,9 @@ function getRegionsForBounds(lat: number, lng: number, radius: number): string[]
 
   // Taiwan
   if (lat > 21.9 && lat < 25.3 && lng > 119.5 && lng < 122.1) regions.push('taiwan');
+
+  // Thailand — mainland through the Gulf islands
+  if (lat > 5.5 && lat < 20.5 && lng > 97.3 && lng < 105.7) regions.push('thailand');
 
   // Asia live webcams — spans West Asia (Turkey / Levant / Gulf) through Japan and Indonesia
   if (lat > -11 && lat < 46 && lng > 25 && lng < 155) regions.push('asia-live');

--- a/src/app/api/cctv/thailand.ts
+++ b/src/app/api/cctv/thailand.ts
@@ -1,0 +1,99 @@
+import type { CctvCamera } from './types';
+
+/**
+ * OSIRIS — Thailand live cameras.
+ *
+ * Thailand publishes no open machine-readable CCTV feed: the BMA's traffic
+ * cameras sit behind a portal that refuses connections from here, and the
+ * Highways Department serves its cameras through a viewer rather than an API.
+ * SkylineWebcams lists Bangkok, but those `liveNNNN.jpg` posters are catalog
+ * stills — the three Bangkok ones were byte-identical 25 seconds apart, which
+ * is why they carry no feed_url and the map showed nothing playable here.
+ *
+ * These are fixed-position 24/7 streams instead. Every id below was checked to
+ * be live *and* embeddable at the time of writing (`playableInEmbed`), because
+ * a stream that refuses embedding renders as an error inside the viewer — one
+ * candidate was dropped for exactly that.
+ *
+ * Coordinates are area-level: the streams name a venue and a road, not a
+ * survey point, so these land within a few hundred metres rather than on the
+ * lens. Live streams also end at the owner's whim; a dead id shows as an
+ * unavailable embed rather than breaking the layer.
+ */
+const THAILAND_CAMERAS: CctvCamera[] = [
+  // ── Bangkok ──
+  {
+    id: 'th-bangkok-sukhumvit-soi-11',
+    lat: 13.7437, lng: 100.5556,
+    name: 'Sukhumvit Soi 11 — Bangkok',
+    city: 'Bangkok',
+    country: 'Thailand',
+    stream_url: 'https://www.youtube.com/embed/UemFRPrl1hk?autoplay=1&mute=1',
+    stream_type: 'iframe',
+    external_url: 'https://www.youtube.com/watch?v=UemFRPrl1hk',
+    source: 'The Real Samui Webcam',
+  },
+  {
+    id: 'th-bangkok-sukhumvit-soi-19',
+    lat: 13.7396, lng: 100.5601,
+    name: 'Sukhumvit Soi 19 — Bangkok',
+    city: 'Bangkok',
+    country: 'Thailand',
+    stream_url: 'https://www.youtube.com/embed/Q71sLS8h9a4?autoplay=1&mute=1',
+    stream_type: 'iframe',
+    external_url: 'https://www.youtube.com/watch?v=Q71sLS8h9a4',
+    source: 'The Real Samui Webcam',
+  },
+
+  // ── Koh Samui ──
+  {
+    id: 'th-samui-chaweng-green-mango',
+    lat: 9.5071545, lng: 99.9957562,
+    name: 'Chaweng — Soi Green Mango',
+    city: 'Ko Samui',
+    country: 'Thailand',
+    stream_url: 'https://www.youtube.com/embed/DwKCna1mumk?autoplay=1&mute=1',
+    stream_type: 'iframe',
+    external_url: 'https://www.youtube.com/watch?v=DwKCna1mumk',
+    source: 'The Real Samui Webcam',
+  },
+  {
+    id: 'th-samui-chaweng-munchies',
+    lat: 9.5071545, lng: 99.9957562,
+    name: 'Chaweng — Soi Green Mango (Munchies)',
+    city: 'Ko Samui',
+    country: 'Thailand',
+    stream_url: 'https://www.youtube.com/embed/yFgVmioYkys?autoplay=1&mute=1',
+    stream_type: 'iframe',
+    external_url: 'https://www.youtube.com/watch?v=yFgVmioYkys',
+    source: 'The Real Samui Webcam',
+  },
+  {
+    id: 'th-samui-lamai-crystal-bay',
+    lat: 9.4700032, lng: 100.0459763,
+    name: 'Lamai — Crystal Bay Beach',
+    city: 'Ko Samui',
+    country: 'Thailand',
+    stream_url: 'https://www.youtube.com/embed/Fw9hgttWzIg?autoplay=1&mute=1',
+    stream_type: 'iframe',
+    external_url: 'https://www.youtube.com/watch?v=Fw9hgttWzIg',
+    source: 'The Real Samui Webcam',
+  },
+
+  // ── Koh Phangan ──
+  {
+    id: 'th-phangan-srithanu-sanskara',
+    lat: 9.7333, lng: 99.9833,
+    name: 'Koh Phangan — Srithanu Beach',
+    city: 'Ko Phangan',
+    country: 'Thailand',
+    stream_url: 'https://www.youtube.com/embed/MW3fisTCXRQ?autoplay=1&mute=1',
+    stream_type: 'iframe',
+    external_url: 'https://www.youtube.com/watch?v=MW3fisTCXRQ',
+    source: 'The Real Samui Webcam',
+  },
+];
+
+export async function fetchThailandCameras(): Promise<CctvCamera[]> {
+  return THAILAND_CAMERAS;
+}


### PR DESCRIPTION
## The problem

Bangkok already had three cameras on the map and **none of them played**. They carried an `external_url` only — and that was the right call: their SkylineWebcams `liveNNNN.jpg` posters are catalog stills, not live frames. I fetched all five Thai ones twice, 25 seconds apart, and they were **byte-identical**. Giving them a `feed_url` would have shown a frozen frame, which is worse than showing nothing.

## Why not an official feed

Thailand publishes nothing machine-readable to replace them with:

| Source | Result |
|---|---|
| BMA Traffic (`bmatraffic.com`) | refuses connections — `UND_ERR_CONNECT_TIMEOUT` |
| Highways Dept (`doh.go.th`) | site up, but cameras are behind a viewer, no API |
| Longdo traffic endpoints | `404` |
| iTIC | site up, no open camera API |

## What this adds

A `thailand.ts` region with **6 fixed-position 24/7 streams**, using the same YouTube-embed pattern `japan.ts` and `taiwan.ts` already use (`stream_type: 'iframe'`, handled by `CameraViewer` at line 265):

- **Bangkok** — Sukhumvit Soi 11, Sukhumvit Soi 19
- **Ko Samui** — Chaweng Soi Green Mango ×2, Lamai Crystal Bay
- **Ko Phangan** — Srithanu Beach

Wired as its own `thailand` region with a bounding box covering the mainland through the Gulf islands.

**Bangkok goes from 0 playable cameras to 2.**

## Candidates rejected

Every id was checked to be live **and** embeddable, and that second check earned its keep:

- **Lamai Crystal Bay Yacht Club** — reports live, but `playableInEmbed: false`. Would have rendered as an error inside the viewer.
- **Bangkok Sathorn Road "24/7"** — embeddable, but not actually live.
- **Two Bangkok streams** — walking tours. A moving camera doesn't belong on a fixed-CCTV pin, and its coordinates would be wrong the moment it moved.

## Verification

- `?region=thailand` → 6 cameras; Bangkok viewport (13.756, 100.502) → 7 cameras, **2 playable** (was 0); `?region=all` → all 6 present among 888.
- 186 tests pass. `thailand.ts` is lint-clean, and `route.ts` reports **41 lint problems before and after** this change — I compared against a stash to confirm none were added.

## Reviewer notes

Two honest limitations, neither hidden:

- **Coordinates are area-level.** The streams name a venue and a road, not a survey point, so pins land within a few hundred metres rather than on the lens.
- **These are third-party streams and will rot.** An owner ending a stream degrades to an unavailable embed rather than breaking the layer, but there is no health check — a dead id stays on the map looking valid. If that matters, the existing `stream-status` route is the natural place to extend.

There is no durable open municipal feed for Bangkok; a permanent fix needs a registered or paid source.

Generated with [SIMPLIFAI](https://Simplifai-1.com)
