### PR TITLE
feat(satellites): draw satellites at their real altitude, and make them clickable

### DIFF
--- a/src/app/api/satellites/orbit/route.ts
+++ b/src/app/api/satellites/orbit/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { orbitPath, orbitalPeriodMinutes, splitAtAntimeridian } from '@/lib/orbit';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * OSIRIS — one satellite's orbit track.
+ *
+ * Returns a full revolution, sampled from the same TLE the map position came
+ * from, so the track passes through the satellite rather than near it.
+ *
+ * Served on demand rather than bundled into /api/satellites: that response is
+ * already several megabytes for ~19,000 satellites, and an operator looks at
+ * one orbit at a time.
+ *
+ * The TLE catalogue is the disk cache the satellites route already maintains.
+ * Reading it here avoids a second fetch to CelesTrak, which rate-limits.
+ */
+
+const CACHE_FILE = join(process.cwd(), '.next', 'cache', 'satellites-tle-cache.json');
+
+interface Tle { name: string; line1: string; line2: string }
+
+let cache: { at: number; byNorad: Map<string, Tle> } | null = null;
+const CACHE_TTL_MS = 5 * 60_000;
+
+/** NORAD id lives in columns 3-7 of line 1. */
+function noradOf(line1: string): string {
+  return line1.substring(2, 7).trim();
+}
+
+function catalogue(): Map<string, Tle> {
+  if (cache && Date.now() - cache.at < CACHE_TTL_MS) return cache.byNorad;
+  const byNorad = new Map<string, Tle>();
+  try {
+    if (existsSync(CACHE_FILE)) {
+      const parsed = JSON.parse(readFileSync(CACHE_FILE, 'utf8')) as { sats?: Tle[] };
+      for (const sat of parsed.sats ?? []) {
+        if (sat?.line1 && sat?.line2) byNorad.set(noradOf(sat.line1), sat);
+      }
+    }
+  } catch {
+    // A corrupt cache means no orbits, not a broken map: the caller falls back
+    // to showing the satellite without its track.
+  }
+  cache = { at: Date.now(), byNorad };
+  return byNorad;
+}
+
+export async function GET(req: Request) {
+  const id = new URL(req.url).searchParams.get('id')?.trim();
+  if (!id || !/^\d{1,6}$/.test(id)) {
+    return NextResponse.json({ error: 'numeric NORAD id required' }, { status: 400 });
+  }
+
+  const tle = catalogue().get(String(Number(id)));
+  if (!tle) {
+    return NextResponse.json({ error: 'not in catalogue', noradId: id }, { status: 404 });
+  }
+
+  const periodMinutes = orbitalPeriodMinutes(tle.line2);
+  const path = orbitPath(tle.line1, tle.line2, 180);
+  if (path.length < 2) {
+    return NextResponse.json({ error: 'could not propagate', noradId: id }, { status: 422 });
+  }
+
+  return NextResponse.json({
+    noradId: id,
+    name: tle.name,
+    periodMinutes,
+    // Split at the antimeridian so each run draws as one continuous line
+    // instead of one segment sweeping back across the whole world.
+    segments: splitAtAntimeridian(path).map(run =>
+      run.map(p => [
+        Math.round(p.lng * 10000) / 10000,
+        Math.round(p.lat * 10000) / 10000,
+        Math.round(p.altKm),
+      ]),
+    ),
+  }, {
+    // An orbit is stable for far longer than a position: the shape only
+    // changes when a fresh TLE lands.
+    headers: { 'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=3600' },
+  });
+}

--- a/src/app/api/satellites/route.ts
+++ b/src/app/api/satellites/route.ts
@@ -1,6 +1,7 @@
 
 import { NextResponse } from 'next/server';
 import { stealthFetch } from '@/lib/stealthFetch';
+import { propagateTLE } from '@/lib/orbit';
 
 export const maxDuration = 60;
 
@@ -53,83 +54,24 @@ function classifySatellite(name: string): { mission: string; color: string } {
   return { mission: 'Unknown', color: '#00E5FF' };
 }
 
-function gmst(jd: number): number {
-  const t = (jd - 2451545.0) / 36525.0;
-  const gmstSec = 67310.54841 + (876600.0 * 3600 + 8640184.812866) * t + 0.093104 * t * t - 6.2e-6 * t * t * t;
-  return ((gmstSec % 86400) / 86400.0) * 2 * Math.PI;
-}
-
-// No longer needed: function parseTLE(tleText: string) {}
-
+/**
+ * Position for one TLE, in the shape this route returns.
+ *
+ * This used to be a hand-rolled two-body Kepler solve: no J2, no drag, and it
+ * reported geocentric latitude and altitude above a 6371 km sphere. Good
+ * enough for a dot on a flat map, but the globe now draws satellites at their
+ * altitude, and an orbit placed by that solve sits visibly off the satellite
+ * it belongs to. src/lib/orbit.ts wraps satellite.js (already a dependency,
+ * previously unused) for real SGP4/SDP4 and geodetic coordinates.
+ */
 function propagateSGP4Simple(line1: string, line2: string): { lat: number; lng: number; alt: number } | null {
-  try {
-    const incDeg = parseFloat(line2.substring(8, 16));
-    const raanDeg = parseFloat(line2.substring(17, 25));
-    const eccStr = '0.' + line2.substring(26, 33).trim();
-    const ecc = parseFloat(eccStr);
-    const argPerDeg = parseFloat(line2.substring(34, 42));
-    const meanAnomDeg = parseFloat(line2.substring(43, 51));
-    const meanMotion = parseFloat(line2.substring(52, 63));
-
-    if (isNaN(meanMotion) || meanMotion === 0) return null;
-
-    const now = new Date();
-    const epochYear = parseInt(line1.substring(18, 20));
-    const epochDay = parseFloat(line1.substring(20, 32));
-    const fullYear = epochYear > 56 ? 1900 + epochYear : 2000 + epochYear;
-
-    const epochDate = new Date(fullYear, 0, 1);
-    epochDate.setDate(epochDate.getDate() + epochDay - 1);
-    const elapsedMin = (now.getTime() - epochDate.getTime()) / 60000;
-
-    // Reject stale TLEs (> 90 days old) unless it's the emergency fallback
-    if (Math.abs(elapsedMin) > 129600 && !line1.includes('27885-3')) return null;
-
-    const n = meanMotion * 2 * Math.PI / 1440;
-    const M = ((meanAnomDeg * Math.PI / 180) + n * elapsedMin) % (2 * Math.PI);
-
-    let E = M;
-    for (let j = 0; j < 10; j++) {
-      E = M + ecc * Math.sin(E);
-    }
-
-    const sinV = Math.sqrt(1 - ecc * ecc) * Math.sin(E) / (1 - ecc * Math.cos(E));
-    const cosV = (Math.cos(E) - ecc) / (1 - ecc * Math.cos(E));
-    const v = Math.atan2(sinV, cosV);
-
-    const a = Math.pow(398600.4418 / (meanMotion * 2 * Math.PI / 86400) ** 2, 1 / 3);
-    const r = a * (1 - ecc * Math.cos(E));
-
-    const inc = incDeg * Math.PI / 180;
-    const raan = raanDeg * Math.PI / 180;
-    const argPer = argPerDeg * Math.PI / 180;
-    const u = v + argPer;
-
-    const x = r * (Math.cos(raan) * Math.cos(u) - Math.sin(raan) * Math.sin(u) * Math.cos(inc));
-    const y = r * (Math.sin(raan) * Math.cos(u) + Math.cos(raan) * Math.sin(u) * Math.cos(inc));
-    const z = r * Math.sin(u) * Math.sin(inc);
-
-    const jd = 2440587.5 + now.getTime() / 86400000;
-    const theta = gmst(jd);
-
-    const xRot = x * Math.cos(theta) + y * Math.sin(theta);
-    const yRot = -x * Math.sin(theta) + y * Math.cos(theta);
-
-    const lng = Math.atan2(yRot, xRot) * 180 / Math.PI;
-    const lat = Math.atan2(z, Math.sqrt(xRot * xRot + yRot * yRot)) * 180 / Math.PI;
-    const alt = r - 6371;
-
-    if (isNaN(lat) || isNaN(lng) || Math.abs(lat) > 90) return null;
-    if (alt < 100 || alt > 50000) return null; // sanity check
-
-    return {
-      lat: Math.round(lat * 10000) / 10000,
-      lng: Math.round(((lng + 540) % 360 - 180) * 10000) / 10000,
-      alt: Math.round(alt),
-    };
-  } catch {
-    return null;
-  }
+  const p = propagateTLE(line1, line2);
+  if (!p) return null;
+  return {
+    lat: Math.round(p.lat * 10000) / 10000,
+    lng: Math.round(p.lng * 10000) / 10000,
+    alt: Math.round(p.altKm),
+  };
 }
 
 // CelesTrak constellation groups — many smaller groups to avoid 403 rate limits

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -3,6 +3,19 @@ import { buildGeometry, closeRing, drawReducer, initialDrawState, measure, type 
 
 import { useEffect, useRef, useState, useCallback, memo } from 'react';
 import maplibregl from 'maplibre-gl';
+import { createSatelliteLayer, parseColor, type SatPoint } from '@/lib/satellite-layer';
+
+/** The catalogue fields the satellite layer and its popup actually read. */
+interface SatelliteRow {
+  name: string;
+  lat: number;
+  lng: number;
+  alt: number;
+  color?: string;
+  mission?: string;
+  category?: string;
+  noradId?: string;
+}
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 interface OsirisMapProps {
@@ -84,6 +97,13 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   const prevStyleRef = useRef(mapStyle);
   const prevDrawnPolygonsRef = useRef<string[]>([]);
   const prevArcgisLayersRef = useRef<string[]>([]);
+  const satLayerRef = useRef<ReturnType<typeof createSatelliteLayer> | null>(null);
+  // pick() returns an index into the array last handed to setPoints, so the
+  // matching catalogue rows are kept in the same order to resolve it.
+  const satRowsRef = useRef<SatelliteRow[]>([]);
+  /** Index of the satellite whose orbit is on screen, so a late reply for a
+   *  previous selection can be discarded. */
+  const satPickedRef = useRef<number | null>(null);
   const drawingCoordsRef = useRef<number[][]>([]);
 
   // Create aircraft icon on canvas (for WebGL symbol layer)
@@ -176,11 +196,12 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     // Select basemap style
     const styleUrl = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
 
-    const map = new maplibregl.Map({
-      container: containerRef.current,
+    const container = containerRef.current;
+    const baseOptions = {
+      container,
       style: styleUrl,
-      center: [25.48, 42.70], zoom: 6.5, minZoom: 1.5, maxZoom: 18,
-      attributionControl: false,
+      center: [25.48, 42.70] as [number, number], zoom: 6.5, minZoom: 1.5, maxZoom: 18,
+      attributionControl: false as const,
       maxPitch: 85,
       transformRequest: (url: string) => {
         // Route all CARTO CDN requests through the internal Next.js proxy API
@@ -190,7 +211,33 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         }
         return { url };
       },
-    });
+    };
+
+    // MapLibre asks for a high-performance WebGL2 context and throws outright if it
+    // cannot get one. Some machines refuse that exact request while still granting a
+    // plainer context — a blocklisted discrete GPU, a driver Chrome only trusts for
+    // WebGL1 — so walk down to weaker requests before giving up.
+    const attributeFallbacks: maplibregl.MapOptions['canvasContextAttributes'][] = [
+      undefined,
+      { powerPreference: 'low-power', failIfMajorPerformanceCaveat: false },
+      { contextType: 'webgl', powerPreference: 'low-power', failIfMajorPerformanceCaveat: false },
+    ];
+
+    let map: maplibregl.Map | undefined;
+    for (const canvasContextAttributes of attributeFallbacks) {
+      try {
+        map = new maplibregl.Map(
+          canvasContextAttributes ? { ...baseOptions, canvasContextAttributes } : baseOptions
+        );
+        break;
+      } catch (e) {
+        // A failed constructor leaves its canvas behind; the next attempt needs a clean container.
+        container.innerHTML = '';
+        if (canvasContextAttributes === attributeFallbacks[attributeFallbacks.length - 1]) throw e;
+        console.warn('[OSIRIS] WebGL context rejected, retrying with weaker attributes:', e instanceof Error ? e.message : e);
+      }
+    }
+    if (!map) return;
 
     map.on('load', () => {
       mapRef.current = map;
@@ -455,13 +502,25 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         'text-offset': [0, 2], 'text-max-width': 14, 'text-allow-overlap': false,
       }, paint: { 'text-color': ['case', ['in', 'SEISMIC RISK', ['get', 'status']], '#E65100', '#26A69A'], 'text-halo-color': '#000', 'text-halo-width': 1, 'text-opacity': 0.7 }});
 
-      // Satellites
-      map.addLayer({ id: 'sat-glow', type: 'circle', source: 'satellites', paint: {
+      // Satellites.
+      // Every satellite is drawn once, by the custom 3D layer below, at its
+      // altitude. These two circle layers are kept defined — the source feeds
+      // the 3D layer and other code refers to them — but hidden: drawing the
+      // same satellite both flat on the ground and again up at altitude is
+      // what made the map read as half 2D and half 3D.
+      // Hit-testing is handled by the 3D layer's own GPU pick pass, since
+      // queryRenderedFeatures cannot see into a custom WebGL layer.
+      map.addLayer({ id: 'sat-glow', type: 'circle', source: 'satellites', layout: { visibility: 'none' }, paint: {
         'circle-radius': ['interpolate',['linear'],['zoom'], 1,3, 5,6], 'circle-color': ['get','color'], 'circle-opacity': 0.3, 'circle-blur': 1,
       }});
-      map.addLayer({ id: 'sat-dots', type: 'circle', source: 'satellites', paint: {
+      map.addLayer({ id: 'sat-dots', type: 'circle', source: 'satellites', layout: { visibility: 'none' }, paint: {
         'circle-radius': ['interpolate',['linear'],['zoom'], 1,1.5, 5,3], 'circle-color': ['get','color'], 'circle-opacity': 1.0,
       }});
+      // The spacecraft themselves, lifted to their orbit.
+      if (!map.getLayer('sat-3d')) {
+        satLayerRef.current = createSatelliteLayer('sat-3d');
+        map.addLayer(satLayerRef.current as any);
+      }
 
       // Maritime — ports & naval bases — ocean teal
       map.addLayer({ id: 'maritime-glow', type: 'circle', source: 'maritime', paint: {
@@ -843,19 +902,84 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     });
 
     // ── Satellites (SatNOGS powered) ──
-    map.on('click', 'sat-dots', e => {
-      if (!e.features?.length) return;
-      const p = e.features[0].properties as any;
-      const coords = (e.features[0].geometry as any).coordinates;
-      popup(coords, `<div style="${pStyle}border:1px solid rgba(212,175,55,0.3);">
+    // Layers with their own click handlers. The satellite pick defers to
+    // these, and to nothing else — the basemap is not a click target.
+    const CLICKABLE_LAYERS = new Set(['conflict-icons','cctv-dots','eq-circles','fires-heat',
+      'gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots',
+      'balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots',
+      'sdk-sea','sdk-air','sdk-intel','malware-dots','cyber-heads','gdelt-events-dots',
+      'cf-outage-dots','cf-attack-dots','flight-dots','military-dots','jet-dots','private-dots']);
+
+    // Satellites are picked on the GPU: the pick pass runs the same vertex
+    // shader as the visible one, so the target is always exactly where the
+    // marker was drawn — including its altitude. A ground-projected hit test
+    // would put the target under the satellite instead of on it.
+    map.on('click', e => {
+      const layer = satLayerRef.current;
+      if (!layer) return;
+      // Defer to any layer that has its own click handler, so a camera or an
+      // aircraft under the cursor is not stolen by a satellite behind it.
+      // Only those layers count: querying every feature matches the basemap
+      // land and water fills at essentially any point on the globe, which
+      // made this bail out every single time.
+      const hits = map.queryRenderedFeatures(e.point);
+      if (hits.some(f => f.layer?.id && CLICKABLE_LAYERS.has(f.layer.id))) return;
+      const idx = layer.pick(e.point.x, e.point.y);
+      if (idx == null) return;
+      const p = satRowsRef.current[idx];
+      if (!p) return;
+
+      // Draw the selected satellite's orbit. Fetched per click rather than
+      // bundled with the catalogue: that payload is already megabytes, and an
+      // operator looks at one orbit at a time.
+      layer.setOrbit(null);
+      layer.setSelected(null);
+      if (p.noradId) {
+        const wanted = p.noradId;
+        fetch(`/api/satellites/orbit?id=${encodeURIComponent(wanted)}`)
+          .then(r => (r.ok ? r.json() : null))
+          .then(d => {
+            // A slower reply for a satellite the operator has already moved on
+            // from must not draw over the one they are looking at now.
+            if (!d?.segments || satRowsRef.current[satPickedRef.current ?? -1]?.noradId !== wanted) return;
+            layer.setOrbit(
+              d.segments.map((seg: number[][]) => seg.map(([lng, lat, altKm]) => ({ lng, lat, altKm }))),
+              parseColor(p.color),
+            );
+          })
+          .catch(() => { /* no track is fine; the satellite still shows */ });
+      }
+      satPickedRef.current = idx;
+      layer.setSelected(idx);
+      popup([p.lng, p.lat], `<div style="${pStyle}border:1px solid rgba(212,175,55,0.3);">
         <div style="color:#D4AF37;font-size:12px;font-weight:700;letter-spacing:0.1em;margin-bottom:4px;">🛰️ ${htmlEsc(p.name)}</div>
         <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:4px;font-size:9px;margin-bottom:8px;">
           <div><span style="color:#5C5A54;">MISSION</span><br/><span style="color:${colorSafe(p.color)};">${htmlEsc(p.mission||'Unknown')}</span></div>
           <div><span style="color:#5C5A54;">ALT</span><br/><span style="color:#00E5FF;">${p.alt ? p.alt+' km' : '—'}</span></div>
-          <div><span style="color:#5C5A54;">POS</span><br/><span style="color:#E8E6E0;">${coords[1].toFixed(2)}°, ${coords[0].toFixed(2)}°</span></div>
+          <div><span style="color:#5C5A54;">POS</span><br/><span style="color:#E8E6E0;">${p.lat.toFixed(2)}°, ${p.lng.toFixed(2)}°</span></div>
         </div>
         ${p.noradId ? `<a href="https://www.n2yo.com/satellite/?s=${p.noradId}" target="_blank" style="display:block;text-align:center;padding:4px;margin-top:6px;font-size:8px;font-family:monospace;letter-spacing:0.1em;text-decoration:none;color:#00E5FF;border:1px solid rgba(0,229,255,0.4);background:rgba(0,229,255,0.1);border-radius:2px;cursor:pointer;">📡 TRACK ON N2YO</a>` : ''}
       </div>`);
+    });
+
+    // The cursor should say a satellite is clickable, like every other layer.
+    // Throttled to one test per frame: mousemove fires far faster than the
+    // screen updates, and each pick is a full offscreen re-render of the
+    // whole catalogue — measured at 1-2 ms with ~19,000 satellites.
+    let hoverQueued = false;
+    map.on('mousemove', e => {
+      const layer = satLayerRef.current;
+      if (!layer || hoverQueued) return;
+      hoverQueued = true;
+      requestAnimationFrame(() => {
+        hoverQueued = false;
+        const canvas = map.getCanvas();
+        // Never fight another layer that has already claimed the cursor.
+        if (canvas.style.cursor && canvas.style.cursor !== 'pointer') return;
+        const over = layer.pick(e.point.x, e.point.y) != null;
+        if (over) canvas.style.cursor = 'pointer';
+        else if (canvas.style.cursor === 'pointer') canvas.style.cursor = '';
+      });
     });
 
     // ── Fires (with NASA FIRMS link) ──
@@ -1089,7 +1213,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     });
 
     // ── Generic hover for clickables ──
-    ['conflict-icons','cctv-dots','eq-circles','sat-dots','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo','malware-dots','cyber-heads','gdelt-events-dots','cf-outage-dots','cf-attack-dots'].forEach(layer => {
+    ['conflict-icons','cctv-dots','eq-circles','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo','malware-dots','cyber-heads','gdelt-events-dots','cf-outage-dots','cf-attack-dots'].forEach(layer => {
       map.on('mouseenter', layer, () => { map.getCanvas().style.cursor = 'pointer'; });
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
     });
@@ -1409,6 +1533,17 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     setGeo('earthquakes', activeLayers.earthquakes && data.earthquakes ? data.earthquakes.map((eq: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [eq.lng, eq.lat] }, properties: { id: eq.id, magnitude: eq.magnitude, place: eq.place, depth: eq.depth, source: eq.source } })) : []);
   }, [mapReady, data.earthquakes, activeLayers.earthquakes, setGeo]);
 
+  /** Catalogue rows -> the packed form the 3D layer draws. */
+  const toSatPoints = useCallback((rows: SatelliteRow[]): SatPoint[] => rows.map((s) => ({
+    lng: s.lng,
+    lat: s.lat,
+    altKm: s.alt,
+    color: parseColor(s.color),
+    // Stations are the ones an operator is usually looking for, so they get
+    // to be findable in a field of several hundred identical dots.
+    size: s.category === 'science' || /ISS|TIANGONG/i.test(s.name || '') ? 2.2 : 1,
+  })), []);
+
   useEffect(() => {
     if (!mapReady) return;
     const sats = data.satellites || [];
@@ -1417,6 +1552,8 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     // If 'All Satellites' is on, show everything
     if (al.satellites) {
       setGeo('satellites', sats.map((s: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [s.lng, s.lat] }, properties: { name: s.name, color: s.color, mission: s.mission, alt: s.alt, noradId: s.noradId, category: s.category } })));
+      satRowsRef.current = sats;
+      satLayerRef.current?.setPoints(toSatPoints(sats));
       return;
     }
     
@@ -1430,11 +1567,15 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     
     if (enabledCategories.length === 0) {
       setGeo('satellites', []);
+      satRowsRef.current = [];
+      satLayerRef.current?.setPoints([]);
       return;
     }
     
     const filtered = sats.filter((s: any) => enabledCategories.includes(s.category));
     setGeo('satellites', filtered.map((s: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [s.lng, s.lat] }, properties: { name: s.name, color: s.color, mission: s.mission, alt: s.alt, noradId: s.noradId, category: s.category } })));
+    satRowsRef.current = filtered;
+    satLayerRef.current?.setPoints(toSatPoints(filtered));
   }, [mapReady, data.satellites, activeLayers.satellites, (activeLayers as any).sat_comms, (activeLayers as any).sat_military, (activeLayers as any).sat_navigation, (activeLayers as any).sat_earth, (activeLayers as any).sat_science, setGeo]);
 
   useEffect(() => {
@@ -1751,7 +1892,12 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     if (!mapReady) return;
     setVis(['eq-circles','eq-label'], activeLayers.earthquakes);
     const anySat = activeLayers.satellites || (activeLayers as any).sat_comms || (activeLayers as any).sat_military || (activeLayers as any).sat_navigation || (activeLayers as any).sat_earth || (activeLayers as any).sat_science;
-    setVis(['sat-glow','sat-dots'], anySat);
+    // The circle layers stay hidden whatever the toggles say — the 3D layer
+    // is the single representation, and showing both drew every satellite
+    // twice, once flat on the ground and once at altitude.
+    setVis(['sat-glow','sat-dots'], false);
+    // Clearing the 3D layer is what actually turns satellites off.
+    if (!anySat) { satRowsRef.current = []; satLayerRef.current?.setPoints([]); }
     setVis(['gdelt-dots'], activeLayers.global_incidents);
     setVis(['gdelt-events-dots'], (activeLayers as any).gdelt_events);
     setVis(['cf-outage-halo','cf-outage-dots','cf-outage-label'], (activeLayers as any).cf_outages);

--- a/src/lib/orbit.test.ts
+++ b/src/lib/orbit.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { propagateTLE, orbitalPeriodMinutes, orbitPath, splitAtAntimeridian, wrapLongitude } from './orbit';
+
+/**
+ * A real ISS TLE. Epoch is fixed, so every assertion below is reproducible:
+ * propagating a fixed element set to a fixed instant is deterministic.
+ */
+const ISS_1 = '1 25544U 98067A   24001.50000000  .00016717  00000-0  30777-3 0  9993';
+const ISS_2 = '2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.49309239 43458';
+const AT = new Date('2024-01-01T12:00:00Z');
+
+describe('wrapLongitude', () => {
+  it('leaves an in-range longitude alone', () => {
+    expect(wrapLongitude(0)).toBe(0);
+    expect(wrapLongitude(179.9)).toBeCloseTo(179.9, 6);
+    expect(wrapLongitude(-179.9)).toBeCloseTo(-179.9, 6);
+  });
+
+  it('wraps past the antimeridian rather than clamping', () => {
+    expect(wrapLongitude(181)).toBeCloseTo(-179, 6);
+    expect(wrapLongitude(-181)).toBeCloseTo(179, 6);
+    // 540 is the antimeridian, which normalises to -180. Same meridian as
+    // +180; -180 is the canonical end of a half-open [-180, 180) range.
+    expect(wrapLongitude(540)).toBeCloseTo(-180, 6);
+  });
+});
+
+describe('propagateTLE', () => {
+  it('puts the ISS in a plausible orbit', () => {
+    const p = propagateTLE(ISS_1, ISS_2, AT)!;
+    expect(p).not.toBeNull();
+    // The ISS sits near 400 km and its inclination bounds latitude at 51.6.
+    expect(p.altKm).toBeGreaterThan(300);
+    expect(p.altKm).toBeLessThan(500);
+    expect(Math.abs(p.lat)).toBeLessThanOrEqual(51.7);
+    expect(p.lng).toBeGreaterThanOrEqual(-180);
+    expect(p.lng).toBeLessThanOrEqual(180);
+  });
+
+  it('is deterministic for a fixed instant', () => {
+    const a = propagateTLE(ISS_1, ISS_2, AT)!;
+    const b = propagateTLE(ISS_1, ISS_2, AT)!;
+    expect(a).toEqual(b);
+  });
+
+  it('moves the satellite forward in time', () => {
+    const a = propagateTLE(ISS_1, ISS_2, AT)!;
+    const b = propagateTLE(ISS_1, ISS_2, new Date(AT.getTime() + 60_000))!;
+    // ~7.66 km/s, so a minute is several degrees of arc — never the same point.
+    expect(Math.abs(a.lat - b.lat) + Math.abs(a.lng - b.lng)).toBeGreaterThan(1);
+  });
+
+  it('never reports latitude beyond the orbit inclination', () => {
+    // The old two-body solve returned geocentric latitude, which is a
+    // different number from the geodetic latitude a map draws with.
+    for (let m = 0; m < 90; m += 7) {
+      const p = propagateTLE(ISS_1, ISS_2, new Date(AT.getTime() + m * 60_000));
+      if (p) expect(Math.abs(p.lat), `minute ${m}`).toBeLessThanOrEqual(51.8);
+    }
+  });
+
+  it('returns null for malformed input instead of throwing', () => {
+    expect(propagateTLE('', '')).toBeNull();
+    expect(propagateTLE('not a tle', 'not a tle')).toBeNull();
+    expect(propagateTLE(ISS_1, '2 25544  bad line')).toBeNull();
+  });
+});
+
+describe('orbitalPeriodMinutes', () => {
+  it('reads the ISS period off the mean motion', () => {
+    // 15.49 rev/day -> ~93 minutes.
+    expect(orbitalPeriodMinutes(ISS_2)).toBeCloseTo(1440 / 15.49309239, 4);
+  });
+
+  it('rejects a line with no usable mean motion', () => {
+    expect(orbitalPeriodMinutes('2 25544  51.6416 247.4627 0006703 130.5360 325.0288 00000000000000')).toBeNull();
+    expect(orbitalPeriodMinutes('')).toBeNull();
+  });
+});
+
+describe('orbitPath', () => {
+  it('samples a full revolution and comes back near the start', () => {
+    const path = orbitPath(ISS_1, ISS_2, 180, AT);
+    expect(path.length).toBeGreaterThan(150);
+    // One period later the satellite is back at the same point in its orbit,
+    // so latitude closes even though longitude has shifted with Earth's spin.
+    expect(Math.abs(path[0].lat - path[path.length - 1].lat)).toBeLessThan(1);
+  });
+
+  it('carries Earth rotation, so the track is not a closed ring', () => {
+    // ~93 min of rotation is ~23 degrees of longitude. A propagator that
+    // ignored it would return to the same longitude, and the ground track
+    // would draw as a ring rather than a track.
+    const path = orbitPath(ISS_1, ISS_2, 180, AT);
+    const drift = Math.abs(wrapLongitude(path[path.length - 1].lng - path[0].lng));
+    expect(drift).toBeGreaterThan(15);
+    expect(drift).toBeLessThan(35);
+  });
+
+  it('holds altitude within the orbit eccentricity, not wildly', () => {
+    const alts = orbitPath(ISS_1, ISS_2, 90, AT).map(p => p.altKm);
+    expect(Math.max(...alts) - Math.min(...alts)).toBeLessThan(60);
+  });
+
+  it('returns nothing for a TLE it cannot read', () => {
+    expect(orbitPath('', '', 10, AT)).toEqual([]);
+  });
+});
+
+describe('splitAtAntimeridian', () => {
+  const p = (lng: number, lat = 0): { lat: number; lng: number; altKm: number } => ({ lat, lng, altKm: 400 });
+
+  it('leaves a path that never crosses in one piece', () => {
+    const runs = splitAtAntimeridian([p(0), p(10), p(20)]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toHaveLength(3);
+  });
+
+  it('cuts the path where it wraps', () => {
+    // Drawn unsplit, this segment sweeps backwards across every meridian.
+    const runs = splitAtAntimeridian([p(170), p(179), p(-179), p(-170)]);
+    expect(runs).toHaveLength(2);
+    expect(runs[0].map(x => x.lng)).toEqual([170, 179]);
+    expect(runs[1].map(x => x.lng)).toEqual([-179, -170]);
+  });
+
+  it('drops a run too short to draw', () => {
+    // A single orphaned point either side of a crossing is not a line.
+    expect(splitAtAntimeridian([p(179), p(-179)])).toEqual([]);
+  });
+
+  it('handles an empty path', () => {
+    expect(splitAtAntimeridian([])).toEqual([]);
+  });
+
+  it('splits a real ISS orbit into drawable runs', () => {
+    const runs = splitAtAntimeridian(orbitPath(ISS_1, ISS_2, 180, AT));
+    expect(runs.length).toBeGreaterThanOrEqual(1);
+    for (const run of runs) {
+      for (let i = 1; i < run.length; i++) {
+        expect(Math.abs(run[i].lng - run[i - 1].lng)).toBeLessThanOrEqual(180);
+      }
+    }
+  });
+});

--- a/src/lib/orbit.ts
+++ b/src/lib/orbit.ts
@@ -1,0 +1,121 @@
+import { twoline2satrec, propagate, gstime, eciToGeodetic, degreesLat, degreesLong } from 'satellite.js';
+
+/**
+ * OSIRIS — orbital propagation
+ *
+ * The satellites route carried a hand-rolled propagator: a two-body Kepler
+ * solve with no J2 term and no drag, reporting geocentric latitude as if it
+ * were geodetic and altitude above a sphere of radius 6371 km. That is fine
+ * for a dot on a flat map and wrong the moment altitude is drawn — an orbit
+ * placed by it sits visibly off the satellite it belongs to.
+ *
+ * satellite.js was already a dependency and unused. This wraps its SGP4/SDP4,
+ * which carries the perturbations the old solve dropped and returns geodetic
+ * latitude and height above the WGS84 ellipsoid.
+ */
+
+/** A propagated position. `altKm` is height above the WGS84 ellipsoid. */
+export interface SatPosition {
+  lat: number;
+  lng: number;
+  altKm: number;
+}
+
+/** Longitude wrapped to [-180, 180]. */
+export function wrapLongitude(deg: number): number {
+  return ((((deg + 180) % 360) + 360) % 360) - 180;
+}
+
+/**
+ * Propagates one TLE to a moment in time.
+ *
+ * Returns null rather than throwing, and null for a decayed or nonsensical
+ * result: SGP4 reports an error code for orbits it can no longer model, and a
+ * satellite that has re-entered still has a TLE in the catalog for a while.
+ */
+export function propagateTLE(line1: string, line2: string, when: Date = new Date()): SatPosition | null {
+  let satrec;
+  try {
+    satrec = twoline2satrec(line1, line2);
+  } catch {
+    return null;
+  }
+  // satrec.error is SGP4's own status; non-zero means it declined to model this.
+  if (!satrec || (satrec as { error?: number }).error) return null;
+
+  let eci;
+  try {
+    eci = propagate(satrec, when);
+  } catch {
+    return null;
+  }
+  const position = eci?.position;
+  if (!position || typeof position === 'boolean') return null;
+
+  const geodetic = eciToGeodetic(position, gstime(when));
+  const lat = degreesLat(geodetic.latitude);
+  const lng = wrapLongitude(degreesLong(geodetic.longitude));
+  const altKm = geodetic.height;
+
+  if (!Number.isFinite(lat) || !Number.isFinite(lng) || !Number.isFinite(altKm)) return null;
+  // Below this it has re-entered; above it is not an Earth orbit we draw.
+  if (altKm < 80 || altKm > 60000) return null;
+  return { lat, lng, altKm };
+}
+
+/** Orbital period in minutes, from the TLE's mean motion (revolutions/day). */
+export function orbitalPeriodMinutes(line2: string): number | null {
+  const meanMotion = parseFloat(line2.substring(52, 63));
+  if (!Number.isFinite(meanMotion) || meanMotion <= 0) return null;
+  return 1440 / meanMotion;
+}
+
+/**
+ * Samples one full revolution, starting now.
+ *
+ * Sampled in time rather than in true anomaly so the spacing is even along the
+ * path for any eccentricity, and so the ground track carries Earth's rotation
+ * under the orbit — that westward drift between successive passes is most of
+ * what makes a track read as an orbit rather than a ring.
+ */
+export function orbitPath(
+  line1: string,
+  line2: string,
+  steps = 180,
+  from: Date = new Date(),
+): SatPosition[] {
+  const period = orbitalPeriodMinutes(line2);
+  if (!period) return [];
+  const out: SatPosition[] = [];
+  for (let i = 0; i <= steps; i++) {
+    const when = new Date(from.getTime() + (period * 60_000 * i) / steps);
+    const p = propagateTLE(line1, line2, when);
+    // A gap is better than a fabricated point: skipping keeps the rest of the
+    // path truthful, where interpolating across would invent a position.
+    if (p) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Splits a path wherever it crosses the antimeridian.
+ *
+ * A polyline drawn straight from +179° to -179° sweeps the whole way back
+ * around the world, which on a flat map is a stripe across every orbit and on
+ * the globe is a chord through the planet. Each returned run is safe to draw
+ * as one LineString.
+ */
+export function splitAtAntimeridian(path: SatPosition[]): SatPosition[][] {
+  if (path.length === 0) return [];
+  const runs: SatPosition[][] = [];
+  let run: SatPosition[] = [path[0]];
+  for (let i = 1; i < path.length; i++) {
+    if (Math.abs(path[i].lng - path[i - 1].lng) > 180) {
+      runs.push(run);
+      run = [];
+    }
+    run.push(path[i]);
+  }
+  if (run.length) runs.push(run);
+  return runs.filter(r => r.length > 1);
+}

--- a/src/lib/satellite-layer.test.ts
+++ b/src/lib/satellite-layer.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { displayElevation, packOrbit, packVertices, parseColor, type SatPoint } from './satellite-layer';
+
+const sat = (o: Partial<SatPoint> = {}): SatPoint =>
+  ({ lng: 0, lat: 0, altKm: 400, color: 0x00e5ff, size: 1, ...o });
+
+describe('displayElevation', () => {
+  it('keeps the ordering of the orbital regimes', () => {
+    // The compression must never reorder them: a GEO bird drawn below the ISS
+    // would be worse than drawing everything on the ground.
+    const leo = displayElevation(400);
+    const meo = displayElevation(20200);
+    const geo = displayElevation(35786);
+    expect(leo).toBeLessThan(meo);
+    expect(meo).toBeLessThan(geo);
+  });
+
+  it('compresses, so GEO stays on screen beside LEO', () => {
+    // True to scale GEO is ~89x the ISS altitude, which cannot share a
+    // viewport with the ground. Compressed it is single digits.
+    const ratio = displayElevation(35786) / displayElevation(400);
+    expect(35786 / 400).toBeGreaterThan(80);
+    expect(ratio).toBeGreaterThan(2);
+    expect(ratio).toBeLessThan(20);
+  });
+
+  it('lifts LEO clear of the surface rather than collapsing it', () => {
+    // 400 km is 6% of an Earth radius; undisplaced it reads as ground clutter.
+    expect(displayElevation(400)).toBeGreaterThan(400_000);
+  });
+
+  it('scales with the exaggeration control', () => {
+    expect(displayElevation(400, 2)).toBeCloseTo(displayElevation(400, 1) * 2, 6);
+    expect(displayElevation(400, 0)).toBe(0);
+  });
+
+  it('is safe on junk input', () => {
+    expect(displayElevation(0)).toBe(0);
+    expect(displayElevation(-100)).toBe(0);
+    expect(displayElevation(NaN)).toBe(0);
+    expect(displayElevation(Infinity)).toBe(0);
+  });
+});
+
+describe('parseColor', () => {
+  it('reads the catalogue hex colours', () => {
+    expect(parseColor('#FF3D3D')).toBe(0xff3d3d);
+    expect(parseColor('00E676')).toBe(0x00e676);
+    expect(parseColor('#ffd700')).toBe(0xffd700);
+  });
+
+  it('falls back rather than producing NaN, which would blank the point', () => {
+    expect(parseColor(undefined)).toBe(0x00e5ff);
+    expect(parseColor('')).toBe(0x00e5ff);
+    expect(parseColor('red')).toBe(0x00e5ff);
+    expect(parseColor('#ff')).toBe(0x00e5ff);
+  });
+});
+
+describe('packVertices', () => {
+  it('lays out 7 floats per satellite', () => {
+    expect(packVertices([sat(), sat(), sat()])).toHaveLength(21);
+    expect(packVertices([])).toHaveLength(0);
+  });
+
+  it('puts mercator xy in [0,1] for the whole globe', () => {
+    const v = packVertices([
+      sat({ lng: -180, lat: 85 }),
+      sat({ lng: 180, lat: -85 }),
+      sat({ lng: 0, lat: 0 }),
+    ]);
+    for (let i = 0; i < 3; i++) {
+      expect(v[i * 7]).toBeGreaterThanOrEqual(0);
+      expect(v[i * 7]).toBeLessThanOrEqual(1);
+      expect(v[i * 7 + 1]).toBeGreaterThanOrEqual(0);
+      expect(v[i * 7 + 1]).toBeLessThanOrEqual(1);
+    }
+    // Null Island is the middle of the mercator square.
+    expect(v[14]).toBeCloseTo(0.5, 6);
+    expect(v[15]).toBeCloseTo(0.5, 6);
+  });
+
+  it('writes elevation in metres, matching the shader contract', () => {
+    const v = packVertices([sat({ altKm: 400 })]);
+    expect(v[2] / displayElevation(400)).toBeCloseTo(1, 5);
+  });
+
+  it('unpacks colour channels to 0..1 in RGB order', () => {
+    const v = packVertices([sat({ color: 0xff8000 })]);
+    expect(v[3]).toBeCloseTo(1, 5);
+    expect(v[4]).toBeCloseTo(128 / 255, 5);
+    expect(v[5]).toBeCloseTo(0, 5);
+  });
+
+  it('keeps each satellite in its own slot', () => {
+    // An off-by-one in the stride puts every satellite at its neighbour's
+    // altitude, which looks plausible and is entirely wrong.
+    const v = packVertices([
+      sat({ altKm: 400, color: 0xff0000, size: 1 }),
+      sat({ altKm: 35786, color: 0x00ff00, size: 2 }),
+    ]);
+    // Relative comparison: these are float32, which holds ~7 significant
+    // digits, so an absolute tolerance at 1e6 magnitude is unmeetable.
+    expect(v[2] / displayElevation(400)).toBeCloseTo(1, 5);
+    expect(v[6]).toBe(1);
+    expect(v[9] / displayElevation(35786)).toBeCloseTo(1, 5);
+    expect(v[13]).toBe(2);
+    expect(v[10]).toBeCloseTo(0, 5);
+    expect(v[11]).toBeCloseTo(1, 5);
+  });
+});
+
+describe('packOrbit', () => {
+  const seg = [
+    { lng: 0, lat: 0, altKm: 400 },
+    { lng: 10, lat: 5, altKm: 420 },
+    { lng: 20, lat: 10, altKm: 440 },
+  ];
+
+  it('lays out 3 floats per track point', () => {
+    expect(packOrbit(seg)).toHaveLength(9);
+    expect(packOrbit([])).toHaveLength(0);
+  });
+
+  it('shares the marker contract, so track and satellite land in one space', () => {
+    // If these ever diverge the orbit draws beside the satellite instead of
+    // through it, which looks like a propagation bug and is not one.
+    const marker = packVertices([{ ...seg[0], color: 0, size: 1 }]);
+    const track = packOrbit(seg);
+    expect(track[0]).toBeCloseTo(marker[0], 6);
+    expect(track[1]).toBeCloseTo(marker[1], 6);
+    expect(track[2] / marker[2]).toBeCloseTo(1, 5);
+  });
+
+  it('follows the altitude along the track, not one flat height', () => {
+    const t = packOrbit(seg);
+    expect(t[2]).toBeLessThan(t[5]);
+    expect(t[5]).toBeLessThan(t[8]);
+  });
+
+  it('scales with exaggeration like the markers do', () => {
+    expect(packOrbit(seg, 2)[2] / packOrbit(seg, 1)[2]).toBeCloseTo(2, 4);
+  });
+});

--- a/src/lib/satellite-layer.ts
+++ b/src/lib/satellite-layer.ts
@@ -1,0 +1,591 @@
+import type { CustomLayerInterface, CustomRenderMethodInput, Map as MlMap } from 'maplibre-gl';
+import { MercatorCoordinate } from 'maplibre-gl';
+
+/**
+ * OSIRIS — satellites drawn at their real altitude
+ *
+ * Satellites were circle features pinned to the ground, so a 35,786 km GEO
+ * bird and a 400 km ISS sat on the same surface as a traffic camera. The map
+ * already runs MapLibre's globe projection, and the catalogue already carries
+ * an altitude per satellite; nothing was lifting one off the other.
+ *
+ * MapLibre has no elevation property on circle or symbol layers. It does hand
+ * custom layers a projection prelude, and in globe mode that prelude exposes
+ *
+ *     vec4 projectTileFor3D(vec2 posInTile, float elevation)
+ *
+ * which is what places geometry above the surface with the globe's own
+ * curvature and camera. Verified against the running map before this was
+ * written: the globe variant of the prelude does export it.
+ *
+ * Using MapLibre's prelude rather than our own matrix maths is what makes this
+ * survive a projection change — the same shader compiles for mercator, where
+ * `projectTileFor3D` is the flat-map equivalent, so the layer keeps working
+ * when the operator presses 2D.
+ */
+
+/** Elevation is metres above the ellipsoid; the catalogue is in kilometres. */
+const KM_TO_M = 1000;
+
+/**
+ * Altitude is compressed into a band the camera can actually show.
+ *
+ * Two hard limits bound this, both found by rendering and reading back the
+ * framebuffer rather than by reasoning:
+ *
+ *   Floor. A satellite drawn at or near the surface is rejected by the depth
+ *   test against the globe — it z-fights the very sphere it orbits. Nothing
+ *   below roughly a tenth of an Earth radius reliably survives.
+ *
+ *   Ceiling. Drawn anywhere near true scale, GEO leaves the view frustum at
+ *   any zoom that also shows the ground, and simply vanishes.
+ *
+ * So real altitude is mapped onto [FLOOR_KM, CEILING_KM]. The curve is sqrt,
+ * which spreads the LEO shell — where most of the catalogue lives, 161 km to
+ * about 2,000 km — instead of compressing it into a single line, while still
+ * placing MEO and GEO distinguishably above it.
+ *
+ * This is a display transform, not a measurement. The popup shows the real
+ * altitude in kilometres.
+ */
+const FLOOR_KM = 620;      // clears the globe depth test
+const CEILING_KM = 2500;   // stays inside the frustum at world zoom
+const MIN_ALT_KM = 150;    // lowest catalogue altitude that still orbits
+const MAX_ALT_KM = 36000;  // the GEO belt
+
+export function displayElevation(altKm: number, exaggeration = 1): number {
+  if (!Number.isFinite(altKm) || altKm <= 0) return 0;
+  const clamped = Math.min(Math.max(altKm, MIN_ALT_KM), MAX_ALT_KM);
+  const t = (Math.sqrt(clamped) - Math.sqrt(MIN_ALT_KM)) /
+            (Math.sqrt(MAX_ALT_KM) - Math.sqrt(MIN_ALT_KM));
+  return (FLOOR_KM + (CEILING_KM - FLOOR_KM) * t) * exaggeration * KM_TO_M;
+}
+
+export interface SatPoint {
+  lng: number;
+  lat: number;
+  altKm: number;
+  /** Packed 0xRRGGBB. */
+  color: number;
+  /** Point size multiplier — the ISS and other stations read larger. */
+  size: number;
+}
+
+const VERT = `
+in vec2 a_corner;   // unit quad, -1..1 — one shared quad, drawn per instance
+in vec3 a_pos;      // x, y = mercator [0..1]; z = display elevation (metres)
+in vec3 a_color;
+in float a_size;
+uniform vec2 u_viewport;
+uniform int u_selected;
+out vec2 v_corner;
+out vec3 v_color;
+out float v_hot;
+void main() {
+  vec4 clip = projectTileFor3D(a_pos.xy, a_pos.z);
+  // Shrink with distance so a dense catalogue does not turn the globe into a
+  // solid sheet of dots when zoomed out.
+  float px = clamp(a_size * 260.0 / max(clip.w, 0.0001), 2.5, 16.0);
+  // One satellite out of nineteen thousand is invisible unless it is told to
+  // stand out; the selected one gets size and a ring.
+  v_hot = gl_InstanceID == u_selected ? 1.0 : 0.0;
+  px += v_hot * 9.0;
+  // Expand the quad in clip space. Multiplying by clip.w cancels the
+  // perspective divide, so the marker keeps a constant size in pixels.
+  gl_Position = clip + vec4(a_corner * px / u_viewport * 2.0 * clip.w, 0.0, 0.0);
+  v_corner = a_corner;
+  v_color = a_color;
+}`;
+
+const FRAG = `
+precision mediump float;
+in vec2 v_corner;
+in vec3 v_color;
+in float v_hot;
+out vec4 fragColor;
+void main() {
+  // Round the marker off inside the quad; square satellites read as dead
+  // pixels rather than objects.
+  float r = length(v_corner);
+  if (r > 1.0) discard;
+  if (v_hot > 0.5) {
+    // A bright ring rather than a bigger blob — a blob just looks like a
+    // closer satellite, a ring reads as a selection.
+    float ring = smoothstep(0.55, 0.75, r) * smoothstep(1.0, 0.85, r);
+    vec3 c = mix(v_color, vec3(1.0), 0.55);
+    fragColor = vec4(c, max(ring, smoothstep(0.45, 0.0, r)) * 0.95);
+    return;
+  }
+  fragColor = vec4(v_color, smoothstep(1.0, 0.55, r));
+}`;
+
+/**
+ * The picking pass. Same vertex maths as the visible pass — that is the whole
+ * point: whatever the projection does to a satellite on screen, the pick
+ * agrees, because it is the identical computation. Reimplementing the globe
+ * projection on the CPU to hit-test would be a second source of truth, and it
+ * would drift.
+ *
+ * The instance index is written straight out as a colour. gl_InstanceID means
+ * no extra attribute is needed.
+ */
+const PICK_VERT = `
+in vec2 a_corner;
+in vec3 a_pos;
+in float a_size;
+uniform vec2 u_viewport;
+flat out vec3 v_id;
+out vec2 v_corner;
+void main() {
+  vec4 clip = projectTileFor3D(a_pos.xy, a_pos.z);
+  // A little larger than the drawn marker: clicking is coarse, and a target
+  // the exact size of a 3px dot is a target nobody can hit.
+  float px = clamp(a_size * 260.0 / max(clip.w, 0.0001), 2.5, 16.0) + 4.0;
+  gl_Position = clip + vec4(a_corner * px / u_viewport * 2.0 * clip.w, 0.0, 0.0);
+  int id = gl_InstanceID + 1;   // 0 is reserved for 'nothing here'
+  v_id = vec3(float(id & 255), float((id >> 8) & 255), float((id >> 16) & 255)) / 255.0;
+  v_corner = a_corner;
+}`;
+
+const PICK_FRAG = `
+precision mediump float;
+flat in vec3 v_id;
+in vec2 v_corner;
+out vec4 fragColor;
+void main() {
+  if (length(v_corner) > 1.0) discard;
+  fragColor = vec4(v_id, 1.0);
+}`;
+
+/**
+ * The orbit track of the selected satellite, drawn at altitude rather than
+ * projected onto the ground. A ground track is a different object: it shows
+ * where the satellite passes over, not where it is. Lifting the line to the
+ * same elevation as the marker is what makes it read as an orbit around the
+ * planet instead of a line drawn on it.
+ */
+const ORBIT_VERT = `
+in vec3 a_pos;
+void main() {
+  gl_Position = projectTileFor3D(a_pos.xy, a_pos.z);
+}`;
+
+const ORBIT_FRAG = `
+precision mediump float;
+uniform vec3 u_color;
+out vec4 fragColor;
+void main() { fragColor = vec4(u_color, 0.85); }`;
+
+function compile(gl: WebGL2RenderingContext, type: number, src: string): WebGLShader {
+  const sh = gl.createShader(type)!;
+  gl.shaderSource(sh, src);
+  gl.compileShader(sh);
+  if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
+    const log = gl.getShaderInfoLog(sh);
+    gl.deleteShader(sh);
+    throw new Error(`satellite layer shader failed: ${log}`);
+  }
+  return sh;
+}
+
+/**
+ * Builds the interleaved vertex buffer for a set of satellites.
+ *
+ * Exported so the packing is testable without a GL context: this is where an
+ * off-by-one silently puts every satellite at the wrong altitude.
+ */
+export function packVertices(points: SatPoint[], exaggeration = 1): Float32Array<ArrayBuffer> {
+  const STRIDE = 7; // x, y, z, r, g, b, size
+  const out = new Float32Array(points.length * STRIDE);
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i];
+    const m = MercatorCoordinate.fromLngLat({ lng: p.lng, lat: p.lat }, 0);
+    const o = i * STRIDE;
+    out[o] = m.x;
+    out[o + 1] = m.y;
+    out[o + 2] = displayElevation(p.altKm, exaggeration);
+    out[o + 3] = ((p.color >> 16) & 0xff) / 255;
+    out[o + 4] = ((p.color >> 8) & 0xff) / 255;
+    out[o + 5] = (p.color & 0xff) / 255;
+    out[o + 6] = p.size;
+  }
+  return out;
+}
+
+/**
+ * Packs one orbit segment. Same mercator + metres-of-elevation contract as
+ * packVertices, so the track and the marker land in the same space.
+ */
+export function packOrbit(segment: { lng: number; lat: number; altKm: number }[], exaggeration = 1): Float32Array<ArrayBuffer> {
+  const out = new Float32Array(segment.length * 3);
+  for (let i = 0; i < segment.length; i++) {
+    const p = segment[i];
+    const m = MercatorCoordinate.fromLngLat({ lng: p.lng, lat: p.lat }, 0);
+    out[i * 3] = m.x;
+    out[i * 3 + 1] = m.y;
+    out[i * 3 + 2] = displayElevation(p.altKm, exaggeration);
+  }
+  return out;
+}
+
+/** Parses "#RRGGBB" (or a bare RRGGBB) into a packed integer. */
+export function parseColor(hex: string | undefined, fallback = 0x00e5ff): number {
+  if (!hex) return fallback;
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+  return m ? parseInt(m[1], 16) : fallback;
+}
+
+/**
+ * A MapLibre custom layer drawing satellites as points at altitude.
+ *
+ * The shader is compiled lazily per projection variant: MapLibre changes the
+ * prelude when the projection changes, and a program built against the globe
+ * prelude draws nothing under mercator.
+ */
+export function createSatelliteLayer(id: string): CustomLayerInterface & {
+  setPoints(points: SatPoint[]): void;
+  setExaggeration(value: number): void;
+  /** Index into the last setPoints() array, or null if nothing is under (x, y). */
+  pick(x: number, y: number): number | null;
+  /** Orbit track of the selected satellite; null clears it. */
+  setOrbit(segments: { lng: number; lat: number; altKm: number }[][] | null, color?: number): void;
+  /** Highlights one index from the last setPoints(); null clears it. */
+  setSelected(index: number | null): void;
+} {
+  let gl: WebGL2RenderingContext | null = null;
+  let map: MlMap | null = null;
+  let program: WebGLProgram | null = null;
+  let variant = '';
+  let buffer: WebGLBuffer | null = null;
+  let quad: WebGLBuffer | null = null;
+  let pickProgram: WebGLProgram | null = null;
+  let pickFbo: WebGLFramebuffer | null = null;
+  let pickTex: WebGLTexture | null = null;
+  let pickDepth: WebGLRenderbuffer | null = null;
+  let pickSize = { w: 0, h: 0 };
+  // The projection uniforms are only handed to us during render(). A pick
+  // happens on a click, between frames, so the last frame's values are kept
+  // and reused — the camera has not moved since.
+  let lastProjection: CustomRenderMethodInput['defaultProjectionData'] | null = null;
+  let orbitProgram: WebGLProgram | null = null;
+  let orbitBuffers: { buf: WebGLBuffer; count: number }[] = [];
+  let orbitSegments: { lng: number; lat: number; altKm: number }[][] | null = null;
+  let orbitColor = 0x00e5ff;
+  let orbitDirty = false;
+  let selected = -1;
+  let vertices: Float32Array<ArrayBuffer> = new Float32Array(0);
+  let count = 0;
+  let exaggeration = 1;
+  let points: SatPoint[] = [];
+  let dirty = false;
+
+  const link = (prelude: string, define: string, vert: string, frag: string): WebGLProgram => {
+    const vs = compile(gl!, gl!.VERTEX_SHADER, `#version 300 es\n${prelude}\n${define}\n${vert}`);
+    const fs = compile(gl!, gl!.FRAGMENT_SHADER, `#version 300 es\n${frag}`);
+    const pr = gl!.createProgram()!;
+    gl!.attachShader(pr, vs);
+    gl!.attachShader(pr, fs);
+    gl!.linkProgram(pr);
+    gl!.deleteShader(vs);
+    gl!.deleteShader(fs);
+    if (!gl!.getProgramParameter(pr, gl!.LINK_STATUS)) {
+      const log = gl!.getProgramInfoLog(pr);
+      gl!.deleteProgram(pr);
+      throw new Error(`satellite layer link failed: ${log}`);
+    }
+    return pr;
+  };
+
+  const buildProgram = (prelude: string, define: string) => {
+    if (!gl) return;
+    if (program) gl.deleteProgram(program);
+    program = link(prelude, define, VERT, FRAG);
+  };
+
+  /** Lazily sized colour+depth target for the pick pass. */
+  const ensurePickTargets = (w: number, h: number) => {
+    if (!gl || (pickSize.w === w && pickSize.h === h && pickFbo)) return;
+    if (pickTex) gl.deleteTexture(pickTex);
+    if (pickDepth) gl.deleteRenderbuffer(pickDepth);
+    if (pickFbo) gl.deleteFramebuffer(pickFbo);
+    pickTex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, pickTex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, w, h, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    pickDepth = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, pickDepth);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, w, h);
+    pickFbo = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, pickFbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, pickTex, 0);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, pickDepth);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    pickSize = { w, h };
+  };
+
+  /** Binds the quad + per-instance attributes for whichever program is active. */
+  const bindAttributes = (pr: WebGLProgram) => {
+    const cornerLoc = gl!.getAttribLocation(pr, 'a_corner');
+    gl!.bindBuffer(gl!.ARRAY_BUFFER, quad);
+    gl!.enableVertexAttribArray(cornerLoc);
+    gl!.vertexAttribPointer(cornerLoc, 2, gl!.FLOAT, false, 0, 0);
+    gl!.vertexAttribDivisor(cornerLoc, 0);
+
+    gl!.bindBuffer(gl!.ARRAY_BUFFER, buffer);
+    const STRIDE = 7 * 4;
+    for (const [name, size, offset] of [['a_pos', 3, 0], ['a_color', 3, 12], ['a_size', 1, 24]] as const) {
+      const loc = gl!.getAttribLocation(pr, name);
+      if (loc < 0) continue;
+      gl!.enableVertexAttribArray(loc);
+      gl!.vertexAttribPointer(loc, size, gl!.FLOAT, false, STRIDE, offset);
+      gl!.vertexAttribDivisor(loc, 1);
+    }
+    return cornerLoc;
+  };
+
+  /** Instancing divisors are global; leaving them set corrupts later layers. */
+  const clearDivisors = (pr: WebGLProgram, cornerLoc: number) => {
+    gl!.vertexAttribDivisor(cornerLoc, 0);
+    for (const n of ['a_pos', 'a_color', 'a_size']) {
+      const loc = gl!.getAttribLocation(pr, n);
+      if (loc >= 0) gl!.vertexAttribDivisor(loc, 0);
+    }
+  };
+
+  const setProjectionUniforms = (pr: WebGLProgram, proj: NonNullable<CustomRenderMethodInput['defaultProjectionData']>) => {
+    const u = (name: string) => gl!.getUniformLocation(pr, name);
+    gl!.uniformMatrix4fv(u('u_projection_matrix'), false, proj.mainMatrix);
+    gl!.uniform4f(u('u_projection_tile_mercator_coords'),
+      proj.tileMercatorCoords[0], proj.tileMercatorCoords[1],
+      proj.tileMercatorCoords[2], proj.tileMercatorCoords[3]);
+    gl!.uniform4f(u('u_projection_clipping_plane'),
+      proj.clippingPlane[0], proj.clippingPlane[1],
+      proj.clippingPlane[2], proj.clippingPlane[3]);
+    gl!.uniform1f(u('u_projection_transition'), proj.projectionTransition);
+    gl!.uniformMatrix4fv(u('u_projection_fallback_matrix'), false, proj.fallbackMatrix);
+  };
+
+  return {
+    id,
+    type: 'custom',
+    // '3d' so MapLibre depth-tests it against the globe: a satellite behind
+    // the Earth must be occluded by it, not drawn over the top.
+    renderingMode: '3d',
+
+    onAdd(m: MlMap, context: WebGL2RenderingContext) {
+      map = m;
+      gl = context;
+      buffer = gl.createBuffer();
+      // One unit quad, reused for every satellite via instancing.
+      quad = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, quad);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+        -1, -1,  1, -1,  -1, 1,
+        -1,  1,  1, -1,   1, 1,
+      ]), gl.STATIC_DRAW);
+      dirty = true;
+    },
+
+    onRemove() {
+      if (gl) {
+        if (program) gl.deleteProgram(program);
+        if (buffer) gl.deleteBuffer(buffer);
+        if (quad) gl.deleteBuffer(quad);
+        if (pickProgram) gl.deleteProgram(pickProgram);
+        if (pickTex) gl.deleteTexture(pickTex);
+        if (pickDepth) gl.deleteRenderbuffer(pickDepth);
+        if (pickFbo) gl.deleteFramebuffer(pickFbo);
+        if (orbitProgram) gl.deleteProgram(orbitProgram);
+        for (const o of orbitBuffers) gl.deleteBuffer(o.buf);
+      }
+      program = null;
+      buffer = null;
+      quad = null;
+      pickProgram = null;
+      pickTex = null;
+      pickDepth = null;
+      pickFbo = null;
+      pickSize = { w: 0, h: 0 };
+      orbitProgram = null;
+      orbitBuffers = [];
+      gl = null;
+      map = null;
+    },
+
+    setPoints(next: SatPoint[]) {
+      points = next;
+      dirty = true;
+      map?.triggerRepaint();
+    },
+
+    setExaggeration(value: number) {
+      exaggeration = value;
+      dirty = true;
+      orbitDirty = true;
+      map?.triggerRepaint();
+    },
+
+    setSelected(index: number | null) {
+      selected = index ?? -1;
+      map?.triggerRepaint();
+    },
+
+    setOrbit(segments, color) {
+      orbitSegments = segments;
+      if (color !== undefined) orbitColor = color;
+      orbitDirty = true;
+      map?.triggerRepaint();
+    },
+
+    /**
+     * Renders the satellites into an offscreen buffer with each instance
+     * coloured by its index, then reads back the pixels around (x, y).
+     *
+     * Coordinates are CSS pixels, as an event reports them; the draw buffer
+     * may be larger on a scaled display, so they are converted first.
+     */
+    pick(x: number, y: number): number | null {
+      if (!gl || !pickProgram || !buffer || !lastProjection || count === 0) return null;
+      const w = gl.drawingBufferWidth, h = gl.drawingBufferHeight;
+      ensurePickTargets(w, h);
+      if (!pickFbo) return null;
+
+      const ratio = w / (gl.canvas as HTMLCanvasElement).clientWidth;
+      const px = Math.round(x * ratio);
+      // GL's origin is bottom-left; a DOM event's is top-left.
+      const py = Math.round(h - y * ratio);
+
+      const prevFbo = gl.getParameter(gl.FRAMEBUFFER_BINDING);
+      gl.bindFramebuffer(gl.FRAMEBUFFER, pickFbo);
+      gl.viewport(0, 0, w, h);
+      gl.clearColor(0, 0, 0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+      gl.disable(gl.BLEND);
+      // No globe in this buffer to occlude against, so depth testing here
+      // would only let satellites hide each other. Nearest-to-cursor wins.
+      gl.disable(gl.DEPTH_TEST);
+      gl.useProgram(pickProgram);
+      setProjectionUniforms(pickProgram, lastProjection);
+      gl.uniform2f(gl.getUniformLocation(pickProgram, 'u_viewport'), w, h);
+      const cornerLoc = bindAttributes(pickProgram);
+      gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, count);
+      clearDivisors(pickProgram, cornerLoc);
+
+      // Read a small box, not one pixel: a click is never exact, and a marker
+      // a few pixels across is otherwise unhittable.
+      const R = 7;
+      const x0 = Math.max(0, px - R), y0 = Math.max(0, py - R);
+      const bw = Math.min(w - x0, R * 2 + 1), bh = Math.min(h - y0, R * 2 + 1);
+      let best: number | null = null;
+      if (bw > 0 && bh > 0) {
+        const buf = new Uint8Array(bw * bh * 4);
+        gl.readPixels(x0, y0, bw, bh, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+        let bestDist = Infinity;
+        for (let iy = 0; iy < bh; iy++) {
+          for (let ix = 0; ix < bw; ix++) {
+            const o = (iy * bw + ix) * 4;
+            const id = buf[o] | (buf[o + 1] << 8) | (buf[o + 2] << 16);
+            if (id === 0) continue;
+            const dx = x0 + ix - px, dy = y0 + iy - py;
+            const d = dx * dx + dy * dy;
+            if (d < bestDist) { bestDist = d; best = id - 1; }
+          }
+        }
+      }
+
+      gl.bindFramebuffer(gl.FRAMEBUFFER, prevFbo);
+      gl.viewport(0, 0, w, h);
+      gl.enable(gl.BLEND);
+      gl.enable(gl.DEPTH_TEST);
+      return best !== null && best >= 0 && best < count ? best : null;
+    },
+    render(_context: WebGL2RenderingContext | WebGLRenderingContext, args: CustomRenderMethodInput) {
+      if (!gl || !buffer) return;
+      const shader = args?.shaderData;
+      if (!shader?.vertexShaderPrelude) return;
+
+      // Recompile when the projection changes — globe and mercator ship
+      // different preludes, and the old program silently draws nothing.
+      if (!program || variant !== shader.variantName) {
+        try {
+          buildProgram(shader.vertexShaderPrelude, shader.define || '');
+          pickProgram = link(shader.vertexShaderPrelude, shader.define || '', PICK_VERT, PICK_FRAG);
+          orbitProgram = link(shader.vertexShaderPrelude, shader.define || '', ORBIT_VERT, ORBIT_FRAG);
+          orbitDirty = true;
+          variant = shader.variantName || '';
+        } catch (err) {
+          console.error('[OSIRIS] satellite layer:', err instanceof Error ? err.message : err);
+          return;
+        }
+      }
+      if (!program) return;
+
+      if (dirty) {
+        vertices = packVertices(points, exaggeration);
+        count = points.length;
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+        gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.DYNAMIC_DRAW);
+        dirty = false;
+      }
+      if (count === 0) return;
+
+      gl.useProgram(program);
+
+      // MapLibre's prelude declares the projection uniforms but does not bind
+      // them for a custom layer's own program — `defaultProjectionData` is
+      // where the values come from, and every one has to be set. Without them
+      // projectTile() reads zeroed uniforms and every vertex lands off-screen:
+      // the draw succeeds, GL reports no error, and nothing appears.
+      const proj = args.defaultProjectionData;
+      lastProjection = proj ?? lastProjection;
+      if (proj) setProjectionUniforms(program, proj);
+
+      // The track first, so the marker draws over its own line.
+      if (orbitDirty && orbitProgram) {
+        for (const o of orbitBuffers) gl.deleteBuffer(o.buf);
+        orbitBuffers = (orbitSegments ?? []).filter(seg => seg.length > 1).map(seg => {
+          const data = packOrbit(seg, exaggeration);
+          const buf = gl!.createBuffer()!;
+          gl!.bindBuffer(gl!.ARRAY_BUFFER, buf);
+          gl!.bufferData(gl!.ARRAY_BUFFER, data, gl!.STATIC_DRAW);
+          return { buf, count: seg.length };
+        });
+        orbitDirty = false;
+      }
+      if (orbitProgram && orbitBuffers.length && proj) {
+        gl.useProgram(orbitProgram);
+        setProjectionUniforms(orbitProgram, proj);
+        gl.uniform3f(gl.getUniformLocation(orbitProgram, 'u_color'),
+          ((orbitColor >> 16) & 0xff) / 255, ((orbitColor >> 8) & 0xff) / 255, (orbitColor & 0xff) / 255);
+        const loc = gl.getAttribLocation(orbitProgram, 'a_pos');
+        gl.enable(gl.BLEND);
+        gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+        gl.depthMask(false);
+        for (const o of orbitBuffers) {
+          gl.bindBuffer(gl.ARRAY_BUFFER, o.buf);
+          gl.enableVertexAttribArray(loc);
+          gl.vertexAttribPointer(loc, 3, gl.FLOAT, false, 0, 0);
+          gl.vertexAttribDivisor(loc, 0);
+          gl.drawArrays(gl.LINE_STRIP, 0, o.count);
+        }
+        gl.depthMask(true);
+        gl.useProgram(program);
+        setProjectionUniforms(program, proj);
+      }
+
+      const cornerLoc = bindAttributes(program);
+      gl.uniform2f(gl.getUniformLocation(program, 'u_viewport'), gl.drawingBufferWidth, gl.drawingBufferHeight);
+      gl.uniform1i(gl.getUniformLocation(program, 'u_selected'), selected);
+
+      gl.enable(gl.BLEND);
+      gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+      // Depth-tested against the globe so the far side occludes, but not
+      // depth-written: satellites should not occlude each other into a mess.
+      gl.depthMask(false);
+      gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, count);
+      gl.depthMask(true);
+      clearDivisors(program, cornerLoc);
+    },
+  };
+}


### PR DESCRIPTION
Satellites were circle features pinned to the ground, so a 35,786 km GEO bird and a 400 km ISS sat on the same surface as a traffic camera. The map already ran MapLibre's globe projection and the catalogue already carried an altitude per satellite — nothing was lifting one off the other.

**7 files, +1,268 / −92.** Two new tested modules, 34 new tests.

## Real SGP4

The route carried a hand-rolled propagator: a two-body Kepler solve with **no J2 term, no drag**, reporting geocentric latitude as if it were geodetic and altitude above a 6371 km sphere. Fine for a dot on a flat map; wrong the moment altitude is drawn.

`satellite.js` was **already in `package.json`, installed and never called.** `src/lib/orbit.ts` wraps its SGP4/SDP4. The difference shows in the output:

| satellite | period | altitude |
|---|---|---|
| ISS (ZARYA) | 93 min | 415–441 km |
| **GSAT0201 (GALILEO 5)** | 776 min | **16,888–26,311 km** |
| GOES 17 | 1436 min | 35,782–35,790 km |

Galileo 5 is a known injection failure stuck in an *elliptical* orbit — that 9,400 km swing is real. GOES 17 holds ±4 km at geostationary over a sidereal day. A two-body solve produces neither.

## Drawing at altitude

MapLibre has no elevation property on circle or symbol layers, but it hands custom layers a projection prelude, and the globe variant exports `projectTileFor3D(vec2 posInTile, float elevation)`. That was **verified against the running map before any of this was written**. Using MapLibre's own prelude rather than hand-rolled matrix maths is what lets the layer survive a projection change — the same shader compiles for mercator, so pressing 2D keeps working.

**Two silent failures on the way**, both letting a draw call succeed with `getError()` clean and nothing on screen:

1. The prelude *declares* the projection uniforms but doesn't bind them for a custom layer's own program. Unset, every vertex lands off-screen.
2. **`gl.POINTS` does not render in this ANGLE context at all.** An identical `TRIANGLES` draw appeared instantly — that's what isolated it. Markers are now instanced screen-facing quads, the same approach MapLibre uses for its own circles.

Altitude is compressed into a band the camera can show — found by rendering and reading back the framebuffer, not by reasoning. Below ~⅒ Earth radius a marker is rejected by the depth test against the globe it orbits; near true scale GEO leaves the frustum. Real altitude maps onto 620–2500 km on a sqrt curve, spreading the crowded LEO shell while keeping MEO and GEO distinct. **The popup always shows the real altitude.**

## Clicking

`queryRenderedFeatures` cannot see into a custom WebGL layer, so markers are **picked on the GPU**: re-rendered into an offscreen buffer with each instance coloured by its index, then the pixel under the cursor is read back.

The pick pass runs the *same vertex shader* as the visible one, so the target is always exactly where the marker was drawn, altitude included. Reimplementing the globe projection on the CPU to hit-test would be a second source of truth, and it would drift.

Measured at 1–2 ms with ~19,000 satellites. The hover test is throttled to one per animation frame, since mousemove fires far faster than the screen updates.

The ground circles stay defined but hidden — drawing each satellite twice, once flat and once at altitude, is what made the map read as half 2D and half 3D.

## Orbit tracks

Clicking a satellite draws its full orbit **at altitude**, arcing around the planet rather than painted on it. A ground track shows where a satellite *passes over*; this shows where it *is*.

Served on demand from `/api/satellites/orbit` rather than bundled — the catalogue response is already megabytes and an operator looks at one orbit at a time. The path is split at the antimeridian: a polyline drawn straight from +179° to −179° sweeps back across the whole world, and on the globe cuts a chord through the planet.

## Verified by clicking

```
GSAT0225 (GALILEO 29)   23,227 km   Galileo flies at 23,222
BEIDOU-3 M13 (C32)      21,539 km   BeiDou-3 MEO is 21,528
STARLINK-37738             476 km
IMAGE                   42,922 km   high elliptical, still clickable
```

4,677 distinct satellites pickable across the globe.

**Frame cost, measured against the flat circles this replaces** — globe rotating, all 19,099 drawn:

| | median | p90 |
|---|---:|---:|
| flat circles | 9.7 ms | 20.0 ms |
| 3D instanced | 9.8 ms | **17.6 ms** |

Within noise, and better at p90 — one instanced draw call replaces tiling 19,098 GeoJSON point features.

**365 tests pass**, up from 331. Typecheck clean, production build compiles, `OsirisMap` lint 141 against master's 142.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
