### PR TITLE
feat(routing): readable route panel, and a camera that stops fighting the driver

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -950,6 +950,7 @@ export default function Dashboard() {
               : liveLocation
           }
           followUser={followUser}
+          onFollowInterrupt={() => setFollowUser(false)}
           navigating={Boolean(navSession)}
           aircraftAirports={aircraftAirports}
         />
@@ -968,6 +969,8 @@ export default function Dashboard() {
               destinationLabel={navSession.label}
               fix={liveLocation}
               onProgress={setNavProgress}
+              following={followUser}
+              onRecenter={() => setFollowUser(true)}
               onExit={() => { setNavSession(null); setNavProgress(null); setFollowUser(false); }}
               onReroute={async (fromPt) => {
                 // Re-plan from where the driver actually is, to the same destination.

--- a/src/components/DirectionsBar.tsx
+++ b/src/components/DirectionsBar.tsx
@@ -346,7 +346,7 @@ function PlaceInput({
         }}
         placeholder={placeholder}
         aria-label={placeholder}
-        className="w-full bg-transparent py-2 pr-6 text-[11px] text-[var(--text-primary)] outline-none
+        className="w-full bg-transparent py-2 pr-6 text-[13px] text-[var(--text-primary)] outline-none
                    placeholder:text-[var(--text-muted)] focus:placeholder:text-[var(--text-secondary)]
                    border-b border-transparent focus:border-[var(--border-active)] transition-colors"
         autoComplete="off"
@@ -364,7 +364,7 @@ function PlaceInput({
           disabled={locating}
           title="Use my location"
           aria-label="Use my location"
-          className="absolute right-0 top-1/2 -translate-y-1/2 p-1 rounded text-[var(--text-muted)]
+          className="absolute right-0 top-1/2 -translate-y-1/2 p-1.5 rounded text-[var(--text-muted)]
                      hover:text-[var(--alert-green)] hover:bg-[rgba(0,230,118,0.08)] transition-colors disabled:opacity-50"
         >
           <LocateFixed className={`w-3.5 h-3.5 ${locating ? 'animate-pulse text-[var(--alert-green)]' : ''}`} />
@@ -385,8 +385,8 @@ function PlaceInput({
             >
               <KindIcon kind="current" />
               <span className="min-w-0">
-                <span className="block text-[10px] text-[var(--alert-green)]">Your location</span>
-                <span className="block text-[9px] text-[var(--text-muted)]">Live position</span>
+                <span className="block text-[12px] text-[var(--alert-green)]">Your location</span>
+                <span className="block text-[11px] text-[var(--text-muted)]">Live position</span>
               </span>
             </button>
           )}
@@ -401,11 +401,11 @@ function PlaceInput({
             >
               <KindIcon kind={r.kind} />
               <span className="min-w-0">
-                <span className={`block text-[10px] text-[var(--text-primary)] truncate ${r.kind === 'coordinate' ? 'tabular-nums' : ''}`}>
+                <span className={`block text-[12px] text-[var(--text-primary)] truncate ${r.kind === 'coordinate' ? 'tabular-nums' : ''}`}>
                   {r.label}
                 </span>
                 {r.context && (
-                  <span className="block text-[9px] text-[var(--text-muted)] truncate">{r.context}</span>
+                  <span className="block text-[11px] text-[var(--text-muted)] truncate">{r.context}</span>
                 )}
               </span>
             </button>
@@ -629,9 +629,9 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
       {/* ── header ── */}
       <header className="flex items-center gap-2 px-3 h-9 border-b border-[var(--border-secondary)] flex-shrink-0">
         <Route className="w-3.5 h-3.5 text-[var(--gold-primary)]" />
-        <h2 className="text-[10px] tracking-[0.18em] text-[var(--text-secondary)] uppercase flex-1">Route</h2>
+        <h2 className="text-[12px] tracking-[0.18em] text-[var(--text-secondary)] uppercase flex-1">Route</h2>
         {route && (
-          <span className="text-[9px] text-[var(--text-muted)] tabular-nums">
+          <span className="text-[11px] text-[var(--text-muted)] tabular-nums">
             {route.steps.length} steps
           </span>
         )}
@@ -640,7 +640,7 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
           onClick={toggleTracking}
           aria-pressed={tracking}
           title={tracking ? 'Stop live tracking' : 'Track my location live'}
-          className={`p-1 rounded transition-colors ${
+          className={`p-1.5 rounded transition-colors ${
             tracking
               ? 'text-[#4285F4] bg-[rgba(66,133,244,0.14)]'
               : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
@@ -654,7 +654,7 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
             onClick={() => { const n = !follow; setFollow(n); onFollowChange?.(n); }}
             aria-pressed={follow}
             title={follow ? 'Stop following' : 'Keep the map centred on me'}
-            className={`p-1 rounded transition-colors ${
+            className={`p-1.5 rounded transition-colors ${
               follow
                 ? 'text-[var(--gold-primary)] bg-[rgba(var(--gold-rgb),0.14)]'
                 : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
@@ -667,7 +667,7 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
           <button
             onClick={onClose}
             aria-label="Close directions"
-            className="text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors -mr-1 p-1"
+            className="text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors -mr-1 p-1.5"
           >
             <X className="w-3.5 h-3.5" />
           </button>
@@ -749,7 +749,7 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
                 role="tab"
                 aria-selected={on}
                 onClick={() => pickMode(id)}
-                className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-[6px] text-[10px] transition-all ${
+                className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-[6px] text-[12px] transition-all ${
                   on
                     ? 'bg-[rgba(var(--gold-rgb),0.14)] text-[var(--gold-primary)] shadow-[inset_0_0_0_1px_rgba(var(--gold-rgb),0.25)]'
                     : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
@@ -793,7 +793,7 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
               key={k}
               onClick={() => toggleAvoid(k)}
               aria-pressed={avoid[k]}
-              className={`flex-1 py-1.5 rounded-md border text-[9px] capitalize transition-all ${
+              className={`flex-1 py-1.5 rounded-md border text-[11px] capitalize transition-all ${
                 avoid[k]
                   ? 'border-[var(--border-active)] bg-[rgba(var(--gold-rgb),0.12)] text-[var(--gold-primary)]'
                   : 'border-[var(--border-secondary)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
@@ -823,20 +823,20 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
         )}
 
         {!loading && !error && locateError && (
-          <p className="px-3 pt-2 text-[9px] text-[var(--gold-primary)]">{locateError}</p>
+          <p className="px-3 pt-2 text-[11px] text-[var(--gold-primary)]">{locateError}</p>
         )}
 
         {!loading && error && (
           <div className="px-3 py-4 text-center">
-            <p className="text-[10px] text-[var(--alert-red)]">{error}</p>
-            <p className="text-[9px] text-[var(--text-muted)] mt-1">
+            <p className="text-[12px] text-[var(--alert-red)]">{error}</p>
+            <p className="text-[11px] text-[var(--text-muted)] mt-1">
               Try a different point, or switch travel mode.
             </p>
           </div>
         )}
 
         {!loading && !error && !route && (
-          <p className="px-3 py-4 text-[10px] text-[var(--text-muted)] leading-relaxed">
+          <p className="px-3 py-4 text-[12px] text-[var(--text-muted)] leading-relaxed">
             {ready
               ? 'Calculating…'
               : 'Enter a start and destination. Place names, addresses and lat,lng all work.'}
@@ -849,11 +849,11 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
               <div className="px-3 py-2.5 border-b border-[var(--border-secondary)] bg-[rgba(66,133,244,0.07)]">
                 <div className="flex items-center gap-1.5 mb-1.5">
                   <Navigation className="w-2.5 h-2.5 text-[#4285F4]" />
-                  <span className="text-[8px] uppercase tracking-[0.15em] text-[#4285F4]">Next turn</span>
+                  <span className="text-[10px] uppercase tracking-[0.15em] text-[#4285F4]">Next turn</span>
                 </div>
                 <div className="flex items-start gap-2.5">
                   <span className="mt-0.5 flex-shrink-0"><StepIcon type={guidance.step.type} /></span>
-                  <span className="flex-1 min-w-0 text-[11px] text-[var(--text-primary)] leading-snug">
+                  <span className="flex-1 min-w-0 text-[13px] text-[var(--text-primary)] leading-snug">
                     {guidance.step.instruction}
                   </span>
                   <span className="text-[13px] text-[var(--gold-primary)] tabular-nums flex-shrink-0">
@@ -863,22 +863,23 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
               </div>
             )}
 
-            {/* summary */}
-            <div className="px-3 py-2.5 border-b border-[var(--border-secondary)]">
+            {/* summary — sticky so time, distance and ETA stay visible while
+                the step list scrolls underneath */}
+            <div className="sticky top-0 z-10 px-3 py-2.5 border-b border-[var(--border-secondary)] bg-[var(--bg-panel)] backdrop-blur-xl">
               <div className="flex items-baseline justify-between gap-3">
                 <div className="min-w-0">
                   <div className="text-[17px] leading-none text-[var(--gold-primary)] tabular-nums">
                     {formatDuration(route.duration)}
                   </div>
                   {via && (
-                    <div className="text-[9px] text-[var(--text-muted)] truncate mt-1">via {via}</div>
+                    <div className="text-[11px] text-[var(--text-muted)] truncate mt-1">via {via}</div>
                   )}
                 </div>
                 <div className="text-right flex-shrink-0">
-                  <div className="text-[11px] text-[var(--text-secondary)] tabular-nums">
+                  <div className="text-[13px] text-[var(--text-secondary)] tabular-nums">
                     {formatDistance(route.distance)}
                   </div>
-                  <div className="flex items-center gap-1 justify-end text-[9px] text-[var(--text-muted)] tabular-nums mt-1">
+                  <div className="flex items-center gap-1 justify-end text-[11px] text-[var(--text-muted)] tabular-nums mt-1">
                     <Clock className="w-2.5 h-2.5" />
                     {arrivalTime(route.duration)}
                   </div>
@@ -887,19 +888,19 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
 
               {(route.hasToll || route.hasHighway || route.hasFerry) && (
                 <div className="flex gap-1.5 mt-2">
-                  {route.hasToll && <span className="px-1.5 py-0.5 rounded text-[8px] uppercase tracking-wider border border-[var(--border-secondary)] text-[var(--alert-orange)]">Toll</span>}
-                  {route.hasHighway && <span className="px-1.5 py-0.5 rounded text-[8px] uppercase tracking-wider border border-[var(--border-secondary)] text-[var(--text-muted)]">Motorway</span>}
-                  {route.hasFerry && <span className="px-1.5 py-0.5 rounded text-[8px] uppercase tracking-wider border border-[var(--border-secondary)] text-[var(--cyan-primary)]">Ferry</span>}
+                  {route.hasToll && <span className="px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider border border-[var(--border-secondary)] text-[var(--alert-orange)]">Toll</span>}
+                  {route.hasHighway && <span className="px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider border border-[var(--border-secondary)] text-[var(--text-muted)]">Motorway</span>}
+                  {route.hasFerry && <span className="px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider border border-[var(--border-secondary)] text-[var(--cyan-primary)]">Ferry</span>}
                 </div>
               )}
 
               {route.elevation && route.elevation.length > 1 && (
                 <div className="mt-2.5">
                   <div className="flex items-center justify-between mb-1">
-                    <span className="flex items-center gap-1 text-[8px] uppercase tracking-[0.15em] text-[var(--text-muted)]">
+                    <span className="flex items-center gap-1 text-[10px] uppercase tracking-[0.15em] text-[var(--text-muted)]">
                       <Mountain className="w-2.5 h-2.5" /> Elevation
                     </span>
-                    <span className="text-[9px] text-[var(--text-secondary)] tabular-nums">
+                    <span className="text-[11px] text-[var(--text-secondary)] tabular-nums">
                       ↑{route.ascent ?? 0} m · ↓{route.descent ?? 0} m
                     </span>
                   </div>
@@ -922,7 +923,7 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
                   onClick={() => onStartNavigation(route, to?.label || 'your destination')}
                   className="w-full mt-2.5 flex items-center justify-center gap-2 py-2 rounded-lg
                              bg-[rgba(66,133,244,0.16)] border border-[rgba(66,133,244,0.45)]
-                             text-[#7BAAF7] text-[11px] tracking-wide
+                             text-[#7BAAF7] text-[13px] tracking-wide
                              hover:bg-[rgba(66,133,244,0.24)] transition-colors"
                 >
                   <Play className="w-3.5 h-3.5" />
@@ -952,14 +953,14 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
                             });
                           }
                         }}
-                        className={`flex-1 px-2 py-1.5 rounded-md border text-[9px] transition-all ${
+                        className={`flex-1 px-2 py-2 rounded-md border text-[11px] transition-all ${
                           on
                             ? 'border-[var(--border-active)] bg-[rgba(var(--gold-rgb),0.12)] text-[var(--gold-primary)]'
                             : 'border-[var(--border-secondary)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
                         }`}
                       >
                         <span className="block tabular-nums">{formatDuration(r.duration)}</span>
-                        <span className="block text-[8px] opacity-70 tabular-nums">
+                        <span className="block text-[10px] opacity-70 tabular-nums">
                           {i === 0 ? 'Fastest' : slower > 0 ? `+${slower} min` : formatDistance(r.distance)}
                         </span>
                       </button>
@@ -981,18 +982,18 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
                         segmentBetween(route.geometry.coordinates, s.location, route.steps[i + 1]?.location),
                       );
                     }}
-                    className={`w-full text-left px-3 py-2 flex items-start gap-2.5 border-l-2 transition-colors ${
+                    className={`w-full text-left px-3 py-2.5 flex items-start gap-2.5 border-l-2 transition-colors ${
                       activeStep === i
                         ? 'border-[var(--gold-primary)] bg-[rgba(var(--gold-rgb),0.07)]'
                         : 'border-transparent hover:bg-[rgba(255,255,255,0.03)]'
                     }`}
                   >
                     <span className="mt-px flex-shrink-0"><StepIcon type={s.type} /></span>
-                    <span className="flex-1 min-w-0 text-[10px] text-[var(--text-primary)] leading-snug">
+                    <span className="flex-1 min-w-0 text-[12px] text-[var(--text-primary)] leading-snug">
                       {s.instruction}
                     </span>
                     {s.distance > 0 && (
-                      <span className="text-[9px] text-[var(--text-muted)] tabular-nums flex-shrink-0 mt-px w-12 text-right">
+                      <span className="text-[11px] text-[var(--text-muted)] tabular-nums flex-shrink-0 mt-px w-12 text-right">
                         {formatDistance(s.distance)}
                       </span>
                     )}
@@ -1001,7 +1002,7 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
               ))}
             </ol>
 
-            <p className="px-3 py-2 text-[8px] text-[var(--text-muted)] tracking-wider uppercase border-t border-[var(--border-secondary)]">
+            <p className="px-3 py-2 text-[10px] text-[var(--text-muted)] tracking-wider uppercase border-t border-[var(--border-secondary)]">
               Routing via {route.provider} · OpenStreetMap
             </p>
           </>

--- a/src/components/NavigationView.tsx
+++ b/src/components/NavigationView.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import {
   X, Volume2, VolumeX, CornerUpRight, CornerUpLeft, ArrowUp, RotateCw,
-  Merge, Flag, MapPin, AlertTriangle, Loader2,
+  Merge, Flag, MapPin, AlertTriangle, Loader2, LocateFixed,
 } from 'lucide-react';
 import {
   cumulativeDistances, stepPositions, computeProgress, shouldAnnounce, announcementText,
@@ -32,6 +32,10 @@ interface NavigationViewProps {
   onReroute: (from: { lat: number; lng: number }) => void;
   /** Snapped position + progress, so the map can follow and draw. */
   onProgress?: (p: NavProgress | null) => void;
+  /** Whether the map is currently locked to the driver. */
+  following?: boolean;
+  /** Re-lock the camera after the operator has looked around. */
+  onRecenter?: () => void;
 }
 
 function ManeuverIcon({ type, className }: { type: string; className?: string }) {
@@ -59,7 +63,7 @@ export function navDuration(s: number): string {
 }
 
 export default function NavigationView({
-  route, destinationLabel, fix, onExit, onReroute, onProgress,
+  route, destinationLabel, fix, onExit, onReroute, onProgress, following, onRecenter,
 }: NavigationViewProps) {
   const [muted, setMuted] = useState(false);
   const [rerouting, setRerouting] = useState(false);
@@ -184,6 +188,18 @@ export default function NavigationView({
           </div>
 
           <div className="flex flex-col gap-1 flex-shrink-0">
+            {/* Only offered once the operator has taken the camera off the
+                driver — while following, it would be a no-op. */}
+            {onRecenter && !following && (
+              <button
+                onClick={onRecenter}
+                title="Recenter on me and resume follow"
+                aria-label="Recenter on me and resume follow"
+                className="p-1.5 rounded-md text-[#4285F4] bg-[rgba(66,133,244,0.14)] hover:bg-[rgba(66,133,244,0.24)] transition-colors animate-pulse"
+              >
+                <LocateFixed className="w-4 h-4" />
+              </button>
+            )}
             <button
               onClick={() => { setMuted((m) => !m); window.speechSynthesis?.cancel(); }}
               aria-pressed={muted}
@@ -214,15 +230,15 @@ export default function NavigationView({
         {/* ── trip status ── */}
         <div className="px-4 py-2.5 flex items-center justify-between gap-3">
           {rerouting ? (
-            <span className="flex items-center gap-2 text-[10px] text-[var(--alert-orange)]">
+            <span className="flex items-center gap-2 text-[12px] text-[var(--alert-orange)]">
               <Loader2 className="w-3 h-3 animate-spin" /> Recalculating route…
             </span>
           ) : progress?.offRoute ? (
-            <span className="flex items-center gap-2 text-[10px] text-[var(--alert-orange)]">
+            <span className="flex items-center gap-2 text-[12px] text-[var(--alert-orange)]">
               <AlertTriangle className="w-3 h-3" /> Off route
             </span>
           ) : (
-            <span className="text-[10px] text-[var(--text-muted)] truncate">
+            <span className="text-[12px] text-[var(--text-muted)] truncate">
               to {destinationLabel}
             </span>
           )}
@@ -230,8 +246,8 @@ export default function NavigationView({
           {progress && !arrived && (
             <span className="flex items-baseline gap-2.5 flex-shrink-0 tabular-nums">
               <span className="text-[13px] text-[var(--text-primary)]">{navDuration(progress.durationRemaining)}</span>
-              <span className="text-[10px] text-[var(--text-secondary)]">{navDistance(progress.distanceRemaining)}</span>
-              <span className="text-[10px] text-[var(--text-muted)]">
+              <span className="text-[12px] text-[var(--text-secondary)]">{navDistance(progress.distanceRemaining)}</span>
+              <span className="text-[12px] text-[var(--text-muted)]">
                 {new Date(now + progress.durationRemaining * 1000)
                   .toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
               </span>
@@ -243,16 +259,16 @@ export default function NavigationView({
       {/* ── the turn after this one ── */}
       {progress && !arrived && route.steps[progress.stepIndex + 1] && (
         <div className="glass-panel px-4 py-2 flex items-center gap-3">
-          <span className="text-[8px] uppercase tracking-[0.15em] text-[var(--text-muted)] flex-shrink-0">Then</span>
+          <span className="text-[10px] uppercase tracking-[0.15em] text-[var(--text-muted)] flex-shrink-0">Then</span>
           <ManeuverIcon type={route.steps[progress.stepIndex + 1].type} className="w-4 h-4" />
-          <span className="text-[10px] text-[var(--text-secondary)] truncate">
+          <span className="text-[12px] text-[var(--text-secondary)] truncate">
             {route.steps[progress.stepIndex + 1].instruction}
           </span>
         </div>
       )}
 
       {!fix && (
-        <div className="glass-panel px-4 py-2 text-[10px] text-[var(--alert-orange)]">
+        <div className="glass-panel px-4 py-2 text-[12px] text-[var(--alert-orange)]">
           Waiting for a position fix… navigation needs HTTPS or localhost.
         </div>
       )}

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -37,6 +37,8 @@ interface OsirisMapProps {
   userLocation?: { lat: number; lng: number; accuracy?: number; heading?: number | null } | null;
   /** Keep the camera centred on userLocation as it moves. */
   followUser?: boolean;
+  /** Fired when the operator pans/zooms/rotates while follow mode is on. */
+  onFollowInterrupt?: () => void;
   /** Live navigation: tighter zoom and the map turned to face travel direction. */
   navigating?: boolean;
   /** Corroborated endpoint airports for watched aircraft, keyed by icao24. */
@@ -65,7 +67,7 @@ function computeSolarTerminator(): [number, number][] {
 
 const EMPTY_FC = { type: 'FeatureCollection' as const, features: [] };
 
-function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null, userLocation = null, followUser = false, navigating = false, aircraftAirports = {} }: OsirisMapProps) {
+function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawingMode = false, onDrawComplete, onMapCenter, route = null, userLocation = null, followUser = false, onFollowInterrupt, navigating = false, aircraftAirports = {} }: OsirisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
@@ -2249,6 +2251,27 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   }, [mapReady, userLocation]);
 
   // ── FOLLOW MODE ──
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !followUser) return;
+    const map = mapRef.current;
+    // originalEvent is only set when a real input device drove the change, so
+    // the easeTo below cannot trip this and cancel its own follow.
+    const onGesture = (e: any) => { if (e?.originalEvent) onFollowInterrupt?.(); };
+    map.on('dragstart', onGesture);
+    map.on('zoomstart', onGesture);
+    map.on('rotatestart', onGesture);
+    map.on('pitchstart', onGesture);
+    return () => {
+      map.off('dragstart', onGesture);
+      map.off('zoomstart', onGesture);
+      map.off('rotatestart', onGesture);
+      map.off('pitchstart', onGesture);
+    };
+  }, [mapReady, followUser, onFollowInterrupt]);
+
+  // Recentering runs on every position fix, so without the handover above the
+  // map fights the operator: zoom out to look ahead and the next GPS tick drags
+  // the camera back to 16.5. Follow itself is unchanged and resumes on recenter.
   useEffect(() => {
     if (!mapReady || !mapRef.current || !followUser || !userLocation) return;
     // While navigating, sit close in and rotate the map so travel direction is


### PR DESCRIPTION
Two problems in the routing experience, both found by **measuring** the panel in the running app rather than eyeballing it.

## 1. The panel was hard to read and partly untappable

| | before | after |
|---|---|---|
| Smallest text | **8px** (23 of 25 nodes ≤10px) | **10px**, most 11–12px |
| Controls under 24px tall | **16**, smallest **22px** | **0**, smallest **26px** |
| Route summary while scrolling | scrolled away | **pinned** |

22px controls fail **WCAG 2.5.8**, which sets 24px as the minimum target size — so this was an accessibility defect, not just a taste call.

The type scale is lifted in a single pass so sizes don't cascade (8→10, 9→11, 10→12, 11→13), keeping the 17px trip duration as the anchor so hierarchy survives rather than flattening. Header icons, close, locate, step rows and alternate-route tabs all enlarged. `NavigationView` had the same 8/10px problem and gets the same treatment.

The **route summary is now sticky** — trip time, distance and ETA stay on screen instead of vanishing the moment you look at step five. Verified by scrolling the step list 446px and watching it hold at `top: 173`.

## 2. Follow mode fought the driver

Recentering runs on **every position fix**, so zooming out to look ahead survived about a second before the next GPS tick dragged the camera back to zoom 16.5.

A deliberate gesture now **suspends** follow instead of losing to it — `dragstart`, `zoomstart`, `rotatestart`, `pitchstart` are watched while following, and the handler fires only when `e.originalEvent` is present.

That guard is the crux: `originalEvent` is set **only** when a real input device caused the change, so follow's own `easeTo` cannot trip its own kill switch and cancel itself on the first fix.

**The zoom-in is unchanged.** Starting navigation still locks to the driver at 16.5 zoom, 50° pitch, heading-up — it just stops being compulsory. A **recenter control** appears in the navigation header once the camera has been taken off the driver, and stays hidden while following, where it would be a no-op.

## Verified

Full flow driven end to end in the browser: autocomplete ~1.2s / 8 results, routing ~820ms, alternates and start-navigation both render. The API is healthy — Valhalla, 3 alternates, proper 400s on malformed input.

186 tests pass · production build compiles · typecheck unchanged at its pre-existing 17-error baseline.

## Not verified

The on-road feel of the handover needs a real GPS fix and an active navigation session, which a headless browser can't produce. The wiring, the `originalEvent` guard and the build are checked — **the actual driving is not.** Worth a real-world try before merge.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
