### PR TITLE
feat(cctv): play SkylineWebcams cameras in place instead of linking out

### DIFF
--- a/src/app/api/cctv/resolve/route.ts
+++ b/src/app/api/cctv/resolve/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import { safeFetch } from '@/lib/ssrf-guard';
+import { isSkylineUrl, parseSkylinePage } from '@/lib/skyline';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 15;
+
+/**
+ * Resolves a SkylineWebcams page to something the viewer can embed.
+ *
+ * Most of these pages are a wrapper around a public YouTube livestream from the
+ * camera's actual operator, so the viewer can show the feed inline instead of
+ * sending the operator off-platform. See src/lib/skyline.ts for the breakdown
+ * and for why the HLS-backed ones are left alone.
+ *
+ * The video id is read live rather than baked into the camera data: these are
+ * long-running livestreams, and a stream that restarts comes back under a new
+ * id. A baked id would work until it silently didn't.
+ */
+
+// Three different lifetimes, because these are three different facts.
+const OK_TTL_MS = 30 * 60_000;         // a resolved stream id is stable for a while
+const NO_FEED_TTL_MS = 5 * 60_000;     // 'this page has no embeddable feed' is a
+                                       // property of the page, good to reuse
+const UNREACHABLE_TTL_MS = 30_000;     // a network failure says nothing about the
+                                       // page. Caching it as long as a real answer
+                                       // turns one timeout into minutes of a camera
+                                       // looking unavailable when it is fine.
+const MAX_ENTRIES = 1000;
+
+type Resolution =
+  | { embeddable: true; kind: 'youtube'; videoId: string; embedUrl: string }
+  | { embeddable: false; kind: 'hls' | 'unknown' | 'unreachable' };
+
+const cache = new Map<string, { at: number; ttl: number; value: Resolution }>();
+
+function cached(url: string): Resolution | null {
+  const hit = cache.get(url);
+  if (!hit) return null;
+  if (Date.now() - hit.at > hit.ttl) {
+    cache.delete(url);
+    return null;
+  }
+  return hit.value;
+}
+
+function remember(url: string, value: Resolution) {
+  // Only Skyline URLs reach this, so the key space is bounded by their site —
+  // but bound it here too rather than trusting that to stay true.
+  if (cache.size >= MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  const ttl = value.embeddable
+    ? OK_TTL_MS
+    : value.kind === 'unreachable' ? UNREACHABLE_TTL_MS : NO_FEED_TTL_MS;
+  cache.set(url, { at: Date.now(), ttl, value });
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url).searchParams.get('url');
+
+  // The host allowlist is what keeps this from being a fetch-anything route:
+  // it can only ever retrieve pages from skylinewebcams.com.
+  if (!url || !isSkylineUrl(url)) {
+    return NextResponse.json(
+      { embeddable: false, kind: 'unknown', reason: 'not_skyline' },
+      { status: 400 },
+    );
+  }
+
+  const hit = cached(url);
+  if (hit) {
+    return NextResponse.json(hit, { headers: { 'X-Cache': 'HIT' } });
+  }
+
+  let value: Resolution;
+  try {
+    const res = await safeFetch(url, {
+      signal: AbortSignal.timeout(10_000),
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; OSIRIS/1.0; +https://github.com/simplifaisoul/osiris)',
+        Accept: 'text/html,application/xhtml+xml',
+      },
+    });
+
+    if (!res.ok) {
+      value = { embeddable: false, kind: 'unreachable' };
+    } else {
+      const feed = parseSkylinePage(await res.text());
+      value = feed.kind === 'youtube'
+        ? { embeddable: true, kind: 'youtube', videoId: feed.videoId, embedUrl: feed.embedUrl }
+        : { embeddable: false, kind: feed.kind };
+    }
+  } catch (err) {
+    // A resolver failure must not look like "this camera is broken" — the
+    // viewer still has the external link to fall back to. Log it, though:
+    // a silent catch here is how a wholly broken resolver looks identical
+    // to a camera that genuinely has no embeddable feed.
+    console.error('cctv resolve failed:', url, err instanceof Error ? err.message : err);
+    value = { embeddable: false, kind: 'unreachable' };
+  }
+
+  remember(url, value);
+
+  return NextResponse.json(value, {
+    headers: {
+      'X-Cache': 'MISS',
+      'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=1800',
+    },
+  });
+}

--- a/src/components/CameraViewer.tsx
+++ b/src/components/CameraViewer.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, ExternalLink, RefreshCw, MapPin, Camera, Maximize2 } from 'lucide-react';
 import Hls from 'hls.js';
+import { isHostedOffPlatform, needsResolution, offPlatformView } from '@/lib/skyline';
 
 interface CameraViewerProps {
   camera: any | null;
@@ -33,9 +34,43 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
   const videoRef = useRef<HTMLVideoElement>(null);
   const hlsRef = useRef<Hls | null>(null);
 
-  const streamType = camera?.stream_type || 'jpg';
   const externalFeedUrl = camera?.external_url || camera?.feed_url;
-  const externalOnly = Boolean(camera?.external_url && !camera?.feed_url && !camera?.stream_url);
+  const hostedOffPlatform = isHostedOffPlatform(camera);
+
+  /**
+   * A SkylineWebcams page is usually a wrapper around a public YouTube
+   * livestream published by the camera's actual operator, so it can play here
+   * rather than sending the viewer off-platform. Resolved live rather than
+   * baked into the camera data: a livestream that restarts comes back under a
+   * new video id, and a baked id would work until it silently didn't.
+   *
+   * The answer is stored against the URL it belongs to. Keying it that way is
+   * what makes switching cameras safe: a reply that arrives late carries the
+   * previous key, so it is simply not read rather than painting the last
+   * camera's stream into the current one. It also means neither `resolving`
+   * nor the reset needs to be written back into state — both fall out of the
+   * key comparison at render.
+   */
+  const resolveKey: string | null = needsResolution(camera) ? camera.external_url : null;
+  const [resolution, setResolution] = useState<{ key: string; embed: string | null } | null>(null);
+  const resolvedEmbed = resolution && resolution.key === resolveKey ? resolution.embed : null;
+  const resolving = Boolean(resolveKey) && resolution?.key !== resolveKey;
+
+  useEffect(() => {
+    if (!resolveKey) return;
+    let live = true;
+    fetch(`/api/cctv/resolve?url=${encodeURIComponent(resolveKey)}`)
+      .then(r => r.json())
+      .then(d => { if (live) setResolution({ key: resolveKey, embed: d?.embeddable ? d.embedUrl : null }); })
+      // A resolver failure is not a broken camera — it falls back to the link.
+      .catch(() => { if (live) setResolution({ key: resolveKey, embed: null }); });
+    return () => { live = false; };
+  }, [resolveKey]);
+
+  const streamType = resolvedEmbed ? 'iframe' : (camera?.stream_type || 'jpg');
+  const streamUrl: string | undefined = resolvedEmbed || camera?.stream_url;
+  const view = offPlatformView({ hostedOffPlatform, resolving, resolvedEmbed });
+  const externalOnly = view !== 'inline';
 
   useEffect(() => {
     if (!camera) return;
@@ -82,7 +117,7 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
       return;
     }
 
-    if ((streamType === 'iframe' || streamType === 'mp4') && camera.stream_url) {
+    if ((streamType === 'iframe' || streamType === 'mp4') && streamUrl) {
       setLoading(false);
       return;
     }
@@ -96,7 +131,7 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
       setError(true);
       setLoading(false);
     }
-  }, [camera, streamType, externalOnly, retryCount]);
+  }, [camera, streamType, streamUrl, externalOnly, retryCount]);
 
   // Auto-refresh for JPGs
   useEffect(() => {
@@ -211,7 +246,13 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
               </div>
             )}
 
-            {externalOnly ? (
+            {view === 'resolving' ? (
+              <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/90 z-30 backdrop-blur-sm p-4 text-center">
+                <div className="w-6 h-6 border-2 border-t-transparent rounded-full animate-spin mb-3" style={{ borderColor: 'var(--gold-dim)', borderTopColor: 'transparent' }} />
+                <p className="text-[11px] font-mono uppercase tracking-widest" style={{ color: 'var(--gold-primary)' }}>ACQUIRING UPLINK</p>
+                <p className="text-[9px] font-mono text-[var(--text-muted)] mt-2 uppercase">Locating a direct feed</p>
+              </div>
+            ) : view === 'external' ? (
               <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/90 z-30 backdrop-blur-sm p-4 text-center">
                 <ExternalLink className="w-6 h-6 mb-3 opacity-50" style={{ color: 'var(--gold-primary)' }} />
                 <p className="text-[11px] font-mono uppercase tracking-widest" style={{ color: 'var(--gold-primary)' }}>SECURE FEED ENCRYPTED</p>
@@ -262,9 +303,9 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
                 playsInline
                 loop
               />
-            ) : streamType === 'iframe' && camera.stream_url ? (
+            ) : streamType === 'iframe' && streamUrl ? (
               <iframe
-                src={camera.stream_url}
+                src={streamUrl}
                 className="w-full h-full border-0"
                 allow="autoplay; fullscreen"
                 allowFullScreen
@@ -305,7 +346,7 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
                 <div className="flex flex-col">
                   <span className="text-[9px] text-[var(--text-muted)] font-mono tracking-widest">FEED TYPE</span>
                   <span className="text-[9px] text-white font-mono tracking-widest uppercase">
-                    {externalOnly ? 'EXTERNAL' : streamType}
+                    {externalOnly ? 'EXTERNAL' : resolvedEmbed ? 'YOUTUBE LIVE' : streamType}
                   </span>
                 </div>
                 <div className="flex flex-col border-l border-white/10 pl-4">

--- a/src/lib/skyline.test.ts
+++ b/src/lib/skyline.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { isSkylineUrl, extractYouTubeId, youtubeEmbedUrl, parseSkylinePage, isHostedOffPlatform, needsResolution, offPlatformView } from './skyline';
+
+/** Trimmed from the real Yubatake page, which is what this parses in production. */
+const YUBATAKE = `<script>function onYouTubeIframeAPIReady(){player=new YT.Player('live',{playerVars:{autoplay:1,controls:1,hl:'en'},height:'100%',width:'100%',videoId:'GrEEoEmmrKs',host:'https://www.youtube-nocookie.com',events:{'onReady':onPlayerReady}});}</script>`;
+
+describe('isSkylineUrl', () => {
+  it('accepts the site and its subdomains', () => {
+    expect(isSkylineUrl('https://www.skylinewebcams.com/en/webcam/japan/gunma/yubatake/yubatake.html')).toBe(true);
+    expect(isSkylineUrl('https://skylinewebcams.com/x.html')).toBe(true);
+  });
+
+  it('compares the host, not the string', () => {
+    // Every one of these contains the allowed host as a substring.
+    expect(isSkylineUrl('https://evil.com/?x=skylinewebcams.com')).toBe(false);
+    expect(isSkylineUrl('https://skylinewebcams.com.evil.com/x')).toBe(false);
+    expect(isSkylineUrl('https://notskylinewebcams.com/x')).toBe(false);
+  });
+
+  it('rejects anything that is not a URL', () => {
+    expect(isSkylineUrl('')).toBe(false);
+    expect(isSkylineUrl('yubatake.html')).toBe(false);
+  });
+});
+
+describe('extractYouTubeId', () => {
+  it('reads the id out of the IFrame API bootstrap', () => {
+    expect(extractYouTubeId(YUBATAKE)).toBe('GrEEoEmmrKs');
+  });
+
+  it('falls back to a direct embed URL', () => {
+    expect(extractYouTubeId('<iframe src="https://www.youtube-nocookie.com/embed/eU8A7QQOcso?rel=0">')).toBe('eU8A7QQOcso');
+    expect(extractYouTubeId('<iframe src="https://www.youtube.com/embed/YQ4wbAl_7zo">')).toBe('YQ4wbAl_7zo');
+  });
+
+  it('accepts double-quoted ids', () => {
+    expect(extractYouTubeId('videoId: "GrEEoEmmrKs"')).toBe('GrEEoEmmrKs');
+  });
+
+  it('rejects a capture that is not an id, rather than passing it through', () => {
+    // This value ends up interpolated into a URL the browser loads.
+    expect(extractYouTubeId(`videoId:'../../evil'`)).toBeNull();
+    expect(extractYouTubeId(`videoId:'short'`)).toBeNull();
+    expect(extractYouTubeId(`videoId:'waytoolongtobeanid'`)).toBeNull();
+    expect(extractYouTubeId(`videoId:'has space!!'`)).toBeNull();
+  });
+
+  it('returns null when there is no player at all', () => {
+    expect(extractYouTubeId('<html><body>no camera here</body></html>')).toBeNull();
+  });
+});
+
+describe('youtubeEmbedUrl', () => {
+  it('builds a muted autoplaying nocookie embed', () => {
+    const url = new URL(youtubeEmbedUrl('GrEEoEmmrKs'));
+    expect(url.hostname).toBe('www.youtube-nocookie.com');
+    expect(url.pathname).toBe('/embed/GrEEoEmmrKs');
+    // Autoplay only survives muted, and a wall of cameras must not make noise.
+    expect(url.searchParams.get('mute')).toBe('1');
+    expect(url.searchParams.get('autoplay')).toBe('1');
+    // Inline on iOS rather than hijacking the screen with the native player.
+    expect(url.searchParams.get('playsinline')).toBe('1');
+  });
+});
+
+describe('parseSkylinePage', () => {
+  it('resolves a YouTube-backed page', () => {
+    const feed = parseSkylinePage(YUBATAKE);
+    expect(feed).toMatchObject({ kind: 'youtube', videoId: 'GrEEoEmmrKs' });
+  });
+
+  it('reports SkylineWebcams-hosted HLS without trying to serve it', () => {
+    const feed = parseSkylinePage(`<script>src:"https://cdn.skylinewebcams.com/live/xyz/livee.m3u8"</script>`);
+    expect(feed).toEqual({ kind: 'hls' });
+  });
+
+  it('prefers YouTube when a page carries both', () => {
+    expect(parseSkylinePage(YUBATAKE + '<script>"live.m3u8"</script>').kind).toBe('youtube');
+  });
+
+  it('reports unknown for a page with neither', () => {
+    expect(parseSkylinePage('<html>offline</html>')).toEqual({ kind: 'unknown' });
+  });
+});
+
+describe('needsResolution', () => {
+  const SKY = 'https://www.skylinewebcams.com/en/webcam/japan/gunma/yubatake/yubatake.html';
+
+  it('resolves a camera we hold nothing but a Skyline link for', () => {
+    expect(needsResolution({ external_url: SKY })).toBe(true);
+  });
+
+  it('leaves a camera alone when it already has a playable feed', () => {
+    // Resolving these would trade a working stream for a round-trip.
+    expect(needsResolution({ external_url: SKY, stream_url: 'https://x/live.m3u8' })).toBe(false);
+    expect(needsResolution({ external_url: SKY, feed_url: 'https://x/snap.jpg' })).toBe(false);
+  });
+
+  it('leaves other operators alone — this resolver only knows one site', () => {
+    expect(needsResolution({ external_url: 'https://www.windy.com/webcams/12345' })).toBe(false);
+  });
+
+  it('is safe on a missing or empty camera', () => {
+    expect(needsResolution(null)).toBe(false);
+    expect(needsResolution(undefined)).toBe(false);
+    expect(needsResolution({})).toBe(false);
+  });
+
+  it('separates hosted-off-platform from resolvable', () => {
+    // Windy is off-platform, we just cannot open it. Both facts matter: the
+    // viewer shows the external panel for it, but must not call the resolver.
+    const windy = { external_url: 'https://www.windy.com/webcams/12345' };
+    expect(isHostedOffPlatform(windy)).toBe(true);
+    expect(needsResolution(windy)).toBe(false);
+  });
+});
+
+// Live integration test — opt in with RUN_LIVE_TESTS=1 (hits the real site).
+const liveIt = process.env.RUN_LIVE_TESTS === '1' ? it : it.skip;
+
+describe('skyline resolution (live)', () => {
+  liveIt('resolves the Yubatake page to a playable YouTube id', async () => {
+    const res = await fetch('https://www.skylinewebcams.com/en/webcam/japan/gunma/yubatake/yubatake.html', {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; OSIRIS/1.0)' },
+      signal: AbortSignal.timeout(15000),
+    });
+    expect(res.ok).toBe(true);
+    const feed = parseSkylinePage(await res.text());
+    expect(feed.kind).toBe('youtube');
+
+    // The id must be one YouTube will actually serve — a stale or malformed id
+    // is exactly the failure this resolver exists to avoid.
+    if (feed.kind === 'youtube') {
+      const oe = await fetch(`https://www.youtube.com/oembed?url=https%3A//www.youtube.com/watch%3Fv%3D${feed.videoId}&format=json`);
+      expect(oe.status).toBe(200);
+    }
+  });
+});
+
+describe('offPlatformView', () => {
+  const v = (o: Partial<Parameters<typeof offPlatformView>[0]>) =>
+    offPlatformView({ hostedOffPlatform: true, resolving: false, resolvedEmbed: null, ...o });
+
+  it('plays a camera that has its own feed, without consulting anything', () => {
+    expect(v({ hostedOffPlatform: false })).toBe('inline');
+  });
+
+  it('shows the resolving state while looking, not the external panel', () => {
+    // Otherwise a camera that is about to play inline flashes up 'requires
+    // external clearance' first, which reads as a failure.
+    expect(v({ resolving: true })).toBe('resolving');
+  });
+
+  it('plays inline once a feed is found', () => {
+    expect(v({ resolvedEmbed: 'https://www.youtube-nocookie.com/embed/GrEEoEmmrKs' })).toBe('inline');
+  });
+
+  it('falls back to the external link when nothing was found', () => {
+    expect(v({ resolving: false, resolvedEmbed: null })).toBe('external');
+  });
+
+  it('prefers a found feed over a still-running lookup', () => {
+    // Both true is reachable: resolvedEmbed lands before `resolving` clears.
+    expect(v({ resolving: true, resolvedEmbed: 'https://x/embed/y' })).toBe('inline');
+  });
+});

--- a/src/lib/skyline.ts
+++ b/src/lib/skyline.ts
@@ -1,0 +1,135 @@
+/**
+ * OSIRIS — SkylineWebcams feed resolution
+ *
+ * SkylineWebcams cameras arrive in our dataset carrying only an `external_url`,
+ * so the viewer renders them as "this feed requires external clearance" plus a
+ * link off-platform. For most of them that is unnecessary. The page is a thin
+ * wrapper around a public YouTube livestream published by the camera's actual
+ * operator — a town office, a regional broadcaster — and that stream embeds
+ * anywhere.
+ *
+ * Measured across all 601 SkylineWebcams cameras in the dataset:
+ *
+ *   390 (65%)  wrap a YouTube livestream   embeddable
+ *   181 (30%)  SkylineWebcams' own HLS     left external
+ *    30 ( 5%)  neither                     left external
+ *
+ * Japan, which prompted this, is 154 of 157.
+ *
+ * Resolving to YouTube also sends the viewer to the original broadcaster rather
+ * than to an aggregator that reposted them: the Yubatake camera is Kusatsu
+ * town's own stream, the Kawaguchiko one is UTY Yamanashi's.
+ *
+ * The HLS group is deliberately left alone. Those streams are SkylineWebcams'
+ * own product, served through their player behind hotlink protection. Lifting
+ * the manifest out would be fragile and would be taking someone else's content.
+ */
+
+const SKYLINE_HOST = 'skylinewebcams.com';
+
+/** YouTube video ids are exactly 11 characters of [A-Za-z0-9_-]. */
+const YOUTUBE_ID = /^[A-Za-z0-9_-]{11}$/;
+
+export type SkylineFeed =
+  | { kind: 'youtube'; videoId: string; embedUrl: string }
+  | { kind: 'hls' }
+  | { kind: 'unknown' };
+
+/**
+ * Host comparison, not a substring test. "https://evil.com/?skylinewebcams.com"
+ * passes a substring check, and this value decides what the resolver is willing
+ * to fetch.
+ */
+export function isSkylineUrl(url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return host === SKYLINE_HOST || host.endsWith('.' + SKYLINE_HOST);
+}
+
+/**
+ * Pulls the video id out of the page's YouTube IFrame API bootstrap, which
+ * looks like `YT.Player('live',{...,videoId:'GrEEoEmmrKs',...})`.
+ *
+ * Falls back to a direct embed URL, since not every page uses the JS player.
+ * The id is shape-checked either way — an unvalidated capture here would end up
+ * interpolated into a URL the browser then loads.
+ */
+export function extractYouTubeId(html: string): string | null {
+  const patterns = [
+    /videoId\s*:\s*['"]([^'"]+)['"]/,
+    /youtube(?:-nocookie)?\.com\/embed\/([A-Za-z0-9_-]{11})/,
+  ];
+  for (const re of patterns) {
+    const id = html.match(re)?.[1];
+    if (id && YOUTUBE_ID.test(id)) return id;
+  }
+  return null;
+}
+
+/** Privacy-preserving host, and the one the source page itself uses. */
+export function youtubeEmbedUrl(videoId: string): string {
+  const params = new URLSearchParams({
+    autoplay: '1',
+    mute: '1',
+    playsinline: '1',
+    rel: '0',
+    modestbranding: '1',
+    iv_load_policy: '3',
+  });
+  return `https://www.youtube-nocookie.com/embed/${videoId}?${params.toString()}`;
+}
+
+export function parseSkylinePage(html: string): SkylineFeed {
+  const videoId = extractYouTubeId(html);
+  if (videoId) return { kind: 'youtube', videoId, embedUrl: youtubeEmbedUrl(videoId) };
+  // Their own stream. Reachable, but not ours to re-serve.
+  if (/\.m3u8/i.test(html)) return { kind: 'hls' };
+  return { kind: 'unknown' };
+}
+
+/** The fields the viewer uses to decide how to play a camera. */
+export interface ResolvableCamera {
+  external_url?: string;
+  feed_url?: string;
+  stream_url?: string;
+}
+
+/**
+ * True when the only thing we hold for a camera is a link to somebody else's
+ * page — nothing that can be rendered in place.
+ */
+export function isHostedOffPlatform(camera: ResolvableCamera | null | undefined): boolean {
+  return Boolean(camera?.external_url && !camera.feed_url && !camera.stream_url);
+}
+
+/**
+ * True when that link is one we know how to open up. A camera that already has
+ * a playable stream is left alone: resolving it would trade a working feed for
+ * a network round-trip.
+ */
+export function needsResolution(camera: ResolvableCamera | null | undefined): boolean {
+  return isHostedOffPlatform(camera) && isSkylineUrl(camera!.external_url!);
+}
+
+/**
+ * Which state the viewer paints for a camera we hold no local feed for.
+ *
+ *   'resolving' — looking for a direct feed. Shown instead of the external
+ *                 panel so a camera that is about to play inline does not
+ *                 first flash up 'requires external clearance'.
+ *   'external'  — no direct feed. The off-platform link, as before.
+ *   'inline'    — play it here.
+ */
+export function offPlatformView(state: {
+  hostedOffPlatform: boolean;
+  resolving: boolean;
+  resolvedEmbed: string | null;
+}): 'resolving' | 'external' | 'inline' {
+  if (!state.hostedOffPlatform) return 'inline';
+  if (state.resolvedEmbed) return 'inline';
+  return state.resolving ? 'resolving' : 'external';
+}


### PR DESCRIPTION
Every SkylineWebcams camera in the dataset carries only an `external_url`, so the viewer showed **SECURE FEED ENCRYPTED — this feed requires external clearance** and a link off-platform. For most of them that was unnecessary.

**4 files, +462 / −8.** One new tested module, 23 new tests.

## What those pages actually are

The page is a wrapper around a public YouTube livestream published by the camera's *actual operator*. The Yubatake page boots:

```js
YT.Player('live', { videoId:'GrEEoEmmrKs', host:'https://www.youtube-nocookie.com' })
```

That stream belongs to **草津町公式YouTubeチャンネル** — Kusatsu Town's own channel. The Kawaguchiko camera belongs to **UTYテレビ山梨**, a regional broadcaster. So resolving to YouTube doesn't just avoid the external link, it points at the original broadcaster instead of an aggregator that reposted them.

## Measured, not sampled

All **601** SkylineWebcams cameras in the dataset were probed:

| | count | share | result |
|---|---:|---:|---|
| Wrap a YouTube livestream | 390 | 65% | **now play inline** |
| SkylineWebcams' own HLS | 181 | 30% | left as an external link |
| Neither | 30 | 5% | left as an external link |

Japan, which prompted this, is **154 of 157**.

The HLS group is deliberately untouched. Those streams are SkylineWebcams' own product, served through their player behind hotlink protection — lifting the manifest out would be fragile, and would be taking their content rather than the broadcaster's.

## Resolved at runtime, not baked in

The video id is read when a camera is opened rather than written into the generated camera data. These are long-running livestreams, and **a stream that restarts comes back under a new id** — a baked id would work until it silently didn't, and the failure would look like a broken camera rather than stale data. A short-lived server cache keeps the cost to one request per camera.

Three cache lifetimes, because these are three different facts: a resolved id is stable for a while, "this page has no embeddable feed" is a property of the page, and a network failure says nothing about the page at all. Caching that last one as long as a real answer turns one blip into minutes of a working camera looking dead.

## Shape

`src/lib/skyline.ts` holds the parsing and the decisions as pure functions. The route is a thin fetch around them, and the viewer is a thin adapter — the branch it paints comes from `offPlatformView()`, so the logic that runs is the logic under test.

Resolution state is **keyed by the URL it belongs to**. That is what makes switching cameras safe: a reply arriving late carries the previous key and is simply not read, instead of painting the last camera's stream into the current one. It also means neither the loading flag nor the reset is written back into state — both fall out of the key comparison at render.

While resolving, the viewer shows `ACQUIRING UPLINK` rather than the external panel, so a camera about to play inline doesn't first flash a message that reads as a failure.

## Verified

End to end through the real flow — resolve, then confirm YouTube actually serves it via the IFrame Player API, which reports error 101/150 when a video may not be embedded:

```
Yubatake (the reported camera)  GrEEoEmmrKs   plays, live
Mt Fuji / Fujikawaguchiko       eU8A7QQOcso   plays, live
Enoshima, Kanagawa              ESsZ9iB7tz0   plays, live
Amakusa, Kumamoto               HfSrh4sZf1U   plays, live
Lake Yamanakako                 Gn2CJjzY068   plays, live
Shanghai skyline                hls  ->  stays external
```

Plus 25/25 Japan cameras through the endpoint. The host allowlist rejects spoofed hosts (`evil.com/?x=skylinewebcams.com`, `skylinewebcams.com.evil.com`), other operators, and private-range targets with 400 **before any fetch is made**.

**304 tests pass**, up from 281. Typecheck clean, production build compiles, and lint on `CameraViewer` is identical to its baseline — no new problems.

## Not verified

**The viewer rendering itself.** Camera markers are map features, so opening one needs a painted map, which doesn't happen in a headless pane. The branch decision is covered by tests rather than left as untested JSX, but the pixels want a real browser.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
