### PR TITLE
feat(space): live 24/7 video downlink from the ISS behind one button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Layers, BarChart3, Newspaper, Search, X, Globe, MapPinned, Route, Radar, Satellite, Moon, ExternalLink, AlertTriangle, Activity, Database, Wifi, Play, Network, Crosshair, Bluetooth, Pentagon } from 'lucide-react';
+import { Layers, BarChart3, Newspaper, Search, X, Globe, MapPinned, Route, Radar, Satellite, Moon, ExternalLink, AlertTriangle, Activity, Database, Wifi, Play, Network, Crosshair, Bluetooth, Pentagon, Radio } from 'lucide-react';
 import IntelFeed from '@/components/IntelFeed';
 import MarketsPanel from '@/components/MarketsPanel';
 import ScmPanel from '@/components/ScmPanel';
@@ -23,6 +23,7 @@ import WorldRemote from '@/components/WorldRemote';
 import ArcGISPanel from '@/components/ArcGISPanel';
 const OsirisMap = dynamic(() => import('@/components/OsirisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
+const SpaceCam = dynamic(() => import('@/components/SpaceCam'), { ssr: false });
 const CameraViewer = dynamic(() => import('@/components/CameraViewer'));
 const OsintPanel = dynamic(() => import('@/components/OsintPanel'));
 const EntityGraphPanel = dynamic(() => import('@/components/EntityGraphPanel'));
@@ -108,6 +109,7 @@ export default function Dashboard() {
   const [showLayers, setShowLayers] = useState(true);
   const [showMarkets, setShowMarkets] = useState(false);
   const [showAlerts, setShowAlerts] = useState(false);
+  const [showSpaceCam, setShowSpaceCam] = useState(false);
   const [showScmPanel, setShowScmPanel] = useState(true);
   const [showIntel, setShowIntel] = useState(false);
   const [showEntityGraph, setShowEntityGraph] = useState(false);
@@ -339,12 +341,12 @@ export default function Dashboard() {
       if (e.key === 'm') setShowMarkets(p => !p);
       if (e.key === 'c') setShowScmPanel(p => !p);
       if (e.key === 'i') setShowIntel(p => !p);
-      if (e.key === 's') { setShowDesktopSearch(p => !p); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); }
+      if (e.key === 's') { setShowDesktopSearch(p => !p); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); }
       if (e.key === 'r') setFlyToLocation({ lat: 20, lng: 0, ts: Date.now() });
       if (e.key === 'g') setMapProjection(p => p === 'globe' ? 'mercator' : 'globe');
       if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
         e.preventDefault();
-        setShowDesktopSearch(true); setShowIntel(false); setShowMarkets(false); setShowAlerts(false);
+        setShowDesktopSearch(true); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false);
       }
     };
     const fsHandler = () => setIsFullscreen(!!document.fullscreenElement);
@@ -1201,7 +1203,21 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Markets — crypto prices, space weather, global indices">
+          <button onClick={() => { setShowIntel(false); setShowAlerts(false); setShowMarkets(false); setShowSpaceCam(v => !v); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showSpaceCam ? 'bg-[#00E5FF]/20' : 'hover:bg-white/10'}`} title="Live from Space — 24/7 video downlink from the ISS">
+            <Radio className={`w-4 h-4 ${showSpaceCam ? 'text-[#00E5FF]' : 'text-white/60'}`} />
+          </button>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">SPACE</span>
+          <AnimatePresence>
+            {showSpaceCam && (
+              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
+                <SpaceCam />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
+        <div className="relative group">
+          <button onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); setShowSpaceCam(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Markets — crypto prices, space weather, global indices">
             <BarChart3 className={`w-4 h-4 ${showMarkets ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">MARKETS</span>
@@ -1229,21 +1245,21 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowEntityGraph(!showEntityGraph); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showEntityGraph ? 'bg-[#D4AF37]/20' : 'hover:bg-white/10'}`} title="Entity Graph — link analysis between tracked entities">
+          <button onClick={() => { setShowEntityGraph(!showEntityGraph); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showEntityGraph ? 'bg-[#D4AF37]/20' : 'hover:bg-white/10'}`} title="Entity Graph — link analysis between tracked entities">
             <Network className={`w-4 h-4 ${showEntityGraph ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">GRAPH</span>
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowDirections(!showDirections); if (showDirections) { setActiveRoute(null); } setShowDesktopSearch(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDirections ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Directions — turn-by-turn routing">
+          <button onClick={() => { setShowDirections(!showDirections); if (showDirections) { setActiveRoute(null); } setShowDesktopSearch(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDirections ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Directions — turn-by-turn routing">
             <Route className={`w-4 h-4 ${showDirections ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ROUTE</span>
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowDesktopSearch(!showDesktopSearch); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDesktopSearch ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Search — find locations, cities, coordinates">
+          <button onClick={() => { setShowDesktopSearch(!showDesktopSearch); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDesktopSearch ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Search — find locations, cities, coordinates">
             <Search className={`w-4 h-4 ${showDesktopSearch ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">SEARCH</span>
@@ -1289,7 +1305,7 @@ export default function Dashboard() {
 
         {/* ── WORLD REMOTE ── */}
         <div className="relative group">
-          <button onClick={() => { setShowRemote(!showRemote); setShowArcGIS(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowEntityGraph(false); setShowDesktopSearch(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showRemote ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`} title="World Remote — control nearby Bluetooth devices (TVs, speakers, AC)">
+          <button onClick={() => { setShowRemote(!showRemote); setShowArcGIS(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowEntityGraph(false); setShowDesktopSearch(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showRemote ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`} title="World Remote — control nearby Bluetooth devices (TVs, speakers, AC)">
             <Bluetooth className={`w-4 h-4 ${showRemote ? 'text-[var(--cyan-primary)]' : 'text-white/60'}`} />
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">REMOTE</span>

--- a/src/components/SpaceCam.tsx
+++ b/src/components/SpaceCam.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ExternalLink, Radio, Maximize2, X } from 'lucide-react';
+
+/**
+ * OSIRIS — LIVE FROM SPACE
+ *
+ * 24/7 downlink from cameras mounted outside the International Space Station.
+ *
+ * The feed list is deliberately short. Every candidate was checked against
+ * three conditions, not one: the video must be OK (not UNPLAYABLE), it must be
+ * live right now, and it must be embeddable. Eleven well-known "24/7 ISS"
+ * streams were tested and only these three passed — the official NASA ISS
+ * video ids are all UNPLAYABLE now, and several popular mirrors are live but
+ * refuse embedding, which renders as an error box inside the panel rather than
+ * as a missing feed. That is why the list is not longer.
+ *
+ * Sen leads because it is the camera operator rather than a mirror: those are
+ * its own 4K cameras mounted on the ISS. The other two are re-broadcasts and
+ * share a channel, so they are one failure away from going dark together.
+ */
+
+interface SpaceFeed {
+  id: string;
+  label: string;
+  detail: string;
+  videoId: string;
+}
+
+const FEEDS: SpaceFeed[] = [
+  {
+    id: 'sen-4k',
+    label: '4K EARTH',
+    detail: "Sen · 4K cameras mounted on the ISS",
+    videoId: 'fO9e9jnhYK8',
+  },
+  {
+    id: 'iss-earth',
+    label: 'EARTH VIEW',
+    detail: 'ISS external camera · nadir',
+    videoId: 'tj4knR4r1UU',
+  },
+  {
+    id: 'iss-overview',
+    label: 'OVERVIEW CAM',
+    detail: 'ISS overview camera · wide',
+    videoId: 'OKQEMp2555A',
+  },
+];
+
+// The ISS orbits at roughly 408 km and circles the planet about every 93
+// minutes, which is the only "location" this camera has.
+const ORBIT_ALT_KM = 408;
+
+/**
+ * YouTube picks its resolution from the *rendered size of the player*, not from
+ * anything in the embed URL — the old `vq` and `hd` parameters are ignored. In
+ * the 320px-wide rail this panel lives in, that means a 320x180 player and a
+ * correctly-chosen 144p stream. Sen publishes up to 2160p, so the only way to
+ * actually see it is to give the player a big viewport, which is what the
+ * expanded view is for.
+ *
+ * The overlay is portalled to document.body: the tool rail is inside a
+ * translated ancestor, and a transform makes position:fixed resolve against
+ * that ancestor instead of the viewport, so rendering it in place would trap it
+ * in the sidebar.
+ */
+function buildEmbedSrc(videoId: string, big: boolean): string {
+  const params = new URLSearchParams({
+    autoplay: '1',
+    mute: '1',
+    playsinline: '1',
+    modestbranding: '1',
+    rel: '0',
+  });
+  // Only meaningful in the expanded player; harmless in the docked one.
+  if (big) params.set('vq', 'hd1080');
+  return `https://www.youtube-nocookie.com/embed/${videoId}?${params.toString()}`;
+}
+
+export default function SpaceCam() {
+  const [active, setActive] = useState(FEEDS[0]);
+  const [expanded, setExpanded] = useState(false);
+
+  // Escape closes the expanded view — it covers the whole map.
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setExpanded(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [expanded]);
+
+  return (
+    <div className="rounded-xl border border-[var(--border-primary)] bg-[var(--bg-panel)] backdrop-blur-2xl overflow-hidden shadow-[0_4px_24px_rgba(0,0,0,0.5)]">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-[var(--border-secondary)]/40">
+        <Radio className="w-3.5 h-3.5 text-[#00E5FF]" />
+        <span className="text-[10px] font-mono font-bold tracking-widest text-[#00E5FF]">
+          LIVE FROM SPACE
+        </span>
+        <span className="ml-auto flex items-center gap-1">
+          <span className="w-1.5 h-1.5 rounded-full bg-[#FF3D3D] animate-pulse" />
+          <span className="text-[8px] font-mono tracking-wider text-[var(--text-muted)]">24/7</span>
+        </span>
+        <button
+          onClick={() => setExpanded(true)}
+          title="Expand — a bigger player is what makes YouTube serve HD"
+          className="ml-1 p-1 rounded hover:bg-[var(--hover-accent)] text-[var(--text-muted)] hover:text-[#00E5FF] transition-colors"
+        >
+          <Maximize2 className="w-3 h-3" />
+        </button>
+      </div>
+
+      <div className="relative w-full group/player" style={{ aspectRatio: '16 / 9', background: '#000' }}>
+        <iframe
+          key={active.videoId}
+          src={buildEmbedSrc(active.videoId, false)}
+          title={`ISS live — ${active.label}`}
+          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          className="absolute inset-0 w-full h-full border-0"
+        />
+        {/* At 320px wide YouTube will only ever send a low-resolution rendition,
+            so the panel says so rather than looking broken. */}
+        <button
+          onClick={() => setExpanded(true)}
+          className="absolute bottom-1 right-1 px-1.5 py-0.5 rounded bg-black/70 text-[7px] font-mono tracking-wider text-[#00E5FF] opacity-0 group-hover/player:opacity-100 transition-opacity"
+        >
+          EXPAND FOR HD ↗
+        </button>
+      </div>
+
+      {FEEDS.length > 1 && (
+        <div className="flex gap-1 px-2 pt-2">
+          {FEEDS.map(f => (
+            <button
+              key={f.id}
+              onClick={() => setActive(f)}
+              className={`flex-1 px-2 py-1.5 rounded text-[8px] font-mono tracking-wider transition-colors border ${
+                active.id === f.id
+                  ? 'border-[#00E5FF]/40 bg-[#00E5FF]/15 text-[#00E5FF]'
+                  : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--hover-accent)]'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="px-3 py-2 flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-[9px] font-mono text-[var(--text-secondary)] truncate">{active.detail}</div>
+          <div className="text-[8px] font-mono text-[var(--text-muted)]">
+            ALT ~{ORBIT_ALT_KM} KM · ORBIT ~93 MIN
+          </div>
+        </div>
+        <a
+          href={`https://www.youtube.com/watch?v=${active.videoId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 px-2 py-1 rounded border border-[var(--border-secondary)]/40 text-[8px] font-mono text-[var(--text-muted)] hover:text-[#00E5FF] hover:border-[#00E5FF]/40 transition-colors flex-shrink-0"
+        >
+          SOURCE <ExternalLink className="w-2.5 h-2.5" />
+        </a>
+      </div>
+
+      {expanded && typeof document !== 'undefined' && createPortal(
+        <div
+          className="fixed inset-0 z-[9000] bg-black/95 backdrop-blur-sm flex flex-col items-center justify-center p-4 md:p-8"
+          onClick={() => setExpanded(false)}
+        >
+          <div
+            className="w-full max-w-[1600px]"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-2 mb-2">
+              <Radio className="w-4 h-4 text-[#00E5FF]" />
+              <span className="text-[12px] font-mono font-bold tracking-widest text-[#00E5FF]">
+                LIVE FROM SPACE
+              </span>
+              <span className="text-[10px] font-mono text-[var(--text-muted)]">· {active.detail}</span>
+              <span className="ml-auto flex items-center gap-1">
+                <span className="w-1.5 h-1.5 rounded-full bg-[#FF3D3D] animate-pulse" />
+                <span className="text-[9px] font-mono tracking-wider text-[var(--text-muted)]">24/7</span>
+              </span>
+              <button
+                onClick={() => setExpanded(false)}
+                title="Close (Esc)"
+                className="p-1.5 rounded hover:bg-white/10 text-[var(--text-muted)] hover:text-white transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
+            {/* Sized off the viewport so the player is large enough for YouTube
+                to step up to 1080p/4K. Capped by height as well as width so a
+                wide monitor does not push the controls off-screen. */}
+            <div
+              className="relative w-full mx-auto"
+              style={{ aspectRatio: '16 / 9', maxHeight: '82vh', background: '#000' }}
+            >
+              <iframe
+                key={`big-${active.videoId}`}
+                src={buildEmbedSrc(active.videoId, true)}
+                title={`ISS live expanded — ${active.label}`}
+                allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+                allowFullScreen
+                className="absolute inset-0 w-full h-full border-0"
+              />
+            </div>
+
+            <div className="flex items-center gap-2 mt-3">
+              {FEEDS.map(f => (
+                <button
+                  key={f.id}
+                  onClick={() => setActive(f)}
+                  className={`px-3 py-1.5 rounded text-[10px] font-mono tracking-wider transition-colors border ${
+                    active.id === f.id
+                      ? 'border-[#00E5FF]/40 bg-[#00E5FF]/15 text-[#00E5FF]'
+                      : 'border-white/10 text-[var(--text-muted)] hover:bg-white/10'
+                  }`}
+                >
+                  {f.label}
+                </button>
+              ))}
+              <span className="ml-auto text-[9px] font-mono text-[var(--text-muted)]">
+                ALT ~{ORBIT_ALT_KM} KM · ORBIT ~93 MIN · ESC TO CLOSE
+              </span>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a **SPACE** control to the right-hand tool rail — one button, opening a live 24/7 downlink from cameras mounted outside the International Space Station.

Compact docked player, feed switcher, and an expanded theater view.

## Picking the feeds was most of the work

Eleven well-known "24/7 ISS" streams were checked against **three** conditions, not one: playable (not `UNPLAYABLE`), **live right now**, and **embeddable**. Only three passed.

| stream | verdict |
|---|---|
| **Sen — Live 4K Earth** (`fO9e9jnhYK8`) | ✅ OK · live · embeddable · **2160p** |
| afarTV — 24/7 NASA Earth (`tj4knR4r1UU`) | ✅ OK · live · embeddable |
| afarTV — Overview Camera (`OKQEMp2555A`) | ✅ OK · live · embeddable |
| Official NASA ISS streams (3 separate ids) | ❌ **UNPLAYABLE** |
| Dream Trips 24/7 Earth View | ❌ live but **refuses embedding** |
| The Launch Pad 4K ISS (2 ids) | ❌ not live / unplayable |
| 3 others | ❌ error, login-required, or not live |

The embeddability check earned its keep: the Dream Trips stream is genuinely live, so a liveness-only check would have passed it — and it renders as an error box *inside* the panel rather than as an obviously missing feed. Every official NASA ISS id that search results point to is dead.

**Sen leads** because it is the camera operator rather than a re-broadcaster — its own 4K cameras on the ISS. The two afarTV mirrors are fallbacks, but they share a channel and can go dark together; the component says so for whoever debugs it later.

## The expanded view is a fix, not decoration

YouTube selects its rendition from the **rendered pixel size of the player** and ignores the `vq`/`hd` URL parameters. In the 320px tool rail the player is `318x179`, so YouTube correctly serves **144p** — which is what made a 4K feed look like 144p.

Measured in the running app:

```
docked   :  318 x 179   → ~144p (correct for that size)
expanded : 1216 x 590   → 3.8x wider, steps up to 1080p
viewport : 1280 x 720   → larger on a real monitor, where Sen's 4K becomes reachable
```

A hover hint marks the docked player as expandable, so its low resolution reads as deliberate rather than broken.

The overlay is **portalled to `document.body`** — the tool rail sits inside a translated ancestor, and a transform makes `position: fixed` resolve against that ancestor instead of the viewport, which would otherwise trap the theater view inside the sidebar. Escape closes it.

## Verified in the running app

Panel opens on the Sen feed · all three tabs render · switching works in both docked and expanded views · Escape closes the overlay and leaves the docked player intact · player grows `318x179` → `1216x590` · overlay confirmed mounted under `body`.

186 tests pass, production build compiles, typecheck unchanged at the pre-existing 17-error baseline.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
