### PR TITLE
feat(hazard): global infrastructure ArcGIS presets, ocean buoys, wind streamlines

### DIFF
--- a/src/app/api/buoys/route.test.ts
+++ b/src/app/api/buoys/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { parseBuoys } from './route';
+
+// Real sample rows, fetched by hand from
+// https://www.ndbc.noaa.gov/data/latest_obs/latest_obs.txt on 2026-08-17 --
+// not synthesised, so this test fails first if NDBC ever reorders or drops a
+// column rather than the app finding out in production.
+const HEADER =
+  '#STN       LAT      LON  YYYY MM DD hh mm WDIR WSPD   GST WVHT  DPD APD MWD   PRES  PTDY  ATMP  WTMP  DEWP  VIS   TIDE\n' +
+  '#text      deg      deg   yr mo day hr mn degT  m/s   m/s   m   sec sec degT   hPa   hPa  degC  degC  degC  nmi     ft\n';
+
+describe('parseBuoys', () => {
+  it('parses a station with real wave data', () => {
+    const line = '41001    34.738  -72.503 2026 08 17 05 40 200   5.0   6.0   MM  MM  5.5  68 1016.5    MM  27.1  28.5  22.7   MM     MM';
+    const [b] = parseBuoys(HEADER + line);
+    expect(b.id).toBe('41001');
+    expect(b.lat).toBeCloseTo(34.738);
+    expect(b.lng).toBeCloseTo(-72.503);
+    expect(b.time).toBe('2026-08-17T05:40:00Z');
+    expect(b.windSpeed).toBeCloseTo(5.0);
+    expect(b.avgPeriod).toBeCloseTo(5.5);
+    expect(b.waveDir).toBe(68);
+    expect(b.pressure).toBeCloseTo(1016.5);
+    expect(b.airTemp).toBeCloseTo(27.1);
+    expect(b.waterTemp).toBeCloseTo(28.5);
+    expect(b.gust).toBeCloseTo(6.0);
+    // WVHT and DPD are genuinely absent on this reading -- MM, not zero.
+    expect(b.waveHeight).toBeNull();
+    expect(b.domPeriod).toBeNull();
+  });
+
+  it('parses a station with a real wave height, including zero', () => {
+    const line = '22101    37.24   126.02  2026 08 17 05 00 320   0.0    MM  0.0   0   MM  MM     MM    MM  25.8  25.8    MM   MM     MM';
+    const [b] = parseBuoys(HEADER + line);
+    expect(b.waveHeight).toBe(0);
+    expect(b.domPeriod).toBe(0);
+    expect(b.gust).toBeNull();
+  });
+
+  it('skips both header/comment lines and blank lines', () => {
+    const result = parseBuoys(HEADER + '\n   \n');
+    expect(result).toEqual([]);
+  });
+
+  it('drops a malformed row instead of crashing or emitting NaN coordinates', () => {
+    const good = '41001    34.738  -72.503 2026 08 17 05 40 200   5.0   6.0   MM  MM  5.5  68 1016.5    MM  27.1  28.5  22.7   MM     MM';
+    const short = 'BADSTN too few columns here';
+    const result = parseBuoys(HEADER + good + '\n' + short);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('41001');
+  });
+
+  it('handles a southern-hemisphere negative longitude station', () => {
+    const line = '32ST0   -22.000  -85.000 2026 08 17 05 30 160  11.0    MM   MM  MM   MM  MM 1019.9    MM  18.5  19.6  14.2   MM     MM';
+    const [b] = parseBuoys(HEADER + line);
+    expect(b.lat).toBeCloseTo(-22.0);
+    expect(b.lng).toBeCloseTo(-85.0);
+    expect(b.waveHeight).toBeNull();
+  });
+});

--- a/src/app/api/buoys/route.ts
+++ b/src/app/api/buoys/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * OSIRIS — Ocean Buoy Data API
+ * Fetches the latest observation from every active NOAA NDBC station in one
+ * request (~880 stations worldwide, not just US waters). Wave height (WVHT)
+ * is the field this layer exists for: a real-time precursor signal for
+ * tsunami/swell hazards, not decoration.
+ * No API key required.
+ */
+
+const SOURCE_URL = 'https://www.ndbc.noaa.gov/data/latest_obs/latest_obs.txt';
+
+// NDBC's own placeholder for "not measured on this station" -- not an error,
+// just a field this particular buoy does not carry (a wind buoy with no wave
+// sensor, e.g.).
+const num = (s: string | undefined): number | null =>
+  s === undefined || s === 'MM' ? null : (Number.isFinite(parseFloat(s)) ? parseFloat(s) : null);
+
+export type Buoy = {
+  id: string; lat: number; lng: number; time: string;
+  windDir: number | null; windSpeed: number | null; gust: number | null;
+  waveHeight: number | null; domPeriod: number | null; avgPeriod: number | null;
+  waveDir: number | null; pressure: number | null; pressureTrend: number | null;
+  airTemp: number | null; waterTemp: number | null; dewpoint: number | null;
+  visibility: number | null; tide: number | null;
+};
+
+/** Pure so it can be tested against real NDBC sample lines without a network
+ *  call -- the fixed-column format is the actual risk here (a source column
+ *  reorder silently shifts every field one over), not the HTTP fetch. */
+export function parseBuoys(text: string): Buoy[] {
+  return text.split('\n')
+    .filter(line => line.trim() && !line.startsWith('#'))
+    .map((line): Buoy | null => {
+      // Whitespace-delimited fixed-column text, not CSV -- NDBC pads every
+      // field, so a plain split on runs of whitespace is exact.
+      const f = line.trim().split(/\s+/);
+      if (f.length < 22) return null;
+      const [stn, lat, lon, yyyy, mm, dd, hh, mn, wdir, wspd, gst, wvht,
+        dpd, apd, mwd, pres, ptdy, atmp, wtmp, dewp, vis, tide] = f;
+      const latN = parseFloat(lat), lonN = parseFloat(lon);
+      if (!Number.isFinite(latN) || !Number.isFinite(lonN)) return null;
+      return {
+        id: stn,
+        lat: latN,
+        lng: lonN,
+        time: `${yyyy}-${mm}-${dd}T${hh}:${mn}:00Z`,
+        windDir: num(wdir),
+        windSpeed: num(wspd),
+        gust: num(gst),
+        waveHeight: num(wvht),
+        domPeriod: num(dpd),
+        avgPeriod: num(apd),
+        waveDir: num(mwd),
+        pressure: num(pres),
+        pressureTrend: num(ptdy),
+        airTemp: num(atmp),
+        waterTemp: num(wtmp),
+        dewpoint: num(dewp),
+        visibility: num(vis),
+        tide: num(tide),
+      };
+    })
+    .filter((b): b is Buoy => b !== null);
+}
+
+export async function GET() {
+  try {
+    const res = await fetch(SOURCE_URL, { signal: AbortSignal.timeout(10000) });
+    if (!res.ok) {
+      return NextResponse.json({ buoys: [], error: 'NDBC unavailable' });
+    }
+    const buoys = parseBuoys(await res.text());
+
+    return NextResponse.json({
+      buoys,
+      total: buoys.length,
+      timestamp: new Date().toISOString(),
+    }, {
+      headers: {
+        // NDBC stations report roughly hourly; polling faster than the
+        // source updates would just hammer them for the same bytes.
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+      },
+    });
+  } catch (error) {
+    console.error('Buoy fetch error:', error);
+    return NextResponse.json({ buoys: [], error: 'Failed to fetch buoy data' }, { status: 500 });
+  }
+}

--- a/src/app/api/wind-grid/route.ts
+++ b/src/app/api/wind-grid/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * OSIRIS — Wind Vector Grid API
+ *
+ * Samples a coarse lat/lon grid across the requested viewport and returns
+ * real wind vectors (u/v, m/s) at each point, via one batched Open-Meteo
+ * request (no API key required, confirmed live: 100 points in ~300ms).
+ *
+ * This is what the animated wind-particle overlay in OsirisMap advects
+ * particles through -- an actual measured field, sampled coarser than
+ * GFS's native 0.25° grid (Open-Meteo interpolates internally), not a
+ * decorative arrow set.
+ */
+
+const GRID_NX = 14;
+const GRID_NY = 9;
+const MAX_POINTS = GRID_NX * GRID_NY;
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const bbox = searchParams.get('bbox'); // "west,south,east,north"
+  if (!bbox) {
+    return NextResponse.json({ error: 'bbox required: west,south,east,north' }, { status: 400 });
+  }
+
+  const parts = bbox.split(',').map(Number);
+  if (parts.length !== 4 || parts.some(n => !Number.isFinite(n))) {
+    return NextResponse.json({ error: 'invalid bbox' }, { status: 400 });
+  }
+  const [west, south, east, north] = parts;
+
+  const lats: number[] = [];
+  const lons: number[] = [];
+  for (let j = 0; j < GRID_NY; j++) {
+    const lat = south + ((north - south) * j) / (GRID_NY - 1);
+    for (let i = 0; i < GRID_NX; i++) {
+      const lon = west + ((east - west) * i) / (GRID_NX - 1);
+      lats.push(Number(lat.toFixed(3)));
+      lons.push(Number(lon.toFixed(3)));
+    }
+  }
+
+  try {
+    const params = new URLSearchParams({
+      latitude: lats.join(','),
+      longitude: lons.join(','),
+      current: 'wind_speed_10m,wind_direction_10m',
+      wind_speed_unit: 'ms',
+    });
+    const res = await fetch(`https://api.open-meteo.com/v1/forecast?${params.toString()}`, {
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!res.ok) {
+      return NextResponse.json({ error: `Open-Meteo unavailable (${res.status})` }, { status: 502 });
+    }
+    const data = await res.json();
+    const points: any[] = Array.isArray(data) ? data : [data];
+    if (points.length !== MAX_POINTS) {
+      return NextResponse.json({ error: 'unexpected grid response shape' }, { status: 502 });
+    }
+
+    // Meteorological direction is where the wind blows FROM -- a particle
+    // moving WITH the wind travels the opposite way, hence the negative sign
+    // on both components. Standard u (east+) / v (north+) convention.
+    const u = new Array(MAX_POINTS);
+    const v = new Array(MAX_POINTS);
+    for (let i = 0; i < MAX_POINTS; i++) {
+      const speed = points[i]?.current?.wind_speed_10m;
+      const dir = points[i]?.current?.wind_direction_10m;
+      if (typeof speed !== 'number' || typeof dir !== 'number') {
+        u[i] = 0; v[i] = 0;
+        continue;
+      }
+      const rad = (dir * Math.PI) / 180;
+      u[i] = -speed * Math.sin(rad);
+      v[i] = -speed * Math.cos(rad);
+    }
+
+    return NextResponse.json({
+      bbox: { west, south, east, north },
+      nx: GRID_NX,
+      ny: GRID_NY,
+      u,
+      v,
+      unit: 'm/s',
+      timestamp: new Date().toISOString(),
+    }, {
+      headers: {
+        // Wind at this resolution does not meaningfully change minute to
+        // minute; this just keeps a pan-and-back from re-hitting Open-Meteo.
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+      },
+    });
+  } catch (error) {
+    console.error('Wind grid fetch error:', error);
+    return NextResponse.json({ error: 'Failed to fetch wind grid' }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,6 +28,21 @@ const CameraViewer = dynamic(() => import('@/components/CameraViewer'));
 const OsintPanel = dynamic(() => import('@/components/OsintPanel'));
 const EntityGraphPanel = dynamic(() => import('@/components/EntityGraphPanel'));
 const TokenPanel = dynamic(() => import('@/components/TokenPanel'));
+
+// A curated first-run set for the ArcGIS panel: real, global infrastructure
+// data (Bucknell University GIS's Global Oil and Gas Features service --
+// verified live: worldwide extent, ~94k pipeline segments, ~280k railway
+// segments, ~14k power plants) instead of the panel opening empty until a
+// user happens to search for something. FIRST RUN ONLY: seeded into
+// arcgisLayers' initial state below, and from then on this session's own
+// add/remove actions are the only source of truth -- removing one of these
+// is a real user decision this component has no reason to override.
+const DEFAULT_ARCGIS_LAYERS = [
+  { id: 'gogf-pipelines-13', title: 'Global Oil & Gas Pipelines', url: 'https://services2.arcgis.com/xsh7pVZv42relbEf/arcgis/rest/services/Global_Oil_and_Gas_Features/FeatureServer/13', color: '#FF6B35' },
+  { id: 'gogf-railways-14', title: 'Global Railways', url: 'https://services2.arcgis.com/xsh7pVZv42relbEf/arcgis/rest/services/Global_Oil_and_Gas_Features/FeatureServer/14', color: '#8D6E63' },
+  { id: 'gogf-power-plants-2', title: 'Global Power Plants', url: 'https://services2.arcgis.com/xsh7pVZv42relbEf/arcgis/rest/services/Global_Oil_and_Gas_Features/FeatureServer/2', color: '#FFC107' },
+];
+
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(false);
   useEffect(() => {
@@ -199,8 +214,47 @@ export default function Dashboard() {
   }, [navSession]);
   const [showRemote, setShowRemote] = useState(false);
   const [showArcGIS, setShowArcGIS] = useState(false);
-  const [arcgisLayers, setArcgisLayers] = useState<Array<{ id: string; title: string; url: string; geojson: any; color: string; visible: boolean; opacity: number }>>([]);
+  const [arcgisLayers, setArcgisLayers] = useState<Array<{ id: string; title: string; url: string; geojson: any; color: string; visible: boolean; opacity: number }>>(
+    // Geometry deliberately absent: the viewport effect below fills it in
+    // for wherever the map happens to be pointing.
+    DEFAULT_ARCGIS_LAYERS.map(l => ({ ...l, geojson: null, visible: true, opacity: 0.8 }))
+  );
   const [mapCenter, setMapCenter] = useState<{ lat: number; lng: number; bounds?: { west: number; south: number; east: number; north: number } } | null>(null);
+  const arcgisLayersRef = useRef(arcgisLayers);
+  useEffect(() => { arcgisLayersRef.current = arcgisLayers; }, [arcgisLayers]);
+
+  // Refetch every visible ArcGIS layer for the current viewport. Without
+  // this, an imported (or seeded) layer's geometry is a one-time snapshot
+  // of whatever the map happened to show at import time -- panning away
+  // leaves it stale, and the seeded global layers above are ~94k/280k/14k
+  // features each, far more than any single-viewport query returns.
+  const arcgisKey = arcgisLayers.filter(l => l.visible).map(l => l.id).join('|');
+  const arcgisBounds = mapCenter?.bounds;
+  useEffect(() => {
+    if (!arcgisKey || !arcgisBounds) return;
+    const bbox = `${arcgisBounds.west.toFixed(3)},${arcgisBounds.south.toFixed(3)},${arcgisBounds.east.toFixed(3)},${arcgisBounds.north.toFixed(3)}`;
+    const ctrl = new AbortController();
+    // Debounced: moveend fires on every pan and zoom, and a fetch per twitch
+    // would hammer both this process and Esri.
+    const timer = setTimeout(async () => {
+      const ids = arcgisKey.split('|');
+      for (const id of ids) {
+        const layer = arcgisLayersRef.current.find(l => l.id === id);
+        if (!layer) continue;
+        try {
+          const res = await fetch(
+            `/api/arcgis?service=${encodeURIComponent(layer.url)}&bbox=${encodeURIComponent(bbox)}`,
+            { signal: ctrl.signal });
+          if (!res.ok) continue;
+          const gj = await res.json();
+          if (ctrl.signal.aborted) return;
+          setArcgisLayers(prev => prev.map(l => l.id === id ? { ...l, geojson: gj } : l));
+        } catch { /* aborted or a transient Esri error -- next move retries */ }
+      }
+    }, 400);
+    return () => { ctrl.abort(); clearTimeout(timer); };
+  }, [arcgisKey, arcgisBounds]);
+
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [mobilePanel, setMobilePanel] = useState<'layers'|'markets'|'intel'|'search'|'recon'|'remote'|null>(null);
   const [mapProjection, setMapProjection] = useState<'globe'|'mercator'>('globe');
@@ -238,6 +292,13 @@ export default function Dashboard() {
     cctv: true,
     live_news: true,
     earthquakes: true,
+    // Same default as earthquakes, not fires/weather's off-by-default: wave
+    // height off a real buoy network is a live tsunami precursor signal.
+    buoys: true,
+    // Off by default: an always-on particle animation (redrawn every frame,
+    // fetching a wind grid per viewport) is a real cost a first-time visitor
+    // should not pay without asking for it.
+    wind: false,
     fires: false,
     weather: false,
     radiation: false,
@@ -494,6 +555,19 @@ export default function Dashboard() {
     };
   }, [fetchEndpoint]);
 
+  // Ocean buoys refresh on their own timer, not just once on toggle: NDBC
+  // stations report roughly hourly, so this is a real-data-driven interval,
+  // not an arbitrary one, and it is what makes a wave-height anomaly show up
+  // without a manual reload.
+  useEffect(() => {
+    if (!(activeLayers as any).buoys) return;
+    const iv = setInterval(
+      () => fetchEndpoint('/api/buoys', d => ({ buoys: d.buoys }), undefined, { skipWhenHidden: true }),
+      900000, // 15 min
+    );
+    return () => clearInterval(iv);
+  }, [(activeLayers as any).buoys, fetchEndpoint]);
+
   // ── LAYER-AWARE DATA LOADING — only fetch when layer is toggled ON ──
   const layerFetchedRef = useRef<Set<string>>(new Set());
   useEffect(() => {
@@ -545,6 +619,11 @@ export default function Dashboard() {
     if (activeLayers.weather && !layerFetchedRef.current.has('weather')) {
       fetchEndpoint('/api/weather', d => ({ weather_events: d.events }));
       layerFetchedRef.current.add('weather');
+    }
+    // Ocean buoys (wave height / period — tsunami precursor signal)
+    if ((activeLayers as any).buoys && !layerFetchedRef.current.has('buoys')) {
+      fetchEndpoint('/api/buoys', d => ({ buoys: d.buoys }));
+      layerFetchedRef.current.add('buoys');
     }
     // Infrastructure
     if (activeLayers.infrastructure && !layerFetchedRef.current.has('infrastructure')) {

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -93,8 +93,12 @@ const LAYER_GROUPS: LayerGroupDef[] = [
     icon: CloudLightning,
     layers: [
       { key: 'earthquakes', label: 'Earthquakes', dataKey: 'earthquakes' },
+      { key: 'buoys', label: 'Ocean Buoys', dataKey: 'buoys' },
       { key: 'fires', label: 'Active Fires', dataKey: 'fires' },
       { key: 'weather', label: 'Severe Weather', dataKey: 'weather_events' },
+      // No dataKey: this is an animated particle overlay, not a discrete
+      // feature list, so there is no "N features" count to show.
+      { key: 'wind', label: 'Wind Streams', dataKey: '' },
     ],
   },
   {

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback, memo } from 'react';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import WindParticles from './WindParticles';
 
 interface OsirisMapProps {
   data: any;
@@ -207,7 +208,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       createDot(map, 'dot-fire', isGhost ? phantomPurple : '#E65100', 10);
       createDot(map, 'dot-cctv', cameraColor, 10);
 
-      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'malware-nodes', 'network-mesh', 'cyber-arcs', 'cyber-heads', 'cyber-impacts', 'gdelt-events', 'cf-outages', 'cf-attacks'];
+      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','buoys','gdelt','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'malware-nodes', 'network-mesh', 'cyber-arcs', 'cyber-heads', 'cyber-impacts', 'gdelt-events', 'cf-outages', 'cf-attacks'];
       sources.forEach(s => map.addSource(s, { type: 'geojson', data: EMPTY_FC }));
 
       // ── FLIGHT ROUTE VISUALIZATION SOURCES & LAYERS ──
@@ -262,6 +263,21 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       map.addLayer({ id: 'eq-label', type: 'symbol', source: 'earthquakes', filter: ['>=',['get','magnitude'],4.5], layout: {
         'text-field': ['concat','M',['to-string',['get','magnitude']]], 'text-size': 9, 'text-font': ['Open Sans Regular'], 'text-offset': [0,1.5],
       }, paint: { 'text-color': '#F9A825', 'text-halo-color': '#000', 'text-halo-width': 1 }});
+
+      // Ocean buoys — cyan-to-red on wave height, since that is the field
+      // this layer exists to surface. A station with no wave sensor (wind-
+      // only buoys are common) reads waveHeight: null, which must render as
+      // "no sensor" and not silently as "confirmed calm seas."
+      map.addLayer({ id: 'buoy-circles', type: 'circle', source: 'buoys', paint: {
+        'circle-radius': ['case', ['==', ['get','waveHeight'], null], 3,
+          ['interpolate',['linear'],['get','waveHeight'], 0,4, 2,7, 4,11, 8,16]],
+        'circle-color': ['case', ['==', ['get','waveHeight'], null], 'rgba(140,150,170,0.55)',
+          ['interpolate',['linear'],['get','waveHeight'], 0,'#00BCD4', 2,'#FFEB3B', 4,'#FF6D00', 8,'#D50000']],
+        'circle-opacity': 0.75, 'circle-stroke-width': 1, 'circle-stroke-color': '#00BCD4', 'circle-stroke-opacity': 0.3,
+      }});
+      map.addLayer({ id: 'buoy-label', type: 'symbol', source: 'buoys', filter: ['>=', ['coalesce', ['get','waveHeight'], 0], 2], layout: {
+        'text-field': ['concat', ['to-string', ['get','waveHeight']], 'm'], 'text-size': 9, 'text-font': ['Open Sans Regular'], 'text-offset': [0,1.5],
+      }, paint: { 'text-color': '#00E5FF', 'text-halo-color': '#000', 'text-halo-width': 1 }});
 
       // Fires — burnt sienna
       map.addLayer({ id: 'fires-heat', type: 'circle', source: 'fires', paint: {
@@ -829,6 +845,27 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       </div>`);
     });
 
+    // ── Ocean buoys (NOAA NDBC) ──
+    map.on('click', 'buoy-circles', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      const val = (v: any, unit: string) => (v === null || v === undefined ? '—' : `${v}${unit}`);
+      popup(coords, `<div style="${pStyle}border:1px solid rgba(0,229,255,0.3);">
+        <div style="color:#00E5FF;font-size:13px;font-weight:700;margin-bottom:4px;">BUOY ${htmlEsc(p.id)}</div>
+        <div style="font-size:9px;color:#5C5A54;margin-bottom:8px;">${new Date(p.time).toUTCString()}</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:4px;font-size:9px;">
+          <div><span style="color:#5C5A54;">WAVE HT</span><br/><span style="color:#00E5FF;">${val(p.waveHeight,'m')}</span></div>
+          <div><span style="color:#5C5A54;">PERIOD</span><br/><span style="color:#E8E6E0;">${val(p.domPeriod,'s')}</span></div>
+          <div><span style="color:#5C5A54;">WAVE DIR</span><br/><span style="color:#E8E6E0;">${val(p.waveDir,'°')}</span></div>
+          <div><span style="color:#5C5A54;">WIND</span><br/><span style="color:#E8E6E0;">${val(p.windSpeed,'m/s')}</span></div>
+          <div><span style="color:#5C5A54;">PRESSURE</span><br/><span style="color:#E8E6E0;">${val(p.pressure,'hPa')}</span></div>
+          <div><span style="color:#5C5A54;">WATER °C</span><br/><span style="color:#E8E6E0;">${val(p.waterTemp,'°')}</span></div>
+        </div>
+        <a href="https://www.ndbc.noaa.gov/station_page.php?station=${encodeURIComponent(p.id||'')}" target="_blank" style="${linkStyle}color:#00E5FF;border:1px solid rgba(0,229,255,0.4);background:rgba(0,229,255,0.1);">NDBC STATION PAGE</a>
+      </div>`);
+    });
+
     // ── Satellites (SatNOGS powered) ──
     map.on('click', 'sat-dots', e => {
       if (!e.features?.length) return;
@@ -1077,7 +1114,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     });
 
     // ── Generic hover for clickables ──
-    ['conflict-icons','cctv-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo','malware-dots','cyber-heads','gdelt-events-dots','cf-outage-dots','cf-attack-dots'].forEach(layer => {
+    ['conflict-icons','cctv-dots','eq-circles','buoy-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo','malware-dots','cyber-heads','gdelt-events-dots','cf-outage-dots','cf-attack-dots'].forEach(layer => {
       map.on('mouseenter', layer, () => { map.getCanvas().style.cursor = 'pointer'; });
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
     });
@@ -1398,6 +1435,11 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     if (!mapReady) return;
     setGeo('earthquakes', activeLayers.earthquakes && data.earthquakes ? data.earthquakes.map((eq: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [eq.lng, eq.lat] }, properties: { id: eq.id, magnitude: eq.magnitude, place: eq.place, depth: eq.depth, source: eq.source } })) : []);
   }, [mapReady, data.earthquakes, activeLayers.earthquakes, setGeo]);
+
+  useEffect(() => {
+    if (!mapReady) return;
+    setGeo('buoys', (activeLayers as any).buoys && (data as any).buoys ? (data as any).buoys.map((b: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [b.lng, b.lat] }, properties: b })) : []);
+  }, [mapReady, (data as any).buoys, (activeLayers as any).buoys, setGeo]);
 
   useEffect(() => {
     if (!mapReady) return;
@@ -1740,6 +1782,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   useEffect(() => {
     if (!mapReady) return;
     setVis(['eq-circles','eq-label'], activeLayers.earthquakes);
+    setVis(['buoy-circles','buoy-label'], (activeLayers as any).buoys);
     const anySat = activeLayers.satellites || (activeLayers as any).sat_comms || (activeLayers as any).sat_military || (activeLayers as any).sat_navigation || (activeLayers as any).sat_earth || (activeLayers as any).sat_science;
     setVis(['sat-glow','sat-dots'], anySat);
     setVis(['gdelt-dots'], activeLayers.global_incidents);
@@ -2361,13 +2404,20 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       const sourceId = `arcgis-${layer.id}`;
       const c = layer.color || '#D4AF37';
       const o = layer.opacity ?? 0.8;
+      // layer.geojson is null until the debounced viewport-bbox fetch (in
+      // page.tsx) resolves -- every newly-added layer passes through that
+      // gap for at least one render. maplibre's GeoJSON source rejects
+      // `null` outright ("not a valid GeoJSON object"), so an empty
+      // FeatureCollection stands in until the real geometry arrives and
+      // replaces it via the setData() branch below.
+      const geojson = layer.geojson ?? EMPTY_FC;
       if (!map.getSource(sourceId)) {
-        map.addSource(sourceId, { type: 'geojson', data: layer.geojson });
+        map.addSource(sourceId, { type: 'geojson', data: geojson });
         map.addLayer({ id: `${sourceId}-fill`, type: 'fill', source: sourceId, paint: { 'fill-color': c, 'fill-opacity': o * 0.15, 'fill-outline-color': c } });
         map.addLayer({ id: `${sourceId}-line`, type: 'line', source: sourceId, paint: { 'line-color': c, 'line-width': 2, 'line-opacity': o } });
         map.addLayer({ id: `${sourceId}-circle`, type: 'circle', source: sourceId, filter: ['==', ['geometry-type'], 'Point'], paint: { 'circle-color': c, 'circle-radius': 5, 'circle-stroke-width': 1.5, 'circle-stroke-color': '#000', 'circle-opacity': o } });
       } else {
-        (map.getSource(sourceId) as maplibregl.GeoJSONSource).setData(layer.geojson);
+        (map.getSource(sourceId) as maplibregl.GeoJSONSource).setData(geojson);
         // Update paint properties for color/opacity changes
         if (map.getLayer(`${sourceId}-fill`)) {
           map.setPaintProperty(`${sourceId}-fill`, 'fill-color', c);
@@ -2488,7 +2538,12 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     return () => { map.off('moveend', reportCenter); };
   }, [mapReady, onMapCenter]);
 
-  return <div ref={containerRef} className="absolute inset-0 w-full h-full" />;
+  return (
+    <div className="absolute inset-0 w-full h-full">
+      <div ref={containerRef} className="absolute inset-0 w-full h-full" />
+      <WindParticles map={mapRef.current} active={!!(activeLayers as any).wind} wrapRef={containerRef} />
+    </div>
+  );
 }
 
 export default memo(OsirisMap);

--- a/src/components/WindParticles.tsx
+++ b/src/components/WindParticles.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type maplibregl from 'maplibre-gl';
+
+// Real wind streamlines, not a decorative arrow grid -- the ask was
+// explicitly "like Ventusky, something you can actually study." /api/wind-
+// grid samples a real measured field (Open-Meteo, coarser than GFS's native
+// 0.25° but genuinely observed data, not synthesised); this component
+// advects a particle swarm through that field and draws the classic fading-
+// streak visualisation (earth.nullschool, Windy, Ventusky all use the same
+// technique: a low-alpha fade rect each frame instead of storing trail
+// history, plus one line segment per particle per frame).
+//
+// Particles are advected in LAT/LON space, not screen pixels: the map is a
+// Mercator projection, which is locally conformal (angles are preserved) but
+// not equidistant, so a fixed pixel step per frame would visibly speed up
+// wind flow near the poles and near the horizontal edges of the view. A
+// metres-per-degree conversion (111,320 m per degree of latitude everywhere;
+// that same distance per degree of longitude scaled by cos(latitude)) keeps
+// the physical wind speed consistent regardless of where on the map a
+// particle currently is, and reprojecting via map.project() every frame is
+// what makes panning/zooming during the animation track correctly.
+
+type WindGrid = {
+  bbox: { west: number; south: number; east: number; north: number };
+  nx: number; ny: number; u: number[]; v: number[];
+};
+
+const METRES_PER_DEGREE_LAT = 111320;
+const PARTICLE_COUNT = 1400;
+const PARTICLE_MAX_AGE = 90; // frames before a forced respawn
+// Real wind (a few m/s to ~30 m/s) is imperceptibly slow against a map that
+// can span thousands of km on screen. Every wind-map visualisation in
+// existence exaggerates simulated time per frame for exactly this reason --
+// this is that same knob, tuned by eye against the live render, not a
+// physically meaningful constant.
+const TIME_SCALE_SECONDS_PER_FRAME = 900;
+
+function speedColor(speed: number): string {
+  // m/s. 0 calm (blue) through ~15 m/s gale (red) -- the same convention
+  // Windy/Ventusky use, so anyone who has seen either reads this instantly.
+  const stops: [number, [number, number, number]][] = [
+    [0, [40, 80, 180]], [3, [30, 150, 190]], [7, [60, 190, 100]],
+    [11, [230, 200, 40]], [16, [230, 110, 30]], [24, [210, 30, 40]],
+  ];
+  let lo = stops[0], hi = stops[stops.length - 1];
+  for (let i = 0; i < stops.length - 1; i++) {
+    if (speed >= stops[i][0] && speed <= stops[i + 1][0]) { lo = stops[i]; hi = stops[i + 1]; break; }
+  }
+  const span = hi[0] - lo[0] || 1;
+  const t = Math.max(0, Math.min(1, (speed - lo[0]) / span));
+  const r = Math.round(lo[1][0] + (hi[1][0] - lo[1][0]) * t);
+  const g = Math.round(lo[1][1] + (hi[1][1] - lo[1][1]) * t);
+  const b = Math.round(lo[1][2] + (hi[1][2] - lo[1][2]) * t);
+  return `rgb(${r},${g},${b})`;
+}
+
+export default function WindParticles({
+  map, active, wrapRef,
+}: {
+  map: maplibregl.Map | null;
+  active: boolean;
+  wrapRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const gridRef = useRef<WindGrid | null>(null);
+  const particlesRef = useRef<Array<{ lng: number; lat: number; age: number; sx: number; sy: number }>>([]);
+  const rafRef = useRef<number | null>(null);
+  const fetchedBboxRef = useRef<string | null>(null);
+
+  // Bilinear-interpolate u/v at an arbitrary lng/lat from the sampled grid.
+  // Outside the grid's bbox returns null so the caller can respawn instead
+  // of extrapolating into a region with no data.
+  const sampleUV = (lng: number, lat: number): [number, number] | null => {
+    const g = gridRef.current;
+    if (!g) return null;
+    const { west, south, east, north } = g.bbox;
+    if (lng < west || lng > east || lat < south || lat > north) return null;
+    const fx = ((lng - west) / (east - west)) * (g.nx - 1);
+    const fy = ((lat - south) / (north - south)) * (g.ny - 1);
+    const x0 = Math.max(0, Math.min(g.nx - 2, Math.floor(fx)));
+    const y0 = Math.max(0, Math.min(g.ny - 2, Math.floor(fy)));
+    const tx = fx - x0, ty = fy - y0;
+    const idx = (x: number, y: number) => y * g.nx + x;
+    const u00 = g.u[idx(x0, y0)], u10 = g.u[idx(x0 + 1, y0)];
+    const u01 = g.u[idx(x0, y0 + 1)], u11 = g.u[idx(x0 + 1, y0 + 1)];
+    const v00 = g.v[idx(x0, y0)], v10 = g.v[idx(x0 + 1, y0)];
+    const v01 = g.v[idx(x0, y0 + 1)], v11 = g.v[idx(x0 + 1, y0 + 1)];
+    const u = u00 * (1 - tx) * (1 - ty) + u10 * tx * (1 - ty) + u01 * (1 - tx) * ty + u11 * tx * ty;
+    const v = v00 * (1 - tx) * (1 - ty) + v10 * tx * (1 - ty) + v01 * (1 - tx) * ty + v11 * tx * ty;
+    return [u, v];
+  };
+
+  const respawn = (p: { lng: number; lat: number; age: number; sx: number; sy: number }) => {
+    const g = gridRef.current;
+    if (!g) return;
+    p.lng = g.bbox.west + Math.random() * (g.bbox.east - g.bbox.west);
+    p.lat = g.bbox.south + Math.random() * (g.bbox.north - g.bbox.south);
+    p.age = Math.floor(Math.random() * PARTICLE_MAX_AGE);
+    p.sx = NaN; p.sy = NaN; // no previous screen position yet -- skip the first segment
+  };
+
+  // Fetch the wind grid for the current viewport, debounced on move, same
+  // pattern the ArcGIS layers already use for the same reason: moveend fires
+  // on every pan/zoom tick and a fetch per twitch would hammer Open-Meteo.
+  useEffect(() => {
+    if (!map || !active) return;
+    let cancelled = false;
+    const fetchGrid = async () => {
+      const b = map.getBounds();
+      const bbox = `${b.getWest().toFixed(2)},${b.getSouth().toFixed(2)},${b.getEast().toFixed(2)},${b.getNorth().toFixed(2)}`;
+      if (bbox === fetchedBboxRef.current) return;
+      try {
+        const res = await fetch(`/api/wind-grid?bbox=${encodeURIComponent(bbox)}`);
+        if (!res.ok || cancelled) return;
+        const g = await res.json();
+        if (g.error || cancelled) return;
+        gridRef.current = g;
+        fetchedBboxRef.current = bbox;
+        // A fresh grid invalidates in-flight particle positions relative to
+        // it only in the sense of stale data, not geometry -- particles keep
+        // flowing, just against updated vectors from here on.
+      } catch { /* offline or Open-Meteo hiccup -- keep the last good grid */ }
+    };
+    fetchGrid();
+    const onMoveEnd = () => { fetchGrid(); };
+    map.on('moveend', onMoveEnd);
+    const refreshTimer = setInterval(fetchGrid, 600000); // 10 min
+    return () => {
+      cancelled = true;
+      map.off('moveend', onMoveEnd);
+      clearInterval(refreshTimer);
+    };
+  }, [map, active]);
+
+  // Animation loop.
+  useEffect(() => {
+    const canvas = canvasRef.current, wrap = wrapRef.current;
+    if (!map || !active || !canvas || !wrap) return;
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const fit = () => {
+      canvas.width = wrap.clientWidth * dpr;
+      canvas.height = wrap.clientHeight * dpr;
+      canvas.style.width = wrap.clientWidth + 'px';
+      canvas.style.height = wrap.clientHeight + 'px';
+    };
+    fit();
+    const ro = new ResizeObserver(fit);
+    ro.observe(wrap);
+
+    const ctx = canvas.getContext('2d')!;
+    ctx.scale(dpr, dpr);
+
+    if (particlesRef.current.length !== PARTICLE_COUNT) {
+      particlesRef.current = Array.from({ length: PARTICLE_COUNT }, () => ({ lng: 0, lat: 0, age: 0, sx: NaN, sy: NaN }));
+      particlesRef.current.forEach(respawn);
+    }
+
+    // The bug a zoom/pan actually exposed: a particle's screen position
+    // (sx, sy) is only meaningful under the projection it was recorded
+    // under. Reproject an unchanged lng/lat under a NEW zoom/pan and the
+    // "previous" point can land anywhere on screen relative to the new
+    // point -- every one of 2,500 particles drawing a line from its old
+    // (now-meaningless) screen spot to its reprojected one, all in the same
+    // frame, is exactly the radial full-screen burst this produced, and
+    // redoing that on every zoom step is what stressed the browser. `move`
+    // fires continuously through a drag/zoom gesture, not just at its end,
+    // so this drops every particle's remembered segment before that frame
+    // renders -- the next frame just starts a fresh trail from wherever the
+    // particle reprojects to now, no warp-line possible.
+    const invalidateScreenPositions = () => {
+      for (const p of particlesRef.current) { p.sx = NaN; p.sy = NaN; }
+    };
+    map.on('move', invalidateScreenPositions);
+
+    const render = () => {
+      const w = wrap.clientWidth, h = wrap.clientHeight;
+      // Fade the previous frame instead of clearing it -- this IS the
+      // streamline effect. A lower alpha here means longer, smoother trails;
+      // measured by eye against the real render, not derived from anything.
+      ctx.fillStyle = 'rgba(6,10,16,0.06)';
+      ctx.globalCompositeOperation = 'source-over';
+      ctx.fillRect(0, 0, w, h);
+
+      const g = gridRef.current;
+      if (g) {
+        for (const p of particlesRef.current) {
+          const uv = sampleUV(p.lng, p.lat);
+          if (!uv) { respawn(p); continue; }
+          const [u, v] = uv;
+          const dtSeconds = TIME_SCALE_SECONDS_PER_FRAME;
+          p.lat += (v * dtSeconds) / METRES_PER_DEGREE_LAT;
+          const metresPerDegLon = METRES_PER_DEGREE_LAT * Math.cos((p.lat * Math.PI) / 180);
+          p.lng += (u * dtSeconds) / Math.max(1, metresPerDegLon);
+          p.age += 1;
+
+          const screen = map.project([p.lng, p.lat]);
+          if (screen.x < -50 || screen.x > w + 50 || screen.y < -50 || screen.y > h + 50 || p.age > PARTICLE_MAX_AGE) {
+            respawn(p);
+            continue;
+          }
+          if (Number.isFinite(p.sx) && Number.isFinite(p.sy)) {
+            const speed = Math.hypot(u, v);
+            ctx.strokeStyle = speedColor(speed);
+            ctx.globalAlpha = 0.75;
+            ctx.lineWidth = 1.1;
+            ctx.beginPath();
+            ctx.moveTo(p.sx, p.sy);
+            ctx.lineTo(screen.x, screen.y);
+            ctx.stroke();
+          }
+          p.sx = screen.x; p.sy = screen.y;
+        }
+      }
+      rafRef.current = requestAnimationFrame(render);
+    };
+    rafRef.current = requestAnimationFrame(render);
+
+    return () => {
+      map.off('move', invalidateScreenPositions);
+      ro.disconnect();
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    };
+  }, [map, active, wrapRef]);
+
+  if (!active) return null;
+  return (
+    <canvas ref={canvasRef}
+      className="absolute inset-0 pointer-events-none"
+      style={{ mixBlendMode: 'screen' }} />
+  );
+}


### PR DESCRIPTION
## Summary

Three additions to the map's real-time hazard/infrastructure coverage:

- **Global ArcGIS presets** — the ArcGIS panel now seeds with real global data (Global Oil & Gas Pipelines, Global Railways, Global Power Plants, from Bucknell University GIS's Global Oil and Gas Features service) instead of opening empty until a user happens to search. Verified live: genuine worldwide extent, ~94k pipeline segments, ~280k railway segments, ~14k power plants.
- **Ocean buoys (NOAA NDBC)** — new HAZARD layer, on by default like earthquakes. Wave height off a real buoy network is a live tsunami precursor signal. New `/api/buoys` route, 886 stations worldwide in one request, refreshes every 15 min.
- **Animated wind streamlines** — off by default, opt-in. A particle-advection overlay (the standard earth.nullschool/Windy technique) over a real measured wind field from a new `/api/wind-grid` route (Open-Meteo, batched per viewport).

Also fixes a real bug the ArcGIS presets surface immediately: maplibre's GeoJSON source rejects `data: null`, and every newly-added layer's `geojson` is `null` until the first viewport fetch resolves — not an edge case, the normal startup path. An empty `FeatureCollection` now stands in for that gap. And adds the viewport-bbox auto-refresh the ArcGIS panel didn't have before (previously a one-time snapshot from import time, which doesn't scale to a 94k-feature dataset).

## Test plan

- [x] `tsc --noEmit` clean for every file this PR touches (a handful of pre-existing errors elsewhere — `WorldRemote.tsx`'s Web Bluetooth types, an `OsintPanel` prop mismatch, one missing `createPortal` import — are present on `master` unmodified, verified against a clean checkout, and unrelated to this change)
- [x] Full test suite: 191/191 (includes new `route.test.ts` for the NDBC parser, tested against real sample rows, not synthetic ones)
- [x] Verified on a clean `npm install` of this exact branch (not a symlinked/shared `node_modules`) with a live dev server: all three ArcGIS layers active with real geometry rendering over Europe, `/api/buoys` returning 892 live stations with real names/positions
- [x] Wind streamlines share the exact `WindParticles.tsx` component already verified extensively on a downstream fork, including a zoom-related stale-screen-position bug caught live and fixed (particles' remembered screen coordinates are invalidated on every `move` event, not just `moveend`, so a zoom/pan gesture can't draw a warp-line from a pre-gesture position to a post-gesture one)