### PR TITLE
feat(recon): add Hudson Rock infostealer intelligence to the toolkit

### DIFF
--- a/src/app/api/osint/hudsonrock/route.ts
+++ b/src/app/api/osint/hudsonrock/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * OSIRIS — Hudson Rock Infostealer Intelligence
+ *
+ * Cavalier's free OSINT endpoints report whether an asset appears in Hudson
+ * Rock's infostealer corpus — machines compromised by Redline, Lumma, Vidar
+ * and friends, whose saved credentials are circulating. No key required.
+ *
+ * Credentials come back already redacted at source (`0**********e`, IPs as
+ * `202.9.**.**`), so nothing here needs further masking before display.
+ *
+ * Two response shapes, kept distinct rather than flattened:
+ *   person (email / username / phone) → { message, stealers[], total_* }
+ *   domain                            → org-wide counts, password strength
+ *                                       stats, third parties, stealer families
+ */
+
+const BASE = 'https://cavalier.hudsonrock.com/api/json/v2/osint-tools';
+
+export type AssetType = 'email' | 'domain' | 'username' | 'phone';
+
+// A phone number is looked up through the username endpoint — that is what
+// Hudson Rock exposes; there is no search-by-phone.
+const ENDPOINTS: Record<AssetType, { path: string; param: string }> = {
+  email:    { path: 'search-by-email',    param: 'email' },
+  domain:   { path: 'search-by-domain',   param: 'domain' },
+  username: { path: 'search-by-username', param: 'username' },
+  phone:    { path: 'search-by-username', param: 'username' },
+};
+
+/**
+ * One input box serves all four asset types, so the type is inferred unless
+ * the caller pins it with &type=. Order matters: an email also contains the
+ * dot a domain is matched on, and a phone number must be tested before the
+ * username catch-all.
+ */
+export function detectAssetType(raw: string): AssetType {
+  const q = raw.trim();
+  if (q.includes('@')) return 'email';
+  if (/^\+?[\d][\d\s().-]{6,}$/.test(q)) return 'phone';
+  if (/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9-]+)+$/i.test(q)) return 'domain';
+  return 'username';
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const query = (searchParams.get('query') || '').trim();
+  const forced = searchParams.get('type') as AssetType | null;
+
+  if (!query) {
+    return NextResponse.json({ error: 'Missing query parameter' }, { status: 400 });
+  }
+
+  const type: AssetType = forced && ENDPOINTS[forced] ? forced : detectAssetType(query);
+  const { path, param } = ENDPOINTS[type];
+  const url = `${BASE}/${path}?${param}=${encodeURIComponent(query)}`;
+
+  try {
+    // A domain lookup aggregates every compromised machine touching that
+    // organisation and measured ~4.5s against tesla.com, so this is well
+    // above what the person lookups (~0.6s) need.
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(25000),
+      headers: { Accept: 'application/json' },
+    });
+
+    const data = await res.json().catch(() => null);
+
+    if (!res.ok) {
+      // Cavalier rejects malformed input with 400 {success:false,error:"…"},
+      // which is worth surfacing verbatim — it names the actual problem
+      // ("Email must be a valid email address") better than we could.
+      return NextResponse.json(
+        { error: data?.error || `Hudson Rock returned ${res.status}`, query, type },
+        { status: res.status === 400 ? 400 : 502 }
+      );
+    }
+
+    if (!data) {
+      return NextResponse.json({ error: 'Hudson Rock returned an unreadable response', query, type }, { status: 502 });
+    }
+
+    // Domain responses have no `stealers` array and no `message`; a clean
+    // person lookup returns 200 with stealers: [] rather than a 404, so
+    // "compromised" has to be read from the payload, not the status code.
+    const compromised =
+      type === 'domain'
+        ? Number(data.totalStealers || 0) > 0
+        : Array.isArray(data.stealers) && data.stealers.length > 0;
+
+    return NextResponse.json(
+      { query, type, compromised, source: 'Hudson Rock Cavalier', ...data },
+      { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' } }
+    );
+  } catch (err: any) {
+    const timedOut = err?.name === 'TimeoutError' || err?.name === 'AbortError';
+    return NextResponse.json(
+      { error: timedOut ? 'Hudson Rock lookup timed out' : 'Hudson Rock lookup failed', query, type },
+      { status: 504 }
+    );
+  }
+}

--- a/src/app/docs/apiCatalog.ts
+++ b/src/app/docs/apiCatalog.ts
@@ -441,6 +441,16 @@ export const API_GROUPS: ApiGroup[] = [
         returns: ['breached', 'breaches', 'data_exposed', 'detail'],
       },
       {
+        path: '/api/osint/hudsonrock',
+        method: 'GET',
+        summary: 'Reports whether an asset appears in Hudson Rock\'s infostealer corpus — machines compromised by credential-stealing malware.',
+        params: [
+          { name: 'query', required: true, desc: 'Email, domain, username or phone number.', example: 'tesla.com' },
+          { name: 'type', required: false, desc: 'Pins the asset type instead of inferring it: email, domain, username or phone.', example: 'domain' },
+        ],
+        returns: ['query', 'type', 'compromised', 'stealers', 'total_corporate_services', 'total_user_services', 'totalStealers', 'employees', 'users'],
+      },
+      {
         path: '/api/osint/cve',
         method: 'GET',
         summary: 'Full NVD record for a single CVE identifier.',

--- a/src/components/OsintPanel.tsx
+++ b/src/components/OsintPanel.tsx
@@ -9,7 +9,7 @@ import {
   ChevronDown, ChevronUp, Loader2, AlertTriangle, Server,
   Wifi, Lock, MapPin, Bug, Code, Layers, Network, Fingerprint,
   CheckCircle, XCircle, Clock, ExternalLink, Crosshair,
-  Maximize2, Minimize2, Gavel, Bitcoin, Phone, Terminal, ShieldAlert, User
+  Maximize2, Minimize2, Gavel, Bitcoin, Phone, Terminal, ShieldAlert, User, Skull, Monitor, KeyRound
 } from 'lucide-react';
 import { ipToNumber, numberToIp, calculateSubnetStart, classifyDevice, assessRisk, batchFetch, ShodanInternetDBResponse, SweepDevice } from '@/lib/osint-utils';
 import ChainBrief from '@/components/ChainBrief';
@@ -62,6 +62,7 @@ const TABS: ToolDef[] = [
 
   { id: 'threats', label: 'THREATS', icon: AlertTriangle, placeholder: 'IP, domain, or hash', color: '#FF9500', group: 'threat', blurb: 'Reputation across feeds' },
   { id: 'leaks', label: 'DATA LEAKS', icon: ShieldAlert, placeholder: 'Email address', color: '#E040FB', group: 'threat', blurb: 'Breach exposure for an address' },
+  { id: 'infostealer', label: 'INFOSTEALER', icon: Skull, placeholder: 'Email, domain, username or phone', color: '#FF1744', group: 'threat', blurb: 'Hudson Rock malware-compromised assets' },
 
   { id: 'crypto', label: 'CHAIN INTEL', icon: Bitcoin, placeholder: 'BTC, ETH or SOL wallet address', color: '#F7931A', group: 'chain', blurb: 'Wallet forensics and daily brief' },
 ];
@@ -258,6 +259,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
         case 'mac': url = `/api/osint/mac?mac=${encodeURIComponent(query)}`; break;
         case 'phone': url = `/api/osint/phone?number=${encodeURIComponent(query)}`; break;
         case 'leaks': url = `https://api.xposedornot.com/v1/breach-analytics?email=${encodeURIComponent(query)}`; break;
+        case 'infostealer': url = `/api/osint/hudsonrock?query=${encodeURIComponent(query)}`; break;
         case 'crypto': url = `/api/osint/crypto?address=${encodeURIComponent(query)}`; break;
         case 'username': url = `/api/osint/username?username=${encodeURIComponent(query)}`; break;
         case 'github': url = `/api/osint/github?user=${encodeURIComponent(query)}`; break;
@@ -313,7 +315,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           if (data.lat && data.lng && onScanGeolocate) {
              onScanGeolocate(query, { lat: data.lat, lng: data.lng, type: 'phone', region: data.region });
           }
-        } else if (activeTab !== 'sweep' && activeTab !== 'vuln' && activeTab !== 'crypto' && activeTab !== 'username' && activeTab !== 'mac' && activeTab !== 'bgp' && activeTab !== 'github' && activeTab !== 'leaks' && activeTab !== 'phone') {
+        } else if (activeTab !== 'sweep' && activeTab !== 'vuln' && activeTab !== 'crypto' && activeTab !== 'username' && activeTab !== 'mac' && activeTab !== 'bgp' && activeTab !== 'github' && activeTab !== 'leaks' && activeTab !== 'phone' && activeTab !== 'infostealer') {
           fetch(`/api/osint/ip?ip=${encodeURIComponent(query)}`)
             .then(r => r.json())
             .then(locData => {
@@ -375,6 +377,21 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
       </div>
     );
   };
+
+  // Cavalier's data is complimentary; the terms ask that it be credited.
+  const HudsonRockCredit = () => (
+    <a
+      href="https://www.hudsonrock.com/free-tools"
+      target="_blank"
+      rel="noreferrer"
+      className="mt-2 flex items-center justify-between px-2 py-1.5 rounded bg-[#1A1A18] border border-[var(--border-secondary)]/30 hover:border-[#FF1744]/40 transition-colors"
+    >
+      <span className="text-[8px] font-mono text-[var(--text-muted)]">
+        Data by Hudson Rock Cavalier · free infostealer intelligence
+      </span>
+      <ExternalLink className="w-2.5 h-2.5 text-[var(--text-muted)]" />
+    </a>
+  );
 
   const SectionHeader = ({ title, icon: Icon, color }: { title: string; icon: any; color: string }) => (
     <div className="flex items-center gap-2 mt-3 mb-1.5 first:mt-0">
@@ -963,6 +980,158 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
               </div>
             </div>
           )}
+        </div>
+      );
+    }
+
+    // ── INFOSTEALER (Hudson Rock) ──
+    if (activeTab === 'infostealer') {
+      const hit = r.compromised;
+      const accent = hit ? '#FF1744' : '#00E676';
+      const TYPE_LABEL: Record<string, string> = {
+        email: 'EMAIL ADDRESS', domain: 'DOMAIN', username: 'USERNAME', phone: 'PHONE NUMBER',
+      };
+
+      // Domain lookups answer a different question — how much of an
+      // organisation is exposed — so they get their own view rather than an
+      // empty version of the per-machine one.
+      if (r.type === 'domain') {
+        const families = Object.entries(r.stealerFamilies || {})
+          .filter(([k, v]) => k !== 'total' && Number(v) > 0)
+          .sort((a, b) => Number(b[1]) - Number(a[1]));
+        const pw = r.employeePasswords || {};
+        const weakPct = (Number(pw.too_weak?.perc) || 0) + (Number(pw.weak?.perc) || 0);
+
+        return (
+          <div>
+            <SectionHeader title="INFOSTEALER EXPOSURE" icon={Skull} color={accent} />
+            <ResultRow label="Domain" value={r.query} color={accent} />
+            <ResultRow label="Status" value={hit ? 'COMPROMISED MACHINES FOUND' : 'NO RECORDS'} color={accent} />
+            {hit && (
+              <>
+                <div className="grid grid-cols-2 gap-1.5 mt-2">
+                  {[
+                    ['Employees', r.employees, '#FF1744'],
+                    ['Users', r.users, '#FF9500'],
+                    ['Third parties', r.third_parties, '#FFD500'],
+                    ['Total machines', r.totalStealers, '#E040FB'],
+                  ].map(([label, value, color]: any) => (
+                    <div key={label} className="p-2 rounded border border-[var(--border-secondary)]/30 bg-[var(--bg-tertiary)]/30">
+                      <div className="text-[9px] font-mono text-[var(--text-muted)] uppercase tracking-wider">{label}</div>
+                      <div className="text-[15px] font-mono font-bold" style={{ color }}>{Number(value || 0).toLocaleString()}</div>
+                    </div>
+                  ))}
+                </div>
+
+                <ResultRow label="Last employee" value={r.last_employee_compromised?.slice(0, 10)} />
+                <ResultRow label="Last user" value={r.last_user_compromised?.slice(0, 10)} />
+                <ResultRow label="Exposed URLs" value={Number(r.totalUrls || 0).toLocaleString()} />
+
+                {pw.has_stats && (
+                  <div className="mt-2 p-2 border border-[#FF9500]/30 bg-[#FF9500]/10 rounded">
+                    <span className="text-[10px] font-mono text-[#FF9500] font-bold mb-1 block">
+                      EMPLOYEE PASSWORD STRENGTH ({Number(pw.totalPass || 0).toLocaleString()})
+                    </span>
+                    <div className="flex h-2 rounded overflow-hidden mb-1">
+                      {[['too_weak', '#FF1744'], ['weak', '#FF9500'], ['medium', '#FFD500'], ['strong', '#00E676']].map(([k, c]) => (
+                        <div key={k} style={{ width: `${Number(pw[k]?.perc) || 0}%`, background: c }} />
+                      ))}
+                    </div>
+                    <div className="text-[9px] font-mono text-[var(--text-muted)]">
+                      {weakPct.toFixed(0)}% weak or worse · {(Number(pw.strong?.perc) || 0).toFixed(0)}% strong
+                    </div>
+                  </div>
+                )}
+
+                {families.length > 0 && (
+                  <div className="mt-2 p-2 border border-[#FF1744]/30 bg-[#FF1744]/10 rounded">
+                    <span className="text-[10px] font-mono text-[#FF1744] font-bold mb-1 block">STEALER FAMILIES</span>
+                    <div className="flex flex-wrap gap-1">
+                      {families.slice(0, 14).map(([name, count]) => (
+                        <span key={name} className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#E8E6E0] border border-[#FF1744]/20">
+                          {name} <span className="text-[#FF1744]">{String(count)}</span>
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {Array.isArray(r.thirdPartyDomains) && r.thirdPartyDomains.length > 0 && (
+                  <div className="mt-2 p-2 border border-[var(--border-secondary)]/30 rounded">
+                    <span className="text-[10px] font-mono text-[var(--text-secondary)] font-bold mb-1 block">
+                      TOP THIRD-PARTY DOMAINS ({r.thirdPartyDomains.length})
+                    </span>
+                    {r.thirdPartyDomains.slice(0, 8).map((d: any) => (
+                      <div key={d.domain} className="flex items-center justify-between py-0.5">
+                        <span className="text-[9px] font-mono text-[var(--text-primary)] break-all">{d.domain}</span>
+                        <span className="text-[9px] font-mono text-[var(--text-muted)] flex-shrink-0 ml-2">{d.occurrence}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+            <HudsonRockCredit />
+          </div>
+        );
+      }
+
+      // email / username / phone — one card per compromised machine.
+      const stealers: any[] = Array.isArray(r.stealers) ? r.stealers : [];
+      return (
+        <div>
+          <SectionHeader title="INFOSTEALER EXPOSURE" icon={Skull} color={accent} />
+          <ResultRow label={TYPE_LABEL[r.type] || 'TARGET'} value={r.query} color={accent} />
+          <ResultRow label="Status" value={hit ? 'COMPROMISED' : 'NOT FOUND IN CORPUS'} color={accent} />
+          {hit && (
+            <>
+              <ResultRow label="Machines" value={stealers.length} color="#FF1744" />
+              <ResultRow label="Corporate svcs" value={r.total_corporate_services} />
+              <ResultRow label="User svcs" value={r.total_user_services} />
+
+              {stealers.map((s: any, i: number) => (
+                <div key={i} className="mt-2 p-2 rounded border border-[#FF1744]/30 bg-[#FF1744]/5">
+                  <div className="flex items-center gap-2 mb-1.5">
+                    <Monitor className="w-3 h-3 text-[#FF1744]" />
+                    <span className="text-[10px] font-mono font-bold text-[#FF1744] break-all">
+                      {s.computer_name || 'UNKNOWN MACHINE'}
+                    </span>
+                  </div>
+                  <ResultRow label="Compromised" value={s.date_compromised?.slice(0, 10)} color="#FF9500" />
+                  <ResultRow label="Stealer" value={s.stealer_family} color="#FF9500" />
+                  <ResultRow label="OS" value={s.operating_system} />
+                  <ResultRow label="IP" value={s.ip} />
+                  <ResultRow label="Antivirus" value={(s.antiviruses || []).join(', ')} />
+                  <ResultRow label="Malware path" value={s.malware_path} />
+
+                  {(s.top_logins?.length > 0 || s.top_passwords?.length > 0) && (
+                    <div className="mt-1.5 pt-1.5 border-t border-[#FF1744]/20">
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <KeyRound className="w-2.5 h-2.5 text-[var(--text-muted)]" />
+                        <span className="text-[9px] font-mono text-[var(--text-muted)] uppercase tracking-wider">
+                          Credentials (redacted by Hudson Rock)
+                        </span>
+                      </div>
+                      <div className="flex flex-wrap gap-1">
+                        {(s.top_logins || []).map((l: string, j: number) => (
+                          <span key={`l${j}`} className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#87CEEB] border border-[#87CEEB]/20 break-all">{l}</span>
+                        ))}
+                        {(s.top_passwords || []).map((p: string, j: number) => (
+                          <span key={`p${j}`} className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#E040FB] border border-[#E040FB]/20 break-all">{p}</span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </>
+          )}
+          {!hit && r.message && (
+            <div className="mt-2 text-[9px] font-mono text-[var(--text-muted)] leading-relaxed">
+              {String(r.message).split('Visit')[0].trim()}
+            </div>
+          )}
+          <HudsonRockCredit />
         </div>
       );
     }


### PR DESCRIPTION
Closes #261.

Adds Hudson Rock's complimentary Cavalier data to the Recon toolkit — whether a digital asset appears in their infostealer corpus, i.e. sits on a machine compromised by credential-stealing malware whose saved logins are circulating. No API key required.

## One module, four asset types

A single **INFOSTEALER** tool under **THREAT & EXPOSURE**, backed by `/api/osint/hudsonrock`, rather than four near-identical tools. The asset type is inferred from the input and can be pinned with `&type=`.

Inference order matters: an email also contains the dot a domain is matched on, and a phone number has to be tested before the username catch-all.

Phone numbers go through `search-by-username` — that is what Hudson Rock exposes; there is no `search-by-phone` endpoint. All four sample URLs from the issue are covered.

## Two response shapes, two views

They answer different questions, so flattening them into one renderer would have served both badly:

**Email / username / phone** — per-machine records, one card each: infection date, stealer family, OS, IP, antivirus present at the time of infection, malware path, and the top logins and passwords.

**Domain** — an organisation-wide picture: employee / user / third-party counts, a password-strength bar, the stealer families observed, and the most common third-party domains.

## Handling details worth noting

- **Credentials are redacted at source** (`0**********e`, IPs as `202.9.**.**`), so nothing needed further masking. The UI labels them as redacted so that isn't mistaken for plaintext.
- **A clean target returns HTTP 200 with an empty `stealers` array**, not a 404 — so `compromised` is derived from the payload, never the status code.
- **Malformed input returns 400 with Cavalier's own message** (`"Email must be a valid email address"`), passed through verbatim; it names the actual problem better than a generic message would.
- Registered in the API docs catalog, and credited per Cavalier's terms.

## Verified against the live API

Every sample target from the issue, through the running route:

| target | detected type | result |
|---|---|---|
| `testadmin` | username | compromised — **5 machines** |
| `manvirdi2000@gmail.com` | email | compromised — 1 machine (`Dell_Laptop`, 2023-08-09) |
| `tesla.com` | domain | **548 employees**, 28,330 users, 774 third parties |
| `+19777334049` | phone | compromised — 1 machine (`IZUMI DESKTOP`, Lumma) |

Edge cases: clean address → `compromised: false`; malformed email → 400 with the upstream message; `type` override beats inference; missing query → 400. A production build registers `/api/osint/hudsonrock` and ships the UI strings into the client chunks. 186 tests pass; no type errors in the three files touched.

## Reviewer note

The API layer is verified end to end. **The rendered UI is not** — the page never became interactive in my headless browser (intro splash overlay stays up, buttons inert, HMR socket dead), which blocked the Recon panel entirely, pre-existing tools included. The build proves the code compiles and ships; someone should click through **Recon → THREAT & EXPOSURE → INFOSTEALER** with `tesla.com` before merge.

Also observed while testing: intermittent outbound connect timeouts from the dev server, hitting unrelated feeds (GDACS, DGT) too. One username lookup 504'd and then passed on three straight retries. The route's timeout path returns a clean 504 rather than throwing.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
