### PR TITLE
fix(ui): repair markets fullscreen, and give the tool panels a shared frame

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2306,3 +2306,101 @@ input[type="range"]::-moz-range-thumb {
   box-shadow: 0 0 8px rgba(212,175,55,0.4);
   border: 2px solid rgba(0,0,0,0.3);
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   INSTRUMENT PANEL
+   Shared chrome for the tool panels — route planner, markets, and
+   anything else that should read as an instrument rather than a form.
+   Kept here rather than in each component so the panels cannot drift
+   apart, which is what makes a set of tools feel assembled instead of
+   designed.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Faint engineering grid. Sits under the content at very low contrast —
+   readable as texture, never as lines competing with the data. */
+/* Deliberately does NOT set `position`. These rules are appended after the
+   Tailwind utilities, so a `position: relative` here would beat a `fixed`
+   utility on the same element at equal specificity — which is exactly how the
+   markets panel stopped going fullscreen. The consumer owns positioning; this
+   only needs *some* positioned ancestor, which every panel already has. */
+.instrument-grid::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(var(--gold-rgb), 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(var(--gold-rgb), 0.045) 1px, transparent 1px);
+  background-size: 22px 22px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.9), transparent 65%);
+  -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.9), transparent 65%);
+  border-radius: inherit;
+}
+
+/* Corner brackets. Four hairlines that frame a panel the way a sight or a
+   viewfinder does, without the cost of a full border. */
+.instrument-corners::after,
+.instrument-corners::before {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  pointer-events: none;
+  border-color: rgba(var(--gold-rgb), 0.45);
+}
+.instrument-corners::before {
+  top: 6px;
+  left: 6px;
+  border-top: 1px solid;
+  border-left: 1px solid;
+}
+.instrument-corners::after {
+  bottom: 6px;
+  right: 6px;
+  border-bottom: 1px solid;
+  border-right: 1px solid;
+}
+
+/* Header treatment: an accent bar and a hairline rule that reads as a
+   masthead rather than a title. */
+.instrument-title {
+  font-family: var(--font-hud);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-heading);
+}
+
+.instrument-rule {
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    rgba(var(--gold-rgb), 0.35) 0%,
+    rgba(var(--gold-rgb), 0.10) 40%,
+    transparent 100%
+  );
+}
+
+/* Small state chip — STANDBY / READY / LIVE. */
+.instrument-chip {
+  font-family: var(--font-hud);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid currentColor;
+  opacity: 0.85;
+}
+
+/* Monospace sample of an accepted input format, for empty states that would
+   otherwise just say "type something". */
+.instrument-sample {
+  font-family: var(--font-hud);
+  font-size: 10px;
+  color: var(--text-secondary);
+  background: rgba(var(--gold-rgb), 0.06);
+  border: 1px solid rgba(var(--gold-rgb), 0.12);
+  border-radius: 4px;
+  padding: 1px 5px;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1259,10 +1259,16 @@ export default function Dashboard() {
       {/* ── RIGHT TOOL STRIP (desktop only — mobile uses bottom nav) ── */}
       {!isMobile && <div className="absolute right-2 top-1/2 -translate-y-1/2 flex flex-col gap-2 z-[250] pointer-events-auto bg-black/40 backdrop-blur-sm p-1 rounded-full border border-white/5">
         <div className="relative group">
-          <button onClick={() => { setShowIntel(!showIntel); setShowMarkets(false); setShowAlerts(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showIntel ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`} title="OSINT Recon — IP lookup, network sweep, geolocation">
+          <button onClick={() => { setShowIntel(!showIntel); setShowMarkets(false); setShowAlerts(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showIntel ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`} title="OSINT Recon — IP lookup, network sweep, geolocation" aria-label="OSINT Recon" aria-expanded={showIntel}>
             <Radar className={`w-4 h-4 ${showIntel ? 'text-[var(--cyan-primary)]' : 'text-white/60'}`} />
+            {showIntel && (
+              <span
+                aria-hidden="true"
+                className="absolute -right-1 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full bg-current text-[var(--cyan-primary)]"
+              />
+            )}
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">RECON</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">RECON</span>
           <AnimatePresence>
             {showIntel && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
@@ -1279,10 +1285,16 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowIntel(false); setShowAlerts(false); setShowMarkets(false); setShowSpaceCam(v => !v); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showSpaceCam ? 'bg-[#00E5FF]/20' : 'hover:bg-white/10'}`} title="Live from Space — 24/7 video downlink from the ISS">
+          <button onClick={() => { setShowIntel(false); setShowAlerts(false); setShowMarkets(false); setShowSpaceCam(v => !v); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showSpaceCam ? 'bg-[#00E5FF]/20' : 'hover:bg-white/10'}`} title="Live from Space — 24/7 video downlink from the ISS" aria-label="Live from Space" aria-expanded={showSpaceCam}>
             <Radio className={`w-4 h-4 ${showSpaceCam ? 'text-[#00E5FF]' : 'text-white/60'}`} />
+            {showSpaceCam && (
+              <span
+                aria-hidden="true"
+                className="absolute -right-1 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full bg-current text-[#00E5FF]"
+              />
+            )}
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">SPACE</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">SPACE</span>
           <AnimatePresence>
             {showSpaceCam && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
@@ -1293,10 +1305,16 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); setShowSpaceCam(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Markets — crypto prices, space weather, global indices">
+          <button onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); setShowSpaceCam(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Markets — crypto prices, space weather, global indices" aria-label="Markets" aria-expanded={showMarkets}>
             <BarChart3 className={`w-4 h-4 ${showMarkets ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
+            {showMarkets && (
+              <span
+                aria-hidden="true"
+                className="absolute -right-1 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full bg-current text-[var(--gold-primary)]"
+              />
+            )}
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">MARKETS</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">MARKETS</span>
           <AnimatePresence>
             {showMarkets && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
@@ -1307,10 +1325,16 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowAlerts(!showAlerts); setShowIntel(false); setShowMarkets(false); setShowDrawing(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showAlerts ? 'bg-[#FF3D3D]/20' : 'hover:bg-white/10'}`} title="Live Alerts — earthquakes, conflicts, breaking news">
+          <button onClick={() => { setShowAlerts(!showAlerts); setShowIntel(false); setShowMarkets(false); setShowDrawing(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showAlerts ? 'bg-[#FF3D3D]/20' : 'hover:bg-white/10'}`} title="Live Alerts — earthquakes, conflicts, breaking news" aria-label="Live Alerts" aria-expanded={showAlerts}>
             <AlertTriangle className={`w-4 h-4 ${showAlerts ? 'text-[#FF3D3D]' : 'text-white/60'}`} />
+            {showAlerts && (
+              <span
+                aria-hidden="true"
+                className="absolute -right-1 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full bg-current text-[#FF3D3D]"
+              />
+            )}
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ALERTS</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">ALERTS</span>
           <AnimatePresence>
             {showAlerts && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
@@ -1321,24 +1345,42 @@ export default function Dashboard() {
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowDrawing(!showDrawing); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDrawing ? 'bg-[#00E5FF]/20' : 'hover:bg-white/10'}`} title="Draw — measure areas of interest on the map">
+          <button onClick={() => { setShowDrawing(!showDrawing); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showDrawing ? 'bg-[#00E5FF]/20' : 'hover:bg-white/10'}`} title="Draw — measure areas of interest on the map" aria-label="Draw" aria-expanded={showDrawing}>
             <PenLine className={`w-4 h-4 ${showDrawing ? 'text-[#00E5FF]' : 'text-white/60'}`} />
+            {showDrawing && (
+              <span
+                aria-hidden="true"
+                className="absolute -right-1 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full bg-current text-[#00E5FF]"
+              />
+            )}
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">DRAW</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">DRAW</span>
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowDirections(!showDirections); if (showDirections) { setActiveRoute(null); } setShowDesktopSearch(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowDrawing(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDirections ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Directions — turn-by-turn routing">
+          <button onClick={() => { setShowDirections(!showDirections); if (showDirections) { setActiveRoute(null); } setShowDesktopSearch(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowDrawing(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showDirections ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Directions — turn-by-turn routing" aria-label="Directions" aria-expanded={showDirections}>
             <Route className={`w-4 h-4 ${showDirections ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
+            {showDirections && (
+              <span
+                aria-hidden="true"
+                className="absolute -right-1 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full bg-current text-[var(--gold-primary)]"
+              />
+            )}
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ROUTE</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">ROUTE</span>
         </div>
 
         <div className="relative group">
-          <button onClick={() => { setShowDesktopSearch(!showDesktopSearch); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowDrawing(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showDesktopSearch ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Search — find locations, cities, coordinates">
+          <button onClick={() => { setShowDesktopSearch(!showDesktopSearch); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowDrawing(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showDesktopSearch ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Search — find locations, cities, coordinates" aria-label="Search" aria-expanded={showDesktopSearch}>
             <Search className={`w-4 h-4 ${showDesktopSearch ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
+            {showDesktopSearch && (
+              <span
+                aria-hidden="true"
+                className="absolute -right-1 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full bg-current text-[var(--gold-primary)]"
+              />
+            )}
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">SEARCH</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">SEARCH</span>
           <AnimatePresence>
             {showDesktopSearch && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
@@ -1353,11 +1395,17 @@ export default function Dashboard() {
 
         {/* ── ARCGIS INTEL ── */}
         <div className="relative group">
-          <button onClick={() => { setShowArcGIS(!showArcGIS); setShowRemote(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showArcGIS ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="ArcGIS — search & import geospatial intel layers">
+          <button onClick={() => { setShowArcGIS(!showArcGIS); setShowRemote(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showArcGIS ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="ArcGIS — search & import geospatial intel layers" aria-label="ArcGIS" aria-expanded={showArcGIS}>
             <Database className={`w-4 h-4 ${showArcGIS ? 'text-[var(--gold-primary)]' : 'text-white/60'}`} />
+            {showArcGIS && (
+              <span
+                aria-hidden="true"
+                className="absolute -right-1 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full bg-current text-[var(--gold-primary)]"
+              />
+            )}
             {arcgisLayers.length > 0 && <span className="absolute -top-0.5 -right-0.5 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-[var(--gold-primary)] text-black text-[9px] font-mono font-bold leading-none px-0.5">{arcgisLayers.length}</span>}
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">ARCGIS</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">ARCGIS</span>
           <AnimatePresence>
             {showArcGIS && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-[340px]">
@@ -1381,10 +1429,16 @@ export default function Dashboard() {
 
         {/* ── WORLD REMOTE ── */}
         <div className="relative group">
-          <button onClick={() => { setShowRemote(!showRemote); setShowArcGIS(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowDrawing(false); setShowDesktopSearch(false); }} className={`w-8 h-8 rounded-full flex items-center justify-center transition-colors ${showRemote ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`} title="World Remote — control nearby Bluetooth devices (TVs, speakers, AC)">
+          <button onClick={() => { setShowRemote(!showRemote); setShowArcGIS(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowDrawing(false); setShowDesktopSearch(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showRemote ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`} title="World Remote — control nearby Bluetooth devices (TVs, speakers, AC)" aria-label="World Remote" aria-expanded={showRemote}>
             <Bluetooth className={`w-4 h-4 ${showRemote ? 'text-[var(--cyan-primary)]' : 'text-white/60'}`} />
+            {showRemote && (
+              <span
+                aria-hidden="true"
+                className="absolute -right-1 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full bg-current text-[var(--cyan-primary)]"
+              />
+            )}
           </button>
-          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">REMOTE</span>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">REMOTE</span>
           <AnimatePresence>
             {showRemote && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">

--- a/src/components/DirectionsBar.tsx
+++ b/src/components/DirectionsBar.tsx
@@ -623,18 +623,28 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
 
   return (
     <div
-      className="glass-panel overflow-hidden flex flex-col max-h-[min(78vh,640px)]"
+      className="glass-panel instrument-grid instrument-corners relative overflow-hidden flex flex-col max-h-[min(78vh,640px)]"
       style={{ boxShadow: '0 18px 56px rgba(0,0,0,0.7), 0 0 0 1px rgba(var(--gold-rgb),0.04)' }}
     >
       {/* ── header ── */}
-      <header className="flex items-center gap-2 px-3 h-9 border-b border-[var(--border-secondary)] flex-shrink-0">
+      <header className="relative flex items-center gap-2 px-3 h-10 flex-shrink-0">
+        {/* A lit accent bar reads as an instrument being powered, where a
+            plain heading just reads as a form label. */}
+        <span
+          aria-hidden="true"
+          className="absolute left-0 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-r"
+          style={{ background: 'var(--gold-primary)', boxShadow: '0 0 8px rgba(var(--gold-rgb),0.6)' }}
+        />
         <Route className="w-3.5 h-3.5 text-[var(--gold-primary)]" />
-        <h2 className="text-[11px] tracking-[0.18em] text-[var(--text-secondary)] uppercase flex-1">Route</h2>
-        {route && (
-          <span className="text-[10px] text-[var(--text-muted)] tabular-nums">
-            {route.steps.length} steps
-          </span>
-        )}
+        <h2 className="instrument-title flex-1">Route</h2>
+
+        {/* State at a glance: standby until both ends are set, then the leg. */}
+        <span
+          className="instrument-chip"
+          style={{ color: route ? 'var(--alert-green)' : 'var(--text-muted)' }}
+        >
+          {route ? `${route.steps.length} STEPS` : ready ? 'PLOTTING' : 'STANDBY'}
+        </span>
 
         <button
           onClick={toggleTracking}
@@ -673,6 +683,7 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
           </button>
         )}
       </header>
+      <div className="instrument-rule flex-shrink-0" />
 
       {/* ── origin / destination rail ── */}
       <div className="flex items-stretch gap-2.5 px-3 py-2">
@@ -749,14 +760,24 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
                 role="tab"
                 aria-selected={on}
                 onClick={() => pickMode(id)}
-                className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-[6px] text-[11px] transition-all ${
+                className={`relative flex-1 flex items-center justify-center gap-1.5 py-2 rounded-[6px] text-[11px] tracking-[0.12em] uppercase transition-all ${
                   on
-                    ? 'bg-[rgba(var(--gold-rgb),0.14)] text-[var(--gold-primary)] shadow-[inset_0_0_0_1px_rgba(var(--gold-rgb),0.25)]'
-                    : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+                    ? 'bg-[rgba(var(--gold-rgb),0.14)] text-[var(--gold-primary)] shadow-[inset_0_0_0_1px_rgba(var(--gold-rgb),0.30),0_0_14px_rgba(var(--gold-rgb),0.10)]'
+                    : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-white/[0.03]'
                 }`}
+                style={on ? { fontFamily: 'var(--font-hud)' } : undefined}
               >
                 <Icon className="w-3.5 h-3.5" />
                 {label}
+                {/* A lit underline on the selected mode — the fill alone is
+                    subtle enough to miss against a bright basemap. */}
+                {on && (
+                  <span
+                    aria-hidden="true"
+                    className="absolute bottom-[3px] left-1/2 -translate-x-1/2 h-[2px] w-5 rounded-full"
+                    style={{ background: 'var(--gold-primary)', boxShadow: '0 0 8px rgba(var(--gold-rgb),0.7)' }}
+                  />
+                )}
               </button>
             );
           })}
@@ -836,11 +857,25 @@ export default function DirectionsBar({ onRoute, onLocate, onClose, center = nul
         )}
 
         {!loading && !error && !route && (
-          <p className="px-3 py-4 text-[11px] text-[var(--text-muted)] leading-relaxed">
-            {ready
-              ? 'Calculating…'
-              : 'Enter a start and destination. Place names, addresses and lat,lng all work.'}
-          </p>
+          <div className="px-3 py-4">
+            {ready ? (
+              <p className="text-[11px] text-[var(--text-muted)] leading-relaxed">Calculating…</p>
+            ) : (
+              <>
+                <p className="hud-label mb-2">Accepted input</p>
+                {/* Showing the formats beats describing them: the sample is the
+                    documentation, and it is scannable at a glance. */}
+                <div className="flex flex-wrap gap-1.5">
+                  <span className="instrument-sample">Heathrow</span>
+                  <span className="instrument-sample">10 Downing St</span>
+                  <span className="instrument-sample">51.5074,-0.1278</span>
+                </div>
+                <p className="mt-2.5 text-[11px] text-[var(--text-muted)] leading-relaxed">
+                  Set a start and a destination to plot a route.
+                </p>
+              </>
+            )}
+          </div>
         )}
 
         {!loading && route && (

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Plane, Satellite, Sun, AlertTriangle, Camera,
@@ -137,11 +137,16 @@ const LAYER_GROUPS: LayerGroupDef[] = [
 ];
 
 /* ── Minimal Toggle Switch ── */
-function ToggleSwitch({ active, onClick }: { active: boolean; onClick: () => void }) {
+/**
+ * Presentational only. The row around it is the button, and a button inside a
+ * button is invalid HTML — the browser reparents it, which breaks hydration and
+ * silently drops the click handler on the inner control.
+ */
+function ToggleSwitch({ active }: { active: boolean }) {
   return (
-    <button
-      onClick={onClick}
-      className="relative flex-shrink-0 cursor-pointer"
+    <span
+      role="presentation"
+      className="relative flex-shrink-0 block"
       style={{ width: 28, height: 14 }}
     >
       <div
@@ -163,14 +168,37 @@ function ToggleSwitch({ active, onClick }: { active: boolean; onClick: () => voi
         animate={{ left: active ? 16 : 2 }}
         transition={{ type: 'spring', stiffness: 500, damping: 30 }}
       />
-    </button>
+    </span>
   );
 }
 
 function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'core', setTheme, capabilities = {} }: LayerPanelProps) {
   const [hoveredGroup, setHoveredGroup] = useState<string | null>(null);
+  /**
+   * A pinned group stays open when the pointer leaves. Hover-only flyouts are
+   * fine to glance at and impossible to work in — reaching for a toggle at the
+   * far edge closes the thing you were reaching for.
+   */
+  const [pinnedGroup, setPinnedGroup] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!pinnedGroup) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setPinnedGroup(null); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [pinnedGroup]);
 
   const toggle = (key: string) => setActiveLayers((prev: any) => ({ ...prev, [key]: !prev[key] }));
+
+  /** Switch a whole group at once — off if any are on, otherwise all on. */
+  const toggleGroup = (layers: LayerDef[]) => {
+    const anyOn = layers.some(l => activeLayers[l.key]);
+    setActiveLayers((prev: any) => {
+      const next = { ...prev };
+      for (const l of layers) next[l.key] = !anyOn;
+      return next;
+    });
+  };
 
   /* Drop layers whose backing capability is not configured, then drop any group
      left with nothing to show. */
@@ -209,20 +237,22 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                 const isLayerActive = activeLayers[layer.key];
                 const count = getCount(layer.dataKey, layer.catKey);
                 return (
-                  <div key={layer.key} className="flex items-center gap-3 px-1 py-1.5">
-                    <ToggleSwitch
-                      active={!!isLayerActive}
-                      onClick={() => toggle(layer.key)}
-                    />
+                  <button
+                    key={layer.key}
+                    onClick={() => toggle(layer.key)}
+                    aria-pressed={!!isLayerActive}
+                    className="w-full flex items-center gap-3 px-1 py-2 rounded-md text-left hover:bg-white/[0.04] transition-colors"
+                  >
+                    <ToggleSwitch active={!!isLayerActive} />
                     <span className={`text-[11px] font-mono uppercase tracking-wider flex-1 transition-colors ${isLayerActive ? 'text-white/80' : 'text-white/40'}`}>
                       {layer.label}
                     </span>
                     {count !== null && (
-                      <span className="text-[9px] font-mono tabular-nums text-white/20">
+                      <span className="text-[10px] font-mono tabular-nums text-white/25">
                         {count.toLocaleString()}
                       </span>
                     )}
-                  </div>
+                  </button>
                 );
               })}
             </div>
@@ -268,6 +298,10 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
           const isHovered = hoveredGroup === group.label;
           const Icon = group.icon;
 
+          const activeCount = group.layers.filter(l => activeLayers[l.key]).length;
+          const isPinned = pinnedGroup === group.label;
+          const isOpen = isHovered || isPinned;
+
           return (
             <div
               key={group.label}
@@ -275,11 +309,19 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
               onMouseEnter={() => setHoveredGroup(group.label)}
               onMouseLeave={() => setHoveredGroup(null)}
             >
-              {/* Icon Button */}
-              <div
-                className="w-10 h-10 flex items-center justify-center cursor-pointer rounded-lg transition-all duration-300"
+              {/* A real button, not a div: this is keyboard reachable, focusable
+                  and announced. Clicking pins the flyout open so it can be
+                  worked in rather than only glanced at. */}
+              <button
+                onClick={() => setPinnedGroup(isPinned ? null : group.label)}
+                aria-expanded={isOpen}
+                aria-label={`${group.fullLabel}${activeCount ? ` — ${activeCount} active` : ''}`}
+                title={group.fullLabel}
+                className="relative w-10 h-10 flex items-center justify-center cursor-pointer rounded-lg transition-all duration-300 focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
                 style={{
-                  background: isHovered ? 'rgba(255,255,255,0.05)' : 'transparent',
+                  background: isPinned
+                    ? 'rgba(255,255,255,0.10)'
+                    : isHovered ? 'rgba(255,255,255,0.05)' : 'transparent',
                 }}
               >
                 <Icon
@@ -288,18 +330,33 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                     width: 16,
                     height: 16,
                     color: groupActive
-                      ? 'rgba(255,255,255,0.7)'
-                      : isHovered
-                        ? 'rgba(255,255,255,0.4)'
-                        : 'rgba(255,255,255,0.2)',
+                      ? 'rgba(255,255,255,0.75)'
+                      : isOpen
+                        ? 'rgba(255,255,255,0.45)'
+                        : 'rgba(255,255,255,0.22)',
                     filter: groupActive ? 'drop-shadow(0 0 4px rgba(255,255,255,0.3))' : 'none',
                   }}
                 />
-              </div>
+
+                {/* How many layers in this group are live. Without it the rail
+                    gives no reading at all until each icon is hovered in turn. */}
+                {activeCount > 0 && (
+                  <span
+                    className="absolute top-1 right-1 min-w-[13px] h-[13px] px-[3px] rounded-full flex items-center justify-center text-[9px] font-mono tabular-nums leading-none"
+                    style={{
+                      background: 'rgba(0,229,255,0.9)',
+                      color: '#04040A',
+                      boxShadow: '0 0 6px rgba(0,229,255,0.5)',
+                    }}
+                  >
+                    {activeCount}
+                  </span>
+                )}
+              </button>
 
               {/* Flyout (LEFT side) */}
               <AnimatePresence>
-                {isHovered && (
+                {isOpen && (
                   <motion.div
                     initial={{ opacity: 0, x: -8, filter: 'blur(4px)' }}
                     animate={{ opacity: 1, x: 0, filter: 'blur(0px)' }}
@@ -314,8 +371,27 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                       boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
                     }}
                   >
-                    <div className="text-[10px] font-mono tracking-[0.2em] uppercase text-white/30 mb-2.5 pb-1.5 border-b border-white/[0.04]">
-                      {group.fullLabel}
+                    <div className="flex items-center gap-2 mb-2.5 pb-1.5 border-b border-white/[0.04]">
+                      <span className="text-[10px] font-mono tracking-[0.2em] uppercase text-white/35 flex-1">
+                        {group.fullLabel}
+                      </span>
+                      {/* Switching eight satellite layers one at a time is the
+                          kind of thing that makes a panel feel unfinished. */}
+                      <button
+                        onClick={(e) => { e.stopPropagation(); toggleGroup(group.layers); }}
+                        className="px-1.5 py-0.5 rounded text-[10px] font-mono tracking-wider text-white/40 hover:text-white hover:bg-white/10 transition-colors"
+                      >
+                        {activeCount > 0 ? 'NONE' : 'ALL'}
+                      </button>
+                      {isPinned && (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); setPinnedGroup(null); }}
+                          aria-label="Close"
+                          className="px-1.5 py-0.5 rounded text-[10px] font-mono text-white/40 hover:text-white hover:bg-white/10 transition-colors"
+                        >
+                          ✕
+                        </button>
+                      )}
                     </div>
                     <div className="flex flex-col gap-0.5">
                       {group.layers.map((layer) => {
@@ -323,21 +399,22 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                         const count = getCount(layer.dataKey, layer.catKey);
 
                         return (
-                          <div
+                          <button
                             key={layer.key}
-                            className="flex items-center gap-3 px-1 py-[5px] rounded-md hover:bg-white/[0.03] transition-colors cursor-pointer"
                             onClick={() => toggle(layer.key)}
+                            aria-pressed={!!isLayerActive}
+                            className="w-full flex items-center gap-3 px-1 py-1.5 rounded-md hover:bg-white/[0.05] transition-colors cursor-pointer text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-white/30"
                           >
-                            <ToggleSwitch active={!!isLayerActive} onClick={() => {}} />
+                            <ToggleSwitch active={!!isLayerActive} />
                             <span className={`text-[11px] font-mono uppercase tracking-wider flex-1 transition-colors duration-200 ${isLayerActive ? 'text-white/70' : 'text-white/35'}`}>
                               {layer.label}
                             </span>
                             {count !== null && (
-                              <span className="text-[10px] font-mono tabular-nums text-white/20">
+                              <span className={`text-[10px] font-mono tabular-nums transition-colors ${isLayerActive ? 'text-white/45' : 'text-white/20'}`}>
                                 {count.toLocaleString()}
                               </span>
                             )}
-                          </div>
+                          </button>
                         );
                       })}
                     </div>

--- a/src/components/MarketsPanel.tsx
+++ b/src/components/MarketsPanel.tsx
@@ -301,14 +301,30 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
   );
 
   const content = (
-    <motion.div initial={{ opacity: 0, x: -20 }} animate={{ opacity: 1, x: 0 }} transition={{ delay: 0.6, duration: 0.6 }} className={`glass-panel p-3 pointer-events-auto transition-all duration-300 flex flex-col ${maximized ? 'fixed inset-3 z-[9999] bg-[#0a0a09]/95 backdrop-blur-3xl' : ''}`}>
+    // The entry slide is opacity-only. A translateX here leaves a transform on
+    // the element, and when the panel goes fullscreen that transform offsets a
+    // `fixed` box away from its inset — the panel was landing 20px off the left
+    // edge of the viewport, because the animation had never settled back to 0.
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.6, duration: 0.6 }} className={`glass-panel instrument-grid instrument-corners p-3 pointer-events-auto transition-all duration-300 flex flex-col ${
+      // `relative` and `fixed` are both position utilities, so listing them
+      // together lets CSS order decide the winner rather than the state —
+      // which is what stopped the panel going fullscreen.
+      maximized ? 'fixed inset-3 z-[9999] bg-[#0a0a09]/95 backdrop-blur-3xl' : 'relative'
+    }`}>
       {/* Header controls sit side by side, not nested — a button inside a
           button is invalid HTML and React fails hydration on it. */}
       <div className="flex items-center justify-between w-full mb-2">
-        <button onClick={() => setExpanded(!expanded)} className="flex items-center gap-2">
+        <button onClick={() => setExpanded(!expanded)} className="relative flex items-center gap-2 pl-2">
+          {/* Same lit accent bar as the route planner, so the two panels read
+              as one instrument set rather than two unrelated widgets. */}
+          <span
+            aria-hidden="true"
+            className="absolute left-[-10px] top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-r"
+            style={{ background: 'var(--gold-primary)', boxShadow: '0 0 8px rgba(var(--gold-rgb),0.6)' }}
+          />
           <BarChart3 className="w-3.5 h-3.5 text-[var(--gold-primary)]" />
-          <span className="hud-text text-[11px] text-[var(--text-primary)]">MARKETS & INTEL</span>
-          <span className="gotham-tag gotham-tag--low" style={{ fontSize: '9px', padding: '1px 4px' }}>LIVE</span>
+          <span className="instrument-title">Markets &amp; Intel</span>
+          <span className="instrument-chip" style={{ color: 'var(--alert-green)' }}>Live</span>
         </button>
         <div className="flex items-center gap-2">
           {age && <span className="text-[9px] font-mono text-[var(--text-muted)]">{age}</span>}
@@ -321,6 +337,7 @@ export default function MarketsPanel({ data, spaceWeather }: MarketsPanelProps) 
           </button>
         </div>
       </div>
+      <div className="instrument-rule mb-2 flex-shrink-0" />
 
       {/* Fades rather than animating height. Fullscreen makes this a flex child
           and docked lets it size to content; animating height across that


### PR DESCRIPTION
The markets panel stopped going fullscreen. Fixing it turned up three separate faults stacked on top of each other, all introduced by the instrument styling in this same change — and each one was independently sufficient to break it.

**5 files, +349 / −68.**

## Why fullscreen broke

**1. Two position utilities in the same className.** The panel carried `relative` *and* `fixed` when maximized. Both are position utilities at equal specificity, so CSS source order picked the winner rather than the component state.

**2. A stylesheet rule outranking Tailwind.** `.instrument-grid` set `position: relative`, and these rules are appended *after* the Tailwind utilities. Equal specificity, later in the file — so it beat the `fixed` utility even once the className was clean.

This was the one worth naming, because it was a trap rather than a bug: the class only wanted a positioned ancestor for its `::before` grid overlay, and every panel already has one. It would have silently broken the positioning of *any* future panel using it with `fixed`, `absolute` or `sticky`. `DirectionsBar` had dodged it by declaring `relative` explicitly — luck, not design. The class no longer sets position at all, with a comment saying why.

**3. A transform that never settled.** With position and inset both correct, the panel *still* landed at `x = -8`, hanging off the left edge of a 1280px viewport. Computed transform was `matrix(1,0,0,1,-20,0)` — the `initial={{ x: -20 }}` entry slide had never animated back to zero, and a transform offsets a `fixed` box away from its inset. The entry animation is opacity-only now.

Measured after the fix, 1280×720 viewport:

```
              position    size        origin
docked        relative    320×630     right rail
fullscreen    fixed       1256×696    @12,12
expected                  1256×696    @12,12    exact
transform     (none)
restore       relative    320×630     ok
```

1256×696 at 12,12 is the viewport less the 12px inset on every side.

## Shared panel chrome

The route planner and markets panel now draw from one set of classes in `globals.css` instead of each styling itself — a faint engineering grid, corner brackets, a masthead rule, a state chip, and a monospace sample for input formats. Central so the panels can't drift apart, which is what makes a set of tools feel assembled rather than designed.

Route also gets a `STANDBY / PLOTTING / n STEPS` chip, a lit underline on the selected travel mode (the fill alone was easy to miss against a bright basemap), and an empty state that **shows** the accepted input formats rather than describing them.

## Right tool strip

Every button gains an `aria-label`, `aria-expanded` and a visible focus ring, and its hover tooltip now appears on keyboard focus too. An open panel is marked by a lit edge indicator in the tool's own colour — previously the only signal was a faint background tint.

## Layer rail

Group icons were `div`s, so the rail was unreachable by keyboard and announced as nothing. They're buttons now, carrying a badge of how many layers in the group are live — the rail gave no reading at all until each icon was hovered in turn.

Clicking a group **pins** the flyout open, closable with Escape or its own control. A hover-only flyout is fine to glance at and impossible to work in: reaching for a toggle at the far edge closes the thing you're reaching for. Each flyout also gets an ALL / NONE control, because switching eight satellite layers one at a time is the kind of thing that makes a panel feel unfinished.

Two correctness fixes fell out of that:

- `ToggleSwitch` rendered a `<button>` inside the row's `<button>`. The browser reparents nested buttons, which breaks hydration and silently drops the inner handler. It's presentational now and the row owns the click.
- The mobile rows were plain `div`s leaning on that same dead inner handler, so they're buttons too.

## Verified

281 tests pass, typecheck clean, production build compiles. Fullscreen, restore and the panel geometry were measured in a real browser rather than assumed.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
