### PR TITLE
feat(cctv): play YouTube-backed cameras, and stop mislabelling the rest

### DIFF
--- a/src/app/api/cctv/resolve/route.ts
+++ b/src/app/api/cctv/resolve/route.ts
@@ -1,21 +1,30 @@
 import { NextResponse } from 'next/server';
 import { safeFetch } from '@/lib/ssrf-guard';
 import { isSkylineUrl, parseSkylinePage } from '@/lib/skyline';
+import { extractYouTubeId, isYouTubeUrl, parseYouTubeUrl, youtubeEmbedUrl } from '@/lib/youtube';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 15;
 
 /**
- * Resolves a SkylineWebcams page to something the viewer can embed.
+ * Resolves a camera's external link to something the viewer can embed.
  *
- * Most of these pages are a wrapper around a public YouTube livestream from the
- * camera's actual operator, so the viewer can show the feed inline instead of
- * sending the operator off-platform. See src/lib/skyline.ts for the breakdown
- * and for why the HLS-backed ones are left alone.
+ * Two providers need a lookup:
  *
- * The video id is read live rather than baked into the camera data: these are
- * long-running livestreams, and a stream that restarts comes back under a new
- * id. A baked id would work until it silently didn't.
+ *   SkylineWebcams pages — mostly a wrapper around a public YouTube livestream
+ *     from the camera's actual operator. See src/lib/skyline.ts for the
+ *     breakdown, and for why the HLS-backed ones are left alone.
+ *
+ *   YouTube channel "/live" links — these name a channel, not a broadcast, so
+ *     only the page can say what is on air right now.
+ *
+ * A link that already names a video never reaches here: the viewer builds that
+ * embed itself (see localEmbed), because asking a server to repeat what the URL
+ * already says would add a round-trip and a failure mode for nothing.
+ *
+ * Nothing is baked into the camera data. These are long-running livestreams,
+ * and one that restarts comes back under a new id — a baked id would work until
+ * it silently didn't, and would fail looking like a broken camera.
  */
 
 // Three different lifetimes, because these are three different facts.
@@ -30,7 +39,7 @@ const MAX_ENTRIES = 1000;
 
 type Resolution =
   | { embeddable: true; kind: 'youtube'; videoId: string; embedUrl: string }
-  | { embeddable: false; kind: 'hls' | 'unknown' | 'unreachable' };
+  | { embeddable: false; kind: 'hls' | 'offline' | 'missing' | 'unknown' | 'unreachable' };
 
 const cache = new Map<string, { at: number; ttl: number; value: Resolution }>();
 
@@ -45,8 +54,8 @@ function cached(url: string): Resolution | null {
 }
 
 function remember(url: string, value: Resolution) {
-  // Only Skyline URLs reach this, so the key space is bounded by their site —
-  // but bound it here too rather than trusting that to stay true.
+  // Only allowlisted hosts reach this, so the key space is bounded by their
+  // sites — but bound it here too rather than trusting that to stay true.
   if (cache.size >= MAX_ENTRIES) {
     const oldest = cache.keys().next().value;
     if (oldest !== undefined) cache.delete(oldest);
@@ -57,14 +66,23 @@ function remember(url: string, value: Resolution) {
   cache.set(url, { at: Date.now(), ttl, value });
 }
 
+/**
+ * The host allowlist, and the only thing keeping this from being a
+ * fetch-anything route. A YouTube URL is additionally required to be a channel
+ * live link — the shapes that name a video are handled without a request, so
+ * accepting them here would only widen what this route will go and load.
+ */
+function isResolvable(url: string): boolean {
+  if (isSkylineUrl(url)) return true;
+  return isYouTubeUrl(url) && parseYouTubeUrl(url)?.kind === 'live-channel';
+}
+
 export async function GET(req: Request) {
   const url = new URL(req.url).searchParams.get('url');
 
-  // The host allowlist is what keeps this from being a fetch-anything route:
-  // it can only ever retrieve pages from skylinewebcams.com.
-  if (!url || !isSkylineUrl(url)) {
+  if (!url || !isResolvable(url)) {
     return NextResponse.json(
-      { embeddable: false, kind: 'unknown', reason: 'not_skyline' },
+      { embeddable: false, kind: 'unknown', reason: 'not_resolvable' },
       { status: 400 },
     );
   }
@@ -84,13 +102,28 @@ export async function GET(req: Request) {
       },
     });
 
-    if (!res.ok) {
+    if (res.status === 404 || res.status === 410) {
+      // The camera was withdrawn from the source. Durable, unlike a network
+      // failure, and worth distinguishing: otherwise the viewer offers a link
+      // to a page that is not there.
+      value = { embeddable: false, kind: 'missing' };
+    } else if (!res.ok) {
       value = { embeddable: false, kind: 'unreachable' };
     } else {
-      const feed = parseSkylinePage(await res.text());
-      value = feed.kind === 'youtube'
-        ? { embeddable: true, kind: 'youtube', videoId: feed.videoId, embedUrl: feed.embedUrl }
-        : { embeddable: false, kind: feed.kind };
+      const html = await res.text();
+      if (isSkylineUrl(url)) {
+        const feed = parseSkylinePage(html);
+        value = feed.kind === 'youtube'
+          ? { embeddable: true, kind: 'youtube', videoId: feed.videoId, embedUrl: feed.embedUrl }
+          : { embeddable: false, kind: feed.kind };
+      } else {
+        // A channel live page. Off air, there is no video id to find, which is
+        // a real answer about the page rather than a failure.
+        const videoId = extractYouTubeId(html);
+        value = videoId
+          ? { embeddable: true, kind: 'youtube', videoId, embedUrl: youtubeEmbedUrl(videoId) }
+          : { embeddable: false, kind: 'unknown' };
+      }
     }
   } catch (err) {
     // A resolver failure must not look like "this camera is broken" — the

--- a/src/components/CameraViewer.tsx
+++ b/src/components/CameraViewer.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, ExternalLink, RefreshCw, MapPin, Camera, Maximize2 } from 'lucide-react';
+import { X, ExternalLink, RefreshCw, MapPin, Camera, CameraOff, Maximize2, PlayCircle } from 'lucide-react';
 import Hls from 'hls.js';
-import { isHostedOffPlatform, needsResolution, offPlatformView } from '@/lib/skyline';
+import { isHostedOffPlatform, liveFeedAtSource, localEmbed, needsResolution, offPlatformView } from '@/lib/camera-feed';
 
 interface CameraViewerProps {
   camera: any | null;
@@ -51,25 +51,36 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
    * nor the reset needs to be written back into state — both fall out of the
    * key comparison at render.
    */
-  const resolveKey: string | null = needsResolution(camera) ? camera.external_url : null;
-  const [resolution, setResolution] = useState<{ key: string; embed: string | null } | null>(null);
-  const resolvedEmbed = resolution && resolution.key === resolveKey ? resolution.embed : null;
+  // A link that already names the video needs no lookup at all.
+  const directEmbed = localEmbed(camera);
+  // Snapshot cameras are checked too, in the background: the picture shows
+  // immediately and is withdrawn only if the source says the camera is gone.
+  const resolveKey: string | null =
+    (needsResolution(camera) ? camera.external_url : null) ?? liveFeedAtSource(camera);
+  const [resolution, setResolution] = useState<{ key: string; embed: string | null; offline: boolean; kind?: string } | null>(null);
+  const resolvedEmbed = directEmbed ?? (resolution && resolution.key === resolveKey ? resolution.embed : null);
   const resolving = Boolean(resolveKey) && resolution?.key !== resolveKey;
+  const offline = resolution?.key === resolveKey && resolution.offline;
+  const gone = resolution?.key === resolveKey && resolution.kind === 'missing';
+
+  // Live video exists at the source but cannot be replayed here, so offer the
+  // way through to it and stop calling the still image a live feed.
+  const watchLiveUrl = liveFeedAtSource(camera);
 
   useEffect(() => {
     if (!resolveKey) return;
     let live = true;
     fetch(`/api/cctv/resolve?url=${encodeURIComponent(resolveKey)}`)
       .then(r => r.json())
-      .then(d => { if (live) setResolution({ key: resolveKey, embed: d?.embeddable ? d.embedUrl : null }); })
+      .then(d => { if (live) setResolution({ key: resolveKey, embed: d?.embeddable ? d.embedUrl : null, offline: d?.kind === 'offline' || d?.kind === 'missing', kind: d?.kind }); })
       // A resolver failure is not a broken camera — it falls back to the link.
-      .catch(() => { if (live) setResolution({ key: resolveKey, embed: null }); });
+      .catch(() => { if (live) setResolution({ key: resolveKey, embed: null, offline: false }); });
     return () => { live = false; };
   }, [resolveKey]);
 
   const streamType = resolvedEmbed ? 'iframe' : (camera?.stream_type || 'jpg');
   const streamUrl: string | undefined = resolvedEmbed || camera?.stream_url;
-  const view = offPlatformView({ hostedOffPlatform, resolving, resolvedEmbed });
+  const view = offPlatformView({ hostedOffPlatform, resolving, resolvedEmbed, offline });
   const externalOnly = view !== 'inline';
 
   useEffect(() => {
@@ -252,6 +263,14 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
                 <p className="text-[11px] font-mono uppercase tracking-widest" style={{ color: 'var(--gold-primary)' }}>ACQUIRING UPLINK</p>
                 <p className="text-[9px] font-mono text-[var(--text-muted)] mt-2 uppercase">Locating a direct feed</p>
               </div>
+            ) : view === 'offline' ? (
+              <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/90 z-30 backdrop-blur-sm p-4 text-center">
+                <CameraOff className="w-6 h-6 mb-3 opacity-50 text-[var(--text-muted)]" />
+                <p className="text-[11px] font-mono uppercase tracking-widest text-[var(--text-secondary)]">{gone ? 'CAMERA WITHDRAWN' : 'CAMERA OFFLINE'}</p>
+                <p className="text-[9px] font-mono text-[var(--text-muted)] mt-2 max-w-[80%] uppercase">{gone ? 'No longer published at source' : 'The operator has this feed off air'}</p>
+                {/* No ACCESS TERMINAL button: the page it would open is either
+                    showing the same 'offline' banner we just read, or a 404. */}
+              </div>
             ) : view === 'external' ? (
               <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/90 z-30 backdrop-blur-sm p-4 text-center">
                 <ExternalLink className="w-6 h-6 mb-3 opacity-50" style={{ color: 'var(--gold-primary)' }} />
@@ -325,9 +344,23 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
               <div className="absolute top-3 left-3 flex items-center gap-2 bg-black/80 border border-[var(--gold-primary)]/50 px-2 py-1 shadow-[0_0_10px_rgba(0,0,0,0.8)]">
                 <div className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse shadow-[0_0_8px_#ef4444]" />
                 <span className="text-[9px] font-mono text-white tracking-[0.2em]">
-                  {streamType === 'jpg' ? 'LIVE SAT-LINK' : 'LIVE FEED'}
+                  {watchLiveUrl ? 'SNAPSHOT' : streamType === 'jpg' ? 'LIVE SAT-LINK' : 'LIVE FEED'}
                 </span>
               </div>
+            )}
+
+            {/* Live video is on the operator's own page; this is the way to it. */}
+            {watchLiveUrl && !error && !externalOnly && (
+              <a
+                href={watchLiveUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="absolute bottom-3 right-3 z-30 flex items-center gap-1.5 px-3 py-1.5 rounded-sm border text-[10px] font-mono font-bold tracking-widest transition-all hover:bg-[var(--gold-primary)]/25"
+                style={{ borderColor: 'var(--gold-primary)', color: 'var(--gold-primary)', background: 'rgba(0,0,0,0.75)' }}
+                title="Live video is hosted by the camera operator — opens their page"
+              >
+                <PlayCircle className="w-3 h-3" /> WATCH LIVE
+              </a>
             )}
 
             {/* Tactical Crosshairs */}
@@ -346,19 +379,21 @@ export default function CameraViewer({ camera, onClose, onLocate }: CameraViewer
                 <div className="flex flex-col">
                   <span className="text-[9px] text-[var(--text-muted)] font-mono tracking-widest">FEED TYPE</span>
                   <span className="text-[9px] text-white font-mono tracking-widest uppercase">
-                    {externalOnly ? 'EXTERNAL' : resolvedEmbed ? 'YOUTUBE LIVE' : streamType}
+                    {view === 'offline' ? (gone ? 'WITHDRAWN' : 'OFFLINE') : watchLiveUrl ? 'SNAPSHOT' : externalOnly ? 'EXTERNAL' : resolvedEmbed ? 'YOUTUBE LIVE' : streamType}
                   </span>
                 </div>
                 <div className="flex flex-col border-l border-white/10 pl-4">
                   <span className="text-[9px] text-[var(--text-muted)] font-mono tracking-widest">STATUS</span>
                   {/* Nothing is being received locally for an external feed — don't claim otherwise. */}
                   <span className={`text-[9px] font-mono tracking-widest ${externalOnly ? 'text-[var(--gold-primary)]' : 'text-[var(--alert-green)]'}`}>
-                    {externalOnly ? 'HOSTED OFF-PLATFORM' : 'ACTIVE / RECORDING'}
+                    {view === 'offline' ? (gone ? 'REMOVED BY SOURCE' : 'OFF AIR AT SOURCE') : watchLiveUrl ? 'LIVE VIDEO AT SOURCE' : externalOnly ? 'HOSTED OFF-PLATFORM' : 'ACTIVE / RECORDING'}
                   </span>
                 </div>
               </div>
               <div className="flex gap-3">
-                {(camera.feed_url || camera.external_url || (streamType === 'iframe' && camera.stream_url)) && (
+                {/* A withdrawn camera's page is a 404 — the big button is already
+                    hidden for it, and this link would lead to the same dead page. */}
+                {!gone && (camera.feed_url || camera.external_url || (streamType === 'iframe' && camera.stream_url)) && (
                   <a href={camera.external_url || camera.feed_url || (streamType === 'iframe' ? camera.stream_url : undefined)} target="_blank" rel="noopener noreferrer"
                     className="flex items-center gap-1.5 px-2 py-1 bg-white/5 hover:bg-white/10 border border-white/10 transition-colors text-[9px] font-mono text-[var(--gold-primary)] tracking-widest">
                     <ExternalLink className="w-2.5 h-2.5" /> RAW FEED

--- a/src/lib/camera-feed.test.ts
+++ b/src/lib/camera-feed.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { isHostedOffPlatform, liveFeedAtSource, localEmbed, needsResolution, offPlatformView } from './camera-feed';
+
+const SKY = 'https://www.skylinewebcams.com/en/webcam/japan/gunma/yubatake/yubatake.html';
+const WATCH = 'https://www.youtube.com/watch?v=UemFRPrl1hk';
+const CHANNEL_LIVE = 'https://www.youtube.com/@AaronPreslin/live';
+
+describe('isHostedOffPlatform', () => {
+  it('is true only when we hold nothing but a link', () => {
+    expect(isHostedOffPlatform({ external_url: SKY })).toBe(true);
+    expect(isHostedOffPlatform({ external_url: SKY, stream_url: 'https://x/live.m3u8' })).toBe(false);
+    expect(isHostedOffPlatform({ external_url: SKY, feed_url: 'https://x/snap.jpg' })).toBe(false);
+  });
+
+  it('is safe on a missing or empty camera', () => {
+    expect(isHostedOffPlatform(null)).toBe(false);
+    expect(isHostedOffPlatform(undefined)).toBe(false);
+    expect(isHostedOffPlatform({})).toBe(false);
+  });
+});
+
+describe('localEmbed', () => {
+  it('builds an embed from a link that already names the video', () => {
+    // No round-trip: the URL carries everything needed.
+    expect(localEmbed({ external_url: WATCH })).toContain('/embed/UemFRPrl1hk');
+    expect(localEmbed({ external_url: 'https://youtu.be/GrEEoEmmrKs' })).toContain('/embed/GrEEoEmmrKs');
+  });
+
+  it('cannot answer for a channel link, which names no video', () => {
+    expect(localEmbed({ external_url: CHANNEL_LIVE })).toBeNull();
+  });
+
+  it('cannot answer for an operator page', () => {
+    expect(localEmbed({ external_url: SKY })).toBeNull();
+  });
+
+  it('leaves a camera alone when it already has a playable feed', () => {
+    expect(localEmbed({ external_url: WATCH, stream_url: 'https://x/y.m3u8' })).toBeNull();
+  });
+});
+
+describe('needsResolution', () => {
+  it('resolves an operator page', () => {
+    expect(needsResolution({ external_url: SKY })).toBe(true);
+  });
+
+  it('resolves a channel live link, whose video changes every broadcast', () => {
+    expect(needsResolution({ external_url: CHANNEL_LIVE })).toBe(true);
+  });
+
+  it('does not go to the network for a link that already names the video', () => {
+    // This is the point of localEmbed: asking a server to tell us what the URL
+    // already says would add a round-trip and a failure mode for nothing.
+    expect(needsResolution({ external_url: WATCH })).toBe(false);
+    expect(localEmbed({ external_url: WATCH })).not.toBeNull();
+  });
+
+  it('leaves a camera alone when it already has a playable feed', () => {
+    expect(needsResolution({ external_url: SKY, stream_url: 'https://x/live.m3u8' })).toBe(false);
+    expect(needsResolution({ external_url: SKY, feed_url: 'https://x/snap.jpg' })).toBe(false);
+  });
+
+  it('leaves operators we cannot open alone', () => {
+    // Off-platform and not resolvable are two different facts: the viewer shows
+    // the external panel for these, but must not call the resolver.
+    for (const url of [
+      'https://www.earthcam.com/usa/kentucky/covington/?cam=covington',
+      'https://voyage.aprr.fr/carte-itineraires?type=webcam',
+      'https://www.windy.com/webcams/12345',
+    ]) {
+      expect(isHostedOffPlatform({ external_url: url }), url).toBe(true);
+      expect(needsResolution({ external_url: url }), url).toBe(false);
+    }
+  });
+
+  it('is safe on a missing or empty camera', () => {
+    expect(needsResolution(null)).toBe(false);
+    expect(needsResolution(undefined)).toBe(false);
+    expect(needsResolution({})).toBe(false);
+  });
+});
+
+describe('offPlatformView', () => {
+  const v = (o: Partial<Parameters<typeof offPlatformView>[0]>) =>
+    offPlatformView({ hostedOffPlatform: true, resolving: false, resolvedEmbed: null, ...o });
+
+  it('plays a camera that has its own feed, without consulting anything', () => {
+    expect(v({ hostedOffPlatform: false })).toBe('inline');
+  });
+
+  it('shows the resolving state while looking, not the external panel', () => {
+    // Otherwise a camera that is about to play inline flashes up 'requires
+    // external clearance' first, which reads as a failure.
+    expect(v({ resolving: true })).toBe('resolving');
+  });
+
+  it('plays inline once a feed is found', () => {
+    expect(v({ resolvedEmbed: 'https://www.youtube-nocookie.com/embed/GrEEoEmmrKs' })).toBe('inline');
+  });
+
+  it('says a camera is off air rather than sending the operator after it', () => {
+    // 'external' would offer an ACCESS TERMINAL button leading to a page that
+    // is itself showing an offline banner — a wild goose chase.
+    expect(v({ offline: true })).toBe('offline');
+  });
+
+  it('still plays a feed that was found, even if offline was set', () => {
+    expect(v({ offline: true, resolvedEmbed: 'https://x/embed/y' })).toBe('inline');
+  });
+
+  it('reports resolving before offline, since the answer is not in yet', () => {
+    expect(v({ offline: true, resolving: true })).toBe('resolving');
+  });
+
+  it('treats a withdrawn camera the same as an off-air one', () => {
+    // Both mean "nothing to show and nowhere to send you". The viewer varies
+    // only the wording; offering a link would lead to a 404 or an offline page.
+    expect(v({ offline: true })).toBe('offline');
+  });
+
+  it('falls back to the external link when nothing was found', () => {
+    expect(v({ resolving: false, resolvedEmbed: null })).toBe('external');
+  });
+
+  it('shows a snapshot straight away, without waiting on the lookup', () => {
+    // The picture is already in hand; blocking it behind a network round-trip
+    // would make a working camera feel slower than before.
+    expect(v({ hostedOffPlatform: false, resolving: true })).toBe('inline');
+  });
+
+  it('withdraws a snapshot once the source says the camera is gone', () => {
+    // SkylineWebcams reuses its numeric snapshot ids. live341.jpg is captioned
+    // 'Rome - Trevi Fountain' in our data and currently shows a Canarian beach,
+    // because that camera was withdrawn and the id was reassigned.
+    expect(v({ hostedOffPlatform: false, offline: true })).toBe('offline');
+  });
+
+  it('prefers a found feed over a still-running lookup', () => {
+    // Both true is reachable: resolvedEmbed lands before `resolving` clears.
+    expect(v({ resolving: true, resolvedEmbed: 'https://x/embed/y' })).toBe('inline');
+  });
+});
+
+describe('liveFeedAtSource', () => {
+  const JPG = 'https://cdn.skylinewebcams.com/live5368.jpg';
+
+  it('offers the source page for a Skyline camera we only get stills from', () => {
+    // Cochabamba: a snapshot here, live video on their page behind a token,
+    // a watermark and an ad break. We link to it rather than reproduce it.
+    expect(liveFeedAtSource({ external_url: SKY, feed_url: JPG })).toBe(SKY);
+  });
+
+  it('offers nothing when the camera already plays here', () => {
+    // A resolved YouTube camera has no still and needs no way out.
+    expect(liveFeedAtSource({ external_url: SKY })).toBeNull();
+    expect(liveFeedAtSource({ external_url: SKY, feed_url: JPG, stream_url: 'https://x/y.m3u8' })).toBeNull();
+  });
+
+  it('does not claim live video exists behind other operators', () => {
+    // Only SkylineWebcams is known to keep a live stream behind the still.
+    expect(liveFeedAtSource({ external_url: 'https://www.earthcam.com/x', feed_url: JPG })).toBeNull();
+    expect(liveFeedAtSource({ external_url: 'https://voyage.aprr.fr/x', feed_url: JPG })).toBeNull();
+  });
+
+  it('is safe on a missing or empty camera', () => {
+    expect(liveFeedAtSource(null)).toBeNull();
+    expect(liveFeedAtSource(undefined)).toBeNull();
+    expect(liveFeedAtSource({})).toBeNull();
+    expect(liveFeedAtSource({ feed_url: JPG })).toBeNull();
+  });
+});

--- a/src/lib/camera-feed.ts
+++ b/src/lib/camera-feed.ts
@@ -1,0 +1,116 @@
+/**
+ * OSIRIS — how the camera viewer decides what to show
+ *
+ * Some cameras arrive with nothing but a link to somebody else's page. A few of
+ * those pages we know how to open up, so the feed can play in place instead of
+ * sending the operator off-platform. This module holds that decision, kept out
+ * of the component so the logic that runs is the logic under test.
+ *
+ * Two providers are resolvable today: SkylineWebcams pages, which wrap an
+ * operator's YouTube livestream, and YouTube links given directly.
+ */
+
+import { isSkylineUrl } from './skyline';
+import { isYouTubeUrl, parseYouTubeUrl, youtubeEmbedUrl } from './youtube';
+
+/** The fields the viewer uses to decide how to play a camera. */
+export interface ResolvableCamera {
+  external_url?: string;
+  feed_url?: string;
+  stream_url?: string;
+}
+
+/**
+ * True when the only thing we hold for a camera is a link to somebody else's
+ * page — nothing that can be rendered in place.
+ */
+export function isHostedOffPlatform(camera: ResolvableCamera | null | undefined): boolean {
+  return Boolean(camera?.external_url && !camera.feed_url && !camera.stream_url);
+}
+
+/**
+ * An embed URL we can produce without asking anyone.
+ *
+ * A link to a specific YouTube video already names the stream, so going to the
+ * network to be told what we can read off the URL would add a round-trip and a
+ * failure mode for nothing. Channel "/live" links are not this: they mean
+ * whatever that channel is broadcasting now, which only the page can answer.
+ */
+export function localEmbed(camera: ResolvableCamera | null | undefined): string | null {
+  if (!isHostedOffPlatform(camera)) return null;
+  const target = parseYouTubeUrl(camera!.external_url!);
+  return target?.kind === 'video' ? youtubeEmbedUrl(target.videoId) : null;
+}
+
+/**
+ * The URL of a live stream that exists at the source but that we can only send
+ * the operator to, never play here.
+ *
+ * SkylineWebcams cameras come in two shapes. Some are a wrapper around the
+ * operator's own YouTube livestream, and those we resolve and play (see
+ * skyline.ts). The rest — 250 of the 681 in the dataset — give us a periodic
+ * JPEG snapshot instead, while the live video stays on their page behind a
+ * per-request token, their watermark, and a pre-roll ad break. Reproducing
+ * that stream here would strip all three, so the honest move is a way through
+ * to it rather than a copy of it.
+ *
+ * The snapshot is still worth showing — measured refreshing about every 25
+ * seconds — so this offers the live feed alongside it rather than instead of
+ * it, and lets the viewer label the still as a snapshot rather than as live.
+ */
+export function liveFeedAtSource(camera: ResolvableCamera | null | undefined): string | null {
+  if (!camera?.external_url || !camera.feed_url || camera.stream_url) return null;
+  return isSkylineUrl(camera.external_url) ? camera.external_url : null;
+}
+
+/**
+ * True when the link needs a lookup before it can be played: a SkylineWebcams
+ * page, or a YouTube channel's live URL.
+ *
+ * A camera that already has a playable stream is left alone — resolving it
+ * would trade a working feed for a network round-trip.
+ */
+export function needsResolution(camera: ResolvableCamera | null | undefined): boolean {
+  if (!isHostedOffPlatform(camera)) return false;
+  if (localEmbed(camera)) return false;
+  const url = camera!.external_url!;
+  if (isSkylineUrl(url)) return true;
+  return isYouTubeUrl(url) && parseYouTubeUrl(url)?.kind === 'live-channel';
+}
+
+/**
+ * Which state the viewer paints for a camera we hold no local feed for.
+ *
+ *   'resolving' — looking for a direct feed. Shown instead of the external
+ *                 panel so a camera that is about to play inline does not
+ *                 first flash up 'requires external clearance'.
+ *   'offline'   — nothing to show, and nowhere to send the operator: the
+ *                 source says the camera is off air, or its page is gone.
+ *                 Distinct from 'external', which offers a link — here that
+ *                 link would lead to an offline banner or a 404.
+ *                 The viewer picks its wording from the resolved kind.
+ *   'external'  — no direct feed, but the page is live. The link, as before.
+ *   'inline'    — play it here.
+ */
+export function offPlatformView(state: {
+  hostedOffPlatform: boolean;
+  resolving: boolean;
+  resolvedEmbed: string | null;
+  offline?: boolean;
+}): 'resolving' | 'offline' | 'external' | 'inline' {
+  if (state.resolvedEmbed) return 'inline';
+
+  if (state.hostedOffPlatform) {
+    if (state.resolving) return 'resolving';
+    return state.offline ? 'offline' : 'external';
+  }
+
+  // The camera has a feed of its own — a snapshot — so show it straight
+  // away rather than waiting on a lookup. But drop it if the source says
+  // the camera is gone: SkylineWebcams reuses its numeric snapshot ids, so
+  // a withdrawn camera's still can quietly become a different place
+  // entirely. live341.jpg is captioned 'Rome - Trevi Fountain' here and
+  // currently shows a beach in the Canaries. A wrong picture under a
+  // confident label is worse than no picture.
+  return state.offline ? 'offline' : 'inline';
+}

--- a/src/lib/skyline.test.ts
+++ b/src/lib/skyline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isSkylineUrl, extractYouTubeId, youtubeEmbedUrl, parseSkylinePage, isHostedOffPlatform, needsResolution, offPlatformView } from './skyline';
+import { isSkylineUrl, parseSkylinePage } from './skyline';
 
 /** Trimmed from the real Yubatake page, which is what this parses in production. */
 const YUBATAKE = `<script>function onYouTubeIframeAPIReady(){player=new YT.Player('live',{playerVars:{autoplay:1,controls:1,hl:'en'},height:'100%',width:'100%',videoId:'GrEEoEmmrKs',host:'https://www.youtube-nocookie.com',events:{'onReady':onPlayerReady}});}</script>`;
@@ -23,95 +23,38 @@ describe('isSkylineUrl', () => {
   });
 });
 
-describe('extractYouTubeId', () => {
-  it('reads the id out of the IFrame API bootstrap', () => {
-    expect(extractYouTubeId(YUBATAKE)).toBe('GrEEoEmmrKs');
-  });
-
-  it('falls back to a direct embed URL', () => {
-    expect(extractYouTubeId('<iframe src="https://www.youtube-nocookie.com/embed/eU8A7QQOcso?rel=0">')).toBe('eU8A7QQOcso');
-    expect(extractYouTubeId('<iframe src="https://www.youtube.com/embed/YQ4wbAl_7zo">')).toBe('YQ4wbAl_7zo');
-  });
-
-  it('accepts double-quoted ids', () => {
-    expect(extractYouTubeId('videoId: "GrEEoEmmrKs"')).toBe('GrEEoEmmrKs');
-  });
-
-  it('rejects a capture that is not an id, rather than passing it through', () => {
-    // This value ends up interpolated into a URL the browser loads.
-    expect(extractYouTubeId(`videoId:'../../evil'`)).toBeNull();
-    expect(extractYouTubeId(`videoId:'short'`)).toBeNull();
-    expect(extractYouTubeId(`videoId:'waytoolongtobeanid'`)).toBeNull();
-    expect(extractYouTubeId(`videoId:'has space!!'`)).toBeNull();
-  });
-
-  it('returns null when there is no player at all', () => {
-    expect(extractYouTubeId('<html><body>no camera here</body></html>')).toBeNull();
-  });
-});
-
-describe('youtubeEmbedUrl', () => {
-  it('builds a muted autoplaying nocookie embed', () => {
-    const url = new URL(youtubeEmbedUrl('GrEEoEmmrKs'));
-    expect(url.hostname).toBe('www.youtube-nocookie.com');
-    expect(url.pathname).toBe('/embed/GrEEoEmmrKs');
-    // Autoplay only survives muted, and a wall of cameras must not make noise.
-    expect(url.searchParams.get('mute')).toBe('1');
-    expect(url.searchParams.get('autoplay')).toBe('1');
-    // Inline on iOS rather than hijacking the screen with the native player.
-    expect(url.searchParams.get('playsinline')).toBe('1');
-  });
-});
-
 describe('parseSkylinePage', () => {
   it('resolves a YouTube-backed page', () => {
-    const feed = parseSkylinePage(YUBATAKE);
-    expect(feed).toMatchObject({ kind: 'youtube', videoId: 'GrEEoEmmrKs' });
+    expect(parseSkylinePage(YUBATAKE)).toMatchObject({ kind: 'youtube', videoId: 'GrEEoEmmrKs' });
   });
 
   it('reports SkylineWebcams-hosted HLS without trying to serve it', () => {
-    const feed = parseSkylinePage(`<script>src:"https://cdn.skylinewebcams.com/live/xyz/livee.m3u8"</script>`);
-    expect(feed).toEqual({ kind: 'hls' });
+    expect(parseSkylinePage(`<script>src:"https://cdn.skylinewebcams.com/live/xyz/livee.m3u8"</script>`)).toEqual({ kind: 'hls' });
   });
 
   it('prefers YouTube when a page carries both', () => {
     expect(parseSkylinePage(YUBATAKE + '<script>"live.m3u8"</script>').kind).toBe('youtube');
   });
 
+  it('reports a camera the source says is off air', () => {
+    // Real markup from the Monte Hermoso page. All 8 off-air cameras found in
+    // South America and Africa carried exactly this.
+    const offAir = '<div><p style="font-size:4rem;opacity:0.6"><strong>OFFLINE</strong></p></div>';
+    expect(parseSkylinePage(offAir)).toEqual({ kind: 'offline' });
+  });
+
+  it('does not call a working camera offline', () => {
+    // The banner is absent on every working page checked; a false positive here
+    // would hide a live feed behind an 'off air' message.
+    expect(parseSkylinePage(YUBATAKE).kind).toBe('youtube');
+  });
+
+  it('prefers a playable stream over an offline banner', () => {
+    expect(parseSkylinePage(YUBATAKE + '<strong>OFFLINE</strong>').kind).toBe('youtube');
+  });
+
   it('reports unknown for a page with neither', () => {
     expect(parseSkylinePage('<html>offline</html>')).toEqual({ kind: 'unknown' });
-  });
-});
-
-describe('needsResolution', () => {
-  const SKY = 'https://www.skylinewebcams.com/en/webcam/japan/gunma/yubatake/yubatake.html';
-
-  it('resolves a camera we hold nothing but a Skyline link for', () => {
-    expect(needsResolution({ external_url: SKY })).toBe(true);
-  });
-
-  it('leaves a camera alone when it already has a playable feed', () => {
-    // Resolving these would trade a working stream for a round-trip.
-    expect(needsResolution({ external_url: SKY, stream_url: 'https://x/live.m3u8' })).toBe(false);
-    expect(needsResolution({ external_url: SKY, feed_url: 'https://x/snap.jpg' })).toBe(false);
-  });
-
-  it('leaves other operators alone — this resolver only knows one site', () => {
-    expect(needsResolution({ external_url: 'https://www.windy.com/webcams/12345' })).toBe(false);
-  });
-
-  it('is safe on a missing or empty camera', () => {
-    expect(needsResolution(null)).toBe(false);
-    expect(needsResolution(undefined)).toBe(false);
-    expect(needsResolution({})).toBe(false);
-  });
-
-  it('separates hosted-off-platform from resolvable', () => {
-    // Windy is off-platform, we just cannot open it. Both facts matter: the
-    // viewer shows the external panel for it, but must not call the resolver.
-    const windy = { external_url: 'https://www.windy.com/webcams/12345' };
-    expect(isHostedOffPlatform(windy)).toBe(true);
-    expect(needsResolution(windy)).toBe(false);
   });
 });
 
@@ -134,33 +77,5 @@ describe('skyline resolution (live)', () => {
       const oe = await fetch(`https://www.youtube.com/oembed?url=https%3A//www.youtube.com/watch%3Fv%3D${feed.videoId}&format=json`);
       expect(oe.status).toBe(200);
     }
-  });
-});
-
-describe('offPlatformView', () => {
-  const v = (o: Partial<Parameters<typeof offPlatformView>[0]>) =>
-    offPlatformView({ hostedOffPlatform: true, resolving: false, resolvedEmbed: null, ...o });
-
-  it('plays a camera that has its own feed, without consulting anything', () => {
-    expect(v({ hostedOffPlatform: false })).toBe('inline');
-  });
-
-  it('shows the resolving state while looking, not the external panel', () => {
-    // Otherwise a camera that is about to play inline flashes up 'requires
-    // external clearance' first, which reads as a failure.
-    expect(v({ resolving: true })).toBe('resolving');
-  });
-
-  it('plays inline once a feed is found', () => {
-    expect(v({ resolvedEmbed: 'https://www.youtube-nocookie.com/embed/GrEEoEmmrKs' })).toBe('inline');
-  });
-
-  it('falls back to the external link when nothing was found', () => {
-    expect(v({ resolving: false, resolvedEmbed: null })).toBe('external');
-  });
-
-  it('prefers a found feed over a still-running lookup', () => {
-    // Both true is reachable: resolvedEmbed lands before `resolving` clears.
-    expect(v({ resolving: true, resolvedEmbed: 'https://x/embed/y' })).toBe('inline');
   });
 });

--- a/src/lib/skyline.ts
+++ b/src/lib/skyline.ts
@@ -2,11 +2,11 @@
  * OSIRIS — SkylineWebcams feed resolution
  *
  * SkylineWebcams cameras arrive in our dataset carrying only an `external_url`,
- * so the viewer renders them as "this feed requires external clearance" plus a
- * link off-platform. For most of them that is unnecessary. The page is a thin
- * wrapper around a public YouTube livestream published by the camera's actual
- * operator — a town office, a regional broadcaster — and that stream embeds
- * anywhere.
+ * so the viewer would render them as "this feed requires external clearance"
+ * plus a link off-platform. For most of them that is unnecessary. The page is a
+ * thin wrapper around a public YouTube livestream published by the camera's
+ * actual operator — a town office, a regional broadcaster — and that stream
+ * embeds anywhere.
  *
  * Measured across all 601 SkylineWebcams cameras in the dataset:
  *
@@ -25,15 +25,26 @@
  * the manifest out would be fragile and would be taking someone else's content.
  */
 
-const SKYLINE_HOST = 'skylinewebcams.com';
+import { extractYouTubeId, youtubeEmbedUrl } from './youtube';
 
-/** YouTube video ids are exactly 11 characters of [A-Za-z0-9_-]. */
-const YOUTUBE_ID = /^[A-Za-z0-9_-]{11}$/;
+const SKYLINE_HOST = 'skylinewebcams.com';
 
 export type SkylineFeed =
   | { kind: 'youtube'; videoId: string; embedUrl: string }
   | { kind: 'hls' }
+  | { kind: 'offline' }
   | { kind: 'unknown' };
+
+/**
+ * SkylineWebcams paints this over the player when a camera is off air. Worth
+ * detecting: without it a dead camera is indistinguishable from one we merely
+ * cannot open, and the viewer tells the operator to go and get "external
+ * clearance" for a feed that is not running at all.
+ *
+ * Measured on the 51 South American and African cameras: 8 were off air, and
+ * every one of them carried this. Cameras that are working carry it zero times.
+ */
+const OFFLINE_BANNER = /<strong>\s*OFFLINE\s*<\/strong>/i;
 
 /**
  * Host comparison, not a substring test. "https://evil.com/?skylinewebcams.com"
@@ -50,86 +61,13 @@ export function isSkylineUrl(url: string): boolean {
   return host === SKYLINE_HOST || host.endsWith('.' + SKYLINE_HOST);
 }
 
-/**
- * Pulls the video id out of the page's YouTube IFrame API bootstrap, which
- * looks like `YT.Player('live',{...,videoId:'GrEEoEmmrKs',...})`.
- *
- * Falls back to a direct embed URL, since not every page uses the JS player.
- * The id is shape-checked either way — an unvalidated capture here would end up
- * interpolated into a URL the browser then loads.
- */
-export function extractYouTubeId(html: string): string | null {
-  const patterns = [
-    /videoId\s*:\s*['"]([^'"]+)['"]/,
-    /youtube(?:-nocookie)?\.com\/embed\/([A-Za-z0-9_-]{11})/,
-  ];
-  for (const re of patterns) {
-    const id = html.match(re)?.[1];
-    if (id && YOUTUBE_ID.test(id)) return id;
-  }
-  return null;
-}
-
-/** Privacy-preserving host, and the one the source page itself uses. */
-export function youtubeEmbedUrl(videoId: string): string {
-  const params = new URLSearchParams({
-    autoplay: '1',
-    mute: '1',
-    playsinline: '1',
-    rel: '0',
-    modestbranding: '1',
-    iv_load_policy: '3',
-  });
-  return `https://www.youtube-nocookie.com/embed/${videoId}?${params.toString()}`;
-}
-
 export function parseSkylinePage(html: string): SkylineFeed {
   const videoId = extractYouTubeId(html);
   if (videoId) return { kind: 'youtube', videoId, embedUrl: youtubeEmbedUrl(videoId) };
+  // Checked before HLS so a camera that is merely off air is reported as off
+  // air, rather than as a stream we declined to serve.
+  if (OFFLINE_BANNER.test(html)) return { kind: 'offline' };
   // Their own stream. Reachable, but not ours to re-serve.
   if (/\.m3u8/i.test(html)) return { kind: 'hls' };
   return { kind: 'unknown' };
-}
-
-/** The fields the viewer uses to decide how to play a camera. */
-export interface ResolvableCamera {
-  external_url?: string;
-  feed_url?: string;
-  stream_url?: string;
-}
-
-/**
- * True when the only thing we hold for a camera is a link to somebody else's
- * page — nothing that can be rendered in place.
- */
-export function isHostedOffPlatform(camera: ResolvableCamera | null | undefined): boolean {
-  return Boolean(camera?.external_url && !camera.feed_url && !camera.stream_url);
-}
-
-/**
- * True when that link is one we know how to open up. A camera that already has
- * a playable stream is left alone: resolving it would trade a working feed for
- * a network round-trip.
- */
-export function needsResolution(camera: ResolvableCamera | null | undefined): boolean {
-  return isHostedOffPlatform(camera) && isSkylineUrl(camera!.external_url!);
-}
-
-/**
- * Which state the viewer paints for a camera we hold no local feed for.
- *
- *   'resolving' — looking for a direct feed. Shown instead of the external
- *                 panel so a camera that is about to play inline does not
- *                 first flash up 'requires external clearance'.
- *   'external'  — no direct feed. The off-platform link, as before.
- *   'inline'    — play it here.
- */
-export function offPlatformView(state: {
-  hostedOffPlatform: boolean;
-  resolving: boolean;
-  resolvedEmbed: string | null;
-}): 'resolving' | 'external' | 'inline' {
-  if (!state.hostedOffPlatform) return 'inline';
-  if (state.resolvedEmbed) return 'inline';
-  return state.resolving ? 'resolving' : 'external';
 }

--- a/src/lib/youtube.test.ts
+++ b/src/lib/youtube.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { isYouTubeUrl, parseYouTubeUrl, extractYouTubeId, youtubeEmbedUrl } from './youtube';
+
+describe('isYouTubeUrl', () => {
+  it('accepts the hosts a stream can arrive on', () => {
+    expect(isYouTubeUrl('https://www.youtube.com/watch?v=GrEEoEmmrKs')).toBe(true);
+    expect(isYouTubeUrl('https://youtu.be/GrEEoEmmrKs')).toBe(true);
+    expect(isYouTubeUrl('https://www.youtube-nocookie.com/embed/GrEEoEmmrKs')).toBe(true);
+  });
+
+  it('compares the host, not the string', () => {
+    expect(isYouTubeUrl('https://evil.com/?x=youtube.com')).toBe(false);
+    expect(isYouTubeUrl('https://youtube.com.evil.com/watch?v=GrEEoEmmrKs')).toBe(false);
+    expect(isYouTubeUrl('https://notyoutube.com/watch?v=GrEEoEmmrKs')).toBe(false);
+  });
+});
+
+describe('parseYouTubeUrl', () => {
+  it('reads a specific video out of every link shape', () => {
+    const shapes = [
+      'https://www.youtube.com/watch?v=GrEEoEmmrKs',
+      'https://www.youtube.com/watch?app=desktop&v=GrEEoEmmrKs&t=30s',
+      'https://youtu.be/GrEEoEmmrKs',
+      'https://www.youtube.com/embed/GrEEoEmmrKs?autoplay=1',
+      'https://www.youtube.com/v/GrEEoEmmrKs',
+      'https://www.youtube.com/live/GrEEoEmmrKs',
+      'https://www.youtube.com/shorts/GrEEoEmmrKs',
+    ];
+    for (const url of shapes) {
+      expect(parseYouTubeUrl(url), url).toEqual({ kind: 'video', videoId: 'GrEEoEmmrKs' });
+    }
+  });
+
+  it('separates a live broadcast from a channel that happens to be live', () => {
+    // One path segment apart, and they mean entirely different things:
+    // /live/ID is one specific broadcast, /@handle/live is "whatever is on now".
+    expect(parseYouTubeUrl('https://www.youtube.com/live/GrEEoEmmrKs')).toEqual({ kind: 'video', videoId: 'GrEEoEmmrKs' });
+    expect(parseYouTubeUrl('https://www.youtube.com/@AaronPreslin/live')).toEqual({ kind: 'live-channel' });
+    expect(parseYouTubeUrl('https://www.youtube.com/channel/UCabcdefghijk/live')).toEqual({ kind: 'live-channel' });
+    expect(parseYouTubeUrl('https://www.youtube.com/user/somebody/live')).toEqual({ kind: 'live-channel' });
+    expect(parseYouTubeUrl('https://www.youtube.com/c/somebody/live')).toEqual({ kind: 'live-channel' });
+  });
+
+  it('rejects ids that are not ids rather than passing them through', () => {
+    // These end up interpolated into a URL the browser loads.
+    expect(parseYouTubeUrl('https://www.youtube.com/watch?v=../../evil')).toBeNull();
+    expect(parseYouTubeUrl('https://www.youtube.com/watch?v=short')).toBeNull();
+    expect(parseYouTubeUrl('https://youtu.be/way-too-long-to-be-an-id')).toBeNull();
+  });
+
+  it('returns null for a non-YouTube or malformed URL', () => {
+    expect(parseYouTubeUrl('https://www.skylinewebcams.com/x.html')).toBeNull();
+    expect(parseYouTubeUrl('not a url')).toBeNull();
+    expect(parseYouTubeUrl('https://www.youtube.com/')).toBeNull();
+  });
+});
+
+describe('extractYouTubeId', () => {
+  it('reads the id out of an IFrame API bootstrap', () => {
+    expect(extractYouTubeId(`YT.Player('live',{videoId:'GrEEoEmmrKs',host:'x'})`)).toBe('GrEEoEmmrKs');
+  });
+
+  it('reads the id off a channel live page, which uses player JSON', () => {
+    expect(extractYouTubeId('{"videoId":"Ql8lnRs0J0U","isLive":true}')).toBe('Ql8lnRs0J0U');
+  });
+
+  it('reads the id off a canonical link', () => {
+    expect(extractYouTubeId('<link rel="canonical" href="https://www.youtube.com/watch?v=Ql8lnRs0J0U">')).toBe('Ql8lnRs0J0U');
+  });
+
+  it('falls back to a direct embed URL', () => {
+    expect(extractYouTubeId('<iframe src="https://www.youtube-nocookie.com/embed/eU8A7QQOcso?rel=0">')).toBe('eU8A7QQOcso');
+  });
+
+  it('rejects a capture that is not an id', () => {
+    expect(extractYouTubeId(`videoId:'../../evil'`)).toBeNull();
+    expect(extractYouTubeId(`videoId:'short'`)).toBeNull();
+    expect(extractYouTubeId(`videoId:'has space!!'`)).toBeNull();
+  });
+
+  it('returns null when there is no player at all', () => {
+    expect(extractYouTubeId('<html><body>no camera here</body></html>')).toBeNull();
+  });
+});
+
+describe('youtubeEmbedUrl', () => {
+  it('builds a muted autoplaying nocookie embed', () => {
+    const url = new URL(youtubeEmbedUrl('GrEEoEmmrKs'));
+    expect(url.hostname).toBe('www.youtube-nocookie.com');
+    expect(url.pathname).toBe('/embed/GrEEoEmmrKs');
+    // Autoplay only survives muted, and a wall of cameras must not make noise.
+    expect(url.searchParams.get('mute')).toBe('1');
+    expect(url.searchParams.get('autoplay')).toBe('1');
+    // Inline on iOS rather than hijacking the screen with the native player.
+    expect(url.searchParams.get('playsinline')).toBe('1');
+  });
+});

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -1,0 +1,114 @@
+/**
+ * OSIRIS — YouTube feed primitives
+ *
+ * A surprising number of public cameras are ultimately a YouTube livestream:
+ * either directly, or wrapped in an operator's page (see skyline.ts). This
+ * module knows about YouTube itself — ids, embed URLs, and the several shapes a
+ * link to a stream can take.
+ */
+
+/** YouTube video ids are exactly 11 characters of [A-Za-z0-9_-]. */
+export const YOUTUBE_ID = /^[A-Za-z0-9_-]{11}$/;
+
+const YOUTUBE_HOSTS = ['youtube.com', 'youtube-nocookie.com', 'youtu.be'];
+
+/**
+ * What a YouTube link points at.
+ *
+ *   'video'        — a specific stream. Known without asking anyone.
+ *   'live-channel' — "whatever this channel is broadcasting now", which is a
+ *                    different video every broadcast and can only be answered
+ *                    by fetching the page.
+ */
+export type YouTubeTarget =
+  | { kind: 'video'; videoId: string }
+  | { kind: 'live-channel' };
+
+/** Host comparison, not a substring test — this gates what gets fetched. */
+export function isYouTubeUrl(url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return YOUTUBE_HOSTS.some(h => host === h || host.endsWith('.' + h));
+}
+
+/**
+ * Classifies a YouTube link.
+ *
+ * Note the two readings of "live": `/live/VIDEO_ID` is one specific broadcast,
+ * while `/@handle/live` is whatever that channel happens to be showing. They
+ * differ by one path segment and mean entirely different things.
+ */
+export function parseYouTubeUrl(url: string): YouTubeTarget | null {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return null;
+  }
+  if (!isYouTubeUrl(url)) return null;
+
+  const host = u.hostname.toLowerCase();
+  const segments = u.pathname.split('/').filter(Boolean);
+
+  // youtu.be/VIDEO_ID
+  if (host === 'youtu.be' || host.endsWith('.youtu.be')) {
+    const id = segments[0];
+    return id && YOUTUBE_ID.test(id) ? { kind: 'video', videoId: id } : null;
+  }
+
+  // youtube.com/watch?v=VIDEO_ID
+  const v = u.searchParams.get('v');
+  if (v && YOUTUBE_ID.test(v)) return { kind: 'video', videoId: v };
+
+  // /embed/ID, /v/ID, /live/ID, /shorts/ID
+  if (segments.length >= 2 && ['embed', 'v', 'live', 'shorts'].includes(segments[0])) {
+    const id = segments[1];
+    if (YOUTUBE_ID.test(id)) return { kind: 'video', videoId: id };
+  }
+
+  // /@handle/live, /channel/UC.../live, /user/name/live, /c/name/live
+  if (segments.length >= 2 && segments[segments.length - 1] === 'live') {
+    return { kind: 'live-channel' };
+  }
+
+  return null;
+}
+
+/**
+ * Pulls a video id out of a page. Covers the YouTube IFrame API bootstrap that
+ * operator pages use, a plain embed URL, and the canonical link / player JSON
+ * that a channel's own live page carries.
+ *
+ * The id is shape-checked in every case — an unvalidated capture here ends up
+ * interpolated into a URL the browser then loads.
+ */
+export function extractYouTubeId(html: string): string | null {
+  const patterns = [
+    /videoId\s*:\s*['"]([^'"]+)['"]/,           // YT.Player({ videoId:'...' })
+    /"videoId"\s*:\s*"([A-Za-z0-9_-]{11})"/,    // player response JSON
+    /rel=["']canonical["']\s+href=["'][^"']*[?&]v=([A-Za-z0-9_-]{11})/,
+    /youtube(?:-nocookie)?\.com\/embed\/([A-Za-z0-9_-]{11})/,
+  ];
+  for (const re of patterns) {
+    const id = html.match(re)?.[1];
+    if (id && YOUTUBE_ID.test(id)) return id;
+  }
+  return null;
+}
+
+/** Privacy-preserving host, and the one operator pages themselves use. */
+export function youtubeEmbedUrl(videoId: string): string {
+  const params = new URLSearchParams({
+    autoplay: '1',
+    mute: '1',
+    playsinline: '1',
+    rel: '0',
+    modestbranding: '1',
+    iv_load_policy: '3',
+  });
+  return `https://www.youtube-nocookie.com/embed/${videoId}?${params.toString()}`;
+}


### PR DESCRIPTION
Extends the SkylineWebcams resolver to a second provider, and fixes two ways the viewer was telling the operator something untrue.

**8 files, +636 / −217.** Two new tested modules, 27 new tests.

## A second resolvable provider

YouTube links given directly as a camera's `external_url` now play in place.

Most shapes name a video — `watch?v=`, `youtu.be`, `/embed/`, `/v/`, `/live/`, `/shorts/` — and those are built **client-side with no request at all**. Asking a server to repeat what the URL already says would add a round-trip and a failure mode for nothing; the route rejects them for the same reason, since accepting them would only widen what it will go and fetch.

Channel links are different. `youtube.com/@handle/live` names a channel, not a broadcast, so only the page can say what is on air — that shape is resolved server-side. Worth noting `/live/VIDEO_ID` and `/@handle/live` are one path segment apart and mean entirely different things; both are covered.

Parsing and decisions moved out of `skyline.ts` into modules that describe what they hold — `youtube.ts` and `camera-feed.ts`. Keeping YouTube URL handling in a file called `skyline.ts` would have misled the next reader.

## The snapshot cameras

All **681** SkylineWebcams cameras surveyed. 431 are page-only and wrap the operator's YouTube stream (already playing inline). The other **250** give us a periodic JPEG — and **none** are YouTube-backed. Measured, not assumed:

| | count |
|---|---:|
| SkylineWebcams' own HLS | 237 |
| off air | 11 |
| neither | 2 |

That video can't be reproduced here, and the player config says why:

```
source:'livee.m3u8?a=k8b8bne00h8pc8f8vod1fvu1q2'   ← new token every page load
watermark:'…/SkylineWebcams/web@v2/skylinewebcams.svg'
plugins:{core:[ClapprImaPlugin]}                    ← Google IMA pre-roll ads
```

Replaying that manifest would strip the watermark and the advertising that pays for the camera. Their pages also set `X-Frame-Options: SAMEORIGIN`, so framing is closed too.

So these get a **way through** rather than a copy: a `WATCH LIVE` control over the snapshot, going to the operator's own page. The still is worth keeping — measured refreshing about every 25s — but it no longer claims to be something it isn't: the badge reads **SNAPSHOT** instead of LIVE SAT-LINK, and the footer says **LIVE VIDEO AT SOURCE**.

## Two things the viewer was getting wrong

**Off-air cameras** were reported as needing "external clearance", with a button leading to a page showing an offline banner. They now read **CAMERA OFFLINE**, no button. Five were worse — their pages 404, so the button led nowhere; those read **CAMERA WITHDRAWN**, and the footer's source link is hidden rather than pointing at a dead page. Both handled generally, so any camera that later goes off air gets the same treatment.

**The second was only visible by looking.** SkylineWebcams reuses its numeric snapshot ids, so a withdrawn camera's still can quietly become a *different camera*:

- `live341.jpg` — captioned "Rome – Trevi Fountain" — serves a beach in the Canaries
- `live343.jpg` — captioned "Rome – Piazza Navona" — serves a fishing village near Genoa

Cameras whose page is still live were correct, which pins the cause. In a tool people read locations off, a wrong picture under a confident label is worse than no picture. Snapshot cameras are now verified against their source page in the background — the image appears immediately and is withdrawn only if the source says the camera is gone. **11 cameras affected.**

## Verified by clicking, not inferring

The map paints once the browser pane is displayed, so the viewer could finally be driven directly rather than tested around:

```
Yubatake              iframe embed/GrEEoEmmrKs   YOUTUBE LIVE
Christ the Redeemer   iframe embed/PhYE9txaPlo   YOUTUBE LIVE
Cochabamba            snapshot + WATCH LIVE      LIVE VIDEO AT SOURCE
Trevi Fountain        no image                   CAMERA OFFLINE
Colosseum             no image                   CAMERA OFFLINE
```

Plus 43 of the 51 South American and African cameras now play inline (the other 8 are off air). The host allowlist rejects spoofed hosts, other operators and private-range targets with 400 before any fetch.

**331 tests pass**, up from 304, plus 11 live integration tests. Typecheck clean, production build compiles, `CameraViewer` lint unchanged from baseline.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
