### PR TITLE
fix(flights): restore aircraft — both ADS-B fallbacks had gone dead

### DIFF
--- a/src/app/api/flights/route.ts
+++ b/src/app/api/flights/route.ts
@@ -81,25 +81,36 @@ const MILITARY_INDICATORS = new Set([
 
 const AIRLINE_CODE_RE = /^([A-Z]{3})\d/;
 
-// Both providers speak the same tar1090/ADSBexchange-v2 response shape so
-// classifyFlight() works unchanged. They run on independent feeder networks
-// with minimal overlap — tested: airplanes.live gives ~6K aircraft across 30
-// regions, adsb.lol adds ~650 unique on top. Run them simultaneously.
-const ADSB_MAX_DIST = 250; // nm — hard cap both providers enforce
+// adsb.fi is the last free tar1090/ADSBexchange-v2 shaped feed still serving
+// data without an API key, so classifyFlight() works on it unchanged. The two
+// providers this route used to fan out to have both stopped returning aircraft:
+//   api.airplanes.live  → 403 on every endpoint (now key-gated)
+//   api.adsb.lol/v2     → 200 but always {"ac":[],"total":0}
+//   api.adsb.one/v2     → 403 (checked as a replacement, also unusable)
+// Because both failure modes are silent (403 bodies are discarded, an empty
+// ac[] is indistinguishable from quiet airspace), the fallback path degraded to
+// zero aircraft without ever throwing. Provider counts are reported in the
+// response now so the next feed to die is visible instead of silent.
+const ADSB_MAX_DIST = 250; // nm — hard cap the provider enforces
+const ADSBFI_BASE = 'https://opendata.adsb.fi/api/v2';
 
-async function fetchRegionFrom(
-  lat: number, lon: number,
-  urlFn: (lat: number, lon: number, dist: number) => string,
-  arrayKey: 'ac' | 'aircraft',
-): Promise<any[]> {
+// adsb.fi allows roughly one request per second and soft-throttles over that by
+// returning 200 with an empty ac[] rather than 429, so a parallel fanout looks
+// like it succeeded while returning nothing. The regional sweep is paced.
+const ADSBFI_GAP_MS = 1100;
+
+// adsb.fi serves /mil but returns 400 for /ladd, /pia and /squawk/{code},
+// so the global type feeds collapse to the military one.
+async function fetchAdsbFiRegion(lat: number, lon: number): Promise<any[]> {
   try {
-    const res = await stealthFetch(urlFn(lat, lon, ADSB_MAX_DIST), {
+    const res = await stealthFetch(`${ADSBFI_BASE}/lat/${lat}/lon/${lon}/dist/${ADSB_MAX_DIST}`, {
       signal: AbortSignal.timeout(12000),
     });
     if (res.ok) {
       const data = await res.json();
-      return data[arrayKey] || data.ac || [];
+      return data.ac || [];
     }
+    await res.body?.cancel();
   } catch {}
   return [];
 }
@@ -165,6 +176,26 @@ let lastFetchTime = 0;
 // 4 credits/call = 1000 calls/day ≈ one per 86s). The old 45s TTL at ~1920 calls/day
 // was what got the VPS IP rate-limited on the anonymous pool.
 const CACHE_TTL = 90000;
+
+// OpenSky's budget is per day, not per request, so it needs its own interval
+// separate from the response cache above. Authenticated it is 4000 credits/day
+// and an unbounded /states/all costs 4, which is the 90s the TTL was built for.
+// Anonymous it is only 400 credits/day — 100 calls, one per ~864s — so polling
+// it on the same 90s TTL burns the whole day's budget in about half an hour,
+// after which every call 429s and the route sits permanently in the cooldown
+// branch below. That is what emptied the map: no credentials were configured,
+// so the budget was gone and the feeds it fell back to were the dead ones above.
+const hasOpenSkyCreds = () =>
+  Boolean(process.env.OPENSKY_CLIENT_ID && process.env.OPENSKY_CLIENT_SECRET);
+const openSkyInterval = () => (hasOpenSkyCreds() ? 90000 : 900000);
+
+// The last good OpenSky snapshot is kept and reused between those calls. On the
+// anonymous interval a refetch is only due every 15 minutes, and rebuilding the
+// payload from adsb.fi alone in between would swing the map between ~10K
+// aircraft and a few hundred every 90s. Reusing the snapshot keeps the aircraft
+// on screen stable; only their age varies, which providers.opensky_age_s reports.
+let osSnapshot: any[] = [];
+let osSnapshotTime = 0;
 let fetchPromise: Promise<any> | null = null;
 
 // Back off from OpenSky after a 429 so the daily quota can reset.
@@ -243,48 +274,44 @@ export async function GET() {
     const seenHex = new Set<string>();
     let source: string;
 
-    // ── Phase 1 + 2 in parallel: global type feeds AND OpenSky simultaneously ──
-    // Running them together keeps total wall-clock time to max(global_feeds, opensky)
-    // instead of sum. Global feeds cover mil/ladd/pia from two independent networks
-    // and run regardless of OpenSky status.
-    const skipOpenSky = Date.now() < openSkyCooldownUntil;
+    // ── Phase 1 + 2 in parallel: global military feed AND OpenSky simultaneously ──
+    // Running them together keeps total wall-clock time to max(mil_feed, opensky)
+    // instead of sum. The military feed runs every cycle regardless of OpenSky
+    // status and is always current, so military traffic stays live even while an
+    // anonymous OpenSky snapshot is waiting out its interval.
+    const skipOpenSky =
+      Date.now() < openSkyCooldownUntil ||
+      Date.now() - osSnapshotTime < openSkyInterval();
     const token = skipOpenSky ? null : await getOpenSkyToken();
     const osInit: RequestInit = token
       ? { signal: AbortSignal.timeout(30000), headers: { Authorization: `Bearer ${token}` } }
       : { signal: AbortSignal.timeout(30000) };
 
-    const [apl_mil, apl_ladd, apl_pia, apl_emg, lol_mil, lol_ladd, lol_pia, lol_emg, osRes] = await Promise.allSettled([
-      stealthFetch('https://api.airplanes.live/v2/mil',          { signal: AbortSignal.timeout(15000) }),
-      stealthFetch('https://api.airplanes.live/v2/ladd',         { signal: AbortSignal.timeout(15000) }),
-      stealthFetch('https://api.airplanes.live/v2/pia',          { signal: AbortSignal.timeout(15000) }),
-      stealthFetch('https://api.airplanes.live/v2/squawk/7700',  { signal: AbortSignal.timeout(15000) }),
-      stealthFetch('https://api.adsb.lol/v2/mil',                { signal: AbortSignal.timeout(15000) }),
-      stealthFetch('https://api.adsb.lol/v2/ladd',               { signal: AbortSignal.timeout(15000) }),
-      stealthFetch('https://api.adsb.lol/v2/pia',                { signal: AbortSignal.timeout(15000) }),
-      stealthFetch('https://api.adsb.lol/v2/squawk/7700',        { signal: AbortSignal.timeout(15000) }),
+    const [milRes, osRes] = await Promise.allSettled([
+      stealthFetch(`${ADSBFI_BASE}/mil`, { signal: AbortSignal.timeout(15000) }),
       skipOpenSky
         ? Promise.reject(new Error('OpenSky in cooldown'))
         : stealthFetch('https://opensky-network.org/api/states/all', osInit),
     ]);
 
-    // Drain global type feeds — parse ok responses, discard body on non-ok to free TCP connections.
-    // Covers: military, LADD (limited display), PIA (privacy ICAO), and emergency squawk 7700
-    // from two independent feeder networks (airplanes.live + adsb.lol).
-    const globalFeeds = await Promise.allSettled(
-      [apl_mil, apl_ladd, apl_pia, apl_emg, lol_mil, lol_ladd, lol_pia, lol_emg].map(async r => {
-        if (r.status !== 'fulfilled') return;
-        if (r.value.ok) {
-          const data = await r.value.json();
+    // Drain the military feed — parse on ok, discard the body otherwise to free the connection.
+    if (milRes.status === 'fulfilled') {
+      if (milRes.value.ok) {
+        try {
+          const data = await milRes.value.json();
           ingestAc(data.ac || [], allRaw, seenHex);
-        } else {
-          await r.value.body?.cancel();
+        } catch (e) {
+          console.warn('[OSIRIS] adsb.fi mil parse error:', e);
         }
-      })
-    );
-    void globalFeeds; // allSettled — errors already isolated per feed
+      } else {
+        console.warn('[OSIRIS] adsb.fi mil feed returned', milRes.value.status);
+        await milRes.value.body?.cancel();
+      }
+    }
+    const milCount = allRaw.length;
 
-    // Process OpenSky states
-    let openSkyWorked = false;
+    // Refresh the OpenSky snapshot when one was due; otherwise the existing one
+    // carries over untouched.
     if (osRes.status === 'fulfilled') {
       if (osRes.value.status === 429) {
         openSkyCooldownUntil = Date.now() + OPENSKY_COOLDOWN;
@@ -295,56 +322,57 @@ export async function GET() {
           const data = await osRes.value.json();
           const states = data.states || [];
           if (states.length > 100) {
-            openSkyWorked = true;
-            for (const s of states) {
-              const hex = (s[0] || '').toLowerCase().trim();
-              if (hex && !seenHex.has(hex)) {
-                seenHex.add(hex);
-                allRaw.push({
-                  hex: s[0],
-                  flight: s[1]?.trim(),
-                  lon: s[5],
-                  lat: s[6],
-                  alt_baro: typeof s[7] === 'number' ? s[7] * 3.28084 : null,
-                  gs: typeof s[9] === 'number' ? s[9] * 1.94384 : null,
-                  track: s[10],
-                  squawk: s[14],
-                  category_os: s[17],
-                });
-              }
-            }
+            osSnapshot = states.map((s: any[]) => ({
+              hex: s[0],
+              flight: s[1]?.trim(),
+              lon: s[5],
+              lat: s[6],
+              alt_baro: typeof s[7] === 'number' ? s[7] * 3.28084 : null,
+              gs: typeof s[9] === 'number' ? s[9] * 1.94384 : null,
+              track: s[10],
+              squawk: s[14],
+              category_os: s[17],
+            }));
+            osSnapshotTime = Date.now();
           }
         } catch (e) {
           console.warn('[OSIRIS] OpenSky parse error:', e);
         }
       } else {
+        // A rejected token surfaces here as a 401 — previously discarded silently.
+        console.warn('[OSIRIS] OpenSky returned', osRes.value.status);
         await osRes.value.body?.cancel();
       }
     }
 
-    // ── Phase 3: Regional fallback (when OpenSky unavailable) ─────────────────
-    // airplanes.live + adsb.lol are independent feeder networks. Tested:
-    // airplanes.live gives ~6 K aircraft across 30 regions, adsb.lol adds
-    // ~650 more unique on top — combined ~6.8 K from zero keys.
+    ingestAc(osSnapshot, allRaw, seenHex);
+    const openSkyWorked = osSnapshot.length > 0;
+
+    // ── Phase 3: Regional sweep — last resort only ────────────────────────────
+    // Runs only when there is no OpenSky snapshot at all, never as the steady
+    // state. adsb.fi's geographic endpoint is metered far more tightly than its
+    // /mil feed and answers 200 with an empty ac[] once that budget is spent
+    // rather than 429, so sweeping it every cycle would quietly exhaust it and
+    // look like empty airspace. Paced at ~1 req/s; 30 regions ≈ 33s, inside the
+    // 60s maxDuration above.
     if (!openSkyWorked) {
       source = 'regional';
-      console.warn('[OSIRIS] OpenSky unavailable — fanning out 30×2 regional queries');
+      console.warn('[OSIRIS] no OpenSky snapshot — falling back to adsb.fi regional sweep');
 
-      const aplFn = (la: number, lo: number, d: number) => `https://api.airplanes.live/v2/point/${la}/${lo}/${d}`;
-      const lolFn = (la: number, lo: number, d: number) => `https://api.adsb.lol/v2/point/${la}/${lo}/${d}`;
+      for (const r of REGIONS) {
+        ingestAc(await fetchAdsbFiRegion(r.lat, r.lon), allRaw, seenHex);
+        await new Promise(resolve => setTimeout(resolve, ADSBFI_GAP_MS));
+      }
 
-      const [aplResults, lolResults] = await Promise.all([
-        Promise.allSettled(REGIONS.map(r => fetchRegionFrom(r.lat, r.lon, aplFn, 'ac'))),
-        Promise.allSettled(REGIONS.map(r => fetchRegionFrom(r.lat, r.lon, lolFn, 'ac'))),
-      ]);
-
-      for (const results of [aplResults, lolResults]) {
-        for (const r of results) {
-          if (r.status === 'fulfilled') ingestAc(r.value, allRaw, seenHex);
-        }
+      if (allRaw.length === 0) {
+        console.error(
+          '[OSIRIS] every flight provider returned zero aircraft — ' +
+          'set OPENSKY_CLIENT_ID/OPENSKY_CLIENT_SECRET (free at opensky-network.org); ' +
+          'the anonymous 400 credits/day pool cannot sustain a live map'
+        );
       }
     } else {
-      source = osToken ? 'opensky-auth' : 'opensky-anon';
+      source = hasOpenSkyCreds() ? 'opensky-auth' : 'opensky-anon';
     }
 
     // ── Classify ──────────────────────────────────────────────────────────────
@@ -378,6 +406,15 @@ export async function GET() {
       gps_jamming:        aggregateJamming(gpsJamming, JAMMING_NACAP_THRESHOLD),
       total:              allRaw.length,
       source,
+      // Per-feed counts so a provider that starts answering 200 with no aircraft
+      // is visible in the payload rather than silently emptying the map.
+      providers: {
+        adsbfi_mil:      milCount,
+        adsbfi_regional: openSkyWorked ? 0 : allRaw.length - milCount,
+        opensky:         osSnapshot.length,
+        opensky_auth:    hasOpenSkyCreds(),
+        opensky_age_s:   osSnapshotTime ? Math.round((Date.now() - osSnapshotTime) / 1000) : null,
+      },
       timestamp:          new Date().toISOString(),
     };
   })();


### PR DESCRIPTION
## What was happening

`/api/flights` returned **HTTP 200 with an empty payload**, so the map drew no aircraft:

```json
{"commercial_flights":[],"military_flights":[],"total":0,"source":"regional"}
```

`source: "regional"` means OpenSky had failed *and* the regional fallback returned nothing either.

## Why

Three failures stacked up, and every one of them was silent:

| Provider | Status | Effect |
|---|---|---|
| `api.airplanes.live` | **403** on every endpoint (now key-gated) | 4 global feeds + 30 of 60 regional queries returned nothing. Non-ok bodies were discarded without logging. |
| `api.adsb.lol/v2` | **200** with `{"ac":[],"total":0}` on every endpoint | The other half of the fanout. An empty `ac[]` is indistinguishable from quiet airspace. |
| OpenSky | **429 → permanent cooldown** | Polled anonymously on the 90s TTL. |

The 90s TTL was sized for OpenSky's *authenticated* budget (4000 credits/day ÷ 4 per call ≈ one per 86s). The **anonymous** pool is 400/day — about 100 calls. At 90s that budget is gone in roughly half an hour, after which every call 429s into the 15-minute cooldown. No credentials are configured in production, so the route lived permanently in the fallback branch — and the fallback was the two dead providers.

`api.adsb.one` was also checked as a replacement: 403.

## The fix

- **Replaces both dead providers with `adsb.fi`**, the remaining free feed on the same tar1090/ADSBexchange-v2 shape, so `classifyFlight()` is untouched.
- **`/mil` runs every cycle.** Its geographic endpoint is metered far more tightly and *also* degrades to an empty `ac[]` rather than 429, so the 30-region sweep is now a **last resort** rather than the steady state — sweeping it every cycle would quietly exhaust it and look like empty airspace.
- **The sweep is paced at ~1 req/s** instead of fired in parallel. Parallel produced 30 successful-looking empty responses.
- **OpenSky gets its own interval, separate from the response cache**: 90s with credentials, 900s without, to stay inside whichever budget applies. The last good snapshot is retained and reused between calls, so the map doesn't swing between ~10K aircraft and a few hundred every 90s.
- **Observability**: per-provider counts in the response, plus logs on the paths that were silent — a non-ok OpenSky status (a rejected token surfaces here as a 401), a non-ok mil feed, and an all-providers-empty result. That silence is why this rotted unnoticed.

## Verification

Before: `total: 0`, nothing on the map.

After, locally:

```json
{"source":"opensky-anon","total":6573,
 "providers":{"adsbfi_mil":207,"opensky":6469,"opensky_auth":false,"opensky_age_s":0}}
```

6,289 commercial + 137 military rendering on the map; the Layers panel reports **AIR: 6,426**. `tsc --noEmit` clean; `eslint` shows only the file's pre-existing `no-explicit-any` style errors (13 on master, and the 2 added match the surrounding code).

## Follow-up for production

Set `OPENSKY_CLIENT_ID` / `OPENSKY_CLIENT_SECRET` (free at opensky-network.org — already listed in `.env.example`). The anonymous 400 credits/day pool cannot sustain a live map on its own; with credentials the route runs OpenSky at the full 90s refresh.

Generated with SIMPLIFAI — https://Simplifai-1.com