### PR TITLE
feat(ui): raise the type floor across the app, fix ArcGIS rendering and browsing

### DIFF
--- a/src/app/docs/CommandPalette.tsx
+++ b/src/app/docs/CommandPalette.tsx
@@ -134,7 +134,7 @@ export default function CommandPalette({
             aria-label="Search documentation"
             className="flex-1 bg-transparent text-[13px] font-mono text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none"
           />
-          <kbd className="text-[9px] font-mono px-1.5 py-0.5 rounded border border-white/10 text-[var(--text-muted)]">
+          <kbd className="text-[11px] font-mono px-1.5 py-0.5 rounded border border-white/10 text-[var(--text-muted)]">
             ESC
           </kbd>
         </div>
@@ -156,7 +156,7 @@ export default function CommandPalette({
               }`}
             >
               <span
-                className={`text-[8px] font-mono tracking-widest uppercase px-1.5 py-0.5 rounded border shrink-0 ${
+                className={`text-[10px] font-mono tracking-widest uppercase px-1.5 py-0.5 rounded border shrink-0 ${
                   it.kind === 'Endpoint'
                     ? 'text-[var(--cyan-primary)] border-[var(--cyan-primary)]/25'
                     : 'text-[var(--gold-primary)] border-[var(--gold-primary)]/25'
@@ -169,7 +169,7 @@ export default function CommandPalette({
                 <span className="block text-[11px] text-[var(--text-muted)] truncate">{it.hint}</span>
               </span>
               {i === cursor && (
-                <kbd className="text-[9px] font-mono px-1.5 py-0.5 rounded border border-white/10 text-[var(--text-muted)] shrink-0">
+                <kbd className="text-[11px] font-mono px-1.5 py-0.5 rounded border border-white/10 text-[var(--text-muted)] shrink-0">
                   ↵
                 </kbd>
               )}
@@ -177,7 +177,7 @@ export default function CommandPalette({
           ))}
         </div>
 
-        <div className="flex items-center gap-4 px-4 h-9 border-t border-white/[0.07] text-[9px] font-mono text-[var(--text-muted)]">
+        <div className="flex items-center gap-4 px-4 h-9 border-t border-white/[0.07] text-[11px] font-mono text-[var(--text-muted)]">
           <span className="flex items-center gap-1">
             <kbd className="px-1 py-0.5 rounded border border-white/10">↑</kbd>
             <kbd className="px-1 py-0.5 rounded border border-white/10">↓</kbd> navigate

--- a/src/app/docs/DocsClient.tsx
+++ b/src/app/docs/DocsClient.tsx
@@ -154,7 +154,7 @@ export default function DocsClient() {
               <span className="text-[13px] font-bold tracking-[0.3em] text-[var(--gold-primary)] font-mono">
                 OSIRIS
               </span>
-              <span className="text-[7px] font-mono tracking-[0.22em] text-[var(--text-muted)] uppercase mt-[3px]">
+              <span className="text-[10px] font-mono tracking-[0.22em] text-[var(--text-muted)] uppercase mt-[3px]">
                 Docs
               </span>
             </span>
@@ -173,7 +173,7 @@ export default function DocsClient() {
               <path d="m20 20-3.5-3.5" />
             </svg>
             <span className="hidden sm:inline text-[11.5px] text-[var(--text-muted)] font-mono">Search</span>
-            <kbd className="hidden sm:inline text-[9px] font-mono px-1.5 py-0.5 rounded border border-white/10 text-[var(--text-muted)]">
+            <kbd className="hidden sm:inline text-[11px] font-mono px-1.5 py-0.5 rounded border border-white/10 text-[var(--text-muted)]">
               ⌘K
             </kbd>
           </button>
@@ -192,7 +192,7 @@ export default function DocsClient() {
 
           <Link
             href="/"
-            className="hidden md:inline-flex items-center gap-1.5 text-[10px] font-mono tracking-[0.15em] uppercase px-3 h-8 rounded-lg border border-[var(--gold-primary)]/30 bg-[var(--gold-primary)]/[0.08] text-[var(--gold-primary)] hover:bg-[var(--gold-primary)]/[0.18] transition-colors"
+            className="hidden md:inline-flex items-center gap-1.5 text-[12px] font-mono tracking-[0.15em] uppercase px-3 h-8 rounded-lg border border-[var(--gold-primary)]/30 bg-[var(--gold-primary)]/[0.08] text-[var(--gold-primary)] hover:bg-[var(--gold-primary)]/[0.18] transition-colors"
           >
             Launch Map
             <svg viewBox="0 0 24 24" className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -235,18 +235,18 @@ export default function DocsClient() {
               : '-translate-x-4 opacity-0 pointer-events-none lg:translate-x-0 lg:opacity-100 lg:pointer-events-auto'
           } fixed lg:sticky top-14 left-0 bottom-0 lg:bottom-auto z-[260] lg:z-auto w-64 lg:w-56 shrink-0 lg:h-[calc(100vh-3.5rem)] overflow-y-auto styled-scrollbar bg-[var(--bg-void)] lg:bg-transparent border-r lg:border-r-0 border-white/[0.06] py-6 pr-2 pl-2 lg:pl-0 transition-all duration-200`}
         >
-          <div className="text-[9px] font-mono tracking-[0.3em] uppercase text-[var(--text-muted)]/70 pl-4 mb-2">
+          <div className="text-[11px] font-mono tracking-[0.3em] uppercase text-[var(--text-muted)]/70 pl-4 mb-2">
             Guide
           </div>
           {GUIDE_SECTIONS.map(navLink)}
 
-          <div className="text-[9px] font-mono tracking-[0.3em] uppercase text-[var(--text-muted)]/70 pl-4 mb-2 mt-7">
+          <div className="text-[11px] font-mono tracking-[0.3em] uppercase text-[var(--text-muted)]/70 pl-4 mb-2 mt-7">
             API Reference
           </div>
           {API_SECTIONS.map(navLink)}
 
           <div className="mt-8 mx-2 rounded-lg border border-white/[0.07] bg-white/[0.02] p-3">
-            <div className="text-[10px] font-mono text-[var(--text-secondary)] leading-relaxed">
+            <div className="text-[12px] font-mono text-[var(--text-secondary)] leading-relaxed">
               <span className="text-[var(--gold-primary)] font-bold">{ENDPOINT_COUNT}</span> endpoints, no key
               required.
             </div>
@@ -259,7 +259,7 @@ export default function DocsClient() {
           <div className="mb-20">
             <div className="inline-flex items-center gap-2 px-2.5 py-1 rounded-full border border-[var(--cyan-primary)]/20 bg-[var(--cyan-primary)]/[0.05] mb-6">
               <span className="w-1.5 h-1.5 rounded-full bg-[var(--alert-green)] animate-pulse" />
-              <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-secondary)]">
+              <span className="text-[11px] font-mono tracking-[0.2em] uppercase text-[var(--text-secondary)]">
                 Open Source · MIT
               </span>
             </div>
@@ -304,7 +304,7 @@ export default function DocsClient() {
               ].map(s => (
                 <div key={s.l} className="rounded-xl border border-white/[0.07] bg-white/[0.015] px-4 py-3">
                   <div className="text-[24px] font-bold text-[var(--gold-primary)] font-mono leading-none">{s.n}</div>
-                  <div className="text-[10px] font-mono tracking-[0.15em] uppercase text-[var(--text-muted)] mt-1.5">
+                  <div className="text-[12px] font-mono tracking-[0.15em] uppercase text-[var(--text-muted)] mt-1.5">
                     {s.l}
                   </div>
                 </div>
@@ -571,7 +571,7 @@ docker compose up -d`}</Pre>
                   href={`#${prev.id}`}
                   className="rounded-xl border border-white/[0.07] bg-white/[0.015] p-4 hover:border-[var(--gold-primary)]/30 transition-colors"
                 >
-                  <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1">
+                  <div className="text-[11px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1">
                     ← Previous
                   </div>
                   <div className="text-[13px] text-[var(--text-primary)]">{prev.title}</div>
@@ -584,7 +584,7 @@ docker compose up -d`}</Pre>
                   href={`#${next.id}`}
                   className="rounded-xl border border-white/[0.07] bg-white/[0.015] p-4 hover:border-[var(--gold-primary)]/30 transition-colors sm:text-right"
                 >
-                  <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1">
+                  <div className="text-[11px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1">
                     Next →
                   </div>
                   <div className="text-[13px] text-[var(--text-primary)]">{next.title}</div>
@@ -617,7 +617,7 @@ docker compose up -d`}</Pre>
 
         {/* ── Right rail: on this page ── */}
         <aside className="hidden xl:block w-52 shrink-0 sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto styled-scrollbar py-16">
-          <div className="text-[9px] font-mono tracking-[0.3em] uppercase text-[var(--text-muted)]/70 mb-3">
+          <div className="text-[11px] font-mono tracking-[0.3em] uppercase text-[var(--text-muted)]/70 mb-3">
             On this page
           </div>
           <div className="space-y-0.5">
@@ -638,7 +638,7 @@ docker compose up -d`}</Pre>
 
           <button
             onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-            className="mt-6 flex items-center gap-1.5 text-[10px] font-mono tracking-[0.15em] uppercase text-[var(--text-muted)] hover:text-[var(--gold-primary)] transition-colors"
+            className="mt-6 flex items-center gap-1.5 text-[12px] font-mono tracking-[0.15em] uppercase text-[var(--text-muted)] hover:text-[var(--gold-primary)] transition-colors"
           >
             <svg viewBox="0 0 24 24" className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="m18 15-6-6-6 6" />

--- a/src/app/docs/EndpointCard.tsx
+++ b/src/app/docs/EndpointCard.tsx
@@ -130,7 +130,7 @@ export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: 
           {methods.map(m => (
             <span
               key={m}
-              className={`text-[9px] font-mono font-bold tracking-widest px-1.5 py-0.5 rounded border text-center ${METHOD_STYLES[m]}`}
+              className={`text-[11px] font-mono font-bold tracking-widest px-1.5 py-0.5 rounded border text-center ${METHOD_STYLES[m]}`}
             >
               {m}
             </span>
@@ -165,7 +165,7 @@ export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: 
           {/* Params */}
           {ep.params && ep.params.length > 0 && (
             <div className="mb-4">
-              <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-2">
+              <div className="text-[11px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-2">
                 Query parameters
               </div>
               <div className="space-y-2">
@@ -174,11 +174,11 @@ export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: 
                     <div className="flex items-center gap-1.5 pt-1.5">
                       <span className="font-mono text-[11.5px] text-[var(--gold-primary)]">{p.name}</span>
                       {p.required ? (
-                        <span className="text-[8px] font-mono tracking-wider uppercase text-[var(--alert-red)]/80">
+                        <span className="text-[10px] font-mono tracking-wider uppercase text-[var(--alert-red)]/80">
                           required
                         </span>
                       ) : (
-                        <span className="text-[8px] font-mono tracking-wider uppercase text-[var(--text-muted)]">
+                        <span className="text-[10px] font-mono tracking-wider uppercase text-[var(--text-muted)]">
                           optional
                         </span>
                       )}
@@ -202,7 +202,7 @@ export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: 
           {/* Request body */}
           {ep.bodyExample && (
             <>
-              <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1">
+              <div className="text-[11px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1">
                 Request body
               </div>
               <CodeBlock dense tabs={[{ label: 'JSON', lang: 'json', code: ep.bodyExample }]} />
@@ -210,7 +210,7 @@ export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: 
           )}
 
           {/* Request snippets */}
-          <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1 mt-4">
+          <div className="text-[11px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1 mt-4">
             Request
           </div>
           <CodeBlock dense tabs={tabs} />
@@ -222,7 +222,7 @@ export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: 
                 <button
                   onClick={run}
                   disabled={running || missingRequired.length > 0}
-                  className="inline-flex items-center gap-1.5 text-[10px] font-mono tracking-[0.15em] uppercase px-3 py-1.5 rounded-md border border-[var(--gold-primary)]/40 bg-[var(--gold-primary)]/10 text-[var(--gold-primary)] hover:bg-[var(--gold-primary)]/20 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  className="inline-flex items-center gap-1.5 text-[12px] font-mono tracking-[0.15em] uppercase px-3 py-1.5 rounded-md border border-[var(--gold-primary)]/40 bg-[var(--gold-primary)]/10 text-[var(--gold-primary)] hover:bg-[var(--gold-primary)]/20 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                 >
                   {running ? (
                     <span className="w-2.5 h-2.5 rounded-full border border-current border-t-transparent animate-spin" />
@@ -234,14 +234,14 @@ export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: 
                   {running ? 'Running' : 'Send request'}
                 </button>
                 {missingRequired.length > 0 && (
-                  <span className="text-[10px] font-mono text-[var(--text-muted)]">
+                  <span className="text-[12px] font-mono text-[var(--text-muted)]">
                     Fill {missingRequired.map(p => p.name).join(', ')} first
                   </span>
                 )}
                 <CopyButton value={`${origin}${liveUrl}`} />
               </>
             ) : (
-              <span className="text-[10px] font-mono text-[var(--text-muted)]">
+              <span className="text-[12px] font-mono text-[var(--text-muted)]">
                 {ep.requiresAuth
                   ? 'Requires a credential — run this from your own client.'
                   : 'POST endpoint — run this from your own client.'}
@@ -253,11 +253,11 @@ export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: 
           {result && (
             <div className="mt-3">
               <div className="flex items-center gap-2 mb-1">
-                <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)]">
+                <span className="text-[11px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)]">
                   Response
                 </span>
                 <span
-                  className={`text-[9px] font-mono font-bold px-1.5 py-0.5 rounded border ${
+                  className={`text-[11px] font-mono font-bold px-1.5 py-0.5 rounded border ${
                     result.ok
                       ? 'text-[#00E676] border-[#00E676]/30 bg-[#00E676]/10'
                       : 'text-[#FF3D3D] border-[#FF3D3D]/30 bg-[#FF3D3D]/10'
@@ -265,7 +265,7 @@ export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: 
                 >
                   {result.status || 'ERR'}
                 </span>
-                <span className="text-[9px] font-mono text-[var(--text-muted)]">{result.ms}ms</span>
+                <span className="text-[11px] font-mono text-[var(--text-muted)]">{result.ms}ms</span>
               </div>
               <CodeBlock dense tabs={[{ label: 'JSON', lang: 'json', code: result.body }]} />
             </div>
@@ -273,7 +273,7 @@ export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: 
 
           {/* Returns */}
           <div className="mt-4">
-            <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1.5">
+            <div className="text-[11px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] mb-1.5">
               Response keys
             </div>
             <div className="flex flex-wrap gap-1.5">
@@ -291,7 +291,7 @@ export default function EndpointCard({ ep, origin }: { ep: ApiEndpoint; origin: 
           {/* Env */}
           {ep.env && ep.env.length > 0 && (
             <div className="mt-3 flex flex-wrap items-center gap-1.5">
-              <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)]">
+              <span className="text-[11px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)]">
                 Environment
               </span>
               {ep.env.map(e => (

--- a/src/app/docs/docsPrimitives.tsx
+++ b/src/app/docs/docsPrimitives.tsx
@@ -35,7 +35,7 @@ export function CopyButton({ value, className = '' }: { value: string; className
     <button
       onClick={copy}
       aria-label={copied ? 'Copied' : 'Copy to clipboard'}
-      className={`inline-flex items-center gap-1 text-[9px] font-mono tracking-[0.15em] uppercase px-2 py-1 rounded-[5px] border transition-all duration-200 ${
+      className={`inline-flex items-center gap-1 text-[11px] font-mono tracking-[0.15em] uppercase px-2 py-1 rounded-[5px] border transition-all duration-200 ${
         copied
           ? 'border-[var(--alert-green)]/40 bg-[var(--alert-green)]/10 text-[var(--alert-green)]'
           : 'border-white/10 bg-black/60 text-[var(--text-muted)] hover:text-[var(--gold-primary)] hover:border-[var(--gold-primary)]/40'
@@ -142,14 +142,14 @@ export function CodeBlock({
     <div className={`rounded-xl border border-white/[0.08] bg-[#07070D] overflow-hidden ${dense ? 'my-3' : 'my-5'}`}>
       <div className="flex items-center gap-1 px-2 h-9 border-b border-white/[0.07] bg-white/[0.015]">
         {label && !tabs.length && (
-          <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] px-2">{label}</span>
+          <span className="text-[11px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] px-2">{label}</span>
         )}
         {tabs.length > 1 ? (
           tabs.map((t, i) => (
             <button
               key={t.label}
               onClick={() => setIdx(i)}
-              className={`text-[10px] font-mono tracking-wider px-2.5 py-1 rounded-[5px] transition-colors ${
+              className={`text-[12px] font-mono tracking-wider px-2.5 py-1 rounded-[5px] transition-colors ${
                 i === idx
                   ? 'text-[var(--gold-primary)] bg-[var(--gold-primary)]/10'
                   : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
@@ -159,7 +159,7 @@ export function CodeBlock({
             </button>
           ))
         ) : (
-          <span className="text-[9px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] px-2">
+          <span className="text-[11px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] px-2">
             {label || tabs[0]?.label}
           </span>
         )}
@@ -217,7 +217,7 @@ export function Callout({
           {tone !== 'good' && <circle cx="12" cy="12" r="9" />}
           <path d={t.icon} />
         </svg>
-        <span className="text-[10px] font-mono tracking-[0.2em] uppercase" style={{ color: t.border }}>
+        <span className="text-[12px] font-mono tracking-[0.2em] uppercase" style={{ color: t.border }}>
           {title || t.label}
         </span>
       </div>
@@ -244,7 +244,7 @@ export function Section({
   return (
     <section id={id} className="scroll-mt-28 mb-20">
       {eyebrow && (
-        <div className="text-[9px] font-mono tracking-[0.3em] uppercase text-[var(--cyan-primary)]/60 mb-2">
+        <div className="text-[11px] font-mono tracking-[0.3em] uppercase text-[var(--cyan-primary)]/60 mb-2">
           {eyebrow}
         </div>
       )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -751,7 +751,7 @@ export default function Dashboard() {
               initial={{ opacity: 0 }}
               animate={{ opacity: 0.6 }}
               transition={{ delay: 0.8, duration: 0.5 }}
-              className="absolute top-6 left-6 z-[2] font-mono text-[10px] tracking-[0.3em] text-[var(--gold-primary)]"
+              className="absolute top-6 left-6 z-[2] font-mono text-[12px] tracking-[0.3em] text-[var(--gold-primary)]"
             >
               V4.2
             </motion.div>
@@ -848,7 +848,7 @@ export default function Dashboard() {
                 transition={{ delay: 1.2, duration: 0.8, ease: 'easeInOut' }}
                 className="overflow-hidden whitespace-nowrap"
               >
-                <p className="text-[10px] md:text-[11px] font-mono tracking-[0.5em] text-[var(--gold-primary)]" style={{ opacity: 0.8 }}>
+                <p className="text-[12px] md:text-[11px] font-mono tracking-[0.5em] text-[var(--gold-primary)]" style={{ opacity: 0.8 }}>
                   GLOBAL INTELLIGENCE PLATFORM
                 </p>
               </motion.div>
@@ -880,7 +880,7 @@ export default function Dashboard() {
                     initial={{ opacity: 0 }}
                     animate={{ opacity: [0, 1, 1, 0] }}
                     transition={{ delay: stage.delay, duration: 0.6, times: [0, 0.1, 0.7, 1] }}
-                    className="absolute text-[9px] font-mono tracking-[0.25em]"
+                    className="absolute text-[11px] font-mono tracking-[0.25em]"
                     style={{ color: i === 3 ? 'var(--cyan-primary)' : 'var(--text-muted)' }}
                   >
                     {stage.text}
@@ -1048,7 +1048,7 @@ export default function Dashboard() {
           <div className="flex items-center rounded-xl overflow-hidden border border-[var(--border-primary)] bg-[var(--bg-panel)] backdrop-blur-2xl shadow-[0_4px_24px_rgba(0,0,0,0.5)]">
             <button
               onClick={() => setMapProjection('globe')}
-              className={`flex items-center gap-1.5 px-3 py-2 text-[9px] font-mono tracking-wider transition-all duration-200 ${
+              className={`flex items-center gap-1.5 px-3 py-2 text-[11px] font-mono tracking-wider transition-all duration-200 ${
                 mapProjection === 'globe'
                   ? 'bg-[var(--cyan-primary)]/15 text-[var(--cyan-primary)]'
                   : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
@@ -1061,7 +1061,7 @@ export default function Dashboard() {
             <div className="w-px h-4 bg-[var(--border-primary)]" />
             <button
               onClick={() => setMapProjection('mercator')}
-              className={`flex items-center gap-1.5 px-3 py-2 text-[9px] font-mono tracking-wider transition-all duration-200 ${
+              className={`flex items-center gap-1.5 px-3 py-2 text-[11px] font-mono tracking-wider transition-all duration-200 ${
                 mapProjection === 'mercator'
                   ? 'bg-[var(--gold-primary)]/15 text-[var(--gold-primary)]'
                   : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
@@ -1077,7 +1077,7 @@ export default function Dashboard() {
           <div className="flex items-center rounded-xl overflow-hidden border border-[var(--border-primary)] bg-[var(--bg-panel)] backdrop-blur-2xl shadow-[0_4px_24px_rgba(0,0,0,0.5)]">
             <button
               onClick={() => setMapStyle('dark')}
-              className={`flex items-center gap-1.5 px-3 py-2 text-[9px] font-mono tracking-wider transition-all duration-200 ${
+              className={`flex items-center gap-1.5 px-3 py-2 text-[11px] font-mono tracking-wider transition-all duration-200 ${
                 mapStyle === 'dark'
                   ? 'bg-[var(--cyan-primary)]/15 text-[var(--cyan-primary)]'
                   : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
@@ -1090,7 +1090,7 @@ export default function Dashboard() {
             <div className="w-px h-4 bg-[var(--border-primary)]" />
             <button
               onClick={() => setMapStyle('satellite')}
-              className={`flex items-center gap-1.5 px-3 py-2 text-[9px] font-mono tracking-wider transition-all duration-200 ${
+              className={`flex items-center gap-1.5 px-3 py-2 text-[11px] font-mono tracking-wider transition-all duration-200 ${
                 mapStyle === 'satellite'
                   ? 'bg-[var(--alert-green)]/15 text-[var(--alert-green)]'
                   : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
@@ -1121,11 +1121,11 @@ export default function Dashboard() {
           </svg>
           <div className="flex flex-col items-start gap-0.5">
             <h1 className="text-lg md:text-xl font-bold tracking-[0.4em] text-[#D4AF37] font-mono">OSIRIS</h1>
-            <span className="text-[8px] md:text-[9px] font-mono tracking-[0.2em] opacity-80 uppercase text-[#D4AF37]">OPEN SOURCE INTELLIGENCE</span>
+            <span className="text-[10px] md:text-[11px] font-mono tracking-[0.2em] opacity-80 uppercase text-[#D4AF37]">OPEN SOURCE INTELLIGENCE</span>
           </div>
         </div>
         <div className="flex items-center gap-3 mt-1.5 pl-[44px] min-w-0 pr-4">
-          <span className="text-[5px] md:text-[6px] text-[var(--text-muted)] font-mono tracking-[0.2em] md:tracking-[0.3em] uppercase opacity-40 truncate">
+          <span className="text-[10px] md:text-[10px] text-[var(--text-muted)] font-mono tracking-[0.2em] md:tracking-[0.3em] uppercase opacity-40 truncate">
             REAL-TIME GLOBAL MONITORING <span className="hidden md:inline">· FLIGHTS · MARITIME · SATELLITES · CCTV · WEATHER · CYBER THREATS</span>
           </span>
         </div>
@@ -1133,7 +1133,7 @@ export default function Dashboard() {
 
 
       {/* ── TOP-RIGHT STATUS (desktop) ── */}
-      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 3 }} className="status-bar-desktop absolute top-4 right-6 z-[200] pointer-events-none flex items-center gap-3 text-[9px] font-mono tracking-widest text-[var(--text-muted)]">
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 3 }} className="status-bar-desktop absolute top-4 right-6 z-[200] pointer-events-none flex items-center gap-3 text-[11px] font-mono tracking-widest text-[var(--text-muted)]">
 
         <span className="hidden lg:inline-flex items-center gap-1.5">
           <ZuluClock />
@@ -1153,11 +1153,11 @@ export default function Dashboard() {
 
         {spaceWeather && <span className="hidden lg:inline" title={`Geomagnetic Storm Index — Kp${spaceWeather.kp_index}`}>SOLAR: <span style={{ color: spaceWeather.storm_color, fontWeight: 700 }}>Kp{spaceWeather.kp_index}</span></span>}
 
-        <span className="text-[10px] font-bold tracking-[0.2em] text-[var(--text-muted)] opacity-50">V.4.1</span>
+        <span className="text-[12px] font-bold tracking-[0.2em] text-[var(--text-muted)] opacity-50">V.4.1</span>
         
         <TokenPanel />
 
-        <a href='https://ko-fi.com/M8D41ZYW4Z' target='_blank' rel='noopener noreferrer' className="pointer-events-auto glass-panel px-3 py-1.5 flex items-center gap-1.5 text-[8px] font-mono tracking-widest hover:opacity-80 transition-opacity border-[var(--gold-primary)]/40 bg-[var(--gold-primary)]/10 ml-3 shadow-[0_0_10px_rgba(255,215,0,0.1)]">
+        <a href='https://ko-fi.com/M8D41ZYW4Z' target='_blank' rel='noopener noreferrer' className="pointer-events-auto glass-panel px-3 py-1.5 flex items-center gap-1.5 text-[10px] font-mono tracking-widest hover:opacity-80 transition-opacity border-[var(--gold-primary)]/40 bg-[var(--gold-primary)]/10 ml-3 shadow-[0_0_10px_rgba(255,215,0,0.1)]">
           <div className="w-1.5 h-1.5 rounded-full bg-[var(--gold-primary)] animate-osiris-pulse" />
           <span className="text-[var(--gold-primary)] font-bold">SUPPORT</span>
         </a>
@@ -1169,7 +1169,7 @@ export default function Dashboard() {
       {isMobile && !showDirections && !navSession && (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 2.5 }} className="absolute top-3 right-3 z-[200] pointer-events-auto flex items-center gap-2">
           <TokenPanel />
-          <a href='https://ko-fi.com/M8D41ZYW4Z' target='_blank' rel='noopener noreferrer' className="glass-panel px-2 py-1 flex items-center gap-1.5 text-[7px] font-mono tracking-widest hover:opacity-80 transition-opacity border-[var(--gold-primary)]/40 bg-[var(--gold-primary)]/10">
+          <a href='https://ko-fi.com/M8D41ZYW4Z' target='_blank' rel='noopener noreferrer' className="glass-panel px-2 py-1 flex items-center gap-1.5 text-[10px] font-mono tracking-widest hover:opacity-80 transition-opacity border-[var(--gold-primary)]/40 bg-[var(--gold-primary)]/10">
             <div className="w-1 h-1 rounded-full bg-[var(--gold-primary)] animate-osiris-pulse" />
             <span className="text-[var(--gold-primary)] font-bold">SUPPORT</span>
           </a>
@@ -1189,7 +1189,7 @@ export default function Dashboard() {
           <button onClick={() => { setShowIntel(!showIntel); setShowMarkets(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showIntel ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`} title="OSINT Recon — IP lookup, network sweep, geolocation">
             <Radar className={`w-4 h-4 ${showIntel ? 'text-[var(--cyan-primary)]' : 'text-white/60'}`} />
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">RECON</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[10px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">RECON</span>
           <AnimatePresence>
             {showIntel && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
@@ -1209,7 +1209,7 @@ export default function Dashboard() {
           <button onClick={() => { setShowIntel(false); setShowAlerts(false); setShowMarkets(false); setShowSpaceCam(v => !v); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showSpaceCam ? 'bg-[#00E5FF]/20' : 'hover:bg-white/10'}`} title="Live from Space — 24/7 video downlink from the ISS">
             <Radio className={`w-4 h-4 ${showSpaceCam ? 'text-[#00E5FF]' : 'text-white/60'}`} />
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">SPACE</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[10px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">SPACE</span>
           <AnimatePresence>
             {showSpaceCam && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
@@ -1223,7 +1223,7 @@ export default function Dashboard() {
           <button onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); setShowSpaceCam(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Markets — crypto prices, space weather, global indices">
             <BarChart3 className={`w-4 h-4 ${showMarkets ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">MARKETS</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[10px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">MARKETS</span>
           <AnimatePresence>
             {showMarkets && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
@@ -1237,7 +1237,7 @@ export default function Dashboard() {
           <button onClick={() => { setShowAlerts(!showAlerts); setShowIntel(false); setShowMarkets(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showAlerts ? 'bg-[#FF3D3D]/20' : 'hover:bg-white/10'}`} title="Live Alerts — earthquakes, conflicts, breaking news">
             <AlertTriangle className={`w-4 h-4 ${showAlerts ? 'text-[#FF3D3D]' : 'text-white/60'}`} />
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ALERTS</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[10px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ALERTS</span>
           <AnimatePresence>
             {showAlerts && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
@@ -1251,21 +1251,21 @@ export default function Dashboard() {
           <button onClick={() => { setShowEntityGraph(!showEntityGraph); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showEntityGraph ? 'bg-[#D4AF37]/20' : 'hover:bg-white/10'}`} title="Entity Graph — link analysis between tracked entities">
             <Network className={`w-4 h-4 ${showEntityGraph ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">GRAPH</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[10px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">GRAPH</span>
         </div>
 
         <div className="relative group">
           <button onClick={() => { setShowDirections(!showDirections); if (showDirections) { setActiveRoute(null); } setShowDesktopSearch(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDirections ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Directions — turn-by-turn routing">
             <Route className={`w-4 h-4 ${showDirections ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ROUTE</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[10px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ROUTE</span>
         </div>
 
         <div className="relative group">
           <button onClick={() => { setShowDesktopSearch(!showDesktopSearch); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowEntityGraph(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDesktopSearch ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Search — find locations, cities, coordinates">
             <Search className={`w-4 h-4 ${showDesktopSearch ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">SEARCH</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[10px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">SEARCH</span>
           <AnimatePresence>
             {showDesktopSearch && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
@@ -1282,9 +1282,9 @@ export default function Dashboard() {
         <div className="relative group">
           <button onClick={() => { setShowArcGIS(!showArcGIS); setShowRemote(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showArcGIS ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="ArcGIS — search & import geospatial intel layers">
             <Database className={`w-4 h-4 ${showArcGIS ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
-            {arcgisLayers.length > 0 && <span className="absolute -top-0.5 -right-0.5 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-[var(--gold-primary)] text-black text-[7px] font-mono font-bold leading-none px-0.5">{arcgisLayers.length}</span>}
+            {arcgisLayers.length > 0 && <span className="absolute -top-0.5 -right-0.5 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-[var(--gold-primary)] text-black text-[10px] font-mono font-bold leading-none px-0.5">{arcgisLayers.length}</span>}
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ARCGIS</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[10px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ARCGIS</span>
           <AnimatePresence>
             {showArcGIS && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-[340px]">
@@ -1311,7 +1311,7 @@ export default function Dashboard() {
           <button onClick={() => { setShowRemote(!showRemote); setShowArcGIS(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowEntityGraph(false); setShowDesktopSearch(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showRemote ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`} title="World Remote — control nearby Bluetooth devices (TVs, speakers, AC)">
             <Bluetooth className={`w-4 h-4 ${showRemote ? 'text-[var(--cyan-primary)]' : 'text-white/60'}`} />
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[8px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">REMOTE</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[10px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">REMOTE</span>
           <AnimatePresence>
             {showRemote && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
@@ -1353,9 +1353,9 @@ export default function Dashboard() {
                 <div className="flex items-center gap-2">
                   <div className="w-2 h-2 rounded-full bg-[#FF4081] animate-osiris-pulse" />
                   <span className="text-[12px] font-mono font-bold text-white tracking-wider">{liveFeedName}</span>
-                  <span className="px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 font-mono text-[9px] font-bold">LIVE STREAM</span>
+                  <span className="px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 font-mono text-[11px] font-bold">LIVE STREAM</span>
                   {!liveFeedEmbedAllowed && (
-                    <span className="px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 font-mono text-[9px]">EXTERNAL ONLY</span>
+                    <span className="px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 font-mono text-[11px]">EXTERNAL ONLY</span>
                   )}
                 </div>
                 <div className="flex items-center gap-3">
@@ -1487,7 +1487,7 @@ export default function Dashboard() {
                 <div className="mobile-drawer-handle" />
                 <div className="px-3 pb-3">
                   <div className="flex items-center justify-between mb-2">
-                    <span className="hud-text text-[9px] text-[var(--text-primary)]">
+                    <span className="hud-text text-[11px] text-[var(--text-primary)]">
                       {mobilePanel === 'layers' ? 'LAYERS & STATS' : mobilePanel === 'markets' ? 'MARKETS & INTEL' : mobilePanel === 'intel' ? 'INTEL FEED' : mobilePanel === 'recon' ? 'OSIRIS RECON' : mobilePanel === 'remote' ? 'WORLD REMOTE' : 'SEARCH'}
                     </span>
                     <button onClick={() => setMobilePanel(null)} className="text-[var(--text-muted)] p-1"><X className="w-4 h-4" /></button>
@@ -1496,11 +1496,11 @@ export default function Dashboard() {
                     <>
                       <div className="glass-panel-sm p-2 mb-2">
                         <div className="grid grid-cols-5 gap-1 text-center">
-                          <div><div className="hud-label" style={{fontSize:'6px'}}>AIR</div><div className="hud-value text-[9px]">{totalFlights.toLocaleString()}</div></div>
-                          <div><div className="hud-label" style={{fontSize:'6px'}}>SAT</div><div className="hud-value text-[9px]">{(data.satellites?.length||0)}</div></div>
-                          <div><div className="hud-label" style={{fontSize:'6px'}}>CAM</div><div className="hud-value text-[9px]">{(data.cameras?.length||0)}</div></div>
-                          <div><div className="hud-label" style={{fontSize:'6px'}}>WX</div><div className="hud-value text-[9px]" style={{color:'var(--accent-weather)'}}>{(data.weather_events?.length||0)}</div></div>
-                          <div><div className="hud-label" style={{fontSize:'6px'}}>NUC</div><div className="hud-value text-[9px]" style={{color:'var(--accent-nuclear)'}}>{(data.infrastructure?.length||0)}</div></div>
+                          <div><div className="hud-label" style={{fontSize:'10px'}}>AIR</div><div className="hud-value text-[11px]">{totalFlights.toLocaleString()}</div></div>
+                          <div><div className="hud-label" style={{fontSize:'10px'}}>SAT</div><div className="hud-value text-[11px]">{(data.satellites?.length||0)}</div></div>
+                          <div><div className="hud-label" style={{fontSize:'10px'}}>CAM</div><div className="hud-value text-[11px]">{(data.cameras?.length||0)}</div></div>
+                          <div><div className="hud-label" style={{fontSize:'10px'}}>WX</div><div className="hud-value text-[11px]" style={{color:'var(--accent-weather)'}}>{(data.weather_events?.length||0)}</div></div>
+                          <div><div className="hud-label" style={{fontSize:'10px'}}>NUC</div><div className="hud-value text-[11px]" style={{color:'var(--accent-nuclear)'}}>{(data.infrastructure?.length||0)}</div></div>
                         </div>
                       </div>
                       <LayerPanel data={data} activeLayers={activeLayers} setActiveLayers={setActiveLayers} isMobile={true} theme={osirisTheme} setTheme={setOsirisTheme} capabilities={capabilities} />
@@ -1543,7 +1543,7 @@ export default function Dashboard() {
       {/* ── BOTTOM CURSOR INFO (desktop) ── */}
       {!isMobile && (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 3, duration: 0.8 }} className="desktop-only absolute bottom-8 z-[200] pointer-events-auto" style={{ left: '72px' }}>
-          <div className="flex items-center gap-5 text-[8px] font-mono tracking-widest text-[var(--text-muted)] opacity-60">
+          <div className="flex items-center gap-5 text-[10px] font-mono tracking-widest text-[var(--text-muted)] opacity-60">
             <div className="flex gap-2 items-center" title="Cursor coordinates (hover over map)">
               <span>CURSOR</span>
               <span ref={coordsDisplayRef} className="text-[var(--gold-primary)] font-bold tabular-nums">—</span>
@@ -1573,7 +1573,7 @@ export default function Dashboard() {
             {dossierLoading ? (
               <div className="text-center py-8">
                 <div className="w-5 h-5 border-2 border-[var(--gold-primary)] border-t-transparent rounded-full animate-spin mx-auto mb-2" />
-                <span className="text-[8px] font-mono text-[var(--text-muted)] tracking-widest">COMPILING INTEL...</span>
+                <span className="text-[10px] font-mono text-[var(--text-muted)] tracking-widest">COMPILING INTEL...</span>
               </div>
             ) : regionDossier && (
               <div className="space-y-3">
@@ -1588,8 +1588,8 @@ export default function Dashboard() {
                     <div><div className="hud-label mb-0.5">AREA</div><div className="text-xs text-[var(--text-primary)]">{regionDossier.country.area?.toLocaleString()} km²</div></div>
                   </div>
                 )}
-                {regionDossier.head_of_state && (<div><div className="hud-label mb-0.5">HEAD OF STATE</div><div className="text-xs text-[var(--gold-primary)]">{regionDossier.head_of_state.name}</div><div className="text-[8px] text-[var(--text-muted)]">{regionDossier.head_of_state.position}</div></div>)}
-                {regionDossier.wikipedia && (<div><div className="hud-label mb-1">INTELLIGENCE BRIEF</div><div className="flex gap-3">{regionDossier.wikipedia.thumbnail && <img src={regionDossier.wikipedia.thumbnail} alt="" className="w-14 h-14 rounded object-cover flex-shrink-0" />}<p className="text-[8px] text-[var(--text-secondary)] leading-relaxed">{regionDossier.wikipedia.extract}</p></div></div>)}
+                {regionDossier.head_of_state && (<div><div className="hud-label mb-0.5">HEAD OF STATE</div><div className="text-xs text-[var(--gold-primary)]">{regionDossier.head_of_state.name}</div><div className="text-[10px] text-[var(--text-muted)]">{regionDossier.head_of_state.position}</div></div>)}
+                {regionDossier.wikipedia && (<div><div className="hud-label mb-1">INTELLIGENCE BRIEF</div><div className="flex gap-3">{regionDossier.wikipedia.thumbnail && <img src={regionDossier.wikipedia.thumbnail} alt="" className="w-14 h-14 rounded object-cover flex-shrink-0" />}<p className="text-[10px] text-[var(--text-secondary)] leading-relaxed">{regionDossier.wikipedia.extract}</p></div></div>)}
               </div>
             )}
           </div>
@@ -1634,7 +1634,7 @@ export default function Dashboard() {
       <GlobalStatusBar />
 
       {/* Shortcut hint — more visible */}
-      <div className="desktop-only absolute bottom-[26px] right-5 z-[200] pointer-events-none text-[7px] font-mono text-[var(--text-muted)] opacity-50 tracking-widest" title="Press ? to see all keyboard shortcuts">
+      <div className="desktop-only absolute bottom-[26px] right-5 z-[200] pointer-events-none text-[10px] font-mono text-[var(--text-muted)] opacity-50 tracking-widest" title="Press ? to see all keyboard shortcuts">
         Press <span className="text-[var(--gold-primary)] opacity-80">?</span> for shortcuts · <span className="text-[var(--gold-primary)] opacity-80">F</span> fullscreen · <span className="text-[var(--gold-primary)] opacity-80">R</span> reset view
       </div>
 

--- a/src/components/AiAnalyst.tsx
+++ b/src/components/AiAnalyst.tsx
@@ -179,7 +179,7 @@ function renderMarkdown(text: string): string {
     .replace(/# (.+)/g, '<h2 class="text-[13px] font-bold text-[var(--gold-primary)] mt-3 mb-1.5 tracking-wider uppercase font-mono">$1</h2>')
     .replace(/\*\*(.+?)\*\*/g, '<strong class="text-[var(--text-heading)] font-semibold">$1</strong>')
     .replace(/\*(.+?)\*/g, '<em class="text-[var(--text-secondary)] italic">$1</em>')
-    .replace(/^- (.+)/gm, '<div class="flex items-start gap-1.5 ml-1 my-0.5"><span class="text-[var(--gold-dim)] mt-[3px] text-[8px]">◆</span><span>$1</span></div>')
+    .replace(/^- (.+)/gm, '<div class="flex items-start gap-1.5 ml-1 my-0.5"><span class="text-[var(--gold-dim)] mt-[3px] text-[10px]">◆</span><span>$1</span></div>')
     .replace(/\n/g, '<br />');
 }
 
@@ -449,7 +449,7 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                   </div>
                   <div className="flex flex-col">
                     <span className="hud-text text-[11px] text-[var(--text-heading)]">OSIRIS ANALYST</span>
-                    <span className="text-[7px] font-mono tracking-[0.2em] text-[var(--text-muted)]">
+                    <span className="text-[10px] font-mono tracking-[0.2em] text-[var(--text-muted)]">
                       GEMINI 2.0 FLASH • ONLINE
                     </span>
                   </div>
@@ -505,7 +505,7 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                     >
                       <div className="flex items-center gap-2">
                         <Key className="w-3 h-3 text-[var(--gold-dim)]" />
-                        <span className="hud-label" style={{ fontSize: '8px' }}>
+                        <span className="hud-label" style={{ fontSize: '10px' }}>
                           GEMINI API KEY (OPTIONAL)
                         </span>
                       </div>
@@ -524,7 +524,7 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                           <>
                             <button
                               onClick={saveApiKey}
-                              className="px-3 rounded-lg text-[9px] font-mono tracking-wider transition-all"
+                              className="px-3 rounded-lg text-[11px] font-mono tracking-wider transition-all"
                               style={{
                                 background: keySaved ? 'rgba(0, 230, 118, 0.15)' : 'rgba(212, 175, 55, 0.1)',
                                 border: `1px solid ${keySaved ? 'rgba(0, 230, 118, 0.3)' : 'rgba(212, 175, 55, 0.2)'}`,
@@ -535,7 +535,7 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                             </button>
                             <button
                               onClick={clearApiKey}
-                              className="px-2 rounded-lg text-[9px] font-mono tracking-wider transition-all hover:bg-red-500/10"
+                              className="px-2 rounded-lg text-[11px] font-mono tracking-wider transition-all hover:bg-red-500/10"
                               style={{
                                 border: '1px solid rgba(255, 61, 61, 0.2)',
                                 color: 'var(--alert-red)',
@@ -546,7 +546,7 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                           </>
                         )}
                       </div>
-                      <p className="text-[8px] font-mono text-[var(--text-muted)] leading-relaxed">
+                      <p className="text-[10px] font-mono text-[var(--text-muted)] leading-relaxed">
                         Your key is stored locally and sent only to the OSIRIS server. Get a free key at{' '}
                         <a
                           href="https://aistudio.google.com/apikey"
@@ -596,14 +596,14 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                       <h3 className="hud-text text-[12px] text-[var(--text-heading)]">
                         INTELLIGENCE ANALYST READY
                       </h3>
-                      <p className="text-[10px] font-mono text-[var(--text-muted)] leading-relaxed max-w-[280px]">
+                      <p className="text-[12px] font-mono text-[var(--text-muted)] leading-relaxed max-w-[280px]">
                         I correlate live seismic, OSINT, threat, and cyber data to deliver actionable intelligence assessments.
                       </p>
                     </div>
 
                     {/* Quick prompts */}
                     <div className="w-full space-y-1.5">
-                      <span className="hud-label block text-center mb-2" style={{ fontSize: '7px' }}>
+                      <span className="hud-label block text-center mb-2" style={{ fontSize: '10px' }}>
                         SUGGESTED QUERIES
                       </span>
                       {[
@@ -617,7 +617,7 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                             setInputText(prompt);
                             setTimeout(() => inputRef.current?.focus(), 50);
                           }}
-                          className="w-full text-left px-3 py-2 rounded-lg text-[10px] font-mono text-[var(--text-secondary)] transition-all hover:text-[var(--text-primary)] hover:bg-[var(--hover-accent)]"
+                          className="w-full text-left px-3 py-2 rounded-lg text-[12px] font-mono text-[var(--text-secondary)] transition-all hover:text-[var(--text-primary)] hover:bg-[var(--hover-accent)]"
                           style={{
                             border: '1px solid rgba(212, 175, 55, 0.08)',
                           }}
@@ -670,7 +670,7 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                           <Bot className="w-3 h-3 text-[var(--gold-primary)]" />
                         )}
                         <span
-                          className="text-[8px] font-mono tracking-[0.15em] uppercase"
+                          className="text-[10px] font-mono tracking-[0.15em] uppercase"
                           style={{
                             color: msg.role === 'user'
                               ? 'var(--cyan-primary)'
@@ -681,7 +681,7 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                         >
                           {msg.role === 'user' ? 'OPERATOR' : 'OSIRIS ANALYST'}
                         </span>
-                        <span className="text-[7px] font-mono text-[var(--text-muted)] ml-auto">
+                        <span className="text-[10px] font-mono text-[var(--text-muted)] ml-auto">
                           {new Date(msg.timestamp).toLocaleTimeString([], {
                             hour: '2-digit',
                             minute: '2-digit',
@@ -720,7 +720,7 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                     >
                       <Loader2 className="w-3.5 h-3.5 text-[var(--gold-primary)] animate-spin" />
                       <div className="flex items-center gap-1">
-                        <span className="text-[9px] font-mono tracking-[0.15em] text-[var(--gold-primary)] uppercase">
+                        <span className="text-[11px] font-mono tracking-[0.15em] text-[var(--gold-primary)] uppercase">
                           Analyzing intelligence
                         </span>
                         <motion.span
@@ -751,7 +751,7 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                   <button
                     onClick={handleBriefing}
                     disabled={isLoading}
-                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[9px] font-mono tracking-[0.1em] uppercase transition-all disabled:opacity-40"
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-mono tracking-[0.1em] uppercase transition-all disabled:opacity-40"
                     style={{
                       background: 'rgba(212, 175, 55, 0.08)',
                       border: '1px solid rgba(212, 175, 55, 0.2)',
@@ -762,7 +762,7 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
                     GENERATE BRIEFING
                   </button>
                   <div className="flex-1" />
-                  <span className="flex items-center text-[7px] font-mono text-[var(--text-muted)] tracking-wider">
+                  <span className="flex items-center text-[10px] font-mono text-[var(--text-muted)] tracking-wider">
                     <ChevronDown className="w-2.5 h-2.5 mr-0.5" />
                     SHIFT+ENTER FOR NEWLINE
                   </span>
@@ -822,10 +822,10 @@ export default function AiAnalyst({ data }: AiAnalystProps) {
 
                 {/* Footer */}
                 <div className="flex items-center justify-between mt-1.5 px-1">
-                  <span className="text-[7px] font-mono text-[var(--text-muted)] tracking-wider">
+                  <span className="text-[10px] font-mono text-[var(--text-muted)] tracking-wider">
                     {keySaved ? '🔑 CUSTOM KEY' : '🔧 SERVER KEY'} • {messages.filter((m) => m.role === 'user').length} QUERIES
                   </span>
-                  <span className="text-[7px] font-mono text-[var(--text-muted)] tracking-wider">
+                  <span className="text-[10px] font-mono text-[var(--text-muted)] tracking-wider">
                     FEEDS: {(data.earthquakes?.length || 0) + (data.news?.length || 0) + (data.gdelt?.length || 0)} ITEMS
                   </span>
                 </div>

--- a/src/components/AiOverview.tsx
+++ b/src/components/AiOverview.tsx
@@ -59,7 +59,7 @@ export default function AiOverview({ mode, payload, accent = '#7C4DFF' }: AiOver
     <div className="w-full">
       <button
         onClick={handleClick}
-        className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 rounded text-[10px] font-mono tracking-wider transition-all border"
+        className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 rounded text-[12px] font-mono tracking-wider transition-all border"
         style={{
           color: accent,
           borderColor: `${accent}55`,
@@ -80,12 +80,12 @@ export default function AiOverview({ mode, payload, accent = '#7C4DFF' }: AiOver
             className="overflow-hidden"
           >
             <div
-              className="mt-2 p-2.5 rounded-lg border text-[10px] leading-relaxed"
+              className="mt-2 p-2.5 rounded-lg border text-[12px] leading-relaxed"
               style={{ borderColor: `${accent}33`, background: `${accent}08` }}
             >
               {/* Header row */}
               <div className="flex items-center justify-between mb-1.5">
-                <span className="font-mono tracking-widest text-[8px]" style={{ color: accent }}>
+                <span className="font-mono tracking-widest text-[10px]" style={{ color: accent }}>
                   {result ? `OSIRIS ${result.generatedBy === 'gemini' ? 'AI' : 'ANALYST'}` : 'OSIRIS ANALYST'}
                 </span>
                 <div className="flex items-center gap-2">
@@ -115,7 +115,7 @@ export default function AiOverview({ mode, payload, accent = '#7C4DFF' }: AiOver
                       {result.highlights.map((h, i) => (
                         <span
                           key={i}
-                          className="px-1.5 py-0.5 rounded text-[8px] font-mono"
+                          className="px-1.5 py-0.5 rounded text-[10px] font-mono"
                           style={{ background: `${accent}18`, color: accent, border: `1px solid ${accent}33` }}
                         >
                           {h}
@@ -124,7 +124,7 @@ export default function AiOverview({ mode, payload, accent = '#7C4DFF' }: AiOver
                     </div>
                   )}
 
-                  <div className="mt-2 text-[7px] font-mono text-[var(--text-muted)] tracking-wide">
+                  <div className="mt-2 text-[10px] font-mono text-[var(--text-muted)] tracking-wide">
                     {result.generatedBy === 'gemini' ? 'GEMINI 2.0 FLASH' : 'HEURISTIC ANALYST'} ·{' '}
                     {new Date(result.generatedAt).toLocaleTimeString()}
                   </div>

--- a/src/components/ArcGISPanel.tsx
+++ b/src/components/ArcGISPanel.tsx
@@ -103,6 +103,9 @@ export default function ArcGISPanel({
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [featureCounts, setFeatureCounts] = useState<Record<string, number>>({});
   const [expandedLayerId, setExpandedLayerId] = useState<string | null>(null);
+  // The query the visible results actually came from. Reading `query` here
+  // would relabel the list the moment someone starts typing the next search.
+  const [resultsFor, setResultsFor] = useState('');
 
   const importedIds = importedLayers.map(l => l.id);
 
@@ -129,6 +132,7 @@ export default function ArcGISPanel({
 
         const data = await res.json();
         setResults(data.results || []);
+        setResultsFor(searchQuery);
       } catch (err: any) {
         setError(err.message || 'Search failed');
       } finally {
@@ -190,12 +194,12 @@ export default function ArcGISPanel({
       <div className="flex items-center justify-between bg-[#D4AF37]/10 border border-[#D4AF37]/30 rounded-lg p-2.5">
         <div className="flex items-center gap-2">
           <Database className="w-4 h-4 text-[#D4AF37]" />
-          <span className="text-[10px] font-mono font-bold tracking-[0.2em] text-[#D4AF37] uppercase">
+          <span className="text-[12px] font-mono font-bold tracking-[0.2em] text-[#D4AF37] uppercase">
             ArcGIS Intel
           </span>
         </div>
         <div className="text-right">
-          <div className="text-[9px] font-mono text-[#D4AF37]/80 uppercase tracking-widest">
+          <div className="text-[11px] font-mono text-[#D4AF37]/80 uppercase tracking-widest">
             {importedLayers.length} Layers Active
           </div>
           <div className="text-[11px] font-mono font-bold text-[#D4AF37] tabular-nums">
@@ -208,10 +212,10 @@ export default function ArcGISPanel({
       {mapBounds && (
         <div className="flex items-center gap-2 px-2 py-1 rounded border border-white/[0.04] bg-white/[0.02]">
           <Globe className="w-3 h-3 text-[var(--text-muted)]" />
-          <span className="text-[8px] font-mono text-[var(--text-muted)] uppercase tracking-wider flex-1">
+          <span className="text-[10px] font-mono text-[var(--text-muted)] uppercase tracking-wider flex-1">
             Map Extent:
           </span>
-          <span className="text-[8px] font-mono text-[var(--text-muted)] tabular-nums truncate max-w-[150px]">
+          <span className="text-[10px] font-mono text-[var(--text-muted)] tabular-nums truncate max-w-[150px]">
             {mapBounds.west.toFixed(2)}, {mapBounds.south.toFixed(2)} to {mapBounds.east.toFixed(2)}, {mapBounds.north.toFixed(2)}
           </span>
         </div>
@@ -220,7 +224,7 @@ export default function ArcGISPanel({
       {/* ── Active Imported Layers (TOP) ─────────────────────────── */}
       {importedLayers.length > 0 && (
         <div className="flex flex-col gap-1.5 shrink-0">
-          <span className="text-[8px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] px-1">
+          <span className="text-[10px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] px-1">
             Active Data Layers
           </span>
           <div className="flex flex-col gap-1 max-h-[220px] overflow-y-auto styled-scrollbar">
@@ -262,14 +266,14 @@ export default function ArcGISPanel({
                       </button>
 
                       {/* Layer name */}
-                      <span className={`text-[10px] font-mono font-medium truncate flex-1 ${layer.visible ? 'text-white' : 'text-white/40'}`}>
+                      <span className={`text-[12px] font-mono font-medium truncate flex-1 ${layer.visible ? 'text-white' : 'text-white/40'}`}>
                         {layer.title}
                       </span>
 
                       {/* Feature count */}
                       {count !== undefined && (
                         <span
-                          className="text-[8px] font-mono font-bold tabular-nums px-1.5 py-0.5 rounded"
+                          className="text-[10px] font-mono font-bold tabular-nums px-1.5 py-0.5 rounded"
                           style={{ color: layer.color, background: `${layer.color}15` }}
                         >
                           {count.toLocaleString()}
@@ -316,7 +320,7 @@ export default function ArcGISPanel({
                           <div className="px-2.5 pb-2.5 flex flex-col gap-2 border-t border-white/[0.06] pt-2">
                             {/* Color Swatches */}
                             <div className="flex flex-col gap-1">
-                              <span className="text-[7px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] flex items-center gap-1">
+                              <span className="text-[10px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] flex items-center gap-1">
                                 <Palette className="w-2.5 h-2.5" /> Color
                               </span>
                               <div className="flex flex-wrap gap-1.5">
@@ -341,10 +345,10 @@ export default function ArcGISPanel({
                             {/* Opacity Slider */}
                             <div className="flex flex-col gap-1">
                               <div className="flex items-center justify-between">
-                                <span className="text-[7px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] flex items-center gap-1">
+                                <span className="text-[10px] font-mono tracking-[0.2em] uppercase text-[var(--text-muted)] flex items-center gap-1">
                                   <Eye className="w-2.5 h-2.5" /> Opacity
                                 </span>
-                                <span className="text-[9px] font-mono font-bold tabular-nums" style={{ color: layer.color }}>
+                                <span className="text-[11px] font-mono font-bold tabular-nums" style={{ color: layer.color }}>
                                   {Math.round(layer.opacity * 100)}%
                                 </span>
                               </div>
@@ -390,7 +394,7 @@ export default function ArcGISPanel({
         <button
           onClick={() => runSearch(query)}
           disabled={searching || !query.trim()}
-          className="absolute right-1 top-1/2 -translate-y-1/2 px-3 py-1.5 rounded-md text-[9px] font-mono font-bold tracking-widest uppercase disabled:opacity-30 transition-all bg-[#D4AF37]/10 border border-[#D4AF37]/30 text-[#D4AF37] hover:bg-[#D4AF37]/20"
+          className="absolute right-1 top-1/2 -translate-y-1/2 px-3 py-1.5 rounded-md text-[11px] font-mono font-bold tracking-widest uppercase disabled:opacity-30 transition-all bg-[#D4AF37]/10 border border-[#D4AF37]/30 text-[#D4AF37] hover:bg-[#D4AF37]/20"
         >
           {searching ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : 'SCAN'}
         </button>
@@ -402,7 +406,7 @@ export default function ArcGISPanel({
           <button
             key={cat.label}
             onClick={() => handleCategory(cat)}
-            className={`px-3 py-1.5 rounded-full text-[8px] font-mono tracking-[0.1em] uppercase transition-all border ${
+            className={`px-3 py-1.5 rounded-full text-[10px] font-mono tracking-[0.1em] uppercase transition-all border ${
               activeCategory === cat.label
                 ? 'bg-[#D4AF37]/20 border-[#D4AF37]/50 text-[#D4AF37] shadow-[0_0_12px_rgba(212,175,55,0.3)]'
                 : 'bg-white/[0.03] border-white/[0.08] text-[var(--text-muted)] hover:bg-white/[0.06] hover:border-white/20'
@@ -420,7 +424,7 @@ export default function ArcGISPanel({
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            className="flex items-center gap-2 p-2.5 rounded-lg border border-red-500/30 bg-red-500/10 text-[10px] font-mono text-red-400 shrink-0"
+            className="flex items-center gap-2 p-2.5 rounded-lg border border-red-500/30 bg-red-500/10 text-[12px] font-mono text-red-400 shrink-0"
           >
             <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
             <span className="truncate flex-1">{error}</span>
@@ -439,6 +443,26 @@ export default function ArcGISPanel({
             {[...Array(4)].map((_, i) => (
               <div key={i} className="skeleton-shimmer h-[72px] rounded-lg" />
             ))}
+          </div>
+        )}
+
+        {/* Result count — searching without knowing how much came back, or
+            which query it belongs to, leaves the list unanchored. */}
+        {!searching && results.length > 0 && (
+          <div className="flex items-baseline gap-2 px-1 pb-0.5">
+            <span className="text-[11px] font-mono text-white tabular-nums">
+              {results.length} layer{results.length === 1 ? '' : 's'}
+            </span>
+            {resultsFor && (
+              <span className="text-[10px] font-mono text-[var(--text-muted)] truncate">
+                for &ldquo;{resultsFor}&rdquo;
+              </span>
+            )}
+            {results.filter(r => importedIds.includes(r.id)).length > 0 && (
+              <span className="ml-auto text-[10px] font-mono text-[var(--alert-green)] tabular-nums flex-shrink-0">
+                {results.filter(r => importedIds.includes(r.id)).length} live
+              </span>
+            )}
           </div>
         )}
 
@@ -473,14 +497,14 @@ export default function ArcGISPanel({
                         {getGeometryIcon(result.title, result.tags)}
                       </div>
                       <div className="min-w-0">
-                        <h4 className="text-[11px] font-mono font-bold text-white leading-tight truncate">
+                        <h4 className="text-[11px] font-mono font-bold text-white leading-tight line-clamp-2" title={result.title}>
                           {result.title}
                         </h4>
                         <div className="flex items-center gap-2 mt-0.5">
-                          <span className="text-[8px] font-mono text-[var(--text-muted)] truncate">
+                          <span className="text-[10px] font-mono text-[var(--text-muted)] truncate">
                             {result.owner}
                           </span>
-                          <span className="text-[8px] font-mono text-[#D4AF37]/70 tabular-nums flex items-center gap-0.5">
+                          <span className="text-[10px] font-mono text-[#D4AF37]/70 tabular-nums flex items-center gap-0.5">
                             <Eye className="w-2.5 h-2.5" />
                             {result.numViews?.toLocaleString() ?? 0}
                           </span>
@@ -491,7 +515,7 @@ export default function ArcGISPanel({
                     {/* Import / Imported badge */}
                     {isImported ? (
                       <span
-                        className="flex items-center gap-1.5 px-2 py-1 rounded text-[9px] font-mono font-bold tracking-widest uppercase shadow-[0_0_10px_rgba(0,230,118,0.2)]"
+                        className="flex items-center gap-1.5 px-2 py-1 rounded text-[11px] font-mono font-bold tracking-widest uppercase shadow-[0_0_10px_rgba(0,230,118,0.2)]"
                         style={{
                           color: importedLayer?.color || 'var(--alert-green)',
                           background: `${importedLayer?.color || 'var(--alert-green)'}15`,
@@ -506,7 +530,7 @@ export default function ArcGISPanel({
                       <button
                         onClick={() => handleImport(result)}
                         disabled={isImporting || !result.url}
-                        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-[9px] font-mono font-bold tracking-widest uppercase transition-all disabled:opacity-40 bg-[#D4AF37]/10 border border-[#D4AF37]/40 text-[#D4AF37] hover:bg-[#D4AF37]/20 hover:shadow-[0_0_12px_rgba(212,175,55,0.2)] active:scale-95"
+                        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-[11px] font-mono font-bold tracking-widest uppercase transition-all disabled:opacity-40 bg-[#D4AF37]/10 border border-[#D4AF37]/40 text-[#D4AF37] hover:bg-[#D4AF37]/20 hover:shadow-[0_0_12px_rgba(212,175,55,0.2)] active:scale-95"
                       >
                         {isImporting ? (
                           <>
@@ -524,11 +548,11 @@ export default function ArcGISPanel({
                   </div>
 
                   {/* Snippet */}
-                  {result.snippet && (
-                    <p className="text-[9px] font-mono text-[var(--text-muted)]/80 leading-relaxed line-clamp-2 mt-0.5">
-                      {result.snippet}
-                    </p>
-                  )}
+                  <p className={`text-[11px] font-mono leading-relaxed line-clamp-2 mt-0.5 ${
+                    result.snippet ? 'text-[var(--text-muted)]/80' : 'text-[var(--text-muted)]/40 italic'
+                  }`}>
+                    {result.snippet || 'No description published for this layer.'}
+                  </p>
 
                   {/* Tags */}
                   {result.tags?.length > 0 && (
@@ -536,14 +560,14 @@ export default function ArcGISPanel({
                       {result.tags.slice(0, 4).map((tag) => (
                         <span
                           key={tag}
-                          className="px-1.5 py-0.5 rounded-full text-[7px] font-mono tracking-wide text-[#D4AF37]/80 bg-[#D4AF37]/10 border border-[#D4AF37]/20"
+                          className="px-1.5 py-0.5 rounded-full text-[10px] font-mono tracking-wide text-[#D4AF37]/80 bg-[#D4AF37]/10 border border-[#D4AF37]/20"
                         >
                           {tag}
                         </span>
                       ))}
                       {result.tags.length > 4 && (
-                        <span className="text-[7px] font-mono text-[var(--text-muted)]/50 flex items-center px-1">
-                          +{result.tags.length - 4}
+                        <span className="text-[10px] font-mono text-[var(--text-muted)]/50 flex items-center px-1">
+                          +{result.tags.length - 4} more
                         </span>
                       )}
                     </div>
@@ -564,7 +588,7 @@ export default function ArcGISPanel({
               <span className="text-[11px] font-mono font-bold text-white tracking-wide">
                 No active search
               </span>
-              <span className="text-[9px] font-mono text-[var(--text-muted)] max-w-[200px] leading-relaxed">
+              <span className="text-[11px] font-mono text-[var(--text-muted)] max-w-[200px] leading-relaxed">
                 Try searching for Power Plants, Substations, Evacuation Routes, or Pipelines in the designated area.
               </span>
             </div>
@@ -576,12 +600,12 @@ export default function ArcGISPanel({
       <div className="flex items-center justify-between pt-2 border-t border-white/[0.06] shrink-0">
         <div className="flex items-center gap-1.5">
           <Radio className="w-3 h-3 text-[#D4AF37]" />
-          <span className="text-[8px] font-mono tracking-[0.2em] uppercase text-[#D4AF37]/80">
+          <span className="text-[10px] font-mono tracking-[0.2em] uppercase text-[#D4AF37]/80">
             ArcGIS PUBLIC
           </span>
         </div>
         <div className="flex items-center gap-2.5">
-          <span className="text-[8px] font-mono text-[var(--text-muted)] uppercase tracking-wider">
+          <span className="text-[10px] font-mono text-[var(--text-muted)] uppercase tracking-wider">
             Connection Health
           </span>
           <div className="relative flex items-center justify-center">

--- a/src/components/CameraViewer.tsx
+++ b/src/components/CameraViewer.tsx
@@ -137,7 +137,7 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
             {/* Tactical Header */}
             <div className="flex flex-col border-b border-[var(--border-primary)] bg-black/60 relative z-10">
               {/* Top Meta Bar */}
-              <div className="flex items-center justify-between px-3 py-1 border-b border-white/5 text-[7px] font-mono tracking-[0.2em] text-[var(--text-muted)] bg-[var(--hover-accent)]">
+              <div className="flex items-center justify-between px-3 py-1 border-b border-white/5 text-[10px] font-mono tracking-[0.2em] text-[var(--text-muted)] bg-[var(--hover-accent)]">
                 <div className="flex items-center gap-3">
                   <span className="text-[var(--gold-primary)] font-bold">{camId}</span>
                   <span>{camera.lat?.toFixed(4)}, {camera.lng?.toFixed(4)}</span>
@@ -158,7 +158,7 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
                   </div>
                   <div className="min-w-0 flex-1">
                     <h3 className="text-[12px] md:text-[13px] font-mono font-bold tracking-widest truncate text-white uppercase" style={{ textShadow: '0 0 10px rgba(255,255,255,0.3)' }}>{camera.name}</h3>
-                    <p className="text-[7px] md:text-[8px] font-mono text-[var(--gold-primary)] uppercase tracking-wider opacity-80">{camera.city}, {camera.country} • SOURCE: {camera.source}</p>
+                    <p className="text-[10px] md:text-[10px] font-mono text-[var(--gold-primary)] uppercase tracking-wider opacity-80">{camera.city}, {camera.country} • SOURCE: {camera.source}</p>
                   </div>
                 </div>
                 
@@ -206,7 +206,7 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
               <div className="absolute inset-0 flex items-center justify-center bg-black/90 z-30 backdrop-blur-sm">
                 <div className="text-center">
                   <div className="w-6 h-6 border-2 border-t-transparent rounded-full animate-spin mx-auto mb-3" style={{ borderColor: 'var(--gold-dim)', borderTopColor: 'transparent' }} />
-                  <span className="text-[9px] font-mono tracking-[0.25em]" style={{ color: 'var(--gold-primary)' }}>DECRYPTING FEED...</span>
+                  <span className="text-[11px] font-mono tracking-[0.25em]" style={{ color: 'var(--gold-primary)' }}>DECRYPTING FEED...</span>
                 </div>
               </div>
             )}
@@ -214,13 +214,13 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
             {externalOnly ? (
               <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/90 z-30 backdrop-blur-sm p-4 text-center">
                 <ExternalLink className="w-6 h-6 mb-3 opacity-50" style={{ color: 'var(--gold-primary)' }} />
-                <p className="text-[10px] font-mono uppercase tracking-widest" style={{ color: 'var(--gold-primary)' }}>SECURE FEED ENCRYPTED</p>
-                <p className="text-[8px] font-mono text-[var(--text-muted)] mt-2 max-w-[80%] uppercase">This feed requires external clearance</p>
+                <p className="text-[12px] font-mono uppercase tracking-widest" style={{ color: 'var(--gold-primary)' }}>SECURE FEED ENCRYPTED</p>
+                <p className="text-[10px] font-mono text-[var(--text-muted)] mt-2 max-w-[80%] uppercase">This feed requires external clearance</p>
                 <a 
                   href={externalFeedUrl} 
                   target="_blank" 
                   rel="noopener noreferrer"
-                  className="mt-4 px-4 py-2 rounded text-[9px] font-mono font-bold tracking-widest transition-all hover:bg-white/10"
+                  className="mt-4 px-4 py-2 rounded text-[11px] font-mono font-bold tracking-widest transition-all hover:bg-white/10"
                   style={{ border: '1px solid var(--border-primary)', color: 'var(--gold-primary)' }}
                 >
                   ACCESS TERMINAL
@@ -230,9 +230,9 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
               <div className="absolute inset-0 flex items-center justify-center bg-black/90">
                 <div className="text-center">
                   <div className="w-8 h-8 rounded-full bg-red-500/20 flex items-center justify-center mb-2 mx-auto"><Camera className="w-4 h-4 text-red-400" /></div>
-                  <span className="text-[9px] font-mono text-red-400 tracking-widest block mb-1">FEED UNAVAILABLE</span>
-                  <span className="text-[7px] font-mono text-[var(--text-muted)]">Camera may be offline or restricted</span>
-                  <button onClick={() => { setError(false); setRetryCount(c => c + 1); }} className="block mx-auto mt-3 px-3 py-1 text-[8px] font-mono text-[#7E57C2] border border-[#7E57C2]/30 rounded hover:bg-[#7E57C2]/10 transition-colors tracking-wider">
+                  <span className="text-[11px] font-mono text-red-400 tracking-widest block mb-1">FEED UNAVAILABLE</span>
+                  <span className="text-[10px] font-mono text-[var(--text-muted)]">Camera may be offline or restricted</span>
+                  <button onClick={() => { setError(false); setRetryCount(c => c + 1); }} className="block mx-auto mt-3 px-3 py-1 text-[10px] font-mono text-[#7E57C2] border border-[#7E57C2]/30 rounded hover:bg-[#7E57C2]/10 transition-colors tracking-wider">
                     RETRY
                   </button>
                 </div>
@@ -283,7 +283,7 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
             {!error && !loading && !externalOnly && (
               <div className="absolute top-3 left-3 flex items-center gap-2 bg-black/80 border border-[var(--gold-primary)]/50 px-2 py-1 shadow-[0_0_10px_rgba(0,0,0,0.8)]">
                 <div className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse shadow-[0_0_8px_#ef4444]" />
-                <span className="text-[8px] font-mono text-white tracking-[0.2em]">
+                <span className="text-[10px] font-mono text-white tracking-[0.2em]">
                   {streamType === 'jpg' ? 'LIVE SAT-LINK' : 'LIVE FEED'}
                 </span>
               </div>
@@ -303,15 +303,15 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
             <div className="flex items-center justify-between px-3 py-1.5 border-b border-white/5">
               <div className="flex gap-4">
                 <div className="flex flex-col">
-                  <span className="text-[6px] text-[var(--text-muted)] font-mono tracking-widest">FEED TYPE</span>
-                  <span className="text-[8px] text-white font-mono tracking-widest uppercase">
+                  <span className="text-[10px] text-[var(--text-muted)] font-mono tracking-widest">FEED TYPE</span>
+                  <span className="text-[10px] text-white font-mono tracking-widest uppercase">
                     {externalOnly ? 'EXTERNAL' : streamType}
                   </span>
                 </div>
                 <div className="flex flex-col border-l border-white/10 pl-4">
-                  <span className="text-[6px] text-[var(--text-muted)] font-mono tracking-widest">STATUS</span>
+                  <span className="text-[10px] text-[var(--text-muted)] font-mono tracking-widest">STATUS</span>
                   {/* Nothing is being received locally for an external feed — don't claim otherwise. */}
-                  <span className={`text-[8px] font-mono tracking-widest ${externalOnly ? 'text-[var(--gold-primary)]' : 'text-[var(--alert-green)]'}`}>
+                  <span className={`text-[10px] font-mono tracking-widest ${externalOnly ? 'text-[var(--gold-primary)]' : 'text-[var(--alert-green)]'}`}>
                     {externalOnly ? 'HOSTED OFF-PLATFORM' : 'ACTIVE / RECORDING'}
                   </span>
                 </div>
@@ -319,12 +319,12 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
               <div className="flex gap-3">
                 {(camera.feed_url || camera.external_url || (streamType === 'iframe' && camera.stream_url)) && (
                   <a href={camera.external_url || camera.feed_url || (streamType === 'iframe' ? camera.stream_url : undefined)} target="_blank" rel="noopener noreferrer"
-                    className="flex items-center gap-1.5 px-2 py-1 bg-white/5 hover:bg-white/10 border border-white/10 transition-colors text-[8px] font-mono text-[var(--gold-primary)] tracking-widest">
+                    className="flex items-center gap-1.5 px-2 py-1 bg-white/5 hover:bg-white/10 border border-white/10 transition-colors text-[10px] font-mono text-[var(--gold-primary)] tracking-widest">
                     <ExternalLink className="w-2.5 h-2.5" /> RAW FEED
                   </a>
                 )}
                 <a href={`https://www.google.com/maps/@${camera.lat},${camera.lng},17z`} target="_blank" rel="noopener noreferrer"
-                  className="flex items-center gap-1.5 px-2 py-1 bg-white/5 hover:bg-white/10 border border-white/10 transition-colors text-[8px] font-mono text-[var(--cyan-primary)] tracking-widest">
+                  className="flex items-center gap-1.5 px-2 py-1 bg-white/5 hover:bg-white/10 border border-white/10 transition-colors text-[10px] font-mono text-[var(--cyan-primary)] tracking-widest">
                   <MapPin className="w-2.5 h-2.5" /> MAP TARGET
                 </a>
               </div>

--- a/src/components/ChainBrief.tsx
+++ b/src/components/ChainBrief.tsx
@@ -31,9 +31,9 @@ function Head({ title, icon: Icon, color, right }: { title: string; icon: any; c
   return (
     <div className="flex items-center gap-2 mt-3 mb-1.5 first:mt-0">
       <Icon className="w-3.5 h-3.5" style={{ color }} />
-      <span className="text-[10px] font-mono font-bold tracking-widest" style={{ color }}>{title}</span>
+      <span className="text-[12px] font-mono font-bold tracking-widest" style={{ color }}>{title}</span>
       <div className="flex-1 h-px" style={{ background: `${color}30` }} />
-      {right && <span className="text-[9px] font-mono text-[var(--text-muted)]">{right}</span>}
+      {right && <span className="text-[11px] font-mono text-[var(--text-muted)]">{right}</span>}
     </div>
   );
 }
@@ -102,12 +102,12 @@ function ChainBriefInner() {
     <div>
       {/* window selector */}
       <div className="flex items-center gap-1 mb-2">
-        <span className="text-[9px] font-mono text-[var(--text-muted)] mr-1">WINDOW</span>
+        <span className="text-[11px] font-mono text-[var(--text-muted)] mr-1">WINDOW</span>
         {[7, 30, 90].map(d => (
           <button
             key={d}
             onClick={() => setDays(d)}
-            className="px-1.5 py-0.5 rounded text-[9px] font-mono transition-colors"
+            className="px-1.5 py-0.5 rounded text-[11px] font-mono transition-colors"
             style={{
               color: days === d ? ACCENT : 'var(--text-muted)',
               background: days === d ? `${ACCENT}1a` : 'transparent',
@@ -119,7 +119,7 @@ function ChainBriefInner() {
         ))}
         <button
           onClick={() => load(days, true)}
-          className="ml-auto text-[8px] font-mono text-[var(--text-muted)] hover:text-white/70 transition-colors"
+          className="ml-auto text-[10px] font-mono text-[var(--text-muted)] hover:text-white/70 transition-colors"
           title="Refresh now"
         >
           {lastRefresh ? lastRefresh.toLocaleTimeString() : 'refresh'}
@@ -129,10 +129,10 @@ function ChainBriefInner() {
       {loading && !brief && (
         <div className="flex items-center gap-2 py-6 justify-center">
           <Loader2 className="w-4 h-4 animate-spin" style={{ color: ACCENT }} />
-          <span className="text-[10px] font-mono text-[var(--text-muted)]">Building brief…</span>
+          <span className="text-[12px] font-mono text-[var(--text-muted)]">Building brief…</span>
         </div>
       )}
-      {error && <div className="text-[10px] font-mono text-red-400 py-2">{error}</div>}
+      {error && <div className="text-[12px] font-mono text-red-400 py-2">{error}</div>}
 
       {brief && (
         <>
@@ -143,7 +143,7 @@ function ChainBriefInner() {
               { label: 'CVES', value: t?.cve_count ?? 0, color: '#E040FB' },
             ].map(c => (
               <div key={c.label} className="rounded border px-2 py-1.5" style={{ borderColor: `${c.color}33`, background: `${c.color}0d` }}>
-                <div className="text-[8px] font-mono text-[var(--text-muted)]">{c.label}</div>
+                <div className="text-[10px] font-mono text-[var(--text-muted)]">{c.label}</div>
                 <div className="text-[12px] font-mono font-bold" style={{ color: c.color }}>{c.value}</div>
               </div>
             ))}
@@ -152,14 +152,14 @@ function ChainBriefInner() {
           <button
             onClick={runAi}
             disabled={aiLoading}
-            className="w-full flex items-center justify-center gap-1.5 py-1.5 rounded text-[9px] font-mono font-bold tracking-wider transition-colors disabled:opacity-50"
+            className="w-full flex items-center justify-center gap-1.5 py-1.5 rounded text-[11px] font-mono font-bold tracking-wider transition-colors disabled:opacity-50"
             style={{ color: ACCENT, background: `${ACCENT}14`, border: `1px solid ${ACCENT}44` }}
           >
             {aiLoading ? <Loader2 className="w-3 h-3 animate-spin" /> : <Sparkles className="w-3 h-3" />}
             AI OVERVIEW
           </button>
           {ai && (
-            <div className="mt-1.5 px-2 py-1.5 rounded border text-[10px] font-mono leading-relaxed whitespace-pre-wrap"
+            <div className="mt-1.5 px-2 py-1.5 rounded border text-[12px] font-mono leading-relaxed whitespace-pre-wrap"
               style={{ borderColor: `${ACCENT}33`, background: `${ACCENT}0a`, color: 'var(--text-secondary)' }}>
               {ai}
             </div>
@@ -167,26 +167,26 @@ function ChainBriefInner() {
 
           <Head title="ON-CHAIN EXPLOITS" icon={Flame} color="#FF3D3D" right={`${brief.exploits.length} shown`} />
           {brief.exploits.length === 0 && (
-            <div className="text-[9px] font-mono text-[var(--text-muted)] py-1">None in window.</div>
+            <div className="text-[11px] font-mono text-[var(--text-muted)] py-1">None in window.</div>
           )}
           {brief.exploits.slice(0, 12).map((e: any, i: number) => (
             <div key={i} className="py-1.5 border-b border-[var(--border-secondary)]/20 last:border-0">
               <div className="flex items-center gap-2">
-                <span className="text-[10px] font-mono font-bold text-[#FF3D3D] flex-1 break-all">{e.name}</span>
-                <span className="text-[10px] font-mono font-bold text-[#FF9500]">{usd(e.amount_usd)}</span>
+                <span className="text-[12px] font-mono font-bold text-[#FF3D3D] flex-1 break-all">{e.name}</span>
+                <span className="text-[12px] font-mono font-bold text-[#FF9500]">{usd(e.amount_usd)}</span>
               </div>
-              <div className="flex items-center gap-2 text-[9px] font-mono text-[var(--text-muted)] mt-0.5">
+              <div className="flex items-center gap-2 text-[11px] font-mono text-[var(--text-muted)] mt-0.5">
                 <span>{String(e.date).slice(0, 10)}</span>
                 <span className="text-[var(--text-secondary)]">{e.chain}</span>
                 {e.bridge_hack && <span className="text-[#E040FB]">BRIDGE</span>}
               </div>
-              <div className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug">{e.technique}</div>
+              <div className="text-[11px] font-mono text-[var(--text-secondary)] leading-snug">{e.technique}</div>
             </div>
           ))}
 
           <Head title="CRYPTO CVES" icon={Bug} color="#E040FB" right={`${brief.cves.length} shown`} />
           {brief.cves.length === 0 && (
-            <div className="text-[9px] font-mono text-[var(--text-muted)] py-1">None published in window.</div>
+            <div className="text-[11px] font-mono text-[var(--text-muted)] py-1">None published in window.</div>
           )}
           {brief.cves.slice(0, 10).map((c: any, i: number) => {
             const col = SEV_COLOR[String(c.severity || '').toLowerCase()] || '#9B978E';
@@ -194,13 +194,13 @@ function ChainBriefInner() {
               <div key={i} className="py-1.5 border-b border-[var(--border-secondary)]/20 last:border-0">
                 <div className="flex items-center gap-2">
                   <a href={c.url} target="_blank" rel="noopener noreferrer"
-                    className="text-[10px] font-mono font-bold hover:underline flex items-center gap-1" style={{ color: col }}>
+                    className="text-[12px] font-mono font-bold hover:underline flex items-center gap-1" style={{ color: col }}>
                     {c.id} <ExternalLink className="w-2.5 h-2.5" />
                   </a>
-                  {c.cvss != null && <span className="text-[9px] font-mono font-bold" style={{ color: col }}>CVSS {c.cvss}</span>}
-                  <span className="ml-auto text-[8px] font-mono text-[var(--text-muted)]">{String(c.published).slice(0, 10)}</span>
+                  {c.cvss != null && <span className="text-[11px] font-mono font-bold" style={{ color: col }}>CVSS {c.cvss}</span>}
+                  <span className="ml-auto text-[10px] font-mono text-[var(--text-muted)]">{String(c.published).slice(0, 10)}</span>
                 </div>
-                <div className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug mt-0.5">
+                <div className="text-[11px] font-mono text-[var(--text-secondary)] leading-snug mt-0.5">
                   {String(c.description).slice(0, 180)}{c.description.length > 180 ? '…' : ''}
                 </div>
               </div>
@@ -209,7 +209,7 @@ function ChainBriefInner() {
 
           <Head title="OFAC DESIGNATED WALLETS" icon={ShieldAlert} color="#FFD700" right={`${t?.sanctioned_wallet_count ?? 0} total`} />
           {brief.sanctioned_wallets.slice(0, 10).map((w: any, i: number) => (
-            <div key={i} className="flex items-center gap-2 py-1 text-[9px] font-mono">
+            <div key={i} className="flex items-center gap-2 py-1 text-[11px] font-mono">
               <span className="w-[34px] font-bold text-[#FFD700]">{w.asset}</span>
               <span className="flex-1 break-all text-[var(--text-primary)]">{shortAddr(w.address)}</span>
               <span className="text-[var(--text-muted)]">{w.first_seen ? String(w.first_seen).slice(0, 10) : ''}</span>
@@ -218,14 +218,14 @@ function ChainBriefInner() {
 
           {brief.degraded?.length > 0 && (
             <div className="mt-3 px-2 py-1.5 rounded border border-white/10 bg-white/[0.03]">
-              <span className="text-[9px] font-mono text-[var(--text-muted)] block mb-0.5">DEGRADED SOURCES</span>
+              <span className="text-[11px] font-mono text-[var(--text-muted)] block mb-0.5">DEGRADED SOURCES</span>
               {brief.degraded.map((d: string, i: number) => (
-                <div key={i} className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug">↳ {d}</div>
+                <div key={i} className="text-[11px] font-mono text-[var(--text-secondary)] leading-snug">↳ {d}</div>
               ))}
             </div>
           )}
 
-          <div className="mt-2 text-[8px] font-mono text-[var(--text-muted)]">
+          <div className="mt-2 text-[10px] font-mono text-[var(--text-muted)]">
             Sources: {(brief.sources || []).join(' · ')} · auto-refresh 15m
           </div>
         </>

--- a/src/components/DrawingToolbar.tsx
+++ b/src/components/DrawingToolbar.tsx
@@ -140,18 +140,18 @@ export default function DrawingToolbar({
         <div className="px-4 py-3 border-b border-white/[0.06]">
           <div className="flex items-center gap-2 mb-2">
             <Pentagon className="w-3.5 h-3.5 text-[var(--cyan-primary)]" />
-            <span className="text-[10px] font-mono tracking-[0.2em] text-white/90 font-bold">DRAWING TOOLS</span>
+            <span className="text-[12px] font-mono tracking-[0.2em] text-white/90 font-bold">DRAWING TOOLS</span>
           </div>
           
-          <div className="flex items-center justify-between text-[8px] font-mono text-white/50 bg-white/5 rounded px-2 py-1.5 border border-white/[0.04]">
+          <div className="flex items-center justify-between text-[10px] font-mono text-white/50 bg-white/5 rounded px-2 py-1.5 border border-white/[0.04]">
             <div className="flex flex-col">
-              <span className="text-[7px] tracking-wider mb-0.5 uppercase">Tracked Area</span>
-              <span className="text-[10px] text-[var(--cyan-primary)] font-bold">{totalArea.toFixed(1)} km²</span>
+              <span className="text-[10px] tracking-wider mb-0.5 uppercase">Tracked Area</span>
+              <span className="text-[12px] text-[var(--cyan-primary)] font-bold">{totalArea.toFixed(1)} km²</span>
             </div>
             <div className="w-[1px] h-6 bg-white/10" />
             <div className="flex flex-col text-right">
-              <span className="text-[7px] tracking-wider mb-0.5 uppercase">AOIs / Perim</span>
-              <span className="text-[10px] text-white/80">{polygons.length} / {totalPerim.toFixed(1)}km</span>
+              <span className="text-[10px] tracking-wider mb-0.5 uppercase">AOIs / Perim</span>
+              <span className="text-[12px] text-white/80">{polygons.length} / {totalPerim.toFixed(1)}km</span>
             </div>
           </div>
         </div>
@@ -160,7 +160,7 @@ export default function DrawingToolbar({
         <div className="p-3 border-b border-white/[0.04]">
           <button
             onClick={onToggleDrawing}
-            className={`w-full flex items-center justify-center gap-2 px-3 py-2.5 rounded text-[9px] font-mono tracking-[0.2em] transition-all relative overflow-hidden ${
+            className={`w-full flex items-center justify-center gap-2 px-3 py-2.5 rounded text-[11px] font-mono tracking-[0.2em] transition-all relative overflow-hidden ${
               isDrawing
                 ? 'bg-[var(--cyan-primary)]/10 border border-[var(--cyan-primary)]/50 text-[var(--cyan-primary)] shadow-[0_0_15px_rgba(0,229,255,0.2)]'
                 : 'bg-white/5 border border-white/10 text-white/70 hover:bg-white/10 hover:text-white'
@@ -189,7 +189,7 @@ export default function DrawingToolbar({
             </div>
           </button>
           {isDrawing && (
-            <p className="text-[8px] font-mono text-white/40 mt-2 text-center tracking-wide">
+            <p className="text-[10px] font-mono text-white/40 mt-2 text-center tracking-wide">
               Click map to start · Double-click to finish
             </p>
           )}
@@ -206,7 +206,7 @@ export default function DrawingToolbar({
                 className="py-8 px-4 text-center"
               >
                 <Pentagon className="w-6 h-6 text-white/10 mx-auto mb-2" />
-                <p className="text-[9px] font-mono text-white/30 tracking-wider">No polygons drawn yet.</p>
+                <p className="text-[11px] font-mono text-white/30 tracking-wider">No polygons drawn yet.</p>
               </motion.div>
             ) : (
               polygons.map((polygon) => (
@@ -236,12 +236,12 @@ export default function DrawingToolbar({
                           onBlur={commitRename}
                           onKeyDown={e => e.key === 'Enter' && commitRename()}
                           autoFocus
-                          className="bg-black/60 border border-white/20 text-white text-[10px] font-mono px-1.5 py-0.5 rounded w-full outline-none focus:border-[var(--cyan-primary)]/50"
+                          className="bg-black/60 border border-white/20 text-white text-[12px] font-mono px-1.5 py-0.5 rounded w-full outline-none focus:border-[var(--cyan-primary)]/50"
                           onClick={e => e.stopPropagation()}
                         />
                       ) : (
                         <span
-                          className={`text-[10px] font-mono truncate cursor-text transition-colors ${
+                          className={`text-[12px] font-mono truncate cursor-text transition-colors ${
                             selectedPolygon === polygon.id ? 'text-white' : 'text-white/80'
                           }`}
                           onDoubleClick={(e) => { e.stopPropagation(); startRename(polygon); }}
@@ -261,14 +261,14 @@ export default function DrawingToolbar({
                     </div>
                   </div>
                   
-                  <div className="flex items-center justify-between pl-1 text-[8px] font-mono text-white/40">
+                  <div className="flex items-center justify-between pl-1 text-[10px] font-mono text-white/40">
                     <div className="flex items-center gap-3">
                       <span className="flex items-center gap-1">
                         <Ruler className="w-2.5 h-2.5" />
                         {polygon.areaKm2.toFixed(2)} km²
                       </span>
                     </div>
-                    <span className="flex items-center gap-1 text-[7px] text-white/30">
+                    <span className="flex items-center gap-1 text-[10px] text-white/30">
                       <Clock className="w-2 h-2" />
                       {formatRelativeTime(polygon.createdAt)}
                     </span>
@@ -284,14 +284,14 @@ export default function DrawingToolbar({
           <div className="p-3 border-t border-white/[0.04] flex items-center gap-2 bg-black/60">
             <button 
               onClick={onExportGeoJSON} 
-              className="flex-1 flex items-center justify-center gap-1.5 px-2 py-2 rounded text-[8px] font-mono tracking-[0.2em] bg-[var(--cyan-primary)]/10 border border-[var(--cyan-primary)]/30 text-[var(--cyan-primary)]/80 hover:text-[var(--cyan-primary)] hover:bg-[var(--cyan-primary)]/20 hover:border-[var(--cyan-primary)]/50 transition"
+              className="flex-1 flex items-center justify-center gap-1.5 px-2 py-2 rounded text-[10px] font-mono tracking-[0.2em] bg-[var(--cyan-primary)]/10 border border-[var(--cyan-primary)]/30 text-[var(--cyan-primary)]/80 hover:text-[var(--cyan-primary)] hover:bg-[var(--cyan-primary)]/20 hover:border-[var(--cyan-primary)]/50 transition"
             >
               <Download className="w-3 h-3" />
               EXPORT GEOJSON
             </button>
             <button 
               onClick={onClearAll} 
-              className="flex items-center justify-center gap-1.5 px-3 py-2 rounded text-[8px] font-mono tracking-widest bg-[#FF3D57]/10 border border-[#FF3D57]/20 text-[#FF3D57]/60 hover:text-[#FF3D57] hover:bg-[#FF3D57]/20 transition"
+              className="flex items-center justify-center gap-1.5 px-3 py-2 rounded text-[10px] font-mono tracking-widest bg-[#FF3D57]/10 border border-[#FF3D57]/20 text-[#FF3D57]/60 hover:text-[#FF3D57] hover:bg-[#FF3D57]/20 transition"
             >
               <Trash2 className="w-3 h-3" />
               CLEAR

--- a/src/components/EntityGraphPanel.tsx
+++ b/src/components/EntityGraphPanel.tsx
@@ -255,7 +255,7 @@ function EntityGraphPanel({ entity, onClose }: Props) {
           <div className="px-6 py-2 border-b border-[var(--border-primary)] flex items-center gap-3 bg-black/20 relative z-20">
             {(() => { const I = TYPE_ICONS[entity.type] || Globe; return <I className="w-4 h-4" style={{ color: TYPE_COLORS[entity.type] }} />; })()}
             <span className="text-xs font-mono text-white/90 tracking-widest uppercase truncate">{entity.label || entity.id}</span>
-            <span className="text-[10px] font-mono text-[var(--gold-primary)]/70 ml-auto tracking-widest">{graphData.nodes.length} NODES // {graphData.links.length} LINKS</span>
+            <span className="text-[12px] font-mono text-[var(--gold-primary)]/70 ml-auto tracking-widest">{graphData.nodes.length} NODES // {graphData.links.length} LINKS</span>
           </div>
         ) : (
           <div className="px-6 py-3 border-b border-[var(--border-primary)] flex items-center gap-3 bg-black/20 relative z-20">
@@ -268,7 +268,7 @@ function EntityGraphPanel({ entity, onClose }: Props) {
         {error && (
           <div className="px-6 py-2 bg-[#FF1744]/10 border-b border-[#FF1744]/30 flex items-center gap-2 relative z-20 shadow-[inset_0_0_15px_rgba(255,23,68,0.2)]">
             <AlertTriangle className="w-3.5 h-3.5 text-[#FF1744]" />
-            <span className="text-[10px] font-mono font-bold tracking-widest text-[#FF1744] uppercase">[ ERR: {error} ]</span>
+            <span className="text-[12px] font-mono font-bold tracking-widest text-[#FF1744] uppercase">[ ERR: {error} ]</span>
           </div>
         )}
 
@@ -307,7 +307,7 @@ function EntityGraphPanel({ entity, onClose }: Props) {
                   {(() => { const I = TYPE_ICONS[selectedNode.type] || Globe; return <I className="w-4 h-4" style={{ color: TYPE_COLORS[selectedNode.type] }} />; })()}
                   <span className="text-[13px] font-mono font-bold text-white tracking-[0.1em] uppercase">{selectedNode.label}</span>
                 </div>
-                <span className="text-[10px] font-mono font-bold px-2 py-0.5 border"
+                <span className="text-[12px] font-mono font-bold px-2 py-0.5 border"
                   style={{ color: TYPE_COLORS[selectedNode.type], borderColor: `${TYPE_COLORS[selectedNode.type]}80`, background: `${TYPE_COLORS[selectedNode.type]}15`, textShadow: `0 0 5px ${TYPE_COLORS[selectedNode.type]}` }}>
                   [{selectedNode.type.toUpperCase()}]
                 </span>
@@ -316,7 +316,7 @@ function EntityGraphPanel({ entity, onClose }: Props) {
                 <div className="grid grid-cols-2 gap-x-6 gap-y-2 mt-2">
                   {Object.entries(selectedNode.properties).map(([k, v], i) => (
                     <div key={`${selectedNode.id}-${k}`}>
-                      <span className="text-[9px] font-mono text-[var(--gold-primary)]/70 uppercase tracking-widest">{k.replace(/_/g, ' ')}</span>
+                      <span className="text-[11px] font-mono text-[var(--gold-primary)]/70 uppercase tracking-widest">{k.replace(/_/g, ' ')}</span>
                       <div className="text-[11px] font-mono text-white/90 truncate flex items-center gap-1 mt-0.5">
                         <span className="w-1 h-1 bg-[var(--gold-primary)]/40 inline-block" />
                         <span className="typewriter" style={{ animationDelay: `${i * 0.1}s` }}>
@@ -345,7 +345,7 @@ function EntityGraphPanel({ entity, onClose }: Props) {
           {Object.entries(TYPE_COLORS).map(([t, c]) => (
             <div key={t} className="flex items-center gap-1">
               <div className="w-2 h-2 rounded-full" style={{ background: c }} />
-              <span className="text-[8px] font-mono text-white/40 uppercase">{t}</span>
+              <span className="text-[10px] font-mono text-white/40 uppercase">{t}</span>
             </div>
           ))}
         </div>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -34,12 +34,12 @@ export default class ErrorBoundary extends React.Component<Props, State> {
             <div className="text-xs font-mono text-red-400 tracking-widest mb-2">
               ⚠ {this.props.name?.toUpperCase() || 'COMPONENT'} ERROR
             </div>
-            <div className="text-[10px] font-mono text-[var(--text-muted)] max-w-[300px] truncate">
+            <div className="text-[12px] font-mono text-[var(--text-muted)] max-w-[300px] truncate">
               {this.state.error?.message}
             </div>
             <button
               onClick={() => this.setState({ hasError: false })}
-              className="mt-3 px-3 py-1 text-[9px] font-mono tracking-widest text-[var(--gold-primary)] border border-[var(--border-primary)] rounded hover:bg-[var(--hover-accent)] transition-colors"
+              className="mt-3 px-3 py-1 text-[11px] font-mono tracking-widest text-[var(--gold-primary)] border border-[var(--border-primary)] rounded hover:bg-[var(--hover-accent)] transition-colors"
             >
               RETRY
             </button>

--- a/src/components/FlightWatchPanel.tsx
+++ b/src/components/FlightWatchPanel.tsx
@@ -190,7 +190,7 @@ function Row({ flight, telem, onRemove, onLocate, onDetail }: {
         <span className="text-[11px] text-[var(--text-primary)] tracking-wide truncate">
           {flight.callsign || flight.icao24.toUpperCase()}
         </span>
-        <span className="text-[8px] text-[var(--text-muted)] tabular-nums ml-auto flex-shrink-0">
+        <span className="text-[10px] text-[var(--text-muted)] tabular-nums ml-auto flex-shrink-0">
           {flight.icao24.toUpperCase()}
         </span>
         {telem && (
@@ -214,15 +214,15 @@ function Row({ flight, telem, onRemove, onLocate, onDetail }: {
 
       <div className="px-2.5 py-2">
         {loading ? (
-          <div className="flex items-center gap-1.5 text-[9px] text-[var(--text-muted)]">
+          <div className="flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
             <Loader2 className="w-3 h-3 animate-spin" /> Identifying airframe…
           </div>
         ) : (
           <>
-            <div className="text-[10px] text-[var(--text-primary)] leading-snug">
+            <div className="text-[12px] text-[var(--text-primary)] leading-snug">
               {detail?.model || 'Unidentified type'}
             </div>
-            <div className="flex flex-wrap gap-x-2.5 gap-y-0.5 mt-0.5 text-[8px] text-[var(--text-muted)]">
+            <div className="flex flex-wrap gap-x-2.5 gap-y-0.5 mt-0.5 text-[10px] text-[var(--text-muted)]">
               {detail?.registration && <span className="tabular-nums">{detail.registration}</span>}
               {detail?.typeCode && <span>{detail.typeCode}</span>}
               {detail?.operator && <span className="truncate max-w-[170px]">{detail.operator}</span>}
@@ -233,19 +233,19 @@ function Row({ flight, telem, onRemove, onLocate, onDetail }: {
         <div className="grid grid-cols-3 gap-1.5 mt-2">
           <div className="flex items-center gap-1">
             <ArrowUp className="w-2.5 h-2.5 text-[var(--text-muted)] flex-shrink-0" />
-            <span className="text-[9px] text-[var(--text-secondary)] tabular-nums truncate">
+            <span className="text-[11px] text-[var(--text-secondary)] tabular-nums truncate">
               {formatAlt(telem?.alt, telem?.grounded)}
             </span>
           </div>
           <div className="flex items-center gap-1">
             <Gauge className="w-2.5 h-2.5 text-[var(--text-muted)] flex-shrink-0" />
-            <span className="text-[9px] text-[var(--text-secondary)] tabular-nums truncate">
+            <span className="text-[11px] text-[var(--text-secondary)] tabular-nums truncate">
               {telem ? `${Math.round(telem.speed_knots)} kt` : '—'}
             </span>
           </div>
           <div className="flex items-center gap-1">
             <Radio className="w-2.5 h-2.5 text-[var(--text-muted)] flex-shrink-0" />
-            <span className="text-[9px] text-[var(--text-secondary)] tabular-nums truncate">
+            <span className="text-[11px] text-[var(--text-secondary)] tabular-nums truncate">
               {telem?.squawk || '—'}
             </span>
           </div>
@@ -253,28 +253,28 @@ function Row({ flight, telem, onRemove, onLocate, onDetail }: {
 
         {(detail?.origin || detail?.destination) && (
           <div className="flex items-center gap-1.5 mt-2 pt-1.5 border-t border-[var(--border-secondary)]">
-            <span className="text-[10px] text-[var(--text-primary)] tabular-nums">
+            <span className="text-[12px] text-[var(--text-primary)] tabular-nums">
               {detail.origin ? detail.origin.iata || detail.origin.icao : '····'}
             </span>
-            <span className="text-[9px] text-[var(--text-muted)]">&rarr;</span>
-            <span className="text-[10px] text-[var(--text-primary)] tabular-nums">
+            <span className="text-[11px] text-[var(--text-muted)]">&rarr;</span>
+            <span className="text-[12px] text-[var(--text-primary)] tabular-nums">
               {detail.destination ? detail.destination.iata || detail.destination.icao : '····'}
             </span>
             {/* An unconfirmed destination is a schedule claim, not something the
                 aircraft was seen to do — say so rather than imply certainty. */}
-            <span className="text-[8px] text-[var(--text-muted)] ml-auto">
+            <span className="text-[10px] text-[var(--text-muted)] ml-auto">
               {detail.arrival ? 'landed' : detail.destination ? 'scheduled' : 'destination unknown'}
             </span>
           </div>
         )}
 
         {detail && detail.points > 0 && (
-          <div className="mt-1.5 text-[8px] text-[var(--text-muted)] tabular-nums">
+          <div className="mt-1.5 text-[10px] text-[var(--text-muted)] tabular-nums">
             {detail.points} points this leg
           </div>
         )}
         {!telem && (
-          <div className="mt-1.5 text-[8px] text-[var(--alert-orange)]">
+          <div className="mt-1.5 text-[10px] text-[var(--alert-orange)]">
             No longer in the live feed
           </div>
         )}

--- a/src/components/GlobalStatusBar.tsx
+++ b/src/components/GlobalStatusBar.tsx
@@ -65,7 +65,7 @@ const formatChange = (change: number | undefined) => {
   if (change === undefined) return null;
   const isUp = change >= 0;
   return (
-    <span className={`text-[8px] ${isUp ? 'text-[#00E676]' : 'text-[#FF3D57]'}`}>
+    <span className={`text-[10px] ${isUp ? 'text-[#00E676]' : 'text-[#FF3D57]'}`}>
       {isUp ? '▲' : '▼'}{Math.abs(change).toFixed(1)}%
     </span>
   );
@@ -143,7 +143,7 @@ export default function GlobalStatusBar() {
       transition={{ delay: 3, duration: 0.6 }}
       className="hidden md:block absolute bottom-0 left-0 right-0 z-[210] pointer-events-none"
     >
-      <div className="h-[28px] overflow-hidden bg-[#0a0a0f]/95 border-t border-white/[0.06] flex items-center text-[9px] font-mono tracking-wider backdrop-blur-xl relative">
+      <div className="h-[28px] overflow-hidden bg-[#0a0a0f]/95 border-t border-white/[0.06] flex items-center text-[11px] font-mono tracking-wider backdrop-blur-xl relative">
         {/* Animated scan line */}
         <div className="absolute top-0 left-0 right-0 h-[1px] bg-gradient-to-r from-transparent via-[var(--cyan-primary)]/30 to-transparent" style={{ animation: 'hud-scanline 4s linear infinite' }} />
         
@@ -166,7 +166,7 @@ export default function GlobalStatusBar() {
             className="h-full px-3 flex items-center gap-1.5 bg-[var(--gold-primary)]/10 text-[var(--gold-primary)]/80 hover:text-[var(--gold-primary)] hover:bg-[var(--gold-primary)]/25 border-r border-white/[0.04] transition-all duration-200"
           >
             <DocsIcon />
-            <span className="text-[8px] font-bold tracking-[0.15em] uppercase">Docs</span>
+            <span className="text-[10px] font-bold tracking-[0.15em] uppercase">Docs</span>
           </Link>
         </div>
 
@@ -195,7 +195,7 @@ export default function GlobalStatusBar() {
                     onMouseEnter={() => setHoveredQuake(quake)}
                     onMouseLeave={() => setHoveredQuake(null)}
                   >
-                    <span className="text-[#FF5722] text-[8px]">🔴</span>
+                    <span className="text-[#FF5722] text-[10px]">🔴</span>
                     <span className="text-[#FF5722] font-bold">M{quake.magnitude.toFixed(1)}</span>
                     <span className="text-white/30 truncate max-w-[140px]">{quake.place}</span>
                   </span>
@@ -212,7 +212,7 @@ export default function GlobalStatusBar() {
           {/* Status indicator */}
           <div className="h-full px-3 flex items-center gap-1.5">
             <div className="w-1.5 h-1.5 rounded-full bg-[#00E676] animate-pulse" />
-            <span className="text-[#00E676]/70 text-[7px] tracking-[0.2em]">ONLINE</span>
+            <span className="text-[#00E676]/70 text-[10px] tracking-[0.2em]">ONLINE</span>
           </div>
         </div>
       </div>
@@ -220,16 +220,16 @@ export default function GlobalStatusBar() {
       {/* Earthquake hover tooltip */}
       {hoveredQuake && (
         <div className="absolute bottom-[34px] left-1/2 -translate-x-1/2 z-[300] pointer-events-none">
-          <div className="bg-black/90 backdrop-blur-xl border border-white/[0.08] rounded-lg px-4 py-3 text-[10px] font-mono whitespace-nowrap shadow-2xl">
+          <div className="bg-black/90 backdrop-blur-xl border border-white/[0.08] rounded-lg px-4 py-3 text-[12px] font-mono whitespace-nowrap shadow-2xl">
             <div className="flex items-center gap-2 mb-2">
               <span className="text-[12px]">🔴</span>
               <span className="font-bold text-[#FF5722]">Magnitude {hoveredQuake.magnitude.toFixed(1)}</span>
-              <span className="text-white/30 text-[8px] bg-white/5 px-1.5 py-0.5 rounded">USGS</span>
+              <span className="text-white/30 text-[10px] bg-white/5 px-1.5 py-0.5 rounded">USGS</span>
             </div>
             <div className="text-[11px] text-white font-bold mb-2">
               {hoveredQuake.place}
             </div>
-            <div className="flex flex-col gap-1 text-[9px]">
+            <div className="flex flex-col gap-1 text-[11px]">
               <div className="text-white/50"><span className="text-white/30">Depth:</span> {hoveredQuake.depth} km</div>
               <div className="text-white/50 mt-1"><span className="text-white/30">Time:</span> {new Date(hoveredQuake.time).toLocaleString()}</div>
             </div>

--- a/src/components/IntelFeed.tsx
+++ b/src/components/IntelFeed.tsx
@@ -62,9 +62,9 @@ export default function IntelFeed({ data, onLocate }: IntelFeedProps) {
         <div className="flex items-center gap-2">
           <Newspaper className="w-3.5 h-3.5 text-[var(--gold-primary)]" />
           <span className="hud-text text-[12px] text-[var(--text-primary)]">SIGINT FEED</span>
-          <span className="gotham-tag gotham-tag--info" style={{ fontSize: '8px', padding: '1px 5px' }}>{news.length}</span>
+          <span className="gotham-tag gotham-tag--info" style={{ fontSize: '10px', padding: '1px 5px' }}>{news.length}</span>
           {news.some((n: any) => n.risk_score >= 8) && (
-            <span className="gotham-tag gotham-tag--critical" style={{ fontSize: '7px', padding: '1px 4px' }}>ALERTS</span>
+            <span className="gotham-tag gotham-tag--critical" style={{ fontSize: '10px', padding: '1px 4px' }}>ALERTS</span>
           )}
         </div>
         <div className="flex items-center gap-2">
@@ -101,10 +101,10 @@ export default function IntelFeed({ data, onLocate }: IntelFeedProps) {
                   >
                     {/* Top row: risk badge + source + time */}
                     <div className="flex items-center gap-2 mb-1">
-                      <span className={`text-[9px] font-mono font-bold tracking-widest ${getRiskClass(item.risk_score)}`}>
+                      <span className={`text-[11px] font-mono font-bold tracking-widest ${getRiskClass(item.risk_score)}`}>
                         {getRiskLabel(item.risk_score)}
                       </span>
-                      <span className="text-[8px] font-mono text-[var(--text-muted)] bg-[var(--bg-tertiary)] px-1.5 py-0.5 rounded">
+                      <span className="text-[10px] font-mono text-[var(--text-muted)] bg-[var(--bg-tertiary)] px-1.5 py-0.5 rounded">
                         {item.source}
                       </span>
                       {item.coords && (
@@ -118,7 +118,7 @@ export default function IntelFeed({ data, onLocate }: IntelFeedProps) {
                           <MapPin className="w-2.5 h-2.5" />
                         </button>
                       )}
-                      <span className="text-[8px] font-mono text-[var(--text-muted)] ml-auto">
+                      <span className="text-[10px] font-mono text-[var(--text-muted)] ml-auto">
                         {timeAgo(item.published)}
                       </span>
                     </div>
@@ -132,7 +132,7 @@ export default function IntelFeed({ data, onLocate }: IntelFeedProps) {
                     {item.machine_assessment && (
                       <div className="mt-1.5 flex items-start gap-1.5 bg-red-950/20 border border-red-900/20 rounded px-2 py-1">
                         <Zap className="w-2.5 h-2.5 text-red-400 flex-shrink-0 mt-0.5" />
-                        <span className="text-[9px] font-mono text-red-400/80 leading-relaxed">
+                        <span className="text-[11px] font-mono text-red-400/80 leading-relaxed">
                           {item.machine_assessment}
                         </span>
                       </div>
@@ -151,7 +151,7 @@ export default function IntelFeed({ data, onLocate }: IntelFeedProps) {
                             href={item.link}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="flex items-center gap-1 text-[10px] font-mono text-[var(--cyan-primary)] hover:underline"
+                            className="flex items-center gap-1 text-[12px] font-mono text-[var(--cyan-primary)] hover:underline"
                             onClick={(e) => e.stopPropagation()}
                           >
                             <ExternalLink className="w-2.5 h-2.5" />

--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -55,14 +55,14 @@ export default function KeyboardShortcuts() {
             <div className="space-y-2">
               {SHORTCUTS.map(s => (
                 <div key={s.key} className="flex items-center justify-between">
-                  <span className="text-[9px] font-mono text-[var(--text-secondary)]">{s.desc}</span>
-                  <kbd className="px-2 py-0.5 rounded text-[8px] font-mono font-bold text-[var(--gold-primary)] bg-[var(--bg-void)] border border-[var(--border-primary)]">
+                  <span className="text-[11px] font-mono text-[var(--text-secondary)]">{s.desc}</span>
+                  <kbd className="px-2 py-0.5 rounded text-[10px] font-mono font-bold text-[var(--gold-primary)] bg-[var(--bg-void)] border border-[var(--border-primary)]">
                     {s.key}
                   </kbd>
                 </div>
               ))}
             </div>
-            <div className="mt-4 text-center text-[7px] font-mono text-[var(--text-muted)] tracking-widest">
+            <div className="mt-4 text-center text-[10px] font-mono text-[var(--text-muted)] tracking-widest">
               PRESS [?] OR [ESC] TO CLOSE
             </div>
           </motion.div>

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -201,7 +201,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
       <div className="flex flex-col gap-5 py-2">
         {visibleGroups.map((group) => (
           <div key={group.label} className="flex flex-col gap-2">
-            <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-white/30 border-b border-white/[0.06] pb-1.5">
+            <div className="text-[11px] font-mono tracking-[0.2em] uppercase text-white/30 border-b border-white/[0.06] pb-1.5">
               {group.fullLabel}
             </div>
             <div className="flex flex-col gap-1">
@@ -214,11 +214,11 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                       active={!!isLayerActive}
                       onClick={() => toggle(layer.key)}
                     />
-                    <span className={`text-[10px] font-mono uppercase tracking-wider flex-1 transition-colors ${isLayerActive ? 'text-white/80' : 'text-white/40'}`}>
+                    <span className={`text-[12px] font-mono uppercase tracking-wider flex-1 transition-colors ${isLayerActive ? 'text-white/80' : 'text-white/40'}`}>
                       {layer.label}
                     </span>
                     {count !== null && (
-                      <span className="text-[8px] font-mono tabular-nums text-white/20">
+                      <span className="text-[10px] font-mono tabular-nums text-white/20">
                         {count.toLocaleString()}
                       </span>
                     )}
@@ -232,7 +232,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
         {/* MOBILE GHOST TOGGLE */}
         {setTheme && (
           <div className="flex items-center justify-between mt-2 pt-3 border-t border-white/[0.06] px-1">
-            <span className="text-[9px] font-mono tracking-[0.2em] text-white/25 uppercase">Ghost Protocol</span>
+            <span className="text-[11px] font-mono tracking-[0.2em] text-white/25 uppercase">Ghost Protocol</span>
             <button
               onClick={() => setTheme(theme === 'core' ? 'ghost' : 'core')}
               className="w-8 h-8 rounded-full flex items-center justify-center transition-all"
@@ -314,7 +314,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                       boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
                     }}
                   >
-                    <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-white/30 mb-2.5 pb-1.5 border-b border-white/[0.04]">
+                    <div className="text-[11px] font-mono tracking-[0.2em] uppercase text-white/30 mb-2.5 pb-1.5 border-b border-white/[0.04]">
                       {group.fullLabel}
                     </div>
                     <div className="flex flex-col gap-0.5">
@@ -329,11 +329,11 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                             onClick={() => toggle(layer.key)}
                           >
                             <ToggleSwitch active={!!isLayerActive} onClick={() => {}} />
-                            <span className={`text-[10px] font-mono uppercase tracking-wider flex-1 transition-colors duration-200 ${isLayerActive ? 'text-white/70' : 'text-white/35'}`}>
+                            <span className={`text-[12px] font-mono uppercase tracking-wider flex-1 transition-colors duration-200 ${isLayerActive ? 'text-white/70' : 'text-white/35'}`}>
                               {layer.label}
                             </span>
                             {count !== null && (
-                              <span className="text-[9px] font-mono tabular-nums text-white/20">
+                              <span className="text-[11px] font-mono tabular-nums text-white/20">
                                 {count.toLocaleString()}
                               </span>
                             )}

--- a/src/components/LiveAlerts.tsx
+++ b/src/components/LiveAlerts.tsx
@@ -131,13 +131,13 @@ export default function LiveAlerts({ data, onLocate, onWatchFeed }: LiveAlertsPr
       >
         <div className="flex items-center gap-2">
           <Radio className="w-3.5 h-3.5 text-[#FF4081]" />
-          <span className="hud-text text-[10px] text-[var(--text-primary)]">LIVE ALERTS</span>
-          <span className="gotham-tag gotham-tag--high" style={{ fontSize: '7px', padding: '1px 5px' }}>{alerts.filter(a => a.type === 'news' || a.type === 'quake').length}</span>
-          <span className="gotham-tag gotham-tag--info" style={{ fontSize: '7px', padding: '1px 4px' }}>{BUILTIN_FEEDS.length} FEEDS</span>
+          <span className="hud-text text-[12px] text-[var(--text-primary)]">LIVE ALERTS</span>
+          <span className="gotham-tag gotham-tag--high" style={{ fontSize: '10px', padding: '1px 5px' }}>{alerts.filter(a => a.type === 'news' || a.type === 'quake').length}</span>
+          <span className="gotham-tag gotham-tag--info" style={{ fontSize: '10px', padding: '1px 4px' }}>{BUILTIN_FEEDS.length} FEEDS</span>
         </div>
         <div className="flex items-center gap-2">
           <div className="w-1.5 h-1.5 rounded-full bg-[#FF4081] animate-osiris-pulse" />
-          <button onClick={(e) => { e.stopPropagation(); setMaximized(!maximized); if (!expanded && !maximized) setExpanded(true); }} className="hover:text-white transition-colors" title={maximized ? "Restore" : "Maximize"}>
+          <button onClick={(e) => { e.stopPropagation(); setMaximized(!maximized); if (!expanded && !maximized) setExpanded(true); }} className="p-1.5 -m-0.5 rounded hover:text-white hover:bg-white/10 transition-colors" title={maximized ? "Restore" : "Maximize"}>
             {maximized ? <Minimize2 className="w-3 h-3 text-[var(--text-muted)]" /> : <Maximize2 className="w-3 h-3 text-[var(--text-muted)]" />}
           </button>
           {expanded ? <ChevronUp className="w-3.5 h-3.5 text-[var(--text-muted)]" /> : <ChevronDown className="w-3.5 h-3.5 text-[var(--text-muted)]" />}
@@ -159,7 +159,7 @@ export default function LiveAlerts({ data, onLocate, onWatchFeed }: LiveAlertsPr
                 <button
                   key={f}
                   onClick={() => setFilter(f)}
-                  className={`px-3 py-1.5 rounded text-[10px] font-mono tracking-wider transition-all ${filter === f ? 'bg-[var(--cyan-primary)]/20 text-[var(--cyan-primary)] border border-[var(--cyan-primary)]/50' : 'text-[#8A8880] border border-transparent hover:text-[#E8E6E0] hover:bg-[#2A2A28]'}`}
+                  className={`px-3 py-1.5 rounded text-[12px] font-mono tracking-wider transition-all ${filter === f ? 'bg-[var(--cyan-primary)]/20 text-[var(--cyan-primary)] border border-[var(--cyan-primary)]/50' : 'text-[#8A8880] border border-transparent hover:text-[#E8E6E0] hover:bg-[#2A2A28]'}`}
                 >
                   {f.toUpperCase()}
                 </button>
@@ -199,15 +199,15 @@ export default function LiveAlerts({ data, onLocate, onWatchFeed }: LiveAlertsPr
                       <div className="flex-1 min-w-0">
                         <div className="flex items-start gap-1.5 mb-2">
                           <Icon className="w-3.5 h-3.5 flex-shrink-0 mt-[2px]" style={{ color: sevColor }} />
-                          <span className={`text-[10px] font-mono text-[#E8E6E0] leading-relaxed ${alert.type === 'news' ? 'line-clamp-3' : 'truncate'}`}>
+                          <span className={`text-[12px] font-mono text-[#E8E6E0] leading-relaxed ${alert.type === 'news' ? 'line-clamp-3' : 'truncate'}`}>
                             {(alert.description || alert.title || '').replace(/&#39;/g, "'").replace(/&quot;/g, '"').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')}
                           </span>
                         </div>
                         <div className="flex items-center justify-between border-t border-[#2A2A28]/50 pt-1.5 mt-1.5">
                           <div className="flex items-center gap-2">
-                            <span className="text-[9px] font-mono text-[#8A8880] uppercase tracking-wider">{alert.source}</span>
+                            <span className="text-[11px] font-mono text-[#8A8880] uppercase tracking-wider">{alert.source}</span>
                             {alert.time && (
-                              <span className="text-[9px] font-mono text-[#5C5A54] flex items-center gap-1 border-l border-[#2A2A28] pl-2">
+                              <span className="text-[11px] font-mono text-[#5C5A54] flex items-center gap-1 border-l border-[#2A2A28] pl-2">
                                 <Clock className="w-2.5 h-2.5" />
                                 {new Date(alert.time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                               </span>
@@ -218,7 +218,7 @@ export default function LiveAlerts({ data, onLocate, onWatchFeed }: LiveAlertsPr
                               href={alert.url} 
                               target="_blank" 
                               rel="noopener noreferrer" 
-                              className="text-[8px] font-mono text-[var(--cyan-primary)] hover:underline"
+                              className="inline-flex items-center py-1.5 px-1.5 -mx-1 rounded text-[10px] font-mono text-[var(--cyan-primary)] hover:underline hover:bg-[var(--cyan-primary)]/10"
                               onClick={(e) => e.stopPropagation()}
                             >
                               SOURCE
@@ -237,7 +237,7 @@ export default function LiveAlerts({ data, onLocate, onWatchFeed }: LiveAlertsPr
               })}
               </div>
               {filtered.length === 0 && (
-                <div className="text-center py-4 text-[10px] font-mono text-[var(--text-muted)]">
+                <div className="text-center py-4 text-[12px] font-mono text-[var(--text-muted)]">
                   No alerts for this filter
                 </div>
               )}

--- a/src/components/MarketChart.tsx
+++ b/src/components/MarketChart.tsx
@@ -181,10 +181,10 @@ export default function MarketChart({ symbol, name, onClose, large = false }: Ma
         <div className="min-w-0">
           <div className="flex items-center gap-1.5">
             <span className="text-[11px] font-mono font-bold text-[var(--text-primary)] truncate">{name}</span>
-            <span className="text-[8px] font-mono text-[var(--text-muted)]">{symbol}</span>
+            <span className="text-[10px] font-mono text-[var(--text-muted)]">{symbol}</span>
           </div>
           {rangeChange !== null && (
-            <div className="text-[9px] font-mono tabular-nums" style={{ color: rangeChange >= 0 ? UP : DOWN }}>
+            <div className="text-[11px] font-mono tabular-nums" style={{ color: rangeChange >= 0 ? UP : DOWN }}>
               {rangeChange >= 0 ? '+' : ''}{rangeChange.toFixed(2)}% over {range}
             </div>
           )}
@@ -195,7 +195,7 @@ export default function MarketChart({ symbol, name, onClose, large = false }: Ma
       </div>
 
       {/* OHLC readout — tracks the crosshair, resting on the latest bar */}
-      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mb-1 text-[8px] font-mono tabular-nums">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mb-1 text-[10px] font-mono tabular-nums">
         {shown ? (
           <>
             <span className="text-[var(--text-muted)]">O <span className="text-[var(--text-secondary)]">{priceFormat(shown.open)}</span></span>
@@ -213,7 +213,7 @@ export default function MarketChart({ symbol, name, onClose, large = false }: Ma
         <div ref={containerRef} className="w-full" style={{ height }} />
 
         {status !== 'ready' && (
-          <div className="absolute inset-0 flex items-center justify-center gap-1.5 bg-black/40 text-[9px] font-mono text-[var(--text-muted)]">
+          <div className="absolute inset-0 flex items-center justify-center gap-1.5 bg-black/40 text-[11px] font-mono text-[var(--text-muted)]">
             {status === 'loading'
               ? <><Loader2 className="w-3 h-3 animate-spin" /> LOADING {range}</>
               : <><AlertTriangle className="w-3 h-3" /> NO {range} DATA FOR {symbol}</>}
@@ -223,7 +223,7 @@ export default function MarketChart({ symbol, name, onClose, large = false }: Ma
 
       {/* Window extremes + range selector */}
       <div className="flex items-center justify-between gap-2 mt-1.5 flex-wrap">
-        <div className="text-[8px] font-mono text-[var(--text-muted)] tabular-nums">
+        <div className="text-[10px] font-mono text-[var(--text-muted)] tabular-nums">
           {high !== null && low !== null && <>H {priceFormat(high)} · L {priceFormat(low)}</>}
         </div>
         {/* Seven ranges will not fit one line in the docked panel — let them wrap. */}
@@ -232,7 +232,7 @@ export default function MarketChart({ symbol, name, onClose, large = false }: Ma
             <button
               key={r}
               onClick={() => setRange(r)}
-              className={`px-1.5 py-0.5 rounded text-[8px] font-mono tracking-wider transition-all ${
+              className={`px-1.5 py-0.5 rounded text-[10px] font-mono tracking-wider transition-all ${
                 range === r
                   ? 'bg-[var(--hover-accent)] text-[var(--gold-primary)] border border-[var(--border-primary)]'
                   : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)] border border-transparent'

--- a/src/components/MarketsPanel.tsx
+++ b/src/components/MarketsPanel.tsx
@@ -83,9 +83,9 @@ function Ticker({ quote, active, onSelect }: { quote: Quote; active: boolean; on
       title={`${d.name} — open chart`}
       className={`w-full flex items-center justify-between gap-2 py-1.5 px-2 rounded transition-colors ${active ? 'bg-[var(--hover-accent)] border border-[var(--border-primary)]' : 'border border-transparent hover:bg-[var(--hover-accent)]'}`}>
       <div className="min-w-0 flex-1">
-        <div className="text-[10px] font-mono text-[var(--text-secondary)] tracking-wide truncate">{d.name}</div>
+        <div className="text-[12px] font-mono text-[var(--text-secondary)] tracking-wide truncate">{d.name}</div>
         {d.symbol && d.symbol !== d.name && (
-          <div className="text-[8px] font-mono text-[var(--text-muted)] truncate">{d.symbol}</div>
+          <div className="text-[10px] font-mono text-[var(--text-muted)] truncate">{d.symbol}</div>
         )}
       </div>
 
@@ -96,7 +96,7 @@ function Ticker({ quote, active, onSelect }: { quote: Quote; active: boolean; on
           {formatPrice(d.price)}
         </span>
         <span
-          className="text-[9px] font-mono font-bold flex items-center gap-0.5 tabular-nums"
+          className="text-[11px] font-mono font-bold flex items-center gap-0.5 tabular-nums"
           style={{ color: d.up ? GREEN : RED }}
         >
           {d.up ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
@@ -182,8 +182,8 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
   const breadthBlock = breadth && (
     <div className="px-2 py-1.5 rounded-lg border border-[var(--border-primary)] bg-white/[0.02]">
       <div className="flex items-center justify-between">
-        <span className="text-[8px] font-mono tracking-widest text-[var(--text-muted)]">BREADTH</span>
-        <span className="text-[9px] font-mono tabular-nums">
+        <span className="text-[10px] font-mono tracking-widest text-[var(--text-muted)]">BREADTH</span>
+        <span className="text-[11px] font-mono tabular-nums">
           <span style={{ color: GREEN }}>{breadth.up}▲</span>
           <span className="text-[var(--text-muted)]"> / </span>
           <span style={{ color: RED }}>{breadth.down}▼</span>
@@ -193,7 +193,7 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
       <div className="mt-1.5 h-1 rounded-full overflow-hidden bg-[var(--alert-red)]/30">
         <div className="h-full rounded-full" style={{ width: `${(breadth.up / breadth.total) * 100}%`, background: GREEN }} />
       </div>
-      <div className="mt-1.5 flex items-center justify-between text-[8px] font-mono">
+      <div className="mt-1.5 flex items-center justify-between text-[10px] font-mono">
         <span style={{ color: GREEN }}>▲ {breadth.top.name} +{breadth.top.change_percent.toFixed(2)}%</span>
         <span style={{ color: RED }}>▼ {breadth.worst.name} {breadth.worst.change_percent.toFixed(2)}%</span>
       </div>
@@ -205,14 +205,14 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1.5">
           <Zap className="w-3 h-3" style={{ color: spaceWeather.storm_color }} />
-          <span className="text-[10px] font-mono tracking-widest text-[var(--text-muted)]">SPACE WEATHER</span>
+          <span className="text-[12px] font-mono tracking-widest text-[var(--text-muted)]">SPACE WEATHER</span>
         </div>
-        <span className="text-[10px] font-mono font-bold" style={{ color: spaceWeather.storm_color }}>
+        <span className="text-[12px] font-mono font-bold" style={{ color: spaceWeather.storm_color }}>
           Kp {spaceWeather.kp_index} — {spaceWeather.storm_level}
         </span>
       </div>
       {spaceWeather.solar_flares?.length > 0 && (
-        <div className="mt-1 text-[8px] font-mono text-[var(--text-muted)]">
+        <div className="mt-1 text-[10px] font-mono text-[var(--text-muted)]">
           Latest flare: {spaceWeather.solar_flares[0].class}
         </div>
       )}
@@ -224,7 +224,7 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
   const scmBlock = markets.scm_alerts && markets.scm_alerts.length > 0 && (
     <div className="space-y-1">
       {markets.scm_alerts.map((alert: string, i: number) => (
-        <div key={i} className="px-2 py-1.5 rounded border border-[#FF9500] bg-[#FF9500]/10 text-[#FF9500] text-[9px] font-mono leading-tight shadow-[0_0_8px_rgba(255,149,0,0.15)]">
+        <div key={i} className="px-2 py-1.5 rounded border border-[#FF9500] bg-[#FF9500]/10 text-[#FF9500] text-[11px] font-mono leading-tight shadow-[0_0_8px_rgba(255,149,0,0.15)]">
           {alert}
         </div>
       ))}
@@ -247,7 +247,7 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
         const count = Object.keys(markets[s.key] || {}).length;
         return (
           <button key={s.key} onClick={() => setActiveSection(s.key)}
-            className={`flex items-center gap-1 px-2.5 py-1.5 rounded text-[9px] font-mono tracking-wider whitespace-nowrap transition-all ${activeSection === s.key ? 'bg-[var(--hover-accent)] text-[var(--gold-primary)] border border-[var(--border-primary)]' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)] border border-transparent'}`}>
+            className={`flex items-center gap-1 px-2.5 py-1.5 rounded text-[11px] font-mono tracking-wider whitespace-nowrap transition-all ${activeSection === s.key ? 'bg-[var(--hover-accent)] text-[var(--gold-primary)] border border-[var(--border-primary)]' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)] border border-transparent'}`}>
             <Icon className="w-3 h-3" />
             {s.label}
             {count > 0 && <span className="text-[var(--text-muted)]">{count}</span>}
@@ -259,13 +259,13 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
 
   const listHeader = rows.length > 0 && (
     <div className="flex items-center justify-between px-2 py-1 shrink-0">
-      <span className="flex items-center gap-1 text-[8px] font-mono tracking-widest text-[var(--text-muted)]">
+      <span className="flex items-center gap-1 text-[10px] font-mono tracking-widest text-[var(--text-muted)]">
         <span className="w-1 h-1 rounded-full" style={{ background: sessionOpen ? GREEN : 'var(--text-muted)' }} />
         {sessionOpen ? 'SESSION OPEN' : 'SESSION CLOSED'}
       </span>
       <button
         onClick={() => setSortByMove(v => !v)}
-        className={`flex items-center gap-1 text-[8px] font-mono tracking-widest transition-colors ${sortByMove ? 'text-[var(--gold-primary)]' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'}`}
+        className={`flex items-center gap-1 text-[10px] font-mono tracking-widest transition-colors ${sortByMove ? 'text-[var(--gold-primary)]' : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'}`}
         title={sortByMove ? 'Listed by biggest move' : 'Listed in feed order'}
       >
         <ArrowUpDown className="w-2.5 h-2.5" />
@@ -289,12 +289,12 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
 
       {rows.length === 0 && (
         feedLoaded ? (
-          <div className="flex items-center justify-center gap-1.5 py-3 text-[9px] font-mono text-[var(--text-muted)]">
+          <div className="flex items-center justify-center gap-1.5 py-3 text-[11px] font-mono text-[var(--text-muted)]">
             <AlertTriangle className="w-3 h-3" />
             {activeSection.toUpperCase()} FEED UNAVAILABLE — RETRYING
           </div>
         ) : (
-          <div className="text-center py-3 text-[10px] font-mono text-[var(--text-muted)]">Loading {activeSection}...</div>
+          <div className="text-center py-3 text-[12px] font-mono text-[var(--text-muted)]">Loading {activeSection}...</div>
         )
       )}
     </>
@@ -308,12 +308,12 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
         <button onClick={() => setExpanded(!expanded)} className="flex items-center gap-2">
           <BarChart3 className="w-3.5 h-3.5 text-[var(--gold-primary)]" />
           <span className="hud-text text-[12px] text-[var(--text-primary)]">MARKETS & INTEL</span>
-          <span className="gotham-tag gotham-tag--low" style={{ fontSize: '7px', padding: '1px 4px' }}>LIVE</span>
+          <span className="gotham-tag gotham-tag--low" style={{ fontSize: '10px', padding: '1px 4px' }}>LIVE</span>
         </button>
         <div className="flex items-center gap-2">
-          {age && <span className="text-[8px] font-mono text-[var(--text-muted)]">{age}</span>}
+          {age && <span className="text-[10px] font-mono text-[var(--text-muted)]">{age}</span>}
           <div className="w-1.5 h-1.5 rounded-full bg-[var(--alert-green)] animate-osiris-pulse" />
-          <button onClick={() => { setMaximized(!maximized); if (!expanded && !maximized) setExpanded(true); }} className="hover:text-white transition-colors" title={maximized ? "Restore" : "Maximize"}>
+          <button onClick={() => { setMaximized(!maximized); if (!expanded && !maximized) setExpanded(true); }} className="p-1.5 -m-0.5 rounded hover:text-white hover:bg-white/10 transition-colors" title={maximized ? "Restore" : "Maximize"}>
             {maximized ? <Minimize2 className="w-3.5 h-3.5 text-[var(--text-muted)]" /> : <Maximize2 className="w-3.5 h-3.5 text-[var(--text-muted)]" />}
           </button>
           <button onClick={() => setExpanded(!expanded)} title={expanded ? 'Collapse' : 'Expand'}>

--- a/src/components/OsintPanel.tsx
+++ b/src/components/OsintPanel.tsx
@@ -341,8 +341,8 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
     if (value === undefined || value === null || value === '') return null;
     return (
       <div className="flex items-start gap-3 py-1.5 border-b border-[var(--border-secondary)]/20 last:border-0">
-        <span className="text-[9px] font-mono text-[var(--text-muted)] uppercase tracking-wider w-[90px] flex-shrink-0 pt-0.5">{label}</span>
-        <span className={`text-[10px] ${mono ? 'font-mono' : ''} break-all flex-1`} style={{ color: color || 'var(--text-primary)' }}>
+        <span className="text-[11px] font-mono text-[var(--text-muted)] uppercase tracking-wider w-[90px] flex-shrink-0 pt-0.5">{label}</span>
+        <span className={`text-[12px] ${mono ? 'font-mono' : ''} break-all flex-1`} style={{ color: color || 'var(--text-primary)' }}>
           {String(value)}
         </span>
       </div>
@@ -350,7 +350,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
   };
 
   const StatusBadge = ({ ok, label }: { ok: boolean; label: string }) => (
-    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[9px] font-mono font-bold ${ok ? 'bg-green-500/15 text-green-400 border border-green-500/30' : 'bg-red-500/15 text-red-400 border border-red-500/30'}`}>
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-mono font-bold ${ok ? 'bg-green-500/15 text-green-400 border border-green-500/30' : 'bg-red-500/15 text-red-400 border border-red-500/30'}`}>
       {ok ? <CheckCircle className="w-2.5 h-2.5" /> : <XCircle className="w-2.5 h-2.5" />}
       {label}
     </span>
@@ -364,12 +364,12 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
       <div className="mb-2 px-2 py-2 rounded border border-red-500/40 bg-red-500/15">
         <div className="flex items-center gap-2 mb-1.5">
           <AlertTriangle className="w-3.5 h-3.5 text-red-400" />
-          <span className="text-[10px] font-mono font-bold text-red-400 tracking-wider">
+          <span className="text-[12px] font-mono font-bold text-red-400 tracking-wider">
             SANCTIONED — {match.source || 'OFAC SDN'}
           </span>
         </div>
         {match.hits.slice(0, 5).map((h: any, i: number) => (
-          <div key={i} className="text-[9px] font-mono text-red-200 break-all leading-tight">
+          <div key={i} className="text-[11px] font-mono text-red-200 break-all leading-tight">
             <span className="text-[var(--text-muted)]">↳ {h.matched_value}:</span>{' '}
             {(h.entries || []).slice(0, 2).map((e: any) => e.name).join('; ')}
           </div>
@@ -386,7 +386,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
       rel="noreferrer"
       className="mt-2 flex items-center justify-between px-2 py-1.5 rounded bg-[#1A1A18] border border-[var(--border-secondary)]/30 hover:border-[#FF1744]/40 transition-colors"
     >
-      <span className="text-[8px] font-mono text-[var(--text-muted)]">
+      <span className="text-[10px] font-mono text-[var(--text-muted)]">
         Data by Hudson Rock Cavalier · free infostealer intelligence
       </span>
       <ExternalLink className="w-2.5 h-2.5 text-[var(--text-muted)]" />
@@ -396,7 +396,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
   const SectionHeader = ({ title, icon: Icon, color }: { title: string; icon: any; color: string }) => (
     <div className="flex items-center gap-2 mt-3 mb-1.5 first:mt-0">
       <Icon className="w-3.5 h-3.5" style={{ color }} />
-      <span className="text-[10px] font-mono font-bold tracking-widest" style={{ color }}>{title}</span>
+      <span className="text-[12px] font-mono font-bold tracking-widest" style={{ color }}>{title}</span>
       <div className="flex-1 h-px" style={{ background: `${color}30` }} />
     </div>
   );
@@ -405,8 +405,8 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
     <div className="flex items-center gap-2 py-1 px-2 rounded hover:bg-[var(--hover-accent)] transition-colors">
       <span className="text-[11px] font-mono font-bold text-[var(--cyan-primary)] w-[60px]">{port}</span>
       <StatusBadge ok={state === 'open'} label={state.toUpperCase()} />
-      <span className="text-[10px] font-mono text-[var(--text-secondary)] flex-1">{service || 'unknown'}</span>
-      {version && <span className="text-[9px] font-mono text-[var(--text-muted)]">{version}</span>}
+      <span className="text-[12px] font-mono text-[var(--text-secondary)] flex-1">{service || 'unknown'}</span>
+      {version && <span className="text-[11px] font-mono text-[var(--text-muted)]">{version}</span>}
     </div>
   );
 
@@ -466,11 +466,11 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
               {regularVulns.slice(0, 20).map((v: any, i: number) => (
                 <div key={i} className="p-2 rounded-lg border border-red-500/20 bg-red-500/5 flex flex-col">
                   <div className="flex items-center justify-between">
-                    <span className="text-[10px] font-mono font-bold text-red-400">{v.id || v.cve || v.name}</span>
-                    {v.severity && <span className={`text-[8px] font-mono font-bold px-1.5 py-0.5 rounded ${v.severity === 'CRITICAL' ? 'bg-red-500/20 text-red-400' : v.severity === 'HIGH' ? 'bg-orange-500/20 text-orange-400' : 'bg-yellow-500/20 text-yellow-400'}`}>{v.severity}</span>}
+                    <span className="text-[12px] font-mono font-bold text-red-400">{v.id || v.cve || v.name}</span>
+                    {v.severity && <span className={`text-[10px] font-mono font-bold px-1.5 py-0.5 rounded ${v.severity === 'CRITICAL' ? 'bg-red-500/20 text-red-400' : v.severity === 'HIGH' ? 'bg-orange-500/20 text-orange-400' : 'bg-yellow-500/20 text-yellow-400'}`}>{v.severity}</span>}
                   </div>
-                  {v.cvss && <div className="text-[9px] font-mono text-[var(--text-muted)] mt-1">CVSS: {v.cvss} ({v.type || 'cve'})</div>}
-                  {v.description && <p className="text-[9px] font-mono text-[var(--text-muted)] mt-1 line-clamp-2">{v.description}</p>}
+                  {v.cvss && <div className="text-[11px] font-mono text-[var(--text-muted)] mt-1">CVSS: {v.cvss} ({v.type || 'cve'})</div>}
+                  {v.description && <p className="text-[11px] font-mono text-[var(--text-muted)] mt-1 line-clamp-2">{v.description}</p>}
                 </div>
               ))}
             </div>
@@ -483,10 +483,10 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                 {exploits.slice(0, 10).map((e: any, i: number) => (
                   <div key={i} className="p-2 rounded-lg border border-orange-500/30 bg-orange-500/10 flex flex-col">
                     <div className="flex items-center justify-between">
-                      <span className="text-[10px] font-mono font-bold text-orange-400">{e.id}</span>
-                      <span className="text-[8px] font-mono font-bold px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400">EXPLOIT</span>
+                      <span className="text-[12px] font-mono font-bold text-orange-400">{e.id}</span>
+                      <span className="text-[10px] font-mono font-bold px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400">EXPLOIT</span>
                     </div>
-                    <div className="text-[9px] font-mono text-[var(--text-muted)] mt-1 flex justify-between">
+                    <div className="text-[11px] font-mono text-[var(--text-muted)] mt-1 flex justify-between">
                       <span>Source: {e.type?.toUpperCase() || 'UNKNOWN'}</span>
                       {e.cvss && <span>CVSS: {e.cvss}</span>}
                     </div>
@@ -550,12 +550,12 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           {r.tags?.length > 0 && <ResultRow label="Tags" value={r.tags.join(', ')} color="#FF9500" />}
           {r.vulns?.length > 0 && (
             <div className="mt-2 p-2 border border-red-500/30 bg-red-500/10 rounded">
-              <span className="text-[10px] font-mono text-red-400 font-bold mb-1 block">VULNERABILITIES ({r.vulns.length})</span>
+              <span className="text-[12px] font-mono text-red-400 font-bold mb-1 block">VULNERABILITIES ({r.vulns.length})</span>
               <div className="flex flex-wrap gap-1">
                 {r.vulns.slice(0, 10).map((v: string) => (
-                  <a key={v} href={`https://nvd.nist.gov/vuln/detail/${v}`} target="_blank" rel="noreferrer" className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#8A8880] hover:text-[#FF3D3D]">{v}</a>
+                  <a key={v} href={`https://nvd.nist.gov/vuln/detail/${v}`} target="_blank" rel="noreferrer" className="text-[11px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#8A8880] hover:text-[#FF3D3D]">{v}</a>
                 ))}
-                {r.vulns.length > 10 && <span className="text-[9px] font-mono text-[#8A8880]">+{r.vulns.length - 10} more</span>}
+                {r.vulns.length > 10 && <span className="text-[11px] font-mono text-[#8A8880]">+{r.vulns.length - 10} more</span>}
               </div>
             </div>
           )}
@@ -637,7 +637,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
             {r.avatar_url && <img src={r.avatar_url} alt="avatar" className="w-10 h-10 rounded-full border border-[#87CEEB]/30" />}
             <div>
               <div className="text-[12px] font-mono font-bold text-[#87CEEB]">{r.name || r.username}</div>
-              <div className="text-[9px] font-mono text-[var(--text-muted)]">@{r.username} • {r.followers} followers</div>
+              <div className="text-[11px] font-mono text-[var(--text-muted)]">@{r.username} • {r.followers} followers</div>
             </div>
           </div>
           <ResultRow label="Company" value={r.company} />
@@ -648,9 +648,9 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           <ResultRow label="Bio" value={r.bio} />
           {r.recent_repos?.length > 0 && (
             <div className="mt-2 p-2 border border-[#87CEEB]/20 bg-[#87CEEB]/5 rounded">
-              <span className="text-[9px] font-mono text-[#87CEEB] block mb-1">RECENT REPOS</span>
+              <span className="text-[11px] font-mono text-[#87CEEB] block mb-1">RECENT REPOS</span>
               {r.recent_repos.map((repo: any, i: number) => (
-                <div key={i} className="flex justify-between text-[9px] font-mono mb-0.5">
+                <div key={i} className="flex justify-between text-[11px] font-mono mb-0.5">
                   <span className="text-[#E8E6E0]">{repo.name}</span>
                   <span className="text-[var(--text-muted)]">{repo.language || 'Unknown'}</span>
                 </div>
@@ -678,7 +678,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
               { label: 'CHECKED', value: r.checked ?? 0, color: '#87CEEB' },
             ].map((c: any) => (
               <div key={c.label} className="rounded border px-2 py-1.5" style={{ borderColor: `${c.color}33`, background: `${c.color}0d` }}>
-                <div className="text-[8px] font-mono text-[var(--text-muted)]">{c.label}</div>
+                <div className="text-[10px] font-mono text-[var(--text-muted)]">{c.label}</div>
                 <div className="text-[12px] font-mono font-bold" style={{ color: c.color }}>{c.value}</div>
               </div>
             ))}
@@ -694,7 +694,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
             <>
               <SectionHeader title={`CONFIRMED ACCOUNTS (${r.found.length})`} icon={CheckCircle} color={ACCENT} />
               {r.found.map((f: any, i: number) => (
-                <div key={i} className="flex items-center gap-2 py-1 text-[10px] font-mono">
+                <div key={i} className="flex items-center gap-2 py-1 text-[12px] font-mono">
                   <span className="w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ background: ACCENT }} />
                   <span className="w-[110px] flex-shrink-0 font-bold" style={{ color: ACCENT }}>{f.site}</span>
                   <a href={f.url} target="_blank" rel="noopener noreferrer"
@@ -712,11 +712,11 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           {r.inconclusive?.length > 0 && (
             <>
               <SectionHeader title={`UNVERIFIABLE (${r.inconclusive.length})`} icon={AlertTriangle} color="#FF9500" />
-              <div className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug mb-1">
+              <div className="text-[11px] font-mono text-[var(--text-secondary)] leading-snug mb-1">
                 These sites answered &quot;exists&quot; for a random control handle too, so a hit here is not evidence of an account.
               </div>
               {r.inconclusive.map((f: any, i: number) => (
-                <div key={i} className="flex items-center gap-2 py-1 text-[10px] font-mono">
+                <div key={i} className="flex items-center gap-2 py-1 text-[12px] font-mono">
                   <span className="w-1.5 h-1.5 rounded-full flex-shrink-0 bg-[#FF9500]" />
                   <span className="w-[110px] flex-shrink-0 text-[#FF9500]">{f.site}</span>
                   <a href={f.url} target="_blank" rel="noopener noreferrer"
@@ -733,11 +733,11 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           {r.blocked?.length > 0 && (
             <>
               <SectionHeader title={`BLOCKED — NOT CHECKED (${r.blocked.length})`} icon={ShieldAlert} color="#E040FB" />
-              <div className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug mb-1">
+              <div className="text-[11px] font-mono text-[var(--text-secondary)] leading-snug mb-1">
                 These sites refused the lookup, so nothing was learned either way — an account here is neither confirmed nor ruled out.
               </div>
               {r.blocked.map((f: any, i: number) => (
-                <div key={i} className="flex items-center gap-2 py-0.5 text-[9px] font-mono">
+                <div key={i} className="flex items-center gap-2 py-0.5 text-[11px] font-mono">
                   <span className="w-[110px] flex-shrink-0 text-[#E040FB]">{f.site}</span>
                   <a href={f.url} target="_blank" rel="noopener noreferrer"
                     className="flex-1 break-all text-[var(--text-muted)] hover:text-white hover:underline">
@@ -753,7 +753,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
             <>
               <SectionHeader title={`UNREACHABLE (${r.errors.length})`} icon={XCircle} color="#FF3D3D" />
               {r.errors.slice(0, 10).map((f: any, i: number) => (
-                <div key={i} className="flex items-center gap-2 py-0.5 text-[9px] font-mono">
+                <div key={i} className="flex items-center gap-2 py-0.5 text-[11px] font-mono">
                   <span className="w-[110px] flex-shrink-0 text-[#FF3D3D]">{f.site}</span>
                   <span className="flex-1 text-[var(--text-muted)]">{f.reason}</span>
                 </div>
@@ -764,13 +764,13 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           {r.skipped?.length > 0 && (
             <>
               <SectionHeader title={`NOT APPLICABLE (${r.skipped.length})`} icon={XCircle} color="#5C5A54" />
-              <div className="text-[9px] font-mono text-[var(--text-muted)] leading-snug">
+              <div className="text-[11px] font-mono text-[var(--text-muted)] leading-snug">
                 {r.skipped.map((s: any) => s.site).join(', ')} — the handle does not meet these sites&apos; username rules.
               </div>
             </>
           )}
 
-          <div className="mt-3 text-[8px] font-mono text-[var(--text-muted)] leading-relaxed">
+          <div className="mt-3 text-[10px] font-mono text-[var(--text-muted)] leading-relaxed">
             {r.verified
               ? 'Every positive re-tested against a random control handle; sites that accepted it are listed as unverifiable. Calibration catches most soft 404s but is not exhaustive — confirm before acting.'
               : 'Calibration disabled — positives are unfiltered and include soft 404s.'}
@@ -804,12 +804,12 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
             <div className="mb-2 px-2 py-2 rounded border border-red-500/40 bg-red-500/15">
               <div className="flex items-center gap-2 mb-1.5">
                 <AlertTriangle className="w-3.5 h-3.5 text-red-400" />
-                <span className="text-[10px] font-mono font-bold text-red-400 tracking-wider">
+                <span className="text-[12px] font-mono font-bold text-red-400 tracking-wider">
                   OFAC SANCTIONED WALLET
                 </span>
               </div>
               {(r.sanctions.entries || []).map((e: any, i: number) => (
-                <div key={i} className="text-[9px] font-mono text-red-200 break-all leading-tight">
+                <div key={i} className="text-[11px] font-mono text-red-200 break-all leading-tight">
                   ↳ {e.name}{e.programs?.length ? ` — ${e.programs.join(', ')}` : ''}
                 </div>
               ))}
@@ -817,11 +817,11 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           )}
 
           <div className="flex items-center gap-2 mb-2">
-            <span className="px-2 py-0.5 rounded text-[9px] font-mono font-bold border"
+            <span className="px-2 py-0.5 rounded text-[11px] font-mono font-bold border"
               style={{ color: ACCENT, borderColor: `${ACCENT}55`, background: `${ACCENT}18` }}>
               {r.chain_label?.toUpperCase()}
             </span>
-            <span className="px-2 py-0.5 rounded text-[9px] font-mono font-bold border"
+            <span className="px-2 py-0.5 rounded text-[11px] font-mono font-bold border"
               style={{ color: riskColor, borderColor: `${riskColor}55`, background: `${riskColor}18` }}>
               RISK {r.risk?.score} · {String(r.risk?.level || '').toUpperCase()}
             </span>
@@ -849,7 +849,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           {r.labels?.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-2">
               {r.labels.map((l: string, i: number) => (
-                <span key={i} className="px-1.5 py-0.5 rounded text-[9px] font-mono border border-white/15 text-[var(--text-secondary)] bg-white/5">
+                <span key={i} className="px-1.5 py-0.5 rounded text-[11px] font-mono border border-white/15 text-[var(--text-secondary)] bg-white/5">
                   {l}
                 </span>
               ))}
@@ -871,14 +871,14 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
               {r.risk.factors.map((f: any, i: number) => (
                 <div key={i} className="py-1.5 border-b border-[var(--border-secondary)]/20 last:border-0">
                   <div className="flex items-center gap-2">
-                    <span className="text-[9px] font-mono font-bold" style={{ color: RISK_COLOR[f.severity] || '#00E676' }}>
+                    <span className="text-[11px] font-mono font-bold" style={{ color: RISK_COLOR[f.severity] || '#00E676' }}>
                       {f.label}
                     </span>
                     {f.weight > 0 && (
-                      <span className="text-[8px] font-mono text-[var(--text-muted)]">+{f.weight}</span>
+                      <span className="text-[10px] font-mono text-[var(--text-muted)]">+{f.weight}</span>
                     )}
                   </div>
-                  <div className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug mt-0.5">{f.detail}</div>
+                  <div className="text-[11px] font-mono text-[var(--text-secondary)] leading-snug mt-0.5">{f.detail}</div>
                 </div>
               ))}
             </>
@@ -888,7 +888,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
             <>
               <SectionHeader title={`TOP COUNTERPARTIES (${r.counterparties.length})`} icon={Network} color={ACCENT} />
               {r.counterparties.slice(0, 10).map((c: any, i: number) => (
-                <div key={i} className="flex items-center gap-2 py-1 text-[9px] font-mono">
+                <div key={i} className="flex items-center gap-2 py-1 text-[11px] font-mono">
                   <span className={`w-[34px] flex-shrink-0 font-bold ${c.direction === 'out' ? 'text-[#FF9500]' : c.direction === 'in' ? 'text-[#00E676]' : 'text-[var(--text-muted)]'}`}>
                     {c.direction === 'out' ? 'OUT' : c.direction === 'in' ? 'IN' : 'BOTH'}
                   </span>
@@ -905,7 +905,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
               <SectionHeader title={`TOKENS (${r.tokens.length})`} icon={Layers} color={ACCENT} />
               <div className="flex flex-wrap gap-1">
                 {r.tokens.slice(0, 20).map((t: any, i: number) => (
-                  <span key={i} className="px-1.5 py-0.5 rounded text-[9px] font-mono border border-white/15 bg-white/5 text-[var(--text-secondary)]">
+                  <span key={i} className="px-1.5 py-0.5 rounded text-[11px] font-mono border border-white/15 bg-white/5 text-[var(--text-secondary)]">
                     {t.symbol}{t.amount != null ? ` ${fmt(t.amount, 2)}` : ''}
                   </span>
                 ))}
@@ -917,7 +917,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
             <>
               <SectionHeader title={`RECENT TRANSACTIONS (${r.transactions.length})`} icon={Clock} color={ACCENT} />
               {r.transactions.slice(0, 12).map((t: any, i: number) => (
-                <div key={i} className="flex items-center gap-2 py-1 text-[9px] font-mono">
+                <div key={i} className="flex items-center gap-2 py-1 text-[11px] font-mono">
                   <span className={`w-[34px] flex-shrink-0 font-bold ${t.direction === 'out' ? 'text-[#FF9500]' : t.direction === 'in' ? 'text-[#00E676]' : 'text-[var(--text-muted)]'}`}>
                     {t.direction === 'unknown' ? '—' : t.direction.toUpperCase()}
                   </span>
@@ -933,14 +933,14 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           {/* Honesty rail: what this report could not establish. */}
           {r.partial?.length > 0 && (
             <div className="mt-3 px-2 py-1.5 rounded border border-white/10 bg-white/[0.03]">
-              <span className="text-[9px] font-mono text-[var(--text-muted)] block mb-0.5">COVERAGE LIMITS</span>
+              <span className="text-[11px] font-mono text-[var(--text-muted)] block mb-0.5">COVERAGE LIMITS</span>
               {r.partial.map((p: string, i: number) => (
-                <div key={i} className="text-[9px] font-mono text-[var(--text-secondary)] leading-snug">↳ {p}</div>
+                <div key={i} className="text-[11px] font-mono text-[var(--text-secondary)] leading-snug">↳ {p}</div>
               ))}
             </div>
           )}
 
-          <div className="mt-2 text-[8px] font-mono text-[var(--text-muted)]">
+          <div className="mt-2 text-[10px] font-mono text-[var(--text-muted)]">
             Sources: {(r.sources || []).join(' · ')}
             {r.activity && ` · sampled ${r.activity.sample_size} tx${r.activity.history_complete ? ' (full history)' : ' of a longer history'}`}
           </div>
@@ -958,10 +958,10 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           
           {r.breached && r.data_exposed?.length > 0 && (
             <div className="mt-2 p-2 border border-[#E040FB]/30 bg-[#E040FB]/10 rounded">
-              <span className="text-[10px] font-mono text-[#E040FB] font-bold mb-1 block">EXPOSED DATA POINTS</span>
+              <span className="text-[12px] font-mono text-[#E040FB] font-bold mb-1 block">EXPOSED DATA POINTS</span>
               <div className="flex flex-wrap gap-1">
                 {r.data_exposed.map((dc: string) => (
-                  <span key={dc} className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#E8E6E0] border border-[#E040FB]/20">{dc}</span>
+                  <span key={dc} className="text-[11px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#E8E6E0] border border-[#E040FB]/20">{dc}</span>
                 ))}
               </div>
             </div>
@@ -969,10 +969,10 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
 
           {r.breached && r.breaches?.length > 0 && (
             <div className="mt-2 p-2 border border-red-500/30 bg-red-500/10 rounded">
-              <span className="text-[10px] font-mono text-red-400 font-bold mb-1 block">KNOWN BREACHES ({r.breaches.length})</span>
+              <span className="text-[12px] font-mono text-red-400 font-bold mb-1 block">KNOWN BREACHES ({r.breaches.length})</span>
               <div className="flex flex-col gap-1">
                 {r.breaches.map((b: string) => (
-                  <a key={b} href={`https://haveibeenpwned.com/PwnedWebsites#${b}`} target="_blank" rel="noreferrer" className="text-[9px] font-mono px-2 py-1 rounded bg-[#1A1A18] text-red-300 hover:text-white hover:bg-red-500/30 flex items-center justify-between transition-colors">
+                  <a key={b} href={`https://haveibeenpwned.com/PwnedWebsites#${b}`} target="_blank" rel="noreferrer" className="text-[11px] font-mono px-2 py-1 rounded bg-[#1A1A18] text-red-300 hover:text-white hover:bg-red-500/30 flex items-center justify-between transition-colors">
                     <span>{b}</span>
                     <ExternalLink className="w-2.5 h-2.5" />
                   </a>
@@ -1017,7 +1017,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                     ['Total machines', r.totalStealers, '#E040FB'],
                   ].map(([label, value, color]: any) => (
                     <div key={label} className="p-2 rounded border border-[var(--border-secondary)]/30 bg-[var(--bg-tertiary)]/30">
-                      <div className="text-[9px] font-mono text-[var(--text-muted)] uppercase tracking-wider">{label}</div>
+                      <div className="text-[11px] font-mono text-[var(--text-muted)] uppercase tracking-wider">{label}</div>
                       <div className="text-[15px] font-mono font-bold" style={{ color }}>{Number(value || 0).toLocaleString()}</div>
                     </div>
                   ))}
@@ -1029,7 +1029,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
 
                 {pw.has_stats && (
                   <div className="mt-2 p-2 border border-[#FF9500]/30 bg-[#FF9500]/10 rounded">
-                    <span className="text-[10px] font-mono text-[#FF9500] font-bold mb-1 block">
+                    <span className="text-[12px] font-mono text-[#FF9500] font-bold mb-1 block">
                       EMPLOYEE PASSWORD STRENGTH ({Number(pw.totalPass || 0).toLocaleString()})
                     </span>
                     <div className="flex h-2 rounded overflow-hidden mb-1">
@@ -1037,7 +1037,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                         <div key={k} style={{ width: `${Number(pw[k]?.perc) || 0}%`, background: c }} />
                       ))}
                     </div>
-                    <div className="text-[9px] font-mono text-[var(--text-muted)]">
+                    <div className="text-[11px] font-mono text-[var(--text-muted)]">
                       {weakPct.toFixed(0)}% weak or worse · {(Number(pw.strong?.perc) || 0).toFixed(0)}% strong
                     </div>
                   </div>
@@ -1045,10 +1045,10 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
 
                 {families.length > 0 && (
                   <div className="mt-2 p-2 border border-[#FF1744]/30 bg-[#FF1744]/10 rounded">
-                    <span className="text-[10px] font-mono text-[#FF1744] font-bold mb-1 block">STEALER FAMILIES</span>
+                    <span className="text-[12px] font-mono text-[#FF1744] font-bold mb-1 block">STEALER FAMILIES</span>
                     <div className="flex flex-wrap gap-1">
                       {families.slice(0, 14).map(([name, count]) => (
-                        <span key={name} className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#E8E6E0] border border-[#FF1744]/20">
+                        <span key={name} className="text-[11px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#E8E6E0] border border-[#FF1744]/20">
                           {name} <span className="text-[#FF1744]">{String(count)}</span>
                         </span>
                       ))}
@@ -1058,13 +1058,13 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
 
                 {Array.isArray(r.thirdPartyDomains) && r.thirdPartyDomains.length > 0 && (
                   <div className="mt-2 p-2 border border-[var(--border-secondary)]/30 rounded">
-                    <span className="text-[10px] font-mono text-[var(--text-secondary)] font-bold mb-1 block">
+                    <span className="text-[12px] font-mono text-[var(--text-secondary)] font-bold mb-1 block">
                       TOP THIRD-PARTY DOMAINS ({r.thirdPartyDomains.length})
                     </span>
                     {r.thirdPartyDomains.slice(0, 8).map((d: any) => (
                       <div key={d.domain} className="flex items-center justify-between py-0.5">
-                        <span className="text-[9px] font-mono text-[var(--text-primary)] break-all">{d.domain}</span>
-                        <span className="text-[9px] font-mono text-[var(--text-muted)] flex-shrink-0 ml-2">{d.occurrence}</span>
+                        <span className="text-[11px] font-mono text-[var(--text-primary)] break-all">{d.domain}</span>
+                        <span className="text-[11px] font-mono text-[var(--text-muted)] flex-shrink-0 ml-2">{d.occurrence}</span>
                       </div>
                     ))}
                   </div>
@@ -1093,7 +1093,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                 <div key={i} className="mt-2 p-2 rounded border border-[#FF1744]/30 bg-[#FF1744]/5">
                   <div className="flex items-center gap-2 mb-1.5">
                     <Monitor className="w-3 h-3 text-[#FF1744]" />
-                    <span className="text-[10px] font-mono font-bold text-[#FF1744] break-all">
+                    <span className="text-[12px] font-mono font-bold text-[#FF1744] break-all">
                       {s.computer_name || 'UNKNOWN MACHINE'}
                     </span>
                   </div>
@@ -1108,16 +1108,16 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                     <div className="mt-1.5 pt-1.5 border-t border-[#FF1744]/20">
                       <div className="flex items-center gap-1.5 mb-1">
                         <KeyRound className="w-2.5 h-2.5 text-[var(--text-muted)]" />
-                        <span className="text-[9px] font-mono text-[var(--text-muted)] uppercase tracking-wider">
+                        <span className="text-[11px] font-mono text-[var(--text-muted)] uppercase tracking-wider">
                           Credentials (redacted by Hudson Rock)
                         </span>
                       </div>
                       <div className="flex flex-wrap gap-1">
                         {(s.top_logins || []).map((l: string, j: number) => (
-                          <span key={`l${j}`} className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#87CEEB] border border-[#87CEEB]/20 break-all">{l}</span>
+                          <span key={`l${j}`} className="text-[11px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#87CEEB] border border-[#87CEEB]/20 break-all">{l}</span>
                         ))}
                         {(s.top_passwords || []).map((p: string, j: number) => (
-                          <span key={`p${j}`} className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#E040FB] border border-[#E040FB]/20 break-all">{p}</span>
+                          <span key={`p${j}`} className="text-[11px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#E040FB] border border-[#E040FB]/20 break-all">{p}</span>
                         ))}
                       </div>
                     </div>
@@ -1127,7 +1127,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
             </>
           )}
           {!hit && r.message && (
-            <div className="mt-2 text-[9px] font-mono text-[var(--text-muted)] leading-relaxed">
+            <div className="mt-2 text-[11px] font-mono text-[var(--text-muted)] leading-relaxed">
               {String(r.message).split('Visit')[0].trim()}
             </div>
           )}
@@ -1250,7 +1250,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           if (!tools.length) return null;
           return (
             <div key={group.id} className="mb-3 last:mb-0">
-              <div className="text-[9px] font-mono tracking-[0.2em] text-[var(--text-muted)]/70 mb-1.5 pt-1">
+              <div className="text-[11px] font-mono tracking-[0.2em] text-[var(--text-muted)]/70 mb-1.5 pt-1">
                 {group.label}
               </div>
               <div className="flex flex-col gap-0.5">
@@ -1277,7 +1277,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                         >
                           {tab.label}
                         </span>
-                        <span className="block text-[9px] font-mono text-[var(--text-muted)] leading-snug">
+                        <span className="block text-[11px] font-mono text-[var(--text-muted)] leading-snug">
                           {tab.blurb}
                         </span>
                       </span>
@@ -1289,7 +1289,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           );
         })}
         {toolFilter && !TABS.some(matchesFilter) && (
-          <div className="text-[10px] font-mono text-[var(--text-muted)] py-3 text-center">
+          <div className="text-[12px] font-mono text-[var(--text-muted)] py-3 text-center">
             No tool matches “{toolFilter}”.
           </div>
         )}
@@ -1303,7 +1303,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           style={{ borderColor: 'rgba(0, 230, 118, 0.25)' }}
         >
           <LocateFixed className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} style={{ color: '#00E676' }} />
-          <span className="font-mono font-bold tracking-[0.1em] text-[10px]" style={{ color: '#00E676' }}>
+          <span className="font-mono font-bold tracking-[0.1em] text-[12px]" style={{ color: '#00E676' }}>
             {loading ? 'TRACKING…' : 'SELF TRACK'}
           </span>
         </button>
@@ -1355,7 +1355,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
               value={toolFilter}
               onChange={e => setToolFilter(e.target.value)}
               placeholder="Filter tools…"
-              className="w-full bg-[var(--bg-primary)]/60 border border-[var(--border-primary)] rounded-lg pl-7 pr-6 py-1.5 text-[9px] font-mono text-[var(--text-primary)] placeholder:text-[var(--text-muted)]/40 focus:outline-none"
+              className="w-full bg-[var(--bg-primary)]/60 border border-[var(--border-primary)] rounded-lg pl-7 pr-6 py-1.5 text-[11px] font-mono text-[var(--text-primary)] placeholder:text-[var(--text-muted)]/40 focus:outline-none"
             />
             {toolFilter && (
               <button onClick={() => setToolFilter('')} className="absolute right-1.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-white">
@@ -1369,12 +1369,12 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
             if (!tools.length) return null;
             return (
               <div key={group.id} className="mb-2 last:mb-0">
-                <div className="text-[8px] font-mono tracking-[0.18em] text-[var(--text-muted)]/60 mb-1">{group.label}</div>
+                <div className="text-[10px] font-mono tracking-[0.18em] text-[var(--text-muted)]/60 mb-1">{group.label}</div>
                 <div className="grid grid-cols-4 gap-1">
                   {tools.map(tab => (
                     <button key={tab.id} onClick={() => selectTool(tab.id)}
                       title={tab.blurb}
-                      className={`flex flex-col items-center gap-1 px-1 py-2 rounded-lg text-[8px] font-mono tracking-wider transition-all border ${activeTab === tab.id ? 'border-opacity-40 bg-opacity-15' : 'border-transparent hover:bg-[var(--hover-accent)]'}`}
+                      className={`flex flex-col items-center gap-1 px-1 py-2 rounded-lg text-[10px] font-mono tracking-wider transition-all border ${activeTab === tab.id ? 'border-opacity-40 bg-opacity-15' : 'border-transparent hover:bg-[var(--hover-accent)]'}`}
                       style={{ borderColor: activeTab === tab.id ? tab.color : 'transparent', backgroundColor: activeTab === tab.id ? `${tab.color}15` : undefined, color: activeTab === tab.id ? tab.color : 'var(--text-muted)' }}>
                       <tab.icon className="w-3.5 h-3.5" />
                       <span className="leading-tight text-center w-full">{tab.label}</span>
@@ -1386,7 +1386,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           })}
 
           {toolFilter && !TABS.some(t => t.id !== 'sweep' && matchesFilter(t)) && (
-            <div className="text-[9px] font-mono text-[var(--text-muted)] py-2 text-center">
+            <div className="text-[11px] font-mono text-[var(--text-muted)] py-2 text-center">
               No tool matches “{toolFilter}”.
             </div>
           )}
@@ -1403,7 +1403,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
               <button
                 key={id}
                 onClick={() => setChainView(id)}
-                className="px-2 py-1 rounded text-[9px] font-mono font-bold tracking-wider transition-colors"
+                className="px-2 py-1 rounded text-[11px] font-mono font-bold tracking-wider transition-colors"
                 style={{
                   color: chainView === id ? currentTab?.color : 'var(--text-muted)',
                   background: chainView === id ? `${currentTab?.color}1a` : 'transparent',
@@ -1426,7 +1426,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
               style={{ borderColor: query ? `${currentTab?.color}40` : undefined }} />
           </div>
           <button onClick={runLookup} disabled={loading || !query.trim()}
-            className="px-4 py-2 rounded-lg text-[10px] font-mono font-bold tracking-wider disabled:opacity-30 transition-all flex items-center justify-center min-w-[70px]"
+            className="px-4 py-2 rounded-lg text-[12px] font-mono font-bold tracking-wider disabled:opacity-30 transition-all flex items-center justify-center min-w-[70px]"
             style={{ backgroundColor: `${currentTab?.color}20`, border: `1px solid ${currentTab?.color}40`, color: currentTab?.color }}>
             {loading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : 'SCAN'}
           </button>
@@ -1436,17 +1436,17 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
         {/* Secondary Controls */}
         {activeTab === 'scanner' && (
           <select value={scanType} onChange={e => setScanType(e.target.value)}
-            className="bg-[var(--bg-primary)]/60 border border-[var(--border-primary)] rounded-lg px-2 py-1.5 text-[10px] font-mono text-[var(--text-muted)] outline-none w-full">
+            className="bg-[var(--bg-primary)]/60 border border-[var(--border-primary)] rounded-lg px-2 py-1.5 text-[12px] font-mono text-[var(--text-muted)] outline-none w-full">
             <option value="quick">QUICK SCAN</option><option value="deep">DEEP SCAN</option><option value="ports">TOP 1000 PORTS</option>
           </select>
         )}
         {activeTab === 'sweep' && (
           <div className="flex items-center justify-between bg-[var(--bg-primary)]/60 border border-[var(--border-primary)] rounded-lg p-1">
-            <span className="text-[9px] font-mono text-[var(--text-muted)] pl-2">SUBNET MASK:</span>
+            <span className="text-[11px] font-mono text-[var(--text-muted)] pl-2">SUBNET MASK:</span>
             <div className="flex items-center gap-0.5">
               {[24, 25, 26, 27, 28].map(c => (
                 <button key={c} onClick={() => setSweepCidr(c)}
-                  className={`px-2 py-1 text-[10px] font-mono rounded transition-all ${
+                  className={`px-2 py-1 text-[12px] font-mono rounded transition-all ${
                     sweepCidr === c ? 'bg-[#FF3D3D]/20 text-[#FF3D3D]' : 'text-[var(--text-muted)] hover:bg-[var(--bg-tertiary)]'
                   }`}
                 >/{c}</button>
@@ -1466,8 +1466,8 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
       {sweepProgress && loading && (
         <div className="p-3 rounded-lg border border-[#FF3D3D]/30 bg-[#FF3D3D]/5">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-[10px] font-mono tracking-wider text-[#FF3D3D]">SWEEPING SUBNET...</span>
-            <span className="text-[10px] font-mono text-[#E8E6E0]">{sweepProgress.total} hosts</span>
+            <span className="text-[12px] font-mono tracking-wider text-[#FF3D3D]">SWEEPING SUBNET...</span>
+            <span className="text-[12px] font-mono text-[#E8E6E0]">{sweepProgress.total} hosts</span>
           </div>
           <div className="w-full h-1.5 bg-[#1A1A18] rounded-full overflow-hidden">
             <div className="h-full rounded-full" style={{ width: '100%', background: 'linear-gradient(90deg, #FF3D3D, #FF6B00, #FFD700)', animation: 'sweep-pulse 1.5s ease-in-out infinite' }} />
@@ -1483,11 +1483,11 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
             <div className="flex items-center justify-between mb-3">
               <div>
                 <div className="text-[11px] font-mono tracking-wider text-[#E8E6E0]">{sweepResult.subnet}</div>
-                <div className="text-[9px] font-mono text-[#5C5A54]">{sweepResult.center.city}, {sweepResult.center.country} · {sweepResult.center.isp}</div>
+                <div className="text-[11px] font-mono text-[#5C5A54]">{sweepResult.center.city}, {sweepResult.center.country} · {sweepResult.center.isp}</div>
               </div>
               <div className="text-right">
                 <div className="text-[18px] font-mono font-bold text-[#FF3D3D]">{sweepResult.summary.total_responsive}</div>
-                <div className="text-[8px] font-mono text-[#5C5A54] tracking-wider">DEVICES FOUND</div>
+                <div className="text-[10px] font-mono text-[#5C5A54] tracking-wider">DEVICES FOUND</div>
               </div>
             </div>
             {/* Breakdown Bar */}
@@ -1503,8 +1503,8 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                 return (
                   <div key={type} className="flex items-center gap-1">
                     <div className="w-2 h-2 rounded-full" style={{ backgroundColor: device?.device_color || '#666' }} />
-                    <span className="text-[9px] font-mono text-[#8A8880]">{type}</span>
-                    <span className="text-[9px] font-mono text-[#E8E6E0] font-bold">{String(count)}</span>
+                    <span className="text-[11px] font-mono text-[#8A8880]">{type}</span>
+                    <span className="text-[11px] font-mono text-[#E8E6E0] font-bold">{String(count)}</span>
                   </div>
                 );
               })}
@@ -1545,16 +1545,16 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                     <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: device.device_color }} />
                     <span className={`flex-shrink-0 ${isFullScreen ? "text-[14px]" : "text-[11px]"} font-mono font-bold text-[#E8E6E0]`}>{device.ip}</span>
                     {device.hostnames.length > 0 && (
-                      <span className={`${isFullScreen ? "text-[11px]" : "text-[9px]"} font-mono text-[#5C5A54] truncate min-w-0`}>{device.hostnames[0]}</span>
+                      <span className={`${isFullScreen ? "text-[11px]" : "text-[11px]"} font-mono text-[#5C5A54] truncate min-w-0`}>{device.hostnames[0]}</span>
                     )}
                   </div>
                   <div className="flex items-center gap-2 flex-shrink-0">
                     {device.vulns.length > 0 && (
-                      <span className={`${isFullScreen ? "text-[10px]" : "text-[8px]"} font-mono px-1.5 py-0.5 rounded bg-red-500/15 text-red-400 border border-red-500/30 whitespace-nowrap`}>
+                      <span className={`${isFullScreen ? "text-[12px]" : "text-[10px]"} font-mono px-1.5 py-0.5 rounded bg-red-500/15 text-red-400 border border-red-500/30 whitespace-nowrap`}>
                         {device.vulns.length} CVEs
                       </span>
                     )}
-                    <span className={`${isFullScreen ? "text-[10px]" : "text-[8px]"} font-mono px-1.5 py-0.5 rounded whitespace-nowrap`} style={{ backgroundColor: device.device_color + '20', color: device.device_color, border: `1px solid ${device.device_color}40` }}>{device.device_type}</span>
+                    <span className={`${isFullScreen ? "text-[12px]" : "text-[10px]"} font-mono px-1.5 py-0.5 rounded whitespace-nowrap`} style={{ backgroundColor: device.device_color + '20', color: device.device_color, border: `1px solid ${device.device_color}40` }}>{device.device_type}</span>
                     {isFullScreen && (
                       <ChevronDown className={`w-4 h-4 text-[#5C5A54] transition-transform flex-shrink-0 ${isExpanded ? 'rotate-180' : ''}`} />
                     )}
@@ -1564,7 +1564,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                 {/* Compact info (sidebar mode) */}
                 {!isFullScreen && (
                   <>
-                    <div className="flex items-center gap-2 text-[9px] font-mono text-[#5C5A54]">
+                    <div className="flex items-center gap-2 text-[11px] font-mono text-[#5C5A54]">
                       <span>Ports: {device.ports.slice(0, 8).join(', ')}{device.ports.length > 8 ? ` +${device.ports.length - 8}` : ''}</span>
                       {device.vulns.length > 0 && (
                         <div className="group relative flex items-center gap-1 cursor-help">
@@ -1572,10 +1572,10 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                             <AlertTriangle className="w-2.5 h-2.5" /> {device.vulns.length} CVEs
                           </span>
                           <div className="absolute bottom-full left-0 mb-1 hidden group-hover:block z-50 p-2 bg-[#1A1A18] border border-[#FF3D3D50] rounded-md shadow-xl min-w-[140px] max-w-[220px] max-h-[150px] overflow-y-auto styled-scrollbar">
-                            <div className="text-[8px] font-mono text-[#FF3D3D] mb-1 tracking-wider uppercase border-b border-[#FF3D3D30] pb-1">Identified Vulnerabilities</div>
+                            <div className="text-[10px] font-mono text-[#FF3D3D] mb-1 tracking-wider uppercase border-b border-[#FF3D3D30] pb-1">Identified Vulnerabilities</div>
                             <div className="flex flex-col gap-0.5">
                               {device.vulns.map((cve: string) => (
-                                <a key={cve} href={`https://nvd.nist.gov/vuln/detail/${cve}`} target="_blank" rel="noreferrer" className="text-[9px] font-mono text-[#E8E6E0] hover:text-[#FF3D3D] transition-colors truncate">
+                                <a key={cve} href={`https://nvd.nist.gov/vuln/detail/${cve}`} target="_blank" rel="noreferrer" className="text-[11px] font-mono text-[#E8E6E0] hover:text-[#FF3D3D] transition-colors truncate">
                                   {cve}
                                 </a>
                               ))}
@@ -1584,7 +1584,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                         </div>
                       )}
                     </div>
-                    {device.hostnames.length > 0 && <div className="text-[9px] font-mono text-[#8A8880] mt-0.5 truncate">{device.hostnames[0]}</div>}
+                    {device.hostnames.length > 0 && <div className="text-[11px] font-mono text-[#8A8880] mt-0.5 truncate">{device.hostnames[0]}</div>}
                   </>
                 )}
 
@@ -1594,7 +1594,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                     {/* Ports + Hostnames Row */}
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-[#2A2A28]">
                       <div className="bg-[#0D0D0C] p-4">
-                        <div className="text-[10px] font-mono text-[#5C5A54] tracking-widest uppercase mb-2">Open Ports</div>
+                        <div className="text-[12px] font-mono text-[#5C5A54] tracking-widest uppercase mb-2">Open Ports</div>
                         <div className="flex flex-wrap gap-1.5">
                           {device.ports.map((port: number) => (
                             <span key={port} className="px-2 py-1 bg-[#1A1A18] border border-[#2A2A28] rounded text-[11px] font-mono text-[var(--cyan-primary)]">{port}</span>
@@ -1602,7 +1602,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                         </div>
                       </div>
                       <div className="bg-[#0D0D0C] p-4">
-                        <div className="text-[10px] font-mono text-[#5C5A54] tracking-widest uppercase mb-2">Hostnames</div>
+                        <div className="text-[12px] font-mono text-[#5C5A54] tracking-widest uppercase mb-2">Hostnames</div>
                         {device.hostnames.length > 0 ? (
                           <div className="flex flex-col gap-1">
                             {device.hostnames.map((h: string) => (
@@ -1618,7 +1618,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                     {/* CVE Intelligence */}
                     {device.vulns.length > 0 && (
                       <div className="p-4 border-t border-[#2A2A28]">
-                        <div className="text-[10px] font-mono text-[#5C5A54] tracking-widest uppercase mb-3">Vulnerabilities ({device.vulns.length})</div>
+                        <div className="text-[12px] font-mono text-[#5C5A54] tracking-widest uppercase mb-3">Vulnerabilities ({device.vulns.length})</div>
                         <div className="flex flex-col gap-2">
                           {device.vulns.map((cveId: string) => {
                             const info = cveCache[cveId];
@@ -1634,12 +1634,12 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                                   <div className="flex items-center gap-2">
                                     <span className="text-[12px] font-mono font-bold text-[#E8E6E0]">{cveId}</span>
                                     {info?.cvss != null && (
-                                      <span className="text-[10px] font-mono px-1.5 py-0.5 rounded" style={{ backgroundColor: severityColor + '15', color: severityColor, border: `1px solid ${severityColor}40` }}>CVSS {info.cvss}</span>
+                                      <span className="text-[12px] font-mono px-1.5 py-0.5 rounded" style={{ backgroundColor: severityColor + '15', color: severityColor, border: `1px solid ${severityColor}40` }}>CVSS {info.cvss}</span>
                                     )}
                                   </div>
                                   <div className="flex items-center gap-2">
                                     {info?.severity && (
-                                      <span className="text-[9px] font-mono font-bold px-2 py-0.5 rounded" style={{ backgroundColor: severityColor + '15', color: severityColor, border: `1px solid ${severityColor}40` }}>{info.severity}</span>
+                                      <span className="text-[11px] font-mono font-bold px-2 py-0.5 rounded" style={{ backgroundColor: severityColor + '15', color: severityColor, border: `1px solid ${severityColor}40` }}>{info.severity}</span>
                                     )}
                                     <a href={`https://nvd.nist.gov/vuln/detail/${cveId}`} target="_blank" rel="noreferrer" className="text-[#5C5A54] hover:text-[#E8E6E0] transition-colors">
                                       <ExternalLink className="w-3.5 h-3.5" />
@@ -1649,16 +1649,16 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                                 {isLoading ? (
                                   <div className="flex items-center gap-2 py-1">
                                     <Loader2 className="w-3 h-3 animate-spin text-[#5C5A54]" />
-                                    <span className="text-[10px] font-mono text-[#5C5A54]">Fetching vulnerability intelligence...</span>
+                                    <span className="text-[12px] font-mono text-[#5C5A54]">Fetching vulnerability intelligence...</span>
                                   </div>
                                 ) : (
                                   <>
                                     <p className="text-[11px] font-mono text-[#8A8880] leading-relaxed">{info.description}</p>
-                                    {info.cwe && <div className="text-[10px] font-mono text-[#5C5A54] mt-2">Weakness: {info.cwe}</div>}
+                                    {info.cwe && <div className="text-[12px] font-mono text-[#5C5A54] mt-2">Weakness: {info.cwe}</div>}
                                     {info.affected && info.affected.length > 0 && (
                                       <div className="mt-2 flex flex-wrap gap-1.5">
                                         {info.affected.map((a: any, i: number) => (
-                                          <span key={i} className="text-[9px] font-mono px-1.5 py-0.5 bg-[#1A1A18] border border-[#2A2A28] rounded text-[#8A8880]">
+                                          <span key={i} className="text-[11px] font-mono px-1.5 py-0.5 bg-[#1A1A18] border border-[#2A2A28] rounded text-[#8A8880]">
                                             {a.vendor}/{a.product}
                                           </span>
                                         ))}
@@ -1679,7 +1679,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
             })}
           </div>
           <div className="px-3 py-2 border-t border-[#2A2A28]">
-            <div className="text-[8px] font-mono text-[#5C5A54] tracking-wider">SWEPT {sweepResult.summary.total_hosts} HOSTS IN {(sweepResult.sweep_time_ms / 1000).toFixed(1)}s · ASN {sweepResult.center.asn}</div>
+            <div className="text-[10px] font-mono text-[#5C5A54] tracking-wider">SWEPT {sweepResult.summary.total_hosts} HOSTS IN {(sweepResult.sweep_time_ms / 1000).toFixed(1)}s · ASN {sweepResult.center.asn}</div>
           </div>
         </div>
       )}
@@ -1687,8 +1687,8 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
       {(results || (activeTab === 'crypto' && chainView === 'brief')) && !(sweepResult && !loading) && (
         <div className="bg-[var(--bg-primary)]/40 border border-[var(--border-primary)] rounded-lg p-3 max-h-[50vh] overflow-y-auto styled-scrollbar">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-[9px] font-mono tracking-widest" style={{ color: currentTab?.color }}>{currentTab?.label} RESULTS</span>
-            <span className="text-[8px] font-mono text-[var(--text-muted)] flex items-center gap-1"><Clock className="w-2.5 h-2.5" />{new Date().toLocaleTimeString()}</span>
+            <span className="text-[11px] font-mono tracking-widest" style={{ color: currentTab?.color }}>{currentTab?.label} RESULTS</span>
+            <span className="text-[10px] font-mono text-[var(--text-muted)] flex items-center gap-1"><Clock className="w-2.5 h-2.5" />{new Date().toLocaleTimeString()}</span>
           </div>
           {renderStructuredResults()}
         </div>
@@ -1696,15 +1696,15 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
 
       {history.length > 0 && !results && (
         <div className="space-y-1">
-          <span className="text-[9px] font-mono tracking-widest text-[var(--text-muted)]">RECENT SCANS</span>
+          <span className="text-[11px] font-mono tracking-widest text-[var(--text-muted)]">RECENT SCANS</span>
           {history.slice(0, 5).map((h, i) => (
             <button key={i} onClick={() => { setActiveTab(h.tab); setQuery(h.query); }}
               className="w-full flex items-center justify-between px-2.5 py-1.5 rounded-lg hover:bg-[var(--hover-accent)] transition-colors text-left">
               <div className="flex items-center gap-2">
-                <span className="text-[9px] font-mono" style={{ color: TABS.find(t => t.id === h.tab)?.color }}>{TABS.find(t => t.id === h.tab)?.label}</span>
-                <span className="text-[10px] font-mono text-[var(--text-secondary)]">{h.query}</span>
+                <span className="text-[11px] font-mono" style={{ color: TABS.find(t => t.id === h.tab)?.color }}>{TABS.find(t => t.id === h.tab)?.label}</span>
+                <span className="text-[12px] font-mono text-[var(--text-secondary)]">{h.query}</span>
               </div>
-              <span className="text-[8px] font-mono text-[var(--text-muted)]">{h.time}</span>
+              <span className="text-[10px] font-mono text-[var(--text-muted)]">{h.time}</span>
             </button>
           ))}
         </div>
@@ -1725,7 +1725,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
             <div className="flex items-center gap-3 min-w-0">
               <Radar className="w-5 h-5 text-[var(--cyan-primary)] flex-shrink-0" />
               <span className="hud-text text-[16px] text-[var(--text-primary)]">OSIRIS RECON TOOLKIT</span>
-              <span className="gotham-tag gotham-tag--classified" style={{ fontSize: '8px' }}>{TABS.length} MODULES</span>
+              <span className="gotham-tag gotham-tag--classified" style={{ fontSize: '10px' }}>{TABS.length} MODULES</span>
               {currentTab && (
                 <>
                   <span className="text-[var(--text-muted)]/40">/</span>
@@ -1758,7 +1758,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
                         {currentTab.label}
                       </h2>
                     </div>
-                    <p className="text-[10px] font-mono text-[var(--text-muted)]">{currentTab.blurb}</p>
+                    <p className="text-[12px] font-mono text-[var(--text-muted)]">{currentTab.blurb}</p>
                   </div>
                 )}
                 {renderContent()}
@@ -1777,10 +1777,10 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
         <button onClick={() => setExpanded(!expanded)} className="flex items-center gap-2 flex-1">
           <Radar className="w-3.5 h-3.5 text-[var(--cyan-primary)]" />
           <span className="hud-text text-[12px] text-[var(--text-primary)]">RECON TOOLKIT</span>
-          <span className="gotham-tag gotham-tag--info" style={{ fontSize: '7px', padding: '1px 5px' }}>{TABS.length} TOOLS</span>
+          <span className="gotham-tag gotham-tag--info" style={{ fontSize: '10px', padding: '1px 5px' }}>{TABS.length} TOOLS</span>
         </button>
         <div className="flex items-center gap-3">
-          <button onClick={() => setIsFullScreen(true)} className="text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors" title="Full Screen">
+          <button onClick={() => setIsFullScreen(true)} className="p-1.5 -m-0.5 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-white/10 transition-colors" title="Full Screen">
              <Maximize2 className="w-3.5 h-3.5" />
           </button>
           <div className="w-1.5 h-1.5 rounded-full bg-[var(--cyan-primary)] animate-osiris-pulse" />

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -2386,9 +2386,16 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       const o = layer.opacity ?? 0.8;
       if (!map.getSource(sourceId)) {
         map.addSource(sourceId, { type: 'geojson', data: layer.geojson });
-        map.addLayer({ id: `${sourceId}-fill`, type: 'fill', source: sourceId, paint: { 'fill-color': c, 'fill-opacity': o * 0.15, 'fill-outline-color': c } });
-        map.addLayer({ id: `${sourceId}-line`, type: 'line', source: sourceId, paint: { 'line-color': c, 'line-width': 2, 'line-opacity': o } });
-        map.addLayer({ id: `${sourceId}-circle`, type: 'circle', source: sourceId, filter: ['==', ['geometry-type'], 'Point'], paint: { 'circle-color': c, 'circle-radius': 5, 'circle-stroke-width': 1.5, 'circle-stroke-color': '#000', 'circle-opacity': o } });
+        // A fill layer with no geometry filter is applied to LineStrings too,
+        // and maplibre fills an open path by closing it — which is what draws
+        // the triangular wedges across a pipeline or railway dataset. Fill is
+        // only ever meaningful for polygons.
+        map.addLayer({ id: `${sourceId}-fill`, type: 'fill', source: sourceId, filter: ['==', ['geometry-type'], 'Polygon'], paint: { 'fill-color': c, 'fill-opacity': o * 0.15, 'fill-outline-color': c } });
+        map.addLayer({ id: `${sourceId}-line`, type: 'line', source: sourceId, filter: ['match', ['geometry-type'], ['LineString', 'Polygon'], true, false], paint: { 'line-color': c, 'line-width': ['interpolate', ['linear'], ['zoom'], 4, 0.6, 10, 1.4, 14, 2, 18, 3], 'line-opacity': o } });
+        // A fixed radius does not survive a dense dataset: ~1.2k points at
+        // city zoom merge into one blob. Scaling with zoom keeps them as
+        // discrete stations when you are far out, and readable up close.
+        map.addLayer({ id: `${sourceId}-circle`, type: 'circle', source: sourceId, filter: ['==', ['geometry-type'], 'Point'], paint: { 'circle-color': c, 'circle-radius': ['interpolate', ['linear'], ['zoom'], 4, 1.5, 8, 2.5, 11, 4, 14, 6, 18, 9], 'circle-stroke-width': ['interpolate', ['linear'], ['zoom'], 8, 0.4, 14, 1.2], 'circle-stroke-color': '#000', 'circle-opacity': ['interpolate', ['linear'], ['zoom'], 6, 0.55, 12, 0.85] } });
       } else {
         (map.getSource(sourceId) as maplibregl.GeoJSONSource).setData(layer.geojson);
         // Update paint properties for color/opacity changes

--- a/src/components/SatellitePanel.tsx
+++ b/src/components/SatellitePanel.tsx
@@ -196,14 +196,14 @@ export default function SatellitePanel({
             <span className="text-[14px] font-mono font-bold tracking-[0.2em] text-white">
               SATELLITE
             </span>
-            <span className="text-[9px] font-mono tracking-wider text-[#448AFF]">
+            <span className="text-[11px] font-mono tracking-wider text-[#448AFF]">
               IMAGERY ARCHIVE
             </span>
           </div>
         </div>
         <div className="flex items-center gap-2 px-2.5 py-1 rounded-full bg-[#00E676]/10 border border-[#00E676]/20">
           <div className="w-2 h-2 rounded-full bg-[#00E676] animate-pulse shadow-[0_0_8px_#00E676]" />
-          <span className="text-[9px] font-mono font-bold text-[#00E676] tracking-wider">
+          <span className="text-[11px] font-mono font-bold text-[#00E676] tracking-wider">
             STAC ONLINE
           </span>
         </div>
@@ -221,7 +221,7 @@ export default function SatellitePanel({
       <div className="flex flex-col gap-3">
         <div className="flex gap-2">
           <div className="relative flex-1">
-            <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[9px] font-mono font-bold text-[var(--text-muted)] uppercase">
+            <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[11px] font-mono font-bold text-[var(--text-muted)] uppercase">
               LAT
             </span>
             <input
@@ -233,7 +233,7 @@ export default function SatellitePanel({
             />
           </div>
           <div className="relative flex-1">
-            <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[9px] font-mono font-bold text-[var(--text-muted)] uppercase">
+            <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[11px] font-mono font-bold text-[var(--text-muted)] uppercase">
               LNG
             </span>
             <input
@@ -261,7 +261,7 @@ export default function SatellitePanel({
                   setLng(centroidLng.toFixed(4));
                 }
               }}
-              className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-[var(--gold-primary)]/10 border border-[var(--gold-primary)]/20 text-[var(--gold-primary)] text-[10px] font-mono font-bold tracking-wider hover:bg-[var(--gold-primary)]/20 transition-all"
+              className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-[var(--gold-primary)]/10 border border-[var(--gold-primary)]/20 text-[var(--gold-primary)] text-[12px] font-mono font-bold tracking-wider hover:bg-[var(--gold-primary)]/20 transition-all"
             >
               <Layers className="w-3.5 h-3.5" />
               USE POLYGON
@@ -273,7 +273,7 @@ export default function SatellitePanel({
               <button
                 key={d}
                 onClick={() => setDays(d)}
-                className={`flex-1 py-2 text-[10px] font-mono transition-all ${
+                className={`flex-1 py-2 text-[12px] font-mono transition-all ${
                   days === d
                     ? 'bg-[#448AFF]/20 text-[#448AFF] font-bold'
                     : 'text-[var(--text-muted)] hover:bg-white/5 hover:text-white'
@@ -399,12 +399,12 @@ export default function SatellitePanel({
                         </span>
                       </div>
                       <div className="flex items-center gap-2">
-                        <span className="text-[9px] font-mono px-2 py-0.5 rounded-full bg-white/10 text-white font-bold tracking-wider">
+                        <span className="text-[11px] font-mono px-2 py-0.5 rounded-full bg-white/10 text-white font-bold tracking-wider">
                           {scene.platform}
                         </span>
                         {scene.cloud_cover !== null && (
                           <div 
-                            className="flex items-center gap-1 px-2 py-0.5 rounded-full font-mono font-bold text-[9px]"
+                            className="flex items-center gap-1 px-2 py-0.5 rounded-full font-mono font-bold text-[11px]"
                             style={{ 
                               background: `${getCloudColor(scene.cloud_cover)}20`,
                               color: getCloudColor(scene.cloud_cover),
@@ -456,7 +456,7 @@ export default function SatellitePanel({
                                 href={scene.preview}
                                 target="_blank"
                                 rel="noreferrer"
-                                className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-[#448AFF]/15 border border-[#448AFF]/30 text-[#448AFF] text-[10px] font-mono font-bold hover:bg-[#448AFF]/25 transition-all"
+                                className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-[#448AFF]/15 border border-[#448AFF]/30 text-[#448AFF] text-[12px] font-mono font-bold hover:bg-[#448AFF]/25 transition-all"
                                 onClick={(e) => e.stopPropagation()}
                               >
                                 <Eye className="w-3.5 h-3.5" />
@@ -475,7 +475,7 @@ export default function SatellitePanel({
                               }`}
                               target="_blank"
                               rel="noreferrer"
-                              className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white text-[10px] font-mono font-bold hover:bg-white/10 transition-all"
+                              className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white text-[12px] font-mono font-bold hover:bg-white/10 transition-all"
                               onClick={(e) => e.stopPropagation()}
                             >
                               <ExternalLink className="w-3.5 h-3.5" />
@@ -492,7 +492,7 @@ export default function SatellitePanel({
 
             {/* Total results note */}
             {results.total > results.scenes.length && (
-              <div className="text-center text-[9px] font-mono text-[var(--text-muted)] py-1">
+              <div className="text-center text-[11px] font-mono text-[var(--text-muted)] py-1">
                 Showing {results.scenes.length} of {results.total} total scenes
               </div>
             )}
@@ -537,7 +537,7 @@ export default function SatellitePanel({
                   boxShadow: 'inset 0 1px 0 rgba(212,175,55,0.1)',
                 }}
               >
-                <p className="text-[10px] font-mono text-white/80 leading-relaxed">
+                <p className="text-[12px] font-mono text-white/80 leading-relaxed">
                   Order premium commercial satellite imagery (50cm–30cm resolution). 
                   Task new captures or access archive imagery.
                 </p>
@@ -622,7 +622,7 @@ export default function SatellitePanel({
                         </span>
                         <ExternalLink className="w-3.5 h-3.5 text-[var(--text-muted)] opacity-0 group-hover:opacity-80 transition-opacity" />
                       </div>
-                      <p className="text-[9px] font-mono text-[var(--text-muted)] mt-1 leading-relaxed pr-2">
+                      <p className="text-[11px] font-mono text-[var(--text-muted)] mt-1 leading-relaxed pr-2">
                         {src.desc}
                       </p>
                     </div>
@@ -643,10 +643,10 @@ export default function SatellitePanel({
         }}
       />
       <div className="flex items-center justify-between px-1 pb-1">
-        <span className="text-[8px] font-mono font-bold text-[var(--text-muted)] tracking-wider">
+        <span className="text-[10px] font-mono font-bold text-[var(--text-muted)] tracking-wider">
           DATA SOURCE: ELEMENT84 / COPERNICUS
         </span>
-        <span className="text-[8px] font-mono font-bold text-[var(--text-muted)]">
+        <span className="text-[10px] font-mono font-bold text-[var(--text-muted)]">
           {results?.timestamp
             ? new Date(results.timestamp).toLocaleTimeString()
             : '—'}
@@ -661,10 +661,10 @@ export default function SatellitePanel({
 function DetailRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex flex-col gap-1">
-      <span className="text-[9px] font-mono font-bold text-[var(--text-muted)] uppercase tracking-wider">
+      <span className="text-[11px] font-mono font-bold text-[var(--text-muted)] uppercase tracking-wider">
         {label}
       </span>
-      <span className="text-[10px] font-mono text-white break-all leading-tight">
+      <span className="text-[12px] font-mono text-white break-all leading-tight">
         {value}
       </span>
     </div>
@@ -688,7 +688,7 @@ function SpecBadge({
         border: `1px solid ${color}25`,
       }}
     >
-      <span className="text-[8px] font-mono font-bold text-[var(--text-muted)] uppercase tracking-wider">
+      <span className="text-[10px] font-mono font-bold text-[var(--text-muted)] uppercase tracking-wider">
         {label}
       </span>
       <span

--- a/src/components/ScaleBar.tsx
+++ b/src/components/ScaleBar.tsx
@@ -46,7 +46,7 @@ export default function ScaleBar({ zoom, latitude }: ScaleBarProps) {
           <div className="mt-[4px] h-px bg-[var(--text-muted)] opacity-60 w-full" />
         </div>
       </div>
-      <span className="text-[8px] font-mono text-[var(--text-muted)] tracking-widest opacity-70 leading-none">
+      <span className="text-[10px] font-mono text-[var(--text-muted)] tracking-widest opacity-70 leading-none">
         {scaleInfo.label}
       </span>
     </div>

--- a/src/components/ScmPanel.tsx
+++ b/src/components/ScmPanel.tsx
@@ -32,7 +32,7 @@ export default function ScmPanel({ data }: ScmPanelProps) {
           <Target className="w-3.5 h-3.5 text-[#00BCD4]" />
           <span className="hud-text text-[12px] text-[var(--text-primary)]">SCM RISK COMMAND</span>
           {totalRisks > 0 && (
-            <span className="gotham-tag gotham-tag--critical" style={{ fontSize: '7px', padding: '1px 4px' }}>{totalRisks} ALERTS</span>
+            <span className="gotham-tag gotham-tag--critical" style={{ fontSize: '10px', padding: '1px 4px' }}>{totalRisks} ALERTS</span>
           )}
         </div>
         <div className="flex items-center gap-2">
@@ -50,11 +50,11 @@ export default function ScmPanel({ data }: ScmPanelProps) {
                 <div>
                   <div className="flex items-center gap-1.5 mb-1.5">
                     <AlertCircle className="w-3 h-3 text-[#FF9500]" />
-                    <span className="text-[9px] font-mono text-[#FF9500] tracking-widest font-bold">MARKET IMPACT ALERTS</span>
+                    <span className="text-[11px] font-mono text-[#FF9500] tracking-widest font-bold">MARKET IMPACT ALERTS</span>
                   </div>
                   <div className="space-y-1">
                     {marketAlerts.map((alert: string, i: number) => (
-                      <div key={i} className="px-2 py-1.5 rounded border border-[#FF9500] bg-[#FF9500]/10 text-[#FF9500] text-[9px] font-mono leading-tight shadow-[0_0_8px_rgba(255,149,0,0.15)]">
+                      <div key={i} className="px-2 py-1.5 rounded border border-[#FF9500] bg-[#FF9500]/10 text-[#FF9500] text-[11px] font-mono leading-tight shadow-[0_0_8px_rgba(255,149,0,0.15)]">
                         {alert}
                       </div>
                     ))}
@@ -66,10 +66,10 @@ export default function ScmPanel({ data }: ScmPanelProps) {
               <div>
                 <div className="flex items-center gap-1.5 mb-1.5">
                   <AlertTriangle className="w-3 h-3 text-[#FF1744]" />
-                  <span className="text-[9px] font-mono text-[var(--text-muted)] tracking-widest">CRITICAL SUPPLIERS</span>
+                  <span className="text-[11px] font-mono text-[var(--text-muted)] tracking-widest">CRITICAL SUPPLIERS</span>
                 </div>
                 {criticalSuppliers.length === 0 ? (
-                  <div className="text-[9px] font-mono text-[#00E676] px-2">✓ All monitored Tier 1/2 nodes operational.</div>
+                  <div className="text-[11px] font-mono text-[#00E676] px-2">✓ All monitored Tier 1/2 nodes operational.</div>
                 ) : (
                   <div className="space-y-1">
                     {criticalSuppliers.map((s: any, i: number) => {
@@ -77,10 +77,10 @@ export default function ScmPanel({ data }: ScmPanelProps) {
                       return (
                         <div key={i} className="px-2 py-1.5 rounded border border-[#FF1744]/40 bg-[#FF1744]/10">
                           <div className="flex justify-between items-start mb-1">
-                            <span className="text-[10px] font-mono font-bold text-[#FF1744]">{s.name}</span>
-                            <span className="text-[8px] font-mono text-[#FF1744]/80">{s.city}</span>
+                            <span className="text-[12px] font-mono font-bold text-[#FF1744]">{s.name}</span>
+                            <span className="text-[10px] font-mono text-[#FF1744]/80">{s.city}</span>
                           </div>
-                          <div className="text-[8px] font-mono text-[#E8E6E0]">{threats.join(' • ')}</div>
+                          <div className="text-[10px] font-mono text-[#E8E6E0]">{threats.join(' • ')}</div>
                         </div>
                       );
                     })}
@@ -92,28 +92,28 @@ export default function ScmPanel({ data }: ScmPanelProps) {
               <div>
                 <div className="flex items-center gap-1.5 mb-1.5">
                   <Anchor className="w-3 h-3 text-[#FF9500]" />
-                  <span className="text-[9px] font-mono text-[var(--text-muted)] tracking-widest">CONGESTED NODES</span>
+                  <span className="text-[11px] font-mono text-[var(--text-muted)] tracking-widest">CONGESTED NODES</span>
                 </div>
                 {(congestedPorts.length === 0 && riskyChokes.length === 0) ? (
-                  <div className="text-[9px] font-mono text-[#00E676] px-2">✓ Global maritime flow optimal.</div>
+                  <div className="text-[11px] font-mono text-[#00E676] px-2">✓ Global maritime flow optimal.</div>
                 ) : (
                   <div className="space-y-1">
                     {riskyChokes.map((c: any, i: number) => (
                       <div key={`c-${i}`} className="px-2 py-1.5 rounded hover:bg-white/5 transition-colors border-l-2" style={{ borderLeftColor: c.risk === 'CRITICAL' ? '#FF1744' : '#FF9500' }}>
                         <div className="flex justify-between items-center mb-0.5">
-                          <span className="text-[10px] font-mono text-[#FF9500] font-bold">{c.name}</span>
-                          <span className="text-[8px] font-mono font-bold px-1 rounded" style={{ background: c.risk === 'CRITICAL' ? '#FF1744' : '#FF9500', color: '#000' }}>{c.risk}</span>
+                          <span className="text-[12px] font-mono text-[#FF9500] font-bold">{c.name}</span>
+                          <span className="text-[10px] font-mono font-bold px-1 rounded" style={{ background: c.risk === 'CRITICAL' ? '#FF1744' : '#FF9500', color: '#000' }}>{c.risk}</span>
                         </div>
-                        <div className="text-[8px] font-mono text-[#aaa]">{c.traffic}</div>
+                        <div className="text-[10px] font-mono text-[#aaa]">{c.traffic}</div>
                       </div>
                     ))}
                     {congestedPorts.map((p: any, i: number) => (
                       <div key={`p-${i}`} className="px-2 py-1.5 rounded hover:bg-white/5 transition-colors border-l-2" style={{ borderLeftColor: p.congestion === 'SEVERE' ? '#FF1744' : '#FF9500' }}>
                         <div className="flex justify-between items-center mb-0.5">
-                          <span className="text-[10px] font-mono text-[#00BCD4]">{p.name}</span>
-                          <span className="text-[8px] font-mono font-bold px-1 rounded" style={{ background: p.congestion === 'SEVERE' ? '#FF1744' : '#FF9500', color: '#000' }}>{p.congestion}</span>
+                          <span className="text-[12px] font-mono text-[#00BCD4]">{p.name}</span>
+                          <span className="text-[10px] font-mono font-bold px-1 rounded" style={{ background: p.congestion === 'SEVERE' ? '#FF1744' : '#FF9500', color: '#000' }}>{p.congestion}</span>
                         </div>
-                        <div className="flex justify-between items-center text-[8px] font-mono text-[#aaa]">
+                        <div className="flex justify-between items-center text-[10px] font-mono text-[#aaa]">
                           <span>DWELL: <span className="text-[#fff]">{p.dwell_time}</span></span>
                           <span>{p.volume.split(' | ')[1]}</span>
                         </div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -230,7 +230,7 @@ export default function SearchBar({ onLocate, alwaysExpanded = false }: SearchBa
     return (
       <button
         onClick={() => setOpen(true)}
-        className="flex items-center gap-1.5 glass-panel-sm px-3 py-2 text-[9px] font-mono tracking-[0.15em] text-[var(--text-muted)] hover:text-[var(--gold-primary)] hover:border-[var(--border-active)] transition-all hover:shadow-[0_0_12px_rgba(212,175,55,0.08)]"
+        className="flex items-center gap-1.5 glass-panel-sm px-3 py-2 text-[11px] font-mono tracking-[0.15em] text-[var(--text-muted)] hover:text-[var(--gold-primary)] hover:border-[var(--border-active)] transition-all hover:shadow-[0_0_12px_rgba(212,175,55,0.08)]"
       >
         <Search className="w-3 h-3" />
         CMD: LOCATE
@@ -250,12 +250,12 @@ export default function SearchBar({ onLocate, alwaysExpanded = false }: SearchBa
           onChange={(e) => handleSearch(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="SEARCH ADDRESS, CITY, OR COORDINATES..."
-          className="flex-1 bg-transparent text-[10px] text-[var(--text-primary)] font-mono tracking-wider outline-none placeholder:text-[var(--text-muted)]"
+          className="flex-1 bg-transparent text-[12px] text-[var(--text-primary)] font-mono tracking-wider outline-none placeholder:text-[var(--text-muted)]"
           autoComplete="off"
           spellCheck={false}
         />
         {loading && <div className="w-3 h-3 border border-[var(--gold-primary)] border-t-transparent rounded-full animate-spin" />}
-        <span className="text-[8px] text-[var(--text-muted)] font-mono opacity-50 hidden md:inline">CTRL+F</span>
+        <span className="text-[10px] text-[var(--text-muted)] font-mono opacity-50 hidden md:inline">CTRL+F</span>
         {(value || !alwaysExpanded) && (
           <button onClick={() => {
             if (alwaysExpanded) { setValue(''); setResults([]); }
@@ -285,16 +285,16 @@ export default function SearchBar({ onLocate, alwaysExpanded = false }: SearchBa
               >
                 <div className="mt-0.5">{getResultIcon(r.type, r.category)}</div>
                 <div className="flex-1 min-w-0">
-                  <div className="text-[10px] text-[var(--text-primary)] font-mono truncate leading-tight">{primary}</div>
+                  <div className="text-[12px] text-[var(--text-primary)] font-mono truncate leading-tight">{primary}</div>
                   {secondary && (
-                    <div className="text-[8px] text-[var(--text-muted)] font-mono truncate mt-0.5">{secondary}</div>
+                    <div className="text-[10px] text-[var(--text-muted)] font-mono truncate mt-0.5">{secondary}</div>
                   )}
                 </div>
                 <div className="flex flex-col items-end flex-shrink-0">
-                  <span className="text-[7px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
+                  <span className="text-[10px] text-[var(--text-muted)] font-mono uppercase tracking-wider">
                     {r.type === 'coordinate' ? 'COORDS' : r.type}
                   </span>
-                  <span className="text-[7px] text-[var(--gold-primary)] font-mono opacity-40">
+                  <span className="text-[10px] text-[var(--gold-primary)] font-mono opacity-40">
                     Z{r.zoomLevel}
                   </span>
                 </div>

--- a/src/components/SharePanel.tsx
+++ b/src/components/SharePanel.tsx
@@ -88,7 +88,7 @@ export default function SharePanel({ mapView, activeLayers, mouseCoords }: Share
             <div className="flex items-center justify-between mb-3">
               <div className="flex items-center gap-2">
                 <Globe className="w-3.5 h-3.5 text-[var(--gold-primary)]" />
-                <span className="hud-text text-[10px] text-[var(--text-primary)]">SHARE VIEW</span>
+                <span className="hud-text text-[12px] text-[var(--text-primary)]">SHARE VIEW</span>
               </div>
               <button onClick={() => setIsOpen(false)} className="text-[var(--text-muted)] hover:text-[var(--text-primary)]">
                 <X className="w-3 h-3" />
@@ -99,12 +99,12 @@ export default function SharePanel({ mapView, activeLayers, mouseCoords }: Share
             <div className="mb-3 p-2 rounded-lg bg-[var(--bg-void)] border border-[var(--border-primary)]">
               <div className="flex items-center gap-1.5 mb-1">
                 <MapPin className="w-2.5 h-2.5 text-[var(--gold-primary)]" />
-                <span className="text-[7px] font-mono text-[var(--text-muted)] tracking-widest">CURRENT VIEW</span>
+                <span className="text-[10px] font-mono text-[var(--text-muted)] tracking-widest">CURRENT VIEW</span>
               </div>
-              <div className="text-[8px] font-mono text-[var(--text-secondary)]">
+              <div className="text-[10px] font-mono text-[var(--text-secondary)]">
                 {mouseCoords ? `${mouseCoords.lat.toFixed(4)}°, ${mouseCoords.lng.toFixed(4)}°` : '—'} · Zoom {mapView.zoom.toFixed(1)}
               </div>
-              <div className="text-[7px] font-mono text-[var(--text-muted)] mt-1">
+              <div className="text-[10px] font-mono text-[var(--text-muted)] mt-1">
                 {Object.values(activeLayers).filter(Boolean).length} layers active
               </div>
             </div>
@@ -113,15 +113,15 @@ export default function SharePanel({ mapView, activeLayers, mouseCoords }: Share
             <div className="mb-3">
               <div className="flex items-center gap-1.5 mb-1">
                 <Link2 className="w-2.5 h-2.5 text-[var(--text-muted)]" />
-                <span className="text-[7px] font-mono text-[var(--text-muted)] tracking-widest">SHAREABLE LINK</span>
+                <span className="text-[10px] font-mono text-[var(--text-muted)] tracking-widest">SHAREABLE LINK</span>
               </div>
               <div className="flex gap-1.5">
-                <div className="flex-1 p-1.5 rounded bg-[var(--bg-void)] border border-[var(--border-primary)] text-[7px] font-mono text-[var(--gold-primary)] truncate">
+                <div className="flex-1 p-1.5 rounded bg-[var(--bg-void)] border border-[var(--border-primary)] text-[10px] font-mono text-[var(--gold-primary)] truncate">
                   {generateShareUrl()}
                 </div>
                 <button
                   onClick={copyToClipboard}
-                  className={`px-3 py-1.5 rounded text-[7px] font-mono tracking-widest transition-all ${copied ? 'bg-[var(--alert-green)]/20 text-[var(--alert-green)] border border-[var(--alert-green)]/30' : 'bg-[var(--gold-primary)]/10 text-[var(--gold-primary)] border border-[var(--gold-primary)]/30 hover:bg-[var(--gold-primary)]/20'}`}
+                  className={`px-3 py-1.5 rounded text-[10px] font-mono tracking-widest transition-all ${copied ? 'bg-[var(--alert-green)]/20 text-[var(--alert-green)] border border-[var(--alert-green)]/30' : 'bg-[var(--gold-primary)]/10 text-[var(--gold-primary)] border border-[var(--gold-primary)]/30 hover:bg-[var(--gold-primary)]/20'}`}
                 >
                   {copied ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
                 </button>
@@ -133,27 +133,27 @@ export default function SharePanel({ mapView, activeLayers, mouseCoords }: Share
               <a
                 href={`https://twitter.com/intent/tweet?text=${encodeURIComponent('🏛️ OSIRIS — Global Intelligence Dashboard')}&url=${encodeURIComponent(generateShareUrl())}`}
                 target="_blank"
-                className="flex-1 text-center py-1.5 rounded text-[7px] font-mono tracking-wider text-[var(--text-muted)] border border-[var(--border-primary)] hover:border-[#1DA1F2] hover:text-[#1DA1F2] transition-colors"
+                className="flex-1 text-center py-1.5 rounded text-[10px] font-mono tracking-wider text-[var(--text-muted)] border border-[var(--border-primary)] hover:border-[#1DA1F2] hover:text-[#1DA1F2] transition-colors"
               >
                 𝕏 POST
               </a>
               <a
                 href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(generateShareUrl())}`}
                 target="_blank"
-                className="flex-1 text-center py-1.5 rounded text-[7px] font-mono tracking-wider text-[var(--text-muted)] border border-[var(--border-primary)] hover:border-[#0A66C2] hover:text-[#0A66C2] transition-colors"
+                className="flex-1 text-center py-1.5 rounded text-[10px] font-mono tracking-wider text-[var(--text-muted)] border border-[var(--border-primary)] hover:border-[#0A66C2] hover:text-[#0A66C2] transition-colors"
               >
                 IN SHARE
               </a>
               <a
                 href={`https://reddit.com/submit?url=${encodeURIComponent(generateShareUrl())}&title=${encodeURIComponent('OSIRIS — Open Source Global Intelligence Platform')}`}
                 target="_blank"
-                className="flex-1 text-center py-1.5 rounded text-[7px] font-mono tracking-wider text-[var(--text-muted)] border border-[var(--border-primary)] hover:border-[#FF4500] hover:text-[#FF4500] transition-colors"
+                className="flex-1 text-center py-1.5 rounded text-[10px] font-mono tracking-wider text-[var(--text-muted)] border border-[var(--border-primary)] hover:border-[#FF4500] hover:text-[#FF4500] transition-colors"
               >
                 REDDIT
               </a>
             </div>
 
-            <div className="mt-3 text-center text-[6px] font-mono text-[var(--text-muted)] tracking-widest">
+            <div className="mt-3 text-center text-[10px] font-mono text-[var(--text-muted)] tracking-widest">
               PRESS [S] TO TOGGLE · SHAREABLE LINKS PRESERVE VIEW STATE
             </div>
           </motion.div>

--- a/src/components/SpaceCam.tsx
+++ b/src/components/SpaceCam.tsx
@@ -96,12 +96,12 @@ export default function SpaceCam() {
     <div className="rounded-xl border border-[var(--border-primary)] bg-[var(--bg-panel)] backdrop-blur-2xl overflow-hidden shadow-[0_4px_24px_rgba(0,0,0,0.5)]">
       <div className="flex items-center gap-2 px-3 py-2 border-b border-[var(--border-secondary)]/40">
         <Radio className="w-3.5 h-3.5 text-[#00E5FF]" />
-        <span className="text-[10px] font-mono font-bold tracking-widest text-[#00E5FF]">
+        <span className="text-[12px] font-mono font-bold tracking-widest text-[#00E5FF]">
           LIVE FROM SPACE
         </span>
         <span className="ml-auto flex items-center gap-1">
           <span className="w-1.5 h-1.5 rounded-full bg-[#FF3D3D] animate-pulse" />
-          <span className="text-[8px] font-mono tracking-wider text-[var(--text-muted)]">24/7</span>
+          <span className="text-[10px] font-mono tracking-wider text-[var(--text-muted)]">24/7</span>
         </span>
         <button
           onClick={() => setExpanded(true)}
@@ -125,7 +125,7 @@ export default function SpaceCam() {
             so the panel says so rather than looking broken. */}
         <button
           onClick={() => setExpanded(true)}
-          className="absolute bottom-1 right-1 px-1.5 py-0.5 rounded bg-black/70 text-[7px] font-mono tracking-wider text-[#00E5FF] opacity-0 group-hover/player:opacity-100 transition-opacity"
+          className="absolute bottom-1 right-1 px-1.5 py-0.5 rounded bg-black/70 text-[10px] font-mono tracking-wider text-[#00E5FF] opacity-0 group-hover/player:opacity-100 transition-opacity"
         >
           EXPAND FOR HD ↗
         </button>
@@ -137,7 +137,7 @@ export default function SpaceCam() {
             <button
               key={f.id}
               onClick={() => setActive(f)}
-              className={`flex-1 px-2 py-1.5 rounded text-[8px] font-mono tracking-wider transition-colors border ${
+              className={`flex-1 px-2 py-1.5 rounded text-[10px] font-mono tracking-wider transition-colors border ${
                 active.id === f.id
                   ? 'border-[#00E5FF]/40 bg-[#00E5FF]/15 text-[#00E5FF]'
                   : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--hover-accent)]'
@@ -151,8 +151,8 @@ export default function SpaceCam() {
 
       <div className="px-3 py-2 flex items-center justify-between gap-2">
         <div className="min-w-0">
-          <div className="text-[9px] font-mono text-[var(--text-secondary)] truncate">{active.detail}</div>
-          <div className="text-[8px] font-mono text-[var(--text-muted)]">
+          <div className="text-[11px] font-mono text-[var(--text-secondary)] truncate">{active.detail}</div>
+          <div className="text-[10px] font-mono text-[var(--text-muted)]">
             ALT ~{ORBIT_ALT_KM} KM · ORBIT ~93 MIN
           </div>
         </div>
@@ -160,7 +160,7 @@ export default function SpaceCam() {
           href={`https://www.youtube.com/watch?v=${active.videoId}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-1 px-2 py-1 rounded border border-[var(--border-secondary)]/40 text-[8px] font-mono text-[var(--text-muted)] hover:text-[#00E5FF] hover:border-[#00E5FF]/40 transition-colors flex-shrink-0"
+          className="flex items-center gap-1 px-2 py-1 rounded border border-[var(--border-secondary)]/40 text-[10px] font-mono text-[var(--text-muted)] hover:text-[#00E5FF] hover:border-[#00E5FF]/40 transition-colors flex-shrink-0"
         >
           SOURCE <ExternalLink className="w-2.5 h-2.5" />
         </a>
@@ -180,10 +180,10 @@ export default function SpaceCam() {
               <span className="text-[12px] font-mono font-bold tracking-widest text-[#00E5FF]">
                 LIVE FROM SPACE
               </span>
-              <span className="text-[10px] font-mono text-[var(--text-muted)]">· {active.detail}</span>
+              <span className="text-[12px] font-mono text-[var(--text-muted)]">· {active.detail}</span>
               <span className="ml-auto flex items-center gap-1">
                 <span className="w-1.5 h-1.5 rounded-full bg-[#FF3D3D] animate-pulse" />
-                <span className="text-[9px] font-mono tracking-wider text-[var(--text-muted)]">24/7</span>
+                <span className="text-[11px] font-mono tracking-wider text-[var(--text-muted)]">24/7</span>
               </span>
               <button
                 onClick={() => setExpanded(false)}
@@ -216,7 +216,7 @@ export default function SpaceCam() {
                 <button
                   key={f.id}
                   onClick={() => setActive(f)}
-                  className={`px-3 py-1.5 rounded text-[10px] font-mono tracking-wider transition-colors border ${
+                  className={`px-3 py-1.5 rounded text-[12px] font-mono tracking-wider transition-colors border ${
                     active.id === f.id
                       ? 'border-[#00E5FF]/40 bg-[#00E5FF]/15 text-[#00E5FF]'
                       : 'border-white/10 text-[var(--text-muted)] hover:bg-white/10'
@@ -225,7 +225,7 @@ export default function SpaceCam() {
                   {f.label}
                 </button>
               ))}
-              <span className="ml-auto text-[9px] font-mono text-[var(--text-muted)]">
+              <span className="ml-auto text-[11px] font-mono text-[var(--text-muted)]">
                 ALT ~{ORBIT_ALT_KM} KM · ORBIT ~93 MIN · ESC TO CLOSE
               </span>
             </div>

--- a/src/components/TokenPanel.tsx
+++ b/src/components/TokenPanel.tsx
@@ -11,7 +11,7 @@ export default function TokenPanel() {
     <>
       <button 
         onClick={() => setIsOpen(true)}
-        className="pointer-events-auto glass-panel px-3 py-1.5 flex items-center gap-2 text-[8px] font-mono tracking-widest hover:opacity-80 transition-opacity border-[#14F195]/40 bg-[#14F195]/10 ml-3 shadow-[0_0_10px_rgba(20,241,149,0.1)]"
+        className="pointer-events-auto glass-panel px-3 py-1.5 flex items-center gap-2 text-[10px] font-mono tracking-widest hover:opacity-80 transition-opacity border-[#14F195]/40 bg-[#14F195]/10 ml-3 shadow-[0_0_10px_rgba(20,241,149,0.1)]"
       >
         <TrendingUp className="w-3 h-3 text-[#14F195]" />
         <span className="text-[#14F195] font-bold">$OSIRIS</span>

--- a/src/components/ViewPresets.tsx
+++ b/src/components/ViewPresets.tsx
@@ -33,7 +33,7 @@ export default function ViewPresets({ onNavigate }: ViewPresetsProps) {
       <div className="flex items-center gap-2 mb-2">
         <Globe className="w-3.5 h-3.5 text-[var(--gold-primary)]" />
         <span className="hud-text text-[12px] text-[var(--text-primary)] tracking-widest">REGION PRESETS</span>
-        <span className="gotham-tag gotham-tag--critical" style={{ fontSize: '7px', padding: '1px 4px', marginLeft: 'auto' }}>
+        <span className="gotham-tag gotham-tag--critical" style={{ fontSize: '10px', padding: '1px 4px', marginLeft: 'auto' }}>
           {PRESETS.filter(p => (p as any).hot).length} HOT
         </span>
       </div>
@@ -42,7 +42,7 @@ export default function ViewPresets({ onNavigate }: ViewPresetsProps) {
           <button
             key={p.label}
             onClick={() => onNavigate(p.lat, p.lng, p.zoom)}
-            className={`flex items-center gap-1.5 px-2 py-1.5 rounded text-[10px] font-mono tracking-wider border border-transparent hover:border-[var(--border-primary)] hover:text-[var(--gold-primary)] transition-all hover:scale-[1.02] active:scale-[0.98] ${(p as any).hot ? 'text-[var(--alert-red)] hover:border-[var(--alert-red)]/30 hover:bg-[var(--alert-red)]/5' : 'text-[var(--text-muted)] hover:bg-[var(--hover-accent)]'}`}
+            className={`flex items-center gap-1.5 px-2 py-1.5 rounded text-[12px] font-mono tracking-wider border border-transparent hover:border-[var(--border-primary)] hover:text-[var(--gold-primary)] transition-all hover:scale-[1.02] active:scale-[0.98] ${(p as any).hot ? 'text-[var(--alert-red)] hover:border-[var(--alert-red)]/30 hover:bg-[var(--alert-red)]/5' : 'text-[var(--text-muted)] hover:bg-[var(--hover-accent)]'}`}
           >
             <span className="text-[11px] flex-shrink-0">{p.icon}</span>
             <span>{p.label}</span>

--- a/src/components/WorldRemote.tsx
+++ b/src/components/WorldRemote.tsx
@@ -331,21 +331,21 @@ export default function WorldRemote({onClose,onPlaceOnMap}:{onClose?:()=>void,on
         <button onClick={()=>setExpanded(!expanded)} className="flex items-center gap-2 flex-1">
           <Crosshair className="w-3.5 h-3.5 text-[var(--cyan-primary)]"/>
           <span className="hud-text text-[12px] text-[var(--text-primary)]">MARAUDER</span>
-          <span className="gotham-tag gotham-tag--info" style={{fontSize:'7px',padding:'1px 5px'}}>{devices.length} DEVS</span>
-          {scanning&&<span className="gotham-tag" style={{fontSize:'7px',padding:'1px 5px',background:'rgba(0,230,255,0.1)',color:'var(--cyan-primary)'}}>SCANNING</span>}
+          <span className="gotham-tag gotham-tag--info" style={{fontSize:'10px',padding:'1px 5px'}}>{devices.length} DEVS</span>
+          {scanning&&<span className="gotham-tag" style={{fontSize:'10px',padding:'1px 5px',background:'rgba(0,230,255,0.1)',color:'var(--cyan-primary)'}}>SCANNING</span>}
         </button>
         <div className="flex items-center gap-2">
           <motion.button whileTap={{scale:0.95}} onClick={scan} disabled={scanning||!btOk}
-            className="px-2.5 py-1 rounded-md text-[8px] font-mono font-bold tracking-wider flex items-center gap-1.5 disabled:opacity-30"
+            className="px-2.5 py-1 rounded-md text-[10px] font-mono font-bold tracking-wider flex items-center gap-1.5 disabled:opacity-30"
             style={{background:scanning?'rgba(0,230,255,0.08)':'rgba(0,230,255,0.12)',color:'var(--cyan-primary)',border:'1px solid rgba(0,230,255,0.12)'}}>
             {scanning?<BluetoothSearching className="w-3 h-3 animate-pulse"/>:<Bluetooth className="w-3 h-3"/>}{scanning?'...':'SCAN'}
           </motion.button>
           {geoCount>0&&<motion.button whileTap={{scale:0.95}} onClick={placeOnWorldMap}
-            className="px-2.5 py-1 rounded-md text-[8px] font-mono font-bold tracking-wider flex items-center gap-1.5"
+            className="px-2.5 py-1 rounded-md text-[10px] font-mono font-bold tracking-wider flex items-center gap-1.5"
             style={{background:'rgba(255,183,77,0.08)',color:'#FFB74D',border:'1px solid rgba(255,183,77,0.1)'}}>
             <MapPin className="w-3 h-3"/>VIEW ON MAP
           </motion.button>}
-          <button onClick={()=>setFull(!full)} className="text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors" title="Full Screen">
+          <button onClick={()=>setFull(!full)} className="p-1.5 -m-0.5 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-white/10 transition-colors" title="Full Screen">
             {full?<Minimize2 className="w-3.5 h-3.5"/>:<Maximize2 className="w-3.5 h-3.5"/>}
           </button>
           <div className="w-1.5 h-1.5 rounded-full bg-[var(--cyan-primary)] animate-osiris-pulse"/>
@@ -362,7 +362,7 @@ export default function WorldRemote({onClose,onPlaceOnMap}:{onClose?:()=>void,on
           {/* Tab Bar */}
           <div className="flex items-center px-2 py-1.5 shrink-0 gap-0.5 border-b border-[rgba(255,255,255,0.04)]" style={{background:'rgba(0,0,0,0.2)'}}>
             {([['scan','DEVICES',Scan],['intel','INTEL',Globe],['log','LOG',Terminal]] as const).map(([id,label,Icon])=>(
-              <button key={id} onClick={()=>setView(id as any)} className="flex items-center gap-1 px-2.5 py-1.5 rounded-md text-[8px] font-mono font-bold tracking-[0.12em] transition-all flex-1 justify-center"
+              <button key={id} onClick={()=>setView(id as any)} className="flex items-center gap-1 px-2.5 py-1.5 rounded-md text-[10px] font-mono font-bold tracking-[0.12em] transition-all flex-1 justify-center"
                 style={{color:view===id?'var(--cyan-primary)':'var(--text-muted)',background:view===id?'rgba(0,230,255,0.06)':'transparent'}}>
                 <Icon className="w-3 h-3"/>{label}
               </button>
@@ -370,7 +370,7 @@ export default function WorldRemote({onClose,onPlaceOnMap}:{onClose?:()=>void,on
           </div>
 
           {/* Error */}
-          <AnimatePresence>{error&&<motion.div initial={{height:0}} animate={{height:'auto'}} exit={{height:0}} className="overflow-hidden shrink-0"><div className="mx-2 mt-1.5 px-2.5 py-1.5 rounded-lg flex items-center gap-2" style={{background:'rgba(255,61,61,0.04)',border:'1px solid rgba(255,61,61,0.1)'}}><AlertTriangle className="w-3 h-3 text-[#FF3D3D] shrink-0"/><span className="text-[8px] font-mono text-[#FF3D3D] flex-1 truncate">{error}</span><button onClick={()=>setError(null)}><X className="w-2.5 h-2.5 text-[#FF3D3D]/50"/></button></div></motion.div>}</AnimatePresence>
+          <AnimatePresence>{error&&<motion.div initial={{height:0}} animate={{height:'auto'}} exit={{height:0}} className="overflow-hidden shrink-0"><div className="mx-2 mt-1.5 px-2.5 py-1.5 rounded-lg flex items-center gap-2" style={{background:'rgba(255,61,61,0.04)',border:'1px solid rgba(255,61,61,0.1)'}}><AlertTriangle className="w-3 h-3 text-[#FF3D3D] shrink-0"/><span className="text-[10px] font-mono text-[#FF3D3D] flex-1 truncate">{error}</span><button onClick={()=>setError(null)}><X className="w-2.5 h-2.5 text-[#FF3D3D]/50"/></button></div></motion.div>}</AnimatePresence>
 
           {/* Content */}
           <div className="flex-1 overflow-hidden flex min-h-0">
@@ -381,13 +381,13 @@ export default function WorldRemote({onClose,onPlaceOnMap}:{onClose?:()=>void,on
                 {devices.length===0&&!scanning&&btOk&&(
                   <div className="flex flex-col items-center justify-center py-8 opacity-40">
                     <Crosshair className="w-8 h-8 text-[var(--cyan-primary)] mb-2"/>
-                    <p className="text-[9px] font-mono text-[var(--text-muted)] text-center tracking-wider">
+                    <p className="text-[11px] font-mono text-[var(--text-muted)] text-center tracking-wider">
                       Hit <span className="text-[var(--cyan-primary)]">SCAN</span> to acquire targets<br/>
-                      <span className="text-[8px] opacity-50">Auto-vacuum · GPS-tagged · Vault</span>
+                      <span className="text-[10px] opacity-50">Auto-vacuum · GPS-tagged · Vault</span>
                     </p>
                   </div>
                 )}
-                {!btOk&&<div className="p-2 rounded-lg" style={{background:'rgba(255,61,61,0.04)',border:'1px solid rgba(255,61,61,0.08)'}}><span className="text-[8px] font-mono text-[#FF3D3D]">Web Bluetooth unavailable — use Chrome/Edge on localhost</span></div>}
+                {!btOk&&<div className="p-2 rounded-lg" style={{background:'rgba(255,61,61,0.04)',border:'1px solid rgba(255,61,61,0.08)'}}><span className="text-[10px] font-mono text-[#FF3D3D]">Web Bluetooth unavailable — use Chrome/Edge on localhost</span></div>}
 
                 {devices.map(dev=>{const isE=exDev===dev.id;const isG=gattTarget===dev.id;const isC=connecting===dev.id;
                   return(<motion.div key={dev.id} initial={{opacity:0,y:8}} animate={{opacity:1,y:0}} layout>
@@ -401,17 +401,17 @@ export default function WorldRemote({onClose,onPlaceOnMap}:{onClose?:()=>void,on
                         </motion.div>
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-1.5 mb-0.5">
-                            <span className="text-[10px] font-mono font-bold text-[var(--text-primary)] truncate">{dev.name}</span>
-                            {dev.connected&&<span className="text-[6px] font-mono px-1 py-0.5 rounded bg-[var(--alert-green)]/10 text-[var(--alert-green)] tracking-widest font-bold">LIVE</span>}
+                            <span className="text-[12px] font-mono font-bold text-[var(--text-primary)] truncate">{dev.name}</span>
+                            {dev.connected&&<span className="text-[10px] font-mono px-1 py-0.5 rounded bg-[var(--alert-green)]/10 text-[var(--alert-green)] tracking-widest font-bold">LIVE</span>}
                           </div>
                           {dev.probing?(
-                            <div className="flex items-center gap-2"><motion.div className="h-1 rounded-full flex-1" style={{background:`${dev.color}10`}}><motion.div className="h-full rounded-full" style={{background:dev.color}} animate={{width:['0%','60%','100%']}} transition={{duration:3}}/></motion.div><span className="text-[7px] font-mono animate-pulse" style={{color:dev.color}}>VACUUMING</span></div>
+                            <div className="flex items-center gap-2"><motion.div className="h-1 rounded-full flex-1" style={{background:`${dev.color}10`}}><motion.div className="h-full rounded-full" style={{background:dev.color}} animate={{width:['0%','60%','100%']}} transition={{duration:3}}/></motion.div><span className="text-[10px] font-mono animate-pulse" style={{color:dev.color}}>VACUUMING</span></div>
                           ):(
                             <div className="flex items-center gap-1.5 flex-wrap">
-                              <span className="text-[7px] font-mono px-1.5 py-0.5 rounded tracking-wider font-bold" style={{background:`${dev.color}10`,color:dev.color}}>{dev.type.toUpperCase()}</span>
-                              {dev.battery!=null&&<span className="text-[7px] font-mono flex items-center gap-0.5" style={{color:dev.battery>50?'var(--alert-green)':dev.battery>20?'#FFB800':'#FF3D3D'}}><BatteryMedium className="w-2.5 h-2.5"/>{dev.battery}%</span>}
-                              {dev.geo&&<span className="text-[6px] font-mono text-[#FFB74D] flex items-center gap-0.5"><MapPin className="w-2 h-2"/></span>}
-                              <span className="text-[6px] font-mono text-[var(--text-muted)]">{dev.serviceCount}svcs · {dev.probeMs}ms</span>
+                              <span className="text-[10px] font-mono px-1.5 py-0.5 rounded tracking-wider font-bold" style={{background:`${dev.color}10`,color:dev.color}}>{dev.type.toUpperCase()}</span>
+                              {dev.battery!=null&&<span className="text-[10px] font-mono flex items-center gap-0.5" style={{color:dev.battery>50?'var(--alert-green)':dev.battery>20?'#FFB800':'#FF3D3D'}}><BatteryMedium className="w-2.5 h-2.5"/>{dev.battery}%</span>}
+                              {dev.geo&&<span className="text-[10px] font-mono text-[#FFB74D] flex items-center gap-0.5"><MapPin className="w-2 h-2"/></span>}
+                              <span className="text-[10px] font-mono text-[var(--text-muted)]">{dev.serviceCount}svcs · {dev.probeMs}ms</span>
                             </div>
                           )}
                         </div>
@@ -423,53 +423,53 @@ export default function WorldRemote({onClose,onPlaceOnMap}:{onClose?:()=>void,on
 
                         {/* Device Info */}
                         <div className="mt-2 mb-2.5 rounded-lg p-2.5" style={{background:'rgba(0,0,0,0.25)',border:'1px solid rgba(255,255,255,0.03)'}}>
-                          <div className="text-[7px] font-mono text-[var(--text-muted)] tracking-[0.2em] mb-1.5 font-bold">DEVICE INTEL</div>
+                          <div className="text-[10px] font-mono text-[var(--text-muted)] tracking-[0.2em] mb-1.5 font-bold">DEVICE INTEL</div>
                           <div className="space-y-1">
                             {[{k:'Manufacturer',v:dev.manufacturer},{k:'Model',v:dev.model},{k:'Serial',v:dev.serial},{k:'Firmware',v:dev.firmware},{k:'TX Power',v:dev.txPower!=null?`${dev.txPower} dBm`:undefined}].filter(x=>x.v).map(x=>(
-                              <div key={x.k} className="flex gap-2"><span className="text-[7px] font-mono text-[var(--text-muted)] w-[65px] shrink-0 tracking-wider">{x.k}</span><span className="text-[8px] font-mono text-[var(--text-primary)] truncate">{x.v}</span></div>
+                              <div key={x.k} className="flex gap-2"><span className="text-[10px] font-mono text-[var(--text-muted)] w-[65px] shrink-0 tracking-wider">{x.k}</span><span className="text-[10px] font-mono text-[var(--text-primary)] truncate">{x.v}</span></div>
                             ))}
-                            {dev.geo&&<div className="flex gap-2"><span className="text-[7px] font-mono text-[var(--text-muted)] w-[65px] shrink-0 tracking-wider">GPS</span><span className="text-[8px] font-mono text-[#FFB74D]">{dev.geo.lat.toFixed(5)}, {dev.geo.lng.toFixed(5)} ±{Math.round(dev.geo.acc)}m</span></div>}
-                            <div className="flex gap-2"><span className="text-[7px] font-mono text-[var(--text-muted)] w-[65px] shrink-0 tracking-wider">Extracted</span><span className="text-[8px] font-mono text-[var(--text-muted)]">{dev.serviceCount}svcs · {dev.charCount}chars · {dev.gattDump.length}vals · {dev.totalBytes}B</span></div>
+                            {dev.geo&&<div className="flex gap-2"><span className="text-[10px] font-mono text-[var(--text-muted)] w-[65px] shrink-0 tracking-wider">GPS</span><span className="text-[10px] font-mono text-[#FFB74D]">{dev.geo.lat.toFixed(5)}, {dev.geo.lng.toFixed(5)} ±{Math.round(dev.geo.acc)}m</span></div>}
+                            <div className="flex gap-2"><span className="text-[10px] font-mono text-[var(--text-muted)] w-[65px] shrink-0 tracking-wider">Extracted</span><span className="text-[10px] font-mono text-[var(--text-muted)]">{dev.serviceCount}svcs · {dev.charCount}chars · {dev.gattDump.length}vals · {dev.totalBytes}B</span></div>
                           </div>
                         </div>
 
                         {/* Services */}
-                        {dev.services.length>0&&<div className="flex flex-wrap gap-1 mb-2.5">{dev.services.map((s,i)=><span key={i} className="text-[6px] font-mono px-1.5 py-0.5 rounded tracking-wider" style={{background:`${dev.color}06`,color:`${dev.color}70`}}>{s}</span>)}</div>}
+                        {dev.services.length>0&&<div className="flex flex-wrap gap-1 mb-2.5">{dev.services.map((s,i)=><span key={i} className="text-[10px] font-mono px-1.5 py-0.5 rounded tracking-wider" style={{background:`${dev.color}06`,color:`${dev.color}70`}}>{s}</span>)}</div>}
 
                         {/* GATT Dump */}
-                        {dev.gattDump.length>0&&<div className="mb-2.5"><div className="text-[7px] font-mono text-[var(--text-muted)] tracking-[0.15em] mb-1 font-bold">VACUUM DUMP ({dev.gattDump.length})</div><div className="max-h-[120px] overflow-y-auto styled-scrollbar rounded-lg" style={{background:'rgba(0,0,0,0.3)'}}>
-                          {dev.gattDump.map((g,i)=><div key={i} className="px-2 py-1 flex items-start gap-1.5 hover:bg-white/[0.02]" style={{borderBottom:'1px solid rgba(255,255,255,0.02)'}}><span className="text-[6px] font-mono text-[var(--text-muted)] shrink-0 w-[50px] truncate">{g.svc}</span><span className="text-[6px] font-mono shrink-0 w-[50px] truncate" style={{color:dev.color}}>{g.char}</span><span className="text-[7px] font-mono text-[var(--text-primary)] flex-1 truncate">{g.value}</span></div>)}
+                        {dev.gattDump.length>0&&<div className="mb-2.5"><div className="text-[10px] font-mono text-[var(--text-muted)] tracking-[0.15em] mb-1 font-bold">VACUUM DUMP ({dev.gattDump.length})</div><div className="max-h-[120px] overflow-y-auto styled-scrollbar rounded-lg" style={{background:'rgba(0,0,0,0.3)'}}>
+                          {dev.gattDump.map((g,i)=><div key={i} className="px-2 py-1 flex items-start gap-1.5 hover:bg-white/[0.02]" style={{borderBottom:'1px solid rgba(255,255,255,0.02)'}}><span className="text-[10px] font-mono text-[var(--text-muted)] shrink-0 w-[50px] truncate">{g.svc}</span><span className="text-[10px] font-mono shrink-0 w-[50px] truncate" style={{color:dev.color}}>{g.char}</span><span className="text-[10px] font-mono text-[var(--text-primary)] flex-1 truncate">{g.value}</span></div>)}
                         </div></div>}
 
-                        <div className="text-[5px] font-mono text-[var(--text-muted)] mb-2.5 opacity-20 tracking-wider">{dev.id}</div>
+                        <div className="text-[10px] font-mono text-[var(--text-muted)] mb-2.5 opacity-20 tracking-wider">{dev.id}</div>
 
                         {/* Actions */}
                         <div className="flex gap-1.5 flex-wrap">
                           {dev.bt&&(dev.connected?(<>
-                            <motion.button whileTap={{scale:0.95}} onClick={()=>explore(dev)} className="flex-1 py-1.5 rounded-lg text-[7px] font-mono font-bold tracking-wider flex items-center justify-center gap-1.5" style={{background:`${dev.color}08`,color:dev.color,border:`1px solid ${dev.color}10`}}><Layers className="w-3 h-3"/>GATT</motion.button>
-                            <motion.button whileTap={{scale:0.95}} onClick={()=>disconnect(dev)} className="py-1.5 px-2.5 rounded-lg text-[7px] font-mono font-bold flex items-center gap-1" style={{background:'rgba(255,61,61,0.05)',color:'#FF6B6B',border:'1px solid rgba(255,61,61,0.06)'}}><Unplug className="w-3 h-3"/>DROP</motion.button>
+                            <motion.button whileTap={{scale:0.95}} onClick={()=>explore(dev)} className="flex-1 py-1.5 rounded-lg text-[10px] font-mono font-bold tracking-wider flex items-center justify-center gap-1.5" style={{background:`${dev.color}08`,color:dev.color,border:`1px solid ${dev.color}10`}}><Layers className="w-3 h-3"/>GATT</motion.button>
+                            <motion.button whileTap={{scale:0.95}} onClick={()=>disconnect(dev)} className="py-1.5 px-2.5 rounded-lg text-[10px] font-mono font-bold flex items-center gap-1" style={{background:'rgba(255,61,61,0.05)',color:'#FF6B6B',border:'1px solid rgba(255,61,61,0.06)'}}><Unplug className="w-3 h-3"/>DROP</motion.button>
                           </>):(<>
-                            <motion.button whileTap={{scale:0.95}} onClick={()=>connect(dev)} disabled={!!connecting} className="flex-1 py-2 rounded-lg text-[8px] font-mono font-bold tracking-wider flex items-center justify-center gap-1.5 disabled:opacity-30" style={{background:`${dev.color}08`,color:dev.color,border:`1px solid ${dev.color}10`}}><Zap className="w-3 h-3"/>{isC?'PAIRING...':'CONNECT'}</motion.button>
+                            <motion.button whileTap={{scale:0.95}} onClick={()=>connect(dev)} disabled={!!connecting} className="flex-1 py-2 rounded-lg text-[10px] font-mono font-bold tracking-wider flex items-center justify-center gap-1.5 disabled:opacity-30" style={{background:`${dev.color}08`,color:dev.color,border:`1px solid ${dev.color}10`}}><Zap className="w-3 h-3"/>{isC?'PAIRING...':'CONNECT'}</motion.button>
                           </>))}
-                          {dev.geo&&<motion.button whileTap={{scale:0.95}} onClick={()=>placeSingleOnMap(dev)} className="py-1.5 px-2.5 rounded-lg text-[7px] font-mono font-bold tracking-wider flex items-center gap-1" style={{background:'rgba(255,183,77,0.06)',color:'#FFB74D',border:'1px solid rgba(255,183,77,0.08)'}}><MapPin className="w-3 h-3"/>VIEW ON MAP</motion.button>}
+                          {dev.geo&&<motion.button whileTap={{scale:0.95}} onClick={()=>placeSingleOnMap(dev)} className="py-1.5 px-2.5 rounded-lg text-[10px] font-mono font-bold tracking-wider flex items-center gap-1" style={{background:'rgba(255,183,77,0.06)',color:'#FFB74D',border:'1px solid rgba(255,183,77,0.08)'}}><MapPin className="w-3 h-3"/>VIEW ON MAP</motion.button>}
                         </div>
 
                         {/* GATT Explorer */}
                         <AnimatePresence>{isG&&(<motion.div initial={{height:0,opacity:0}} animate={{height:'auto',opacity:1}} exit={{height:0,opacity:0}} className="overflow-hidden"><div className="mt-2.5 pt-2.5" style={{borderTop:`1px solid ${dev.color}08`}}>
-                          <div className="flex items-center justify-between mb-2"><span className="text-[8px] font-mono font-bold tracking-[0.12em]" style={{color:dev.color}}>GATT TREE</span><button onClick={()=>{setGattTarget(null);setGattSvcs([]);}}><X className="w-2.5 h-2.5 text-[var(--text-muted)]"/></button></div>
-                          {gattLoading?<div className="flex items-center justify-center py-3 gap-1.5"><div className="w-3.5 h-3.5 border-2 rounded-full animate-spin" style={{borderColor:dev.color,borderTopColor:'transparent'}}/><span className="text-[8px] font-mono animate-pulse" style={{color:dev.color}}>Enumerating...</span></div>
+                          <div className="flex items-center justify-between mb-2"><span className="text-[10px] font-mono font-bold tracking-[0.12em]" style={{color:dev.color}}>GATT TREE</span><button onClick={()=>{setGattTarget(null);setGattSvcs([]);}}><X className="w-2.5 h-2.5 text-[var(--text-muted)]"/></button></div>
+                          {gattLoading?<div className="flex items-center justify-center py-3 gap-1.5"><div className="w-3.5 h-3.5 border-2 rounded-full animate-spin" style={{borderColor:dev.color,borderTopColor:'transparent'}}/><span className="text-[10px] font-mono animate-pulse" style={{color:dev.color}}>Enumerating...</span></div>
                           :gattSvcs.map(svc=>(<div key={svc.uuid} className="mb-0.5">
                             <button onClick={()=>setExSvc(exSvc===svc.uuid?null:svc.uuid)} className="w-full px-2 py-1.5 rounded-lg flex items-center gap-1.5 text-left hover:bg-white/[0.02]">
-                              <Bluetooth className="w-2.5 h-2.5 shrink-0" style={{color:dev.color}}/><span className="text-[8px] font-mono font-bold text-[var(--text-primary)] truncate flex-1">{svc.name}</span><span className="text-[7px] font-mono" style={{color:`${dev.color}80`}}>{svc.chars.length}</span><ChevronRight className={`w-2.5 h-2.5 text-[var(--text-muted)] transition-transform ${exSvc===svc.uuid?'rotate-90':''}`}/>
+                              <Bluetooth className="w-2.5 h-2.5 shrink-0" style={{color:dev.color}}/><span className="text-[10px] font-mono font-bold text-[var(--text-primary)] truncate flex-1">{svc.name}</span><span className="text-[10px] font-mono" style={{color:`${dev.color}80`}}>{svc.chars.length}</span><ChevronRight className={`w-2.5 h-2.5 text-[var(--text-muted)] transition-transform ${exSvc===svc.uuid?'rotate-90':''}`}/>
                             </button>
                             <AnimatePresence>{exSvc===svc.uuid&&(<motion.div initial={{height:0}} animate={{height:'auto'}} exit={{height:0}} className="overflow-hidden"><div className="pl-3 pr-1 py-1 space-y-1">{svc.chars.map(ch=>{const ck=`${svc.uuid}/${ch.uuid}`;const fl=[ch.p.r&&'R',ch.p.w&&'W',ch.p.wn&&'Wn',ch.p.n&&'N',ch.p.i&&'I'].filter(Boolean).join('·');const wV=wIn[ck]||'';const wOk=!wV||validHex(wV);return(
                               <div key={ch.uuid} className="p-2 rounded-lg" style={{background:'rgba(0,0,0,0.25)',borderLeft:`2px solid ${dev.color}12`}}>
-                                <div className="flex items-center gap-1 mb-1"><span className="text-[7px] font-mono font-bold text-[var(--text-primary)] truncate flex-1">{ch.name}</span><span className="text-[6px] font-mono px-1 py-0.5 rounded" style={{background:`${dev.color}06`,color:`${dev.color}80`}}>{fl}</span></div>
-                                {ch.value&&<div className="flex items-center gap-1 mb-1"><div className="flex-1 rounded px-1.5 py-1 min-w-0" style={{background:'rgba(0,0,0,0.3)'}}><div className={`text-[7px] font-mono truncate ${ch.notifying?'text-[#00FF88]':'text-[var(--alert-green)]'}`}>{ch.value}</div>{ch.hex&&ch.hex!==ch.value&&<div className="text-[5px] font-mono text-[var(--text-muted)] truncate mt-0.5 opacity-40">{ch.hex}</div>}</div><button onClick={()=>{navigator.clipboard?.writeText(ch.value||'');setCopied(ck);setTimeout(()=>setCopied(null),1500);}} className="p-0.5 rounded hover:bg-white/5 shrink-0">{copied===ck?<Check className="w-2 h-2 text-[var(--alert-green)]"/>:<Copy className="w-2 h-2 text-[var(--text-muted)]"/>}</button></div>}
+                                <div className="flex items-center gap-1 mb-1"><span className="text-[10px] font-mono font-bold text-[var(--text-primary)] truncate flex-1">{ch.name}</span><span className="text-[10px] font-mono px-1 py-0.5 rounded" style={{background:`${dev.color}06`,color:`${dev.color}80`}}>{fl}</span></div>
+                                {ch.value&&<div className="flex items-center gap-1 mb-1"><div className="flex-1 rounded px-1.5 py-1 min-w-0" style={{background:'rgba(0,0,0,0.3)'}}><div className={`text-[10px] font-mono truncate ${ch.notifying?'text-[#00FF88]':'text-[var(--alert-green)]'}`}>{ch.value}</div>{ch.hex&&ch.hex!==ch.value&&<div className="text-[10px] font-mono text-[var(--text-muted)] truncate mt-0.5 opacity-40">{ch.hex}</div>}</div><button onClick={()=>{navigator.clipboard?.writeText(ch.value||'');setCopied(ck);setTimeout(()=>setCopied(null),1500);}} className="p-0.5 rounded hover:bg-white/5 shrink-0">{copied===ck?<Check className="w-2 h-2 text-[var(--alert-green)]"/>:<Copy className="w-2 h-2 text-[var(--text-muted)]"/>}</button></div>}
                                 <div className="flex items-center gap-1 flex-wrap">
-                                  {ch.p.r&&<button onClick={async()=>{if(!ch.char)return;try{const v=await ch.char.readValue();const d=decode(v);setGattSvcs(sv=>sv.map(s=>s.uuid===svc.uuid?{...s,chars:s.chars.map(c=>c.uuid===ch.uuid?{...c,value:d.text,hex:d.hex}:c)}:s));log('READ',dev.name,`${ch.name}: ${d.text.slice(0,50)}`,d.hex,v.byteLength);}catch{log('ERROR',dev.name,`Read: ${ch.name}`);}}} className="flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[6px] font-mono" style={{background:`${dev.color}06`,color:dev.color}}><Eye className="w-2 h-2"/>READ</button>}
-                                  {ch.p.n&&<button onClick={()=>toggleN(svc.uuid,ch,dev.name)} className="flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[6px] font-mono" style={{background:ch.notifying?'rgba(0,255,136,0.06)':'rgba(255,255,255,0.02)',color:ch.notifying?'#00FF88':'var(--text-muted)'}}>{ch.notifying?<Bell className="w-2 h-2"/>:<BellOff className="w-2 h-2"/>}{ch.notifying?'LIVE':'SUB'}</button>}
-                                  {(ch.p.w||ch.p.wn)&&<div className="flex items-center gap-0.5 flex-1"><input type="text" placeholder="FF 01" value={wV} onChange={e=>setWIn(iv=>({...iv,[ck]:e.target.value}))} className="flex-1 rounded px-1.5 py-0.5 text-[6px] font-mono text-[var(--text-primary)] outline-none min-w-0" style={{background:'rgba(0,0,0,0.3)',border:`1px solid ${wOk?'transparent':'rgba(255,61,61,0.3)'}`}}/><button onClick={async()=>{if(!ch.char||!wV||!validHex(wV))return;try{await writeSafe(ch.char,parseHex(wV),ch.p.w);log('WRITE',dev.name,`${ch.name} ← ${wV}`);setWIn(iv=>({...iv,[ck]:''}));}catch{log('ERROR',dev.name,`Write: ${ch.name}`);}}} disabled={!wV||!wOk} className="p-0.5 rounded shrink-0 disabled:opacity-30" style={{color:'#FFB800'}}><Send className="w-2 h-2"/></button></div>}
+                                  {ch.p.r&&<button onClick={async()=>{if(!ch.char)return;try{const v=await ch.char.readValue();const d=decode(v);setGattSvcs(sv=>sv.map(s=>s.uuid===svc.uuid?{...s,chars:s.chars.map(c=>c.uuid===ch.uuid?{...c,value:d.text,hex:d.hex}:c)}:s));log('READ',dev.name,`${ch.name}: ${d.text.slice(0,50)}`,d.hex,v.byteLength);}catch{log('ERROR',dev.name,`Read: ${ch.name}`);}}} className="flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-mono" style={{background:`${dev.color}06`,color:dev.color}}><Eye className="w-2 h-2"/>READ</button>}
+                                  {ch.p.n&&<button onClick={()=>toggleN(svc.uuid,ch,dev.name)} className="flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-mono" style={{background:ch.notifying?'rgba(0,255,136,0.06)':'rgba(255,255,255,0.02)',color:ch.notifying?'#00FF88':'var(--text-muted)'}}>{ch.notifying?<Bell className="w-2 h-2"/>:<BellOff className="w-2 h-2"/>}{ch.notifying?'LIVE':'SUB'}</button>}
+                                  {(ch.p.w||ch.p.wn)&&<div className="flex items-center gap-0.5 flex-1"><input type="text" placeholder="FF 01" value={wV} onChange={e=>setWIn(iv=>({...iv,[ck]:e.target.value}))} className="flex-1 rounded px-1.5 py-0.5 text-[10px] font-mono text-[var(--text-primary)] outline-none min-w-0" style={{background:'rgba(0,0,0,0.3)',border:`1px solid ${wOk?'transparent':'rgba(255,61,61,0.3)'}`}}/><button onClick={async()=>{if(!ch.char||!wV||!validHex(wV))return;try{await writeSafe(ch.char,parseHex(wV),ch.p.w);log('WRITE',dev.name,`${ch.name} ← ${wV}`);setWIn(iv=>({...iv,[ck]:''}));}catch{log('ERROR',dev.name,`Write: ${ch.name}`);}}} disabled={!wV||!wOk} className="p-0.5 rounded shrink-0 disabled:opacity-30" style={{color:'#FFB800'}}><Send className="w-2 h-2"/></button></div>}
                                 </div>
                               </div>);})}</div></motion.div>)}</AnimatePresence>
                           </div>))}
@@ -487,25 +487,25 @@ export default function WorldRemote({onClose,onPlaceOnMap}:{onClose?:()=>void,on
                 {/* Network Recon */}
                 <div className="rounded-xl overflow-hidden" style={{background:'rgba(255,255,255,0.015)',border:'1px solid rgba(255,255,255,0.04)'}}>
                   <div className="px-3 py-2 flex items-center justify-between" style={{borderBottom:'1px solid rgba(255,255,255,0.03)'}}>
-                    <div className="flex items-center gap-1.5"><Globe className="w-3 h-3 text-[#80DEEA]"/><span className="text-[8px] font-mono font-bold tracking-[0.12em] text-[var(--text-primary)]">NETWORK RECON</span></div>
-                    <motion.button whileTap={{scale:0.95}} onClick={runNetRecon} disabled={netLoading} className="px-2 py-0.5 rounded text-[7px] font-mono font-bold tracking-wider disabled:opacity-30" style={{background:'rgba(128,222,234,0.06)',color:'#80DEEA',border:'1px solid rgba(128,222,234,0.08)'}}>{netLoading?'...':'PROBE'}</motion.button>
+                    <div className="flex items-center gap-1.5"><Globe className="w-3 h-3 text-[#80DEEA]"/><span className="text-[10px] font-mono font-bold tracking-[0.12em] text-[var(--text-primary)]">NETWORK RECON</span></div>
+                    <motion.button whileTap={{scale:0.95}} onClick={runNetRecon} disabled={netLoading} className="px-2 py-0.5 rounded text-[10px] font-mono font-bold tracking-wider disabled:opacity-30" style={{background:'rgba(128,222,234,0.06)',color:'#80DEEA',border:'1px solid rgba(128,222,234,0.08)'}}>{netLoading?'...':'PROBE'}</motion.button>
                   </div>
-                  {!netIntel&&<div className="px-3 py-4 text-center"><span className="text-[8px] font-mono text-[var(--text-muted)] opacity-30">Tap PROBE to scan local network</span></div>}
+                  {!netIntel&&<div className="px-3 py-4 text-center"><span className="text-[10px] font-mono text-[var(--text-muted)] opacity-30">Tap PROBE to scan local network</span></div>}
                   {netIntel&&<div className="p-2.5 space-y-2">
-                    {netIntel.localIPs.length>0&&<div><div className="text-[7px] font-mono text-[var(--text-muted)] tracking-wider mb-1 font-bold">LOCAL IPs</div>{netIntel.localIPs.map((ip,i)=><div key={i} className="text-[9px] font-mono text-[#80DEEA] pl-2">{ip}</div>)}</div>}
-                    {netIntel.type&&<div className="flex gap-3">{[{l:'TYPE',v:netIntel.type},{l:'DOWN',v:netIntel.downlink!=null?`${netIntel.downlink}Mbps`:undefined},{l:'RTT',v:netIntel.rtt!=null?`${netIntel.rtt}ms`:undefined}].filter(x=>x.v).map(x=><div key={x.l}><div className="text-[6px] font-mono text-[var(--text-muted)] tracking-wider">{x.l}</div><div className="text-[9px] font-mono text-[var(--text-primary)] font-bold">{x.v}</div></div>)}</div>}
-                    {netIntel.openPorts.length>0&&<div><div className="text-[7px] font-mono text-[var(--text-muted)] tracking-wider mb-1 font-bold">OPEN PORTS</div>{netIntel.openPorts.map((p,i)=><div key={i} className="flex items-center gap-2 pl-2 py-0.5"><span className="text-[8px] font-mono font-bold text-[var(--alert-green)]">:{p.port}</span><span className="text-[7px] font-mono text-[var(--text-muted)]">{p.service}</span></div>)}</div>}
+                    {netIntel.localIPs.length>0&&<div><div className="text-[10px] font-mono text-[var(--text-muted)] tracking-wider mb-1 font-bold">LOCAL IPs</div>{netIntel.localIPs.map((ip,i)=><div key={i} className="text-[11px] font-mono text-[#80DEEA] pl-2">{ip}</div>)}</div>}
+                    {netIntel.type&&<div className="flex gap-3">{[{l:'TYPE',v:netIntel.type},{l:'DOWN',v:netIntel.downlink!=null?`${netIntel.downlink}Mbps`:undefined},{l:'RTT',v:netIntel.rtt!=null?`${netIntel.rtt}ms`:undefined}].filter(x=>x.v).map(x=><div key={x.l}><div className="text-[10px] font-mono text-[var(--text-muted)] tracking-wider">{x.l}</div><div className="text-[11px] font-mono text-[var(--text-primary)] font-bold">{x.v}</div></div>)}</div>}
+                    {netIntel.openPorts.length>0&&<div><div className="text-[10px] font-mono text-[var(--text-muted)] tracking-wider mb-1 font-bold">OPEN PORTS</div>{netIntel.openPorts.map((p,i)=><div key={i} className="flex items-center gap-2 pl-2 py-0.5"><span className="text-[10px] font-mono font-bold text-[var(--alert-green)]">:{p.port}</span><span className="text-[10px] font-mono text-[var(--text-muted)]">{p.service}</span></div>)}</div>}
                   </div>}
                 </div>
                 {/* Export */}
                 <div className="rounded-xl overflow-hidden" style={{background:'rgba(255,255,255,0.015)',border:'1px solid rgba(255,255,255,0.04)'}}>
-                  <div className="px-3 py-2 flex items-center gap-1.5" style={{borderBottom:'1px solid rgba(255,255,255,0.03)'}}><Database className="w-3 h-3 text-[#FFB800]"/><span className="text-[8px] font-mono font-bold tracking-[0.12em] text-[var(--text-primary)]">VAULT & EXPORT</span></div>
+                  <div className="px-3 py-2 flex items-center gap-1.5" style={{borderBottom:'1px solid rgba(255,255,255,0.03)'}}><Database className="w-3 h-3 text-[#FFB800]"/><span className="text-[10px] font-mono font-bold tracking-[0.12em] text-[var(--text-primary)]">VAULT & EXPORT</span></div>
                   <div className="p-2.5 space-y-1.5">
-                    <div className="text-[7px] font-mono text-[var(--text-muted)]">{vaultCount} device{vaultCount!==1?'s':''} · {bytes>1024?`${(bytes/1024).toFixed(1)}KB`:`${bytes}B`}</div>
+                    <div className="text-[10px] font-mono text-[var(--text-muted)]">{vaultCount} device{vaultCount!==1?'s':''} · {bytes>1024?`${(bytes/1024).toFixed(1)}KB`:`${bytes}B`}</div>
                     <div className="flex gap-1.5">
-                      <motion.button whileTap={{scale:0.95}} onClick={exportJSON} disabled={devices.length===0} className="flex-1 py-1.5 rounded-lg text-[7px] font-mono font-bold tracking-wider flex items-center justify-center gap-1 disabled:opacity-30" style={{background:'rgba(255,184,0,0.06)',color:'#FFB800',border:'1px solid rgba(255,184,0,0.08)'}}><Download className="w-2.5 h-2.5"/>JSON</motion.button>
-                      <motion.button whileTap={{scale:0.95}} onClick={exportCSV} disabled={devices.length===0} className="flex-1 py-1.5 rounded-lg text-[7px] font-mono font-bold tracking-wider flex items-center justify-center gap-1 disabled:opacity-30" style={{background:'rgba(0,255,136,0.06)',color:'#00FF88',border:'1px solid rgba(0,255,136,0.08)'}}><Download className="w-2.5 h-2.5"/>CSV</motion.button>
-                      <motion.button whileTap={{scale:0.95}} onClick={async()=>{await vaultClear();setVaultCount(0);log('INFO','VAULT','Vault cleared');}} className="py-1.5 px-2.5 rounded-lg text-[7px] font-mono font-bold flex items-center gap-1" style={{background:'rgba(255,61,61,0.04)',color:'#FF6B6B',border:'1px solid rgba(255,61,61,0.06)'}}><Trash2 className="w-2.5 h-2.5"/>WIPE</motion.button>
+                      <motion.button whileTap={{scale:0.95}} onClick={exportJSON} disabled={devices.length===0} className="flex-1 py-1.5 rounded-lg text-[10px] font-mono font-bold tracking-wider flex items-center justify-center gap-1 disabled:opacity-30" style={{background:'rgba(255,184,0,0.06)',color:'#FFB800',border:'1px solid rgba(255,184,0,0.08)'}}><Download className="w-2.5 h-2.5"/>JSON</motion.button>
+                      <motion.button whileTap={{scale:0.95}} onClick={exportCSV} disabled={devices.length===0} className="flex-1 py-1.5 rounded-lg text-[10px] font-mono font-bold tracking-wider flex items-center justify-center gap-1 disabled:opacity-30" style={{background:'rgba(0,255,136,0.06)',color:'#00FF88',border:'1px solid rgba(0,255,136,0.08)'}}><Download className="w-2.5 h-2.5"/>CSV</motion.button>
+                      <motion.button whileTap={{scale:0.95}} onClick={async()=>{await vaultClear();setVaultCount(0);log('INFO','VAULT','Vault cleared');}} className="py-1.5 px-2.5 rounded-lg text-[10px] font-mono font-bold flex items-center gap-1" style={{background:'rgba(255,61,61,0.04)',color:'#FF6B6B',border:'1px solid rgba(255,61,61,0.06)'}}><Trash2 className="w-2.5 h-2.5"/>WIPE</motion.button>
                     </div>
                   </div>
                 </div>
@@ -516,14 +516,14 @@ export default function WorldRemote({onClose,onPlaceOnMap}:{onClose?:()=>void,on
             {view==='log'&&(
               <div className="flex-1 flex flex-col overflow-hidden">
                 <div className="flex items-center justify-between px-3 py-1 shrink-0" style={{background:'rgba(0,0,0,0.3)',borderBottom:'1px solid rgba(255,255,255,0.03)'}}>
-                  <span className="text-[7px] font-mono text-[var(--text-muted)] tracking-wider">{pkts.length} pkts · {bytes>1024?`${(bytes/1024).toFixed(1)}KB`:`${bytes}B`}</span>
+                  <span className="text-[10px] font-mono text-[var(--text-muted)] tracking-wider">{pkts.length} pkts · {bytes>1024?`${(bytes/1024).toFixed(1)}KB`:`${bytes}B`}</span>
                   <div className="flex items-center gap-1.5">
-                    <button onClick={()=>setPaused(!paused)} className={`text-[7px] font-mono tracking-wider px-1 py-0.5 rounded flex items-center gap-0.5 ${paused?'text-[#FFB800]':'text-[var(--text-muted)]'}`}>{paused?<><Pause className="w-2 h-2"/>PAUSE</>:<><Play className="w-2 h-2"/>LIVE</>}</button>
-                    <button onClick={()=>{setPkts([]);setBytes(0);pid.current=0;}} className="text-[7px] font-mono text-[var(--text-muted)] tracking-wider px-1 py-0.5 rounded hover:bg-white/5 flex items-center gap-0.5"><Trash2 className="w-2 h-2"/>CLR</button>
+                    <button onClick={()=>setPaused(!paused)} className={`text-[10px] font-mono tracking-wider px-1 py-0.5 rounded flex items-center gap-0.5 ${paused?'text-[#FFB800]':'text-[var(--text-muted)]'}`}>{paused?<><Pause className="w-2 h-2"/>PAUSE</>:<><Play className="w-2 h-2"/>LIVE</>}</button>
+                    <button onClick={()=>{setPkts([]);setBytes(0);pid.current=0;}} className="text-[10px] font-mono text-[var(--text-muted)] tracking-wider px-1 py-0.5 rounded hover:bg-white/5 flex items-center gap-0.5"><Trash2 className="w-2 h-2"/>CLR</button>
                   </div>
                 </div>
                 <div ref={logEl} className="flex-1 overflow-y-auto styled-scrollbar font-mono" style={{background:'#020406'}}>
-                  {pkts.length===0?<div className="flex items-center justify-center h-full opacity-15"><span className="text-[8px] font-mono text-[var(--text-muted)] tracking-wider">Scan to see packets...</span></div>
+                  {pkts.length===0?<div className="flex items-center justify-center h-full opacity-15"><span className="text-[10px] font-mono text-[var(--text-muted)] tracking-wider">Scan to see packets...</span></div>
                   :<div className="py-0.5">{pkts.map(p=>{const oc=OP_CLR[p.op]||'#90A4AE';return(<div key={p.id} className="px-2 py-[2px] flex items-start hover:bg-white/[0.015] border-b border-white/[0.01] group" style={{fontSize:10,lineHeight:'16px'}}><span className="text-white/8 shrink-0 w-[24px] tabular-nums text-right pr-1.5">{p.id}</span><span className="text-[var(--text-muted)]/30 shrink-0 w-[58px] tabular-nums">{fts(p.ts)}</span><span className="shrink-0 font-bold tracking-wider w-[44px]" style={{color:oc}}>{p.op}</span><span className="text-[var(--cyan-primary)]/40 shrink-0 truncate w-[55px]">{p.src}</span><span className="text-[var(--text-secondary)] flex-1 truncate">{p.msg}</span>{p.len!=null&&<span className="text-[var(--text-muted)]/12 ml-1 shrink-0 tabular-nums">{p.len}B</span>}</div>);})}</div>}
                 </div>
               </div>
@@ -532,8 +532,8 @@ export default function WorldRemote({onClose,onPlaceOnMap}:{onClose?:()=>void,on
 
           {/* Footer */}
           <div className="flex items-center justify-between px-3 py-1.5 shrink-0" style={{borderTop:'1px solid rgba(255,255,255,0.03)',background:'rgba(0,0,0,0.2)'}}>
-            <div className="flex items-center gap-1.5"><div className={`w-1.5 h-1.5 rounded-full ${btOk?'bg-[var(--alert-green)]':'bg-[#FF3D3D]'} ${scanning?'animate-pulse':''}`}/><span className="text-[7px] font-mono text-[var(--text-muted)] tracking-wider">{scanning?'SCANNING':liveCount>0?`${liveCount} LIVE`:'STANDBY'} · {upStr}</span></div>
-            <span className="text-[6px] font-mono text-[var(--text-muted)]/15 tracking-[0.2em]">MARAUDER V8</span>
+            <div className="flex items-center gap-1.5"><div className={`w-1.5 h-1.5 rounded-full ${btOk?'bg-[var(--alert-green)]':'bg-[#FF3D3D]'} ${scanning?'animate-pulse':''}`}/><span className="text-[10px] font-mono text-[var(--text-muted)] tracking-wider">{scanning?'SCANNING':liveCount>0?`${liveCount} LIVE`:'STANDBY'} · {upStr}</span></div>
+            <span className="text-[10px] font-mono text-[var(--text-muted)]/15 tracking-[0.2em]">MARAUDER V8</span>
           </div>
         </motion.div>
       )}</AnimatePresence>


### PR DESCRIPTION
Three things, all found by **measuring the running app** rather than reading the source. Every number below is read from the live DOM, before and after.

## 1. The type floor was 5px

| | before | after |
|---|---|---|
| Smallest text in the app | **5px** | **10px** |
| Text nodes below 10px | hundreds | **0** |
| Sub-11px declarations | **496** across 32 files | 0 |

There were 3 instances of 5px type and 16 at 6px shipping to users. At that size text is decoration, not information.

**496 declarations raised** — 478 Tailwind `text-[Npx]` classes plus **18 inline `style={{fontSize}}` values**, which the first sweep couldn't see and which is why several panels still measured 7px after it.

Applied in a **single pass** so no value is rewritten twice:

```
5, 6, 7, 8 → 10      9 → 11      10 → 12
```

Floor at 10px, three readable tiers kept below 12. Heaviest: OsintPanel (106), WorldRemote (63), page.tsx (43), ChainBrief (24), ArcGISPanel (23).

`DirectionsBar` and `NavigationView` are **deliberately skipped** — tuned in #287, and a second sweep would inflate them again.

## 2. Touch targets below the WCAG minimum

**WCAG 2.5.8** sets 24px as the minimum target size. The alerts feed carried **30 "SOURCE" links at 36×15px**, and the maximize / full-screen controls sat at 12–14px.

Measured on the worst panel, Live Alerts: **37 controls under 24px → 0**, smallest now 24px. Much of that came free — raising the type lifted most control heights on its own.

## 3. ArcGIS — two rendering bugs and a browsing gap

**Both rendering bugs are pre-existing on `master`**, and both appear the moment a layer with real geometry loads:

- The `fill` layer had **no geometry-type filter**, so maplibre applied it to LineStrings and closed each open path in order to fill it — that is what drew the **gold triangular wedges** across pipeline and railway data. Fill is now restricted to polygons, line to lines and polygons.
- Point features used a flat `circle-radius: 5` with no zoom scaling, so a dense import (~1.2k points at city zoom) merged into a **solid blob**. Radius, stroke and opacity now interpolate with zoom.

**Browsing the library** also gave no feedback at all:

- A result header now reports **how many layers came back, which query they came from, and how many are already live**. The query is tracked separately from the input box — reading the input would relabel the list the moment you start typing the next search.
- Titles were truncated to **one line**, which is precisely wrong for ArcGIS naming, where the distinguishing part comes last (*"Outer Continental Shelf Oil and Natural Gas Pipelines - Gulf"*). Now a 2-line clamp with the full title on hover.
- Layers whose description is empty — which the API **does** return — no longer collapse to a shorter card than their neighbours.
- Tag overflow reads **"+17 more"** instead of "+17", which sat next to a view count and read as a score.

## Verified

Smallest text 10px with nothing below it on any panel · 0 controls under 24px · 20 ArcGIS results rendering with the new header.

**186 tests pass · production build compiles · typecheck unchanged at its 17-error baseline.** Almost every line of the diff is a single-token size change — no restructuring, no behaviour changes.

## Not attempted

Colour contrast, focus-visible states, keyboard navigation and screen-reader labelling. Those need decisions about the design language rather than a measurable floor, so they're better as their own pass.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
