### PR TITLE
fix(incidents): link Global Incidents to their real source, not liveuamap Ukraine

### DIFF
--- a/src/app/api/gdelt/route.ts
+++ b/src/app/api/gdelt/route.ts
@@ -59,12 +59,18 @@ export async function GET() {
       const lng = parseFloat(lngMatch[1]);
       const eventType = typeMatch ? typeMatch[1] : 'UNK';
 
-      // Map GDACS event types to Osiris types
-      let type = 'conflict';
+      // Map GDACS event types to Osiris types. WF and DR used to fall through
+      // to the 'conflict' default, which is most of the feed — a live sample
+      // was 330 wildfires and 12 droughts out of 369 events, all of them
+      // reaching the map labelled as conflicts. Unknown types are 'incident'
+      // now; nothing in this feed is a conflict, it is a disaster alert feed.
+      let type = 'incident';
       if (eventType === 'EQ') type = 'earthquake';
       else if (eventType === 'TC') type = 'weather';
-      else if (eventType === 'FL') type = 'weather';
+      else if (eventType === 'FL') type = 'flood';
       else if (eventType === 'VO') type = 'volcano';
+      else if (eventType === 'WF') type = 'wildfire';
+      else if (eventType === 'DR') type = 'drought';
 
       allEvents.push({
         id: `gdacs-${eventId++}`,

--- a/src/app/api/gdelt/route.ts
+++ b/src/app/api/gdelt/route.ts
@@ -10,6 +10,20 @@ export const dynamic = 'force-dynamic';
  * Replaces the old RSS scraper with actual GDELT geo-coded events.
  */
 
+// RSS carries its payload XML-escaped, so every GDACS report link arrives as
+// report.aspx?eventtype=EQ&amp;eventid=… . That form resolves to a generic
+// page — GDACS reads the parameter as "amp;eventid" and serves no event — so
+// the entities have to be decoded before the URL is handed to a client.
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
 export async function GET() {
   try {
     const res = await fetch('https://www.gdacs.org/xml/rss.xml', {
@@ -38,9 +52,9 @@ export async function GET() {
 
       if (!titleMatch || !latMatch || !lngMatch) continue;
 
-      const title = titleMatch[1];
-      const link = linkMatch ? linkMatch[1] : '';
-      const desc = descMatch ? descMatch[1] : '';
+      const title = decodeEntities(titleMatch[1]);
+      const link = decodeEntities(linkMatch ? linkMatch[1] : '');
+      const desc = decodeEntities(descMatch ? descMatch[1] : '');
       const lat = parseFloat(latMatch[1]);
       const lng = parseFloat(lngMatch[1]);
       const eventType = typeMatch ? typeMatch[1] : 'UNK';

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -997,11 +997,23 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       // instead, which sent every event outside the six hardcoded boxes — all
       // of the Americas, Asia and Oceania among them — to the Ukraine map.
       const src = urlSafe(p.url);
+      // GDACS is a natural-disaster feed. Every event here was headed
+      // "CONFLICT EVENT" — on a live sample that mislabelled 342 of 369
+      // events, nearly all of them wildfires.
+      const KIND: Record<string, [string, string]> = {
+        earthquake: ['🌐 EARTHQUAKE',   '#FF9500'],
+        wildfire:   ['🔥 WILDFIRE',     '#FF6B1A'],
+        flood:      ['🌊 FLOOD',        '#00B0FF'],
+        weather:    ['🌀 TROPICAL CYCLONE', '#00E5FF'],
+        volcano:    ['🌋 VOLCANO',      '#FF3D3D'],
+        drought:    ['☀️ DROUGHT',      '#FFD500'],
+      };
+      const [kindLabel, kindColor] = KIND[String(p.kind)] ?? ['⚠️ GLOBAL INCIDENT', '#FF3D3D'];
 
-      popup(coords, `<div style="${pStyle}border:1px solid rgba(255,61,61,0.3);">
-        <div style="color:#FF3D3D;font-size:12px;font-weight:700;margin-bottom:6px;">⚠️ CONFLICT EVENT</div>
+      popup(coords, `<div style="${pStyle}border:1px solid ${kindColor}4d;">
+        <div style="color:${kindColor};font-size:12px;font-weight:700;margin-bottom:6px;">${kindLabel}</div>
         <div style="font-size:9px;color:#E8E6E0;margin-bottom:8px;line-height:1.4;">${htmlEsc(p.name||'Unclassified incident')}</div>
-        ${src !== '#' ? `<a href="${src}" target="_blank" rel="noopener noreferrer" style="${linkStyle}flex:1;text-align:center;color:#FF3D3D;border:1px solid rgba(255,61,61,0.4);background:rgba(255,61,61,0.15);display:inline-block;width:100%;box-sizing:border-box;margin-top:4px;">[ OPEN SOURCE ↗ ]</a>` : ''}
+        ${src !== '#' ? `<a href="${src}" target="_blank" rel="noopener noreferrer" style="${linkStyle}flex:1;text-align:center;color:${kindColor};border:1px solid ${kindColor}66;background:${kindColor}26;display:inline-block;width:100%;box-sizing:border-box;margin-top:4px;">[ OPEN SOURCE ↗ ]</a>` : ''}
       </div>`);
     });
 
@@ -1441,7 +1453,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     // url has to travel with the feature: /api/gdelt gives every event its own
     // GDACS report link, and dropping it here is what left the popup with
     // nothing to link to.
-    setGeo('gdelt', activeLayers.global_incidents && data.gdelt ? data.gdelt.map((e: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [e.lng, e.lat] }, properties: { name: e.name, url: e.url } })) : []);
+    setGeo('gdelt', activeLayers.global_incidents && data.gdelt ? data.gdelt.map((e: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [e.lng, e.lat] }, properties: { name: e.name, url: e.url, kind: e.type } })) : []);
   }, [mapReady, data.gdelt, activeLayers.global_incidents, setGeo]);
 
   /* ── GDELT 2.0 Events ── */

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -992,23 +992,16 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       const p = e.features[0].properties as any;
       const coords = (e.features[0].geometry as any).coordinates;
       
-      // Map coordinates to Liveuamap regions
-      let sourceUrl = p.url || '';
-      if (!sourceUrl || sourceUrl.includes('google.com')) {
-        const [lng, lat] = coords;
-        if (lat > 44 && lat < 53 && lng > 22 && lng < 40) sourceUrl = 'https://liveuamap.com/'; // Ukraine
-        else if (lat > 30 && lat < 33 && lng > 34 && lng < 36) sourceUrl = 'https://israelpalestine.liveuamap.com/'; // Gaza
-        else if (lat > 33 && lat < 34.5 && lng > 35 && lng < 36.5) sourceUrl = 'https://lebanon.liveuamap.com/'; // Lebanon
-        else if (lat > 32 && lat < 37 && lng > 35 && lng < 42) sourceUrl = 'https://syria.liveuamap.com/'; // Syria
-        else if (lat > 10 && lat < 22 && lng > 22 && lng < 38) sourceUrl = 'https://sudan.liveuamap.com/'; // Sudan
-        else if (lat > 12 && lat < 20 && lng > 42 && lng < 55) sourceUrl = 'https://yemen.liveuamap.com/'; // Yemen
-        else sourceUrl = 'https://liveuamap.com/'; // Global fallback
-      }
+      // These are GDACS alerts and each one carries its own report URL. This
+      // used to guess a Liveuamap regional war map from the coordinates
+      // instead, which sent every event outside the six hardcoded boxes — all
+      // of the Americas, Asia and Oceania among them — to the Ukraine map.
+      const src = urlSafe(p.url);
 
       popup(coords, `<div style="${pStyle}border:1px solid rgba(255,61,61,0.3);">
         <div style="color:#FF3D3D;font-size:12px;font-weight:700;margin-bottom:6px;">⚠️ CONFLICT EVENT</div>
         <div style="font-size:9px;color:#E8E6E0;margin-bottom:8px;line-height:1.4;">${htmlEsc(p.name||'Unclassified incident')}</div>
-        <a href="${urlSafe(sourceUrl)}" target="_blank" style="${linkStyle}flex:1;text-align:center;color:#FF3D3D;border:1px solid rgba(255,61,61,0.4);background:rgba(255,61,61,0.15);display:inline-block;width:100%;box-sizing:border-box;margin-top:4px;">[ OPEN SOURCE ↗ ]</a>
+        ${src !== '#' ? `<a href="${src}" target="_blank" rel="noopener noreferrer" style="${linkStyle}flex:1;text-align:center;color:#FF3D3D;border:1px solid rgba(255,61,61,0.4);background:rgba(255,61,61,0.15);display:inline-block;width:100%;box-sizing:border-box;margin-top:4px;">[ OPEN SOURCE ↗ ]</a>` : ''}
       </div>`);
     });
 
@@ -1445,7 +1438,10 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
 
   useEffect(() => {
     if (!mapReady) return;
-    setGeo('gdelt', activeLayers.global_incidents && data.gdelt ? data.gdelt.map((e: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [e.lng, e.lat] }, properties: { name: e.name } })) : []);
+    // url has to travel with the feature: /api/gdelt gives every event its own
+    // GDACS report link, and dropping it here is what left the popup with
+    // nothing to link to.
+    setGeo('gdelt', activeLayers.global_incidents && data.gdelt ? data.gdelt.map((e: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [e.lng, e.lat] }, properties: { name: e.name, url: e.url } })) : []);
   }, [mapReady, data.gdelt, activeLayers.global_incidents, setGeo]);
 
   /* ── GDELT 2.0 Events ── */


### PR DESCRIPTION
Clicking any **Global Incidents** marker opened `liveuamap.com` — the Ukraine war map — regardless of what the event was or where it happened. A drought alert in Colombia linked to Ukraine.

Three separate defects, all on the same layer. Note this layer is backed by `/api/gdelt`, which despite its name serves **GDACS** natural-disaster alerts, not GDELT. (`GDELT Events` is a different layer and was already correct.)

## 1. The map dropped the URL, then invented one

`/api/gdelt` returns a per-event GDACS report link, but the feature built for the `gdelt` source carried only `{ name }`. So `p.url` in the click handler was always `undefined`, the handler read that as "no source available", and fell through to **guessing a Liveuamap regional war map from the coordinates**:

```js
if (lat > 44 && lat < 53 && lng > 22 && lng < 40) sourceUrl = 'https://liveuamap.com/';
...
else sourceUrl = 'https://liveuamap.com/'; // Global fallback
```

Only six boxes existed — Ukraine, Gaza, Lebanon, Syria, Sudan, Yemen — so **all of the Americas, Asia and Oceania** hit that final fallback.

The feature now carries `url` and the handler uses it, matching what the neighbouring `gdelt-events` handler already does — including **hiding the button** when there is genuinely no link, rather than inventing one.

## 2. The URLs were unusable even once carried

RSS delivers its payload XML-escaped, so every link arrived as `report.aspx?eventtype=EQ&amp;eventid=…`. That form **does not resolve to the event** — GDACS reads the parameter as `amp;eventid` and serves a generic page. Verified against the live site:

| URL form | bytes | contains the event |
|---|---|---|
| `…EQ&amp;eventid=1557839` | 53,472 | ❌ |
| `…EQ&eventid=1557839` | 57,041 | ✅ |

It happened to survive inside an `href` because HTML decodes entities on parse, which is why this stayed hidden — but the API payload was wrong for every other consumer. Entities are now decoded at the parse site, so `title` and `description` get the same treatment.

## 3. 93% of the layer was labelled "CONFLICT EVENT"

The type mapping covered only `EQ`, `TC`, `FL` and `VO`, letting everything else fall through to a `conflict` default. Wildfires and droughts aren't in that list — and they're most of the feed:

| GDACS type | count | was | now |
|---|---|---|---|
| WF wildfire | **330** | `conflict` | `wildfire` |
| FL flood | 14 | `weather` | `flood` |
| DR drought | **12** | `conflict` | `drought` |
| TC cyclone | 7 | `weather` | `weather` |
| EQ earthquake | 5 | `earthquake` | ✓ |
| VO volcano | 1 | `volcano` | ✓ |

**342 of 369 events** reached the map headed "⚠️ CONFLICT EVENT" with a red warning triangle. This is a disaster alert feed; nothing in it is a conflict. Unrecognised GDACS types now fall back to `incident` rather than `conflict`, and the popup titles and colours itself from the type — 🔥 WILDFIRE orange, ☀️ DROUGHT yellow, 🌊 FLOOD blue.

## Verified on localhost against the live feed

The exact event from the bug report:

```
name: Drought is on going in Colombia, , Ecuador, Panama, Venezuela
type: drought                                              (was: conflict)
url : gdacs.org/report.aspx?eventtype=DR&eventid=1023877   (was: liveuamap.com — Ukraine)
```

Fetching that URL returns **200, containing "Colombia", "Drought", and the event id**.

Across the layer: **369 events — 0 still typed `conflict`, 0 with an unresolvable URL.** 186 tests pass; no new type errors.

## Not addressed here

The layer key is still `global_incidents` and the endpoint is still called `/api/gdelt` while serving GDACS. Renaming either is a wider change than this fix warrants.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
