### PR TITLE
fix(flights): classify aircraft instead of dumping all 13K into commercial

### DIFF
--- a/src/app/api/flights/route.ts
+++ b/src/app/api/flights/route.ts
@@ -82,6 +82,34 @@ const MILITARY_INDICATORS = new Set([
 
 const AIRLINE_CODE_RE = /^([A-Z]{3})\d/;
 
+// Scheduled-airline ICAO type codes. Only ever usable on the adsb.fi feed —
+// OpenSky state vectors carry no aircraft type at all.
+const AIRLINER_TYPES = new Set([
+  'A319','A320','A321','A332','A333','A339','A343','A359','A388',
+  'B737','B738','B739','B38M','B39M','B752','B753','B763','B764',
+  'B772','B77L','B77W','B788','B789','B78X',
+  'E170','E175','E190','E195','CRJ7','CRJ9','AT43','AT72','DH8D',
+]);
+
+// Fractional-ownership and executive-charter operators. These file airline-style
+// ICAO callsigns (NJE880U, EJA512), so callsign shape alone reads them as
+// scheduled traffic when they are in fact business jets.
+const BIZAV_OPERATORS = new Set([
+  'EJA','EJM','NJE','LXJ','VJT','JTL','XOJ','WUP','OPT','GAJ','DCM',
+]);
+
+// An aircraft only shows a jet profile in cruise: the same Gulfstream on approach
+// at 6000 ft and 200 kt is indistinguishable from a light single on performance
+// alone. Remembering hexes that have shown one keeps a flight in a single bucket
+// for the whole descent instead of flipping between polls.
+const jetHexes = new Set<string>();
+const JET_HEX_CAP = 20000;
+function rememberJet(hex: string) {
+  if (!hex) return;
+  if (jetHexes.size >= JET_HEX_CAP) jetHexes.clear();
+  jetHexes.add(hex);
+}
+
 // adsb.fi is the last free tar1090/ADSBexchange-v2 shaped feed still serving
 // data without an API key, so classifyFlight() works on it unchanged. The two
 // providers this route used to fan out to have both stopped returning aircraft:
@@ -150,20 +178,54 @@ function classifyFlight(f: any) {
   const isHeli = HELI_TYPES.has(modelUpper) || f.category_os === 8;
   const isGrounded = typeof altRaw === 'number' && altRaw < 100;
 
-  const isOsMilitary = f.category_os === 14;
+  // 14 is "UAV". 13 is reserved in the ADS-B spec and is what military
+  // transponders emit in practice: all 150 aircraft carrying it in a live
+  // snapshot were military — GLOCK, SUNDG, SENTRY, PAT, SPAR, NATO42, CFC,
+  // CTM, IAM — with no civilian entry among them. It catches the fleets the
+  // callsign list below misses, and only exists because of extended=1.
+  const isOsMilitary = f.category_os === 14 || f.category_os === 13;
+  // 3 = "Small" (15,500–75,000 lb), 7 = "High Performance". Both are turbine
+  // signatures, but only meaningful once the callsign has ruled out an airline.
   const isOsJet = f.category_os === 7 || f.category_os === 3;
-  const isOsPrivate = f.category_os === 2;
 
-  const airlineMatch = AIRLINE_CODE_RE.exec(callsign);
+  // Match on the transmitted callsign, not on `callsign`, which falls back to the
+  // hex when nothing was transmitted — a hex is not evidence of an operator.
+  const airlineMatch = AIRLINE_CODE_RE.exec(flightStr);
   const airlineCode = airlineMatch ? airlineMatch[1] : '';
+  const isBizav = BIZAV_OPERATORS.has(airlineCode);
+
+  // Three letters then a digit is the ICAO scheduled-callsign shape. Registrations
+  // — N387A, SPWTW, OEKWJ, CFUTP — never take it, and that is the whole basis of
+  // the split on an OpenSky-only feed: ~95% of its aircraft report ADS-B emitter
+  // category 0 ("no information"), so the category field cannot carry it.
+  const isAirline = Boolean(airlineCode) && !isBizav;
+
+  // Separates business jets from light aircraft when no type is available.
+  // FL280 above 300 kt is a turbine profile — unpressurised piston GA cannot get
+  // there. The flat 350 kt clause covers the climb and descent, where a jet
+  // spends much of its flight below FL280 and would otherwise read as a light
+  // single: every non-airline aircraft over 350 kt in a live snapshot was a
+  // business jet or a military type, none were piston GA.
+  const altFeet = typeof altRaw === 'number' ? altRaw : 0;
+  const kts = speedKnots || 0;
+  const jetProfile = (altFeet > 28000 && kts > 300) || kts > 350;
+
+  const hex = (f.hex || '').toLowerCase();
 
   let category: 'commercial' | 'private' | 'jet' | 'military' = 'commercial';
-  if (isOsMilitary || dbFlags & 1 || MILITARY_INDICATORS.has(modelUpper) || (f.flight || '').match(/^(RCH|KING|DUKE|EVAC|JAKE|REACH|CONVOY)\d/i)) {
+  if (isOsMilitary || dbFlags & 1 || MILITARY_INDICATORS.has(modelUpper) || /^(RCH|KING|DUKE|EVAC|JAKE|REACH|CONVOY)\d/.test(flightStr)) {
     category = 'military';
-  } else if (isOsJet || PRIVATE_JET_TYPES.has(modelUpper)) {
+  } else if (isBizav || PRIVATE_JET_TYPES.has(modelUpper)) {
     category = 'jet';
-  } else if (isOsPrivate || (!airlineCode && modelUpper && !['A319','A320','A321','A332','A333','A339','A343','A359','A388','B737','B738','B739','B38M','B39M','B752','B753','B763','B764','B772','B77L','B77W','B788','B789','B78X','E170','E175','E190','E195','CRJ7','CRJ9','AT43','AT72','DH8D'].includes(modelUpper))) {
-    category = 'private';
+    rememberJet(hex);
+  } else if (!isAirline && (flightStr || modelUpper) && !AIRLINER_TYPES.has(modelUpper)) {
+    // No airline callsign, and not a known airliner type — general aviation.
+    if (isOsJet || jetProfile || jetHexes.has(hex)) {
+      category = 'jet';
+      rememberJet(hex);
+    } else {
+      category = 'private';
+    }
   }
 
   return {
@@ -318,7 +380,11 @@ export async function GET() {
       stealthFetch(`${ADSBFI_BASE}/mil`, { signal: AbortSignal.timeout(15000), cache: 'no-store' as any }),
       skipOpenSky
         ? Promise.reject(new Error('OpenSky in cooldown'))
-        : stealthFetch('https://opensky-network.org/api/states/all', { ...osInit, cache: 'no-store' as any }),
+        // extended=1 is what makes s[17] exist at all. Without it the API returns
+        // 17-element state vectors and every category_os read below was undefined,
+        // so the emitter-category branches of classifyFlight had never once run.
+        // It does not change the credit cost — /states/all is billed by area.
+        : stealthFetch('https://opensky-network.org/api/states/all?extended=1', { ...osInit, cache: 'no-store' as any }),
     ]);
 
     // Drain the military feed — parse on ok, discard the body otherwise to free the connection.

--- a/src/app/api/flights/route.ts
+++ b/src/app/api/flights/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server';
 import { stealthFetch } from '@/lib/stealthFetch';
 
+export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
 // 30 regions covering every major aviation corridor at 250 nm radius.
@@ -94,10 +95,24 @@ const AIRLINE_CODE_RE = /^([A-Z]{3})\d/;
 const ADSB_MAX_DIST = 250; // nm — hard cap the provider enforces
 const ADSBFI_BASE = 'https://opendata.adsb.fi/api/v2';
 
-// adsb.fi allows roughly one request per second and soft-throttles over that by
-// returning 200 with an empty ac[] rather than 429, so a parallel fanout looks
-// like it succeeded while returning nothing. The regional sweep is paced.
+// adsb.fi soft-throttles by returning 200 with an empty ac[] rather than 429, so
+// an over-budget request looks like it succeeded while returning nothing.
+//
+// Its /mil feed and its geographic endpoint are metered separately, and the
+// geographic one is metered very tightly: measured against the live API, an
+// isolated query returns ~217 aircraft, but a single 30-region sweep paced at
+// one request per 1.1s returns 0 from all 30, and stays at 0 for tens of
+// minutes afterwards — 18 further requests spread over the following 6 minutes
+// all came back empty. It tolerates a handful of calls per hour, not polling.
+//
+// So the sweep cannot carry commercial traffic, and running it every cycle
+// (which is what happens with no OpenSky credentials) just keeps the server
+// permanently in that penalty box and spends ~35s of the 60s budget for nothing.
+// It is rate-limited here to a genuine outage fallback. Commercial coverage
+// comes from OpenSky, which needs credentials — see the note below.
 const ADSBFI_GAP_MS = 1100;
+const REGIONAL_SWEEP_INTERVAL = 30 * 60 * 1000; // 30 min
+let lastRegionalSweep = 0;
 
 // adsb.fi serves /mil but returns 400 for /ladd, /pia and /squawk/{code},
 // so the global type feeds collapse to the military one.
@@ -105,6 +120,7 @@ async function fetchAdsbFiRegion(lat: number, lon: number): Promise<any[]> {
   try {
     const res = await stealthFetch(`${ADSBFI_BASE}/lat/${lat}/lon/${lon}/dist/${ADSB_MAX_DIST}`, {
       signal: AbortSignal.timeout(12000),
+      cache: 'no-store' as any,
     });
     if (res.ok) {
       const data = await res.json();
@@ -288,10 +304,10 @@ export async function GET() {
       : { signal: AbortSignal.timeout(30000) };
 
     const [milRes, osRes] = await Promise.allSettled([
-      stealthFetch(`${ADSBFI_BASE}/mil`, { signal: AbortSignal.timeout(15000) }),
+      stealthFetch(`${ADSBFI_BASE}/mil`, { signal: AbortSignal.timeout(15000), cache: 'no-store' as any }),
       skipOpenSky
         ? Promise.reject(new Error('OpenSky in cooldown'))
-        : stealthFetch('https://opensky-network.org/api/states/all', osInit),
+        : stealthFetch('https://opensky-network.org/api/states/all', { ...osInit, cache: 'no-store' as any }),
     ]);
 
     // Drain the military feed — parse on ok, discard the body otherwise to free the connection.
@@ -348,27 +364,30 @@ export async function GET() {
     ingestAc(osSnapshot, allRaw, seenHex);
     const openSkyWorked = osSnapshot.length > 0;
 
-    // ── Phase 3: Regional sweep — last resort only ────────────────────────────
-    // Runs only when there is no OpenSky snapshot at all, never as the steady
-    // state. adsb.fi's geographic endpoint is metered far more tightly than its
-    // /mil feed and answers 200 with an empty ac[] once that budget is spent
-    // rather than 429, so sweeping it every cycle would quietly exhaust it and
-    // look like empty airspace. Paced at ~1 req/s; 30 regions ≈ 33s, inside the
-    // 60s maxDuration above.
+    // ── Phase 3: Regional sweep — rate-limited outage fallback ────────────────
+    // Only when there is no OpenSky snapshot at all, and at most once every
+    // 30 minutes for the reasons documented on REGIONAL_SWEEP_INTERVAL. Without
+    // that gate this runs on every cache miss, which is exactly the state a
+    // deployment with no OpenSky credentials sits in permanently.
     if (!openSkyWorked) {
       source = 'regional';
-      console.warn('[OSIRIS] no OpenSky snapshot — falling back to adsb.fi regional sweep');
 
-      for (const r of REGIONS) {
-        ingestAc(await fetchAdsbFiRegion(r.lat, r.lon), allRaw, seenHex);
-        await new Promise(resolve => setTimeout(resolve, ADSBFI_GAP_MS));
+      if (Date.now() - lastRegionalSweep >= REGIONAL_SWEEP_INTERVAL) {
+        lastRegionalSweep = Date.now();
+        console.warn('[OSIRIS] no OpenSky snapshot — attempting adsb.fi regional sweep');
+
+        for (const r of REGIONS) {
+          ingestAc(await fetchAdsbFiRegion(r.lat, r.lon), allRaw, seenHex);
+          await new Promise(resolve => setTimeout(resolve, ADSBFI_GAP_MS));
+        }
       }
 
-      if (allRaw.length === 0) {
+      if (allRaw.length === milCount) {
         console.error(
-          '[OSIRIS] every flight provider returned zero aircraft — ' +
-          'set OPENSKY_CLIENT_ID/OPENSKY_CLIENT_SECRET (free at opensky-network.org); ' +
-          'the anonymous 400 credits/day pool cannot sustain a live map'
+          '[OSIRIS] no commercial traffic — only adsb.fi military is reporting. ' +
+          'Set OPENSKY_CLIENT_ID/OPENSKY_CLIENT_SECRET (free at opensky-network.org); ' +
+          'anonymous OpenSky is 400 credits/day and is refused outright from many ' +
+          'hosting IPs, and adsb.fi geographic queries cannot be polled.'
         );
       }
     } else {

--- a/src/app/api/flights/route.ts
+++ b/src/app/api/flights/route.ts
@@ -212,6 +212,16 @@ const openSkyInterval = () => (hasOpenSkyCreds() ? 90000 : 900000);
 // on screen stable; only their age varies, which providers.opensky_age_s reports.
 let osSnapshot: any[] = [];
 let osSnapshotTime = 0;
+
+// The interval has to be measured from the last *attempt*, not the last success.
+// Measuring it from osSnapshotTime only throttles OpenSky once it has already
+// worked: while it is failing, osSnapshotTime stays put, every cache miss looks
+// due, and the route retries on all of them — ~960 calls a day against a 400
+// credit anonymous budget. A deployment that starts out unable to reach OpenSky
+// therefore never recovers, because it spends each day's quota re-failing and
+// the quota never gets a chance to cover a real request. Throttling attempts
+// holds anonymous to ~96 calls (384 credits) a day, inside the budget.
+let lastOpenSkyAttempt = 0;
 let fetchPromise: Promise<any> | null = null;
 
 // Back off from OpenSky after a 429 so the daily quota can reset.
@@ -297,7 +307,8 @@ export async function GET() {
     // anonymous OpenSky snapshot is waiting out its interval.
     const skipOpenSky =
       Date.now() < openSkyCooldownUntil ||
-      Date.now() - osSnapshotTime < openSkyInterval();
+      Date.now() - lastOpenSkyAttempt < openSkyInterval();
+    if (!skipOpenSky) lastOpenSkyAttempt = Date.now();
     const token = skipOpenSky ? null : await getOpenSkyToken();
     const osInit: RequestInit = token
       ? { signal: AbortSignal.timeout(30000), headers: { Authorization: `Bearer ${token}` } }
@@ -359,6 +370,11 @@ export async function GET() {
         console.warn('[OSIRIS] OpenSky returned', osRes.value.status);
         await osRes.value.body?.cancel();
       }
+    } else if (!skipOpenSky) {
+      // A genuine attempt that never got a response — DNS, TLS, timeout, or the
+      // host refusing the connection. Distinct from the deliberate skip, which
+      // rejects with a sentinel and must not be reported as a provider failure.
+      console.warn('[OSIRIS] OpenSky request failed:', osRes.reason);
     }
 
     ingestAc(osSnapshot, allRaw, seenHex);
@@ -433,6 +449,9 @@ export async function GET() {
         opensky:         osSnapshot.length,
         opensky_auth:    hasOpenSkyCreds(),
         opensky_age_s:   osSnapshotTime ? Math.round((Date.now() - osSnapshotTime) / 1000) : null,
+        // Separates "not tried recently" from "tried and failed", which is the
+        // distinction needed to tell a throttled deployment from a blocked one.
+        opensky_tried_s: lastOpenSkyAttempt ? Math.round((Date.now() - lastOpenSkyAttempt) / 1000) : null,
       },
       timestamp:          new Date().toISOString(),
     };


### PR DESCRIPTION
## The problem

Private and Private Jets were empty layers while Commercial held every aircraft on the map — ~13,000 in one bucket, 0 and 0 in the other two.

## Root cause

Two stacked faults, both silent:

**1. The OpenSky call never asked for the category field.** `/states/all` returns 17-element state vectors; `s[17]` only exists with `?extended=1`. So `category_os` was `undefined` on every aircraft, and the `isOsJet` / `isOsPrivate` / `isOsMilitary` branches had never once executed.

**2. The fallback needed an aircraft type OpenSky does not send.** The private test was gated on `modelUpper &&`, but state vectors carry no type at all — always falsy, so everything fell through to `commercial`. Only the small adsb.fi `/mil` feed carries types, which is why Military worked and nothing else did.

## Why enabling `extended=1` is not the whole fix

Measured against the live API: **94.7% of aircraft report emitter category 0, "no information"**. The category field cannot carry the split.

Callsign shape can. Three letters then a digit is the ICAO scheduled form, and registrations never take it — 9,265 airline-like (`AAL872`) vs 3,837 registration-like (`N387A`, `SPWTW`, `OEKWJ`) in a live snapshot. Fractional operators (NetJets, Flexjet, VistaJet) file airline callsigns, so they are pulled out by operator code.

## Two refinements from checking the first result against real data

- **Emitter category 13 is a military tell.** Spec-reserved, and all 150 aircraft carrying it in a snapshot were military — `GLOCK`, `SUNDG`, `SENTRY`, `PAT`, `SPAR`, `NATO42`, `CFC`, `CTM`, `IAM` — with no civilian entry. Without this, `GLOCK71` was landing in Private at 513 kt. This signal only exists because of `extended=1`.
- **Business jets spend much of a flight below FL280**, where a pure altitude gate reads them as light singles. Every non-airline aircraft over 350 kt below FL280 was a business jet (`N801QS`, `N694QS` — NetJets) or military, none piston GA — so a flat 350 kt clause joins the FL280/300 kt one. A `jetHexes` memo keeps a jet from flipping to Private as it descends.

## Result

| Layer | Before | After |
|---|---|---|
| Commercial | ~13,000 | 9,030 |
| Private | **0** | **3,194** |
| Private Jets | **0** | **747** |
| Military | ~350 | 359 |

Private is now genuinely light GA (`N7801K@351ft/72kt`, `CGBGA@1699ft/81kt`); jets are `N387A@36975ft/422kt`, `EJA598`, `LXJ411`.

## Verification

- Fetched the real route end to end through the running dev server, and again from the browser client on the page's own origin — all four layer keys populated.
- `tsc --noEmit` clean on this file (pre-existing failures elsewhere in `WorldRemote.tsx`, `AstraPanel.tsx`, `cctv/proxy`, `page.tsx` are untouched).
- Full vitest suite: 186 passed, 5 skipped.

No UI changes were needed — `LayerPanel` and `OsirisMap` already read these four keys.

## Known limits

- ~189 aircraft transmit no callsign at all and stay in Commercial; there is no evidence to classify them on.
- The business-aviation operator list is partial. Unlisted fractional operators stay Commercial — same as current behaviour, so no regression.

## Note on scope

This branch also carries the two earlier `fix(flights)` commits (`1f50bde`, `25fe78b`) that were on local `master` but never pushed. They touch the same file and this work builds directly on them, so they cannot be separated out.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
