### PR TITLE
fix(satellites): put the readout on the object, and the orbit on the clock

### DIFF
--- a/src/app/api/satellites/orbit/route.ts
+++ b/src/app/api/satellites/orbit/route.ts
@@ -49,8 +49,30 @@ function catalogue(): Map<string, Tle> {
   return byNorad;
 }
 
+/**
+ * The moment the track is drawn around.
+ *
+ * It defaults to now, but now is usually the wrong answer. The marker on the
+ * map was propagated when /api/satellites was fetched, and that happens once,
+ * when the layer is switched on — it is never re-polled. Twenty minutes later
+ * the marker is where the satellite was twenty minutes ago, and a track
+ * propagated from now starts nine thousand kilometres away from it. The maths
+ * was right in both places and the two answers still did not meet.
+ *
+ * So the caller passes the epoch its marker came from. Anything absurd is
+ * ignored rather than trusted: a far-future `t` would propagate a TLE well
+ * outside the window it is accurate in, and quietly draw a wrong orbit.
+ */
+function anchorTime(raw: string | null): Date {
+  const ms = Number(raw);
+  if (!Number.isFinite(ms) || ms <= 0) return new Date();
+  const drift = Math.abs(ms - Date.now());
+  return drift > 7 * 24 * 3600_000 ? new Date() : new Date(ms);
+}
+
 export async function GET(req: Request) {
-  const id = new URL(req.url).searchParams.get('id')?.trim();
+  const params = new URL(req.url).searchParams;
+  const id = params.get('id')?.trim();
   if (!id || !/^\d{1,6}$/.test(id)) {
     return NextResponse.json({ error: 'numeric NORAD id required' }, { status: 400 });
   }
@@ -61,7 +83,15 @@ export async function GET(req: Request) {
   }
 
   const periodMinutes = orbitalPeriodMinutes(tle.line2);
-  const path = orbitPath(tle.line1, tle.line2, 180);
+  const anchor = anchorTime(params.get('t'));
+  // Half a revolution either side, so the satellite sits in the middle of its
+  // own track rather than at one end of it. Starting the path at the satellite
+  // showed where it was going and nothing of where it came from, and left any
+  // residual timing error hanging the marker off the end of the line.
+  const from = periodMinutes
+    ? new Date(anchor.getTime() - (periodMinutes * 60_000) / 2)
+    : anchor;
+  const path = orbitPath(tle.line1, tle.line2, 180, from);
   if (path.length < 2) {
     return NextResponse.json({ error: 'could not propagate', noradId: id }, { status: 422 });
   }
@@ -70,6 +100,8 @@ export async function GET(req: Request) {
     noradId: id,
     name: tle.name,
     periodMinutes,
+    /** Epoch the track is centred on, so a caller can tell it was honoured. */
+    anchoredAt: anchor.toISOString(),
     // Split at the antimeridian so each run draws as one continuous line
     // instead of one segment sweeping back across the whole world.
     segments: splitAtAntimeridian(path).map(run =>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -575,7 +575,11 @@ export default function Dashboard() {
     // Satellites (any satellite sub-layer triggers fetch)
     const anySatLayer = activeLayers.satellites || activeLayers.sat_comms || activeLayers.sat_military || activeLayers.sat_navigation || activeLayers.sat_earth || activeLayers.sat_science;
     if (anySatLayer && !layerFetchedRef.current.has('satellites')) {
-      fetchEndpoint('/api/satellites');
+      // Keep the moment the positions were propagated for. The catalogue is
+      // fetched once and never re-polled, so by the time an orbit is requested
+      // these markers can be a long way out of date — the orbit route needs the
+      // marker's epoch to draw a track that still passes through it.
+      fetchEndpoint('/api/satellites', d => ({ ...d, satellites_at: d.timestamp }));
       layerFetchedRef.current.add('satellites');
     }
     // Fires

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -4,6 +4,7 @@ import { buildGeometry, closeRing, drawReducer, initialDrawState, measure, type 
 import { useEffect, useRef, useState, useCallback, memo } from 'react';
 import maplibregl from 'maplibre-gl';
 import { createSatelliteLayer, parseColor, type SatPoint } from '@/lib/satellite-layer';
+import SatelliteCard, { type SatelliteDetail } from '@/components/SatelliteCard';
 
 /** The catalogue fields the satellite layer and its popup actually read. */
 interface SatelliteRow {
@@ -101,9 +102,28 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   // pick() returns an index into the array last handed to setPoints, so the
   // matching catalogue rows are kept in the same order to resolve it.
   const satRowsRef = useRef<SatelliteRow[]>([]);
-  /** Index of the satellite whose orbit is on screen, so a late reply for a
-   *  previous selection can be discarded. */
+  /** Index of the selected satellite in the array last handed to setPoints. */
   const satPickedRef = useRef<number | null>(null);
+  /** The selection's NORAD id. The index moves whenever the catalogue is
+   *  re-polled and re-filtered; the id does not, so it is what identifies the
+   *  selection across a refresh and what discards a late orbit reply. */
+  const satSelectedIdRef = useRef<string | null>(null);
+  /** When the catalogue positions were propagated for, so an orbit can be drawn
+   *  around the marker rather than around the moment it was clicked. */
+  const satEpochRef = useRef<number | null>(null);
+  const [selectedSat, setSelectedSat] = useState<SatelliteDetail | null>(null);
+
+  /** Drops the selection: the ring, the orbit track and the readout together.
+   *  Leaving any one of them behind is what made a closed popup look like a
+   *  still-selected satellite. */
+  const clearSat = useCallback(() => {
+    if (satPickedRef.current === null && satSelectedIdRef.current === null) return;
+    satPickedRef.current = null;
+    satSelectedIdRef.current = null;
+    satLayerRef.current?.setSelected(null);
+    satLayerRef.current?.setOrbit(null);
+    setSelectedSat(null);
+  }, []);
   const drawingCoordsRef = useRef<number[][]>([]);
 
   // Create aircraft icon on canvas (for WebGL symbol layer)
@@ -747,7 +767,6 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     const htmlEsc = (s: any): string => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
     const idSafe = (s: any): string => String(s ?? '').replace(/[^a-zA-Z0-9_\.\-]/g, '');
     const urlSafe = (s: any): string => { const u = String(s ?? ''); return /^https?:\/\//i.test(u) ? u : '#'; };
-    const colorSafe = (s: any): string => /^#[0-9a-fA-F]{3,8}$/.test(String(s ?? '')) ? String(s) : '#aaa';
 
     const formatTime = (iso: string | null) => {
       if (!iso) return '—';
@@ -925,41 +944,49 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       const hits = map.queryRenderedFeatures(e.point);
       if (hits.some(f => f.layer?.id && CLICKABLE_LAYERS.has(f.layer.id))) return;
       const idx = layer.pick(e.point.x, e.point.y);
-      if (idx == null) return;
-      const p = satRowsRef.current[idx];
-      if (!p) return;
+      const p = idx == null ? null : satRowsRef.current[idx];
+      // Clicking past every satellite is how a selection is dismissed, so an
+      // empty click has to clear the ring and the track rather than leave them
+      // lit over nothing.
+      if (idx == null || !p) { clearSat(); return; }
+
+      // The readout is a panel, not a MapLibre popup: a popup can only anchor
+      // to a ground coordinate, and these markers are drawn at altitude. Any
+      // other layer's popup is still welcome to the screen, but not on top of
+      // this selection.
+      popupRef.current?.remove();
+      layer.setOrbit(null);
+      satPickedRef.current = idx;
+      satSelectedIdRef.current = p.noradId ?? null;
+      layer.setSelected(idx);
+      setSelectedSat({ ...p, periodMinutes: null, track: p.noradId ? 'loading' : 'unavailable' });
 
       // Draw the selected satellite's orbit. Fetched per click rather than
       // bundled with the catalogue: that payload is already megabytes, and an
       // operator looks at one orbit at a time.
-      layer.setOrbit(null);
-      layer.setSelected(null);
       if (p.noradId) {
         const wanted = p.noradId;
-        fetch(`/api/satellites/orbit?id=${encodeURIComponent(wanted)}`)
+        // A slower reply for a satellite the operator has already moved on
+        // from must not draw over the one they are looking at now.
+        const stale = () => satSelectedIdRef.current !== wanted;
+        const mark = (track: SatelliteDetail['track'], periodMinutes: number | null = null) =>
+          setSelectedSat(prev => (prev && prev.noradId === wanted ? { ...prev, track, periodMinutes } : prev));
+        const at = satEpochRef.current;
+        fetch(`/api/satellites/orbit?id=${encodeURIComponent(wanted)}${at ? `&t=${at}` : ''}`)
           .then(r => (r.ok ? r.json() : null))
           .then(d => {
-            // A slower reply for a satellite the operator has already moved on
-            // from must not draw over the one they are looking at now.
-            if (!d?.segments || satRowsRef.current[satPickedRef.current ?? -1]?.noradId !== wanted) return;
+            if (stale()) return;
+            if (!d?.segments?.length) { mark('unavailable'); return; }
             layer.setOrbit(
               d.segments.map((seg: number[][]) => seg.map(([lng, lat, altKm]) => ({ lng, lat, altKm }))),
               parseColor(p.color),
             );
+            mark('ready', typeof d.periodMinutes === 'number' ? d.periodMinutes : null);
           })
-          .catch(() => { /* no track is fine; the satellite still shows */ });
+          // No track is fine; the satellite still shows — but the readout says so
+          // rather than sitting on 'plotting' forever.
+          .catch(() => { if (!stale()) mark('unavailable'); });
       }
-      satPickedRef.current = idx;
-      layer.setSelected(idx);
-      popup([p.lng, p.lat], `<div style="${pStyle}border:1px solid rgba(212,175,55,0.3);">
-        <div style="color:#D4AF37;font-size:12px;font-weight:700;letter-spacing:0.1em;margin-bottom:4px;">🛰️ ${htmlEsc(p.name)}</div>
-        <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:4px;font-size:9px;margin-bottom:8px;">
-          <div><span style="color:#5C5A54;">MISSION</span><br/><span style="color:${colorSafe(p.color)};">${htmlEsc(p.mission||'Unknown')}</span></div>
-          <div><span style="color:#5C5A54;">ALT</span><br/><span style="color:#00E5FF;">${p.alt ? p.alt+' km' : '—'}</span></div>
-          <div><span style="color:#5C5A54;">POS</span><br/><span style="color:#E8E6E0;">${p.lat.toFixed(2)}°, ${p.lng.toFixed(2)}°</span></div>
-        </div>
-        ${p.noradId ? `<a href="https://www.n2yo.com/satellite/?s=${p.noradId}" target="_blank" style="display:block;text-align:center;padding:4px;margin-top:6px;font-size:8px;font-family:monospace;letter-spacing:0.1em;text-decoration:none;color:#00E5FF;border:1px solid rgba(0,229,255,0.4);background:rgba(0,229,255,0.1);border-radius:2px;cursor:pointer;">📡 TRACK ON N2YO</a>` : ''}
-      </div>`);
     });
 
     // The cursor should say a satellite is clickable, like every other layer.
@@ -1544,16 +1571,40 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     size: s.category === 'science' || /ISS|TIANGONG/i.test(s.name || '') ? 2.2 : 1,
   })), []);
 
+  /**
+   * Re-points the selection at the same satellite after a refresh.
+   *
+   * pick() returns an index into the last setPoints() array, and every poll
+   * rebuilds that array — a filtered one changes length as well as order. Left
+   * as a bare index the highlight ring quietly slides onto whichever satellite
+   * now sits at that slot, taking the readout with it.
+   */
+  const resyncSatSelection = useCallback((rows: SatelliteRow[]) => {
+    const id = satSelectedIdRef.current;
+    if (!id) return;
+    const i = rows.findIndex(r => r.noradId === id);
+    // Filtered out, or gone from the catalogue: there is nothing to point at.
+    if (i < 0) { clearSat(); return; }
+    satPickedRef.current = i;
+    satLayerRef.current?.setSelected(i);
+    // The satellite has moved since it was clicked; the readout should say where
+    // it is now, not where it was.
+    setSelectedSat(prev => (prev ? { ...prev, lat: rows[i].lat, lng: rows[i].lng, alt: rows[i].alt } : prev));
+  }, [clearSat]);
+
   useEffect(() => {
     if (!mapReady) return;
     const sats = data.satellites || [];
     const al = activeLayers as any;
+    const at = Date.parse(data.satellites_at ?? '');
+    satEpochRef.current = Number.isFinite(at) ? at : null;
     
     // If 'All Satellites' is on, show everything
     if (al.satellites) {
       setGeo('satellites', sats.map((s: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [s.lng, s.lat] }, properties: { name: s.name, color: s.color, mission: s.mission, alt: s.alt, noradId: s.noradId, category: s.category } })));
       satRowsRef.current = sats;
       satLayerRef.current?.setPoints(toSatPoints(sats));
+      resyncSatSelection(sats);
       return;
     }
     
@@ -1569,6 +1620,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       setGeo('satellites', []);
       satRowsRef.current = [];
       satLayerRef.current?.setPoints([]);
+      clearSat();
       return;
     }
     
@@ -1576,7 +1628,8 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     setGeo('satellites', filtered.map((s: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [s.lng, s.lat] }, properties: { name: s.name, color: s.color, mission: s.mission, alt: s.alt, noradId: s.noradId, category: s.category } })));
     satRowsRef.current = filtered;
     satLayerRef.current?.setPoints(toSatPoints(filtered));
-  }, [mapReady, data.satellites, activeLayers.satellites, (activeLayers as any).sat_comms, (activeLayers as any).sat_military, (activeLayers as any).sat_navigation, (activeLayers as any).sat_earth, (activeLayers as any).sat_science, setGeo]);
+    resyncSatSelection(filtered);
+  }, [mapReady, data.satellites, activeLayers.satellites, (activeLayers as any).sat_comms, (activeLayers as any).sat_military, (activeLayers as any).sat_navigation, (activeLayers as any).sat_earth, (activeLayers as any).sat_science, data.satellites_at, setGeo, toSatPoints, resyncSatSelection, clearSat]);
 
   useEffect(() => {
     if (!mapReady) return;
@@ -2755,7 +2808,21 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     return () => { map.off('moveend', reportCenter); };
   }, [mapReady, onMapCenter]);
 
-  return <div ref={containerRef} className="absolute inset-0 w-full h-full" />;
+  // Escape clears the selection, the way it cancels a draw — an overlay that
+  // can only be dismissed by hitting a 14px target is one that stays open.
+  useEffect(() => {
+    if (!selectedSat) return;
+    const onKey = (ev: KeyboardEvent) => { if (ev.key === 'Escape') clearSat(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selectedSat, clearSat]);
+
+  return (
+    <>
+      <div ref={containerRef} className="absolute inset-0 w-full h-full" />
+      {selectedSat && <SatelliteCard sat={selectedSat} onClose={clearSat} />}
+    </>
+  );
 }
 
 export default memo(OsirisMap);

--- a/src/components/SatelliteCard.tsx
+++ b/src/components/SatelliteCard.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { ExternalLink, Orbit, Satellite, X } from 'lucide-react';
+
+/**
+ * OSIRIS — selected satellite readout
+ *
+ * Satellites are the one layer drawn off the surface, and that broke the popup
+ * they used to get. A MapLibre popup can only be anchored to a ground
+ * coordinate, so a bird at 35,786 km got a card pinned to the patch of ocean
+ * underneath it — pointing at empty sea while the marker and its orbit sat well
+ * away, up the globe. Every other layer's popup lands on its own marker; this
+ * one could not.
+ *
+ * So the readout stops pretending to be attached. What ties it to the object is
+ * already on the globe and already correct: the selection ring the shader draws
+ * around the picked satellite, and the orbit track in the satellite's own
+ * colour. The card carries the numbers, in a fixed place that does not move
+ * while the satellite does — and the satellite does move, every poll.
+ */
+
+export interface SatelliteDetail {
+  name: string;
+  lat: number;
+  lng: number;
+  /** Kilometres above the ellipsoid — the real figure, not the drawn one. */
+  alt: number;
+  color?: string;
+  mission?: string;
+  category?: string;
+  noradId?: string;
+  /** From the orbit reply; null until it lands or if the TLE gave no period. */
+  periodMinutes?: number | null;
+  /** Whether the orbit track on the globe is on its way, drawn, or unavailable. */
+  track: 'loading' | 'ready' | 'unavailable';
+}
+
+/** Earth's mean radius — only used to turn a period into a speed. */
+const EARTH_RADIUS_KM = 6371;
+
+/**
+ * The orbital shell, by the usual boundaries. GEO is a narrow band rather than
+ * "anything high": a Molniya apogee is not a geostationary satellite, and
+ * labelling it one would be worse than saying nothing.
+ */
+function regime(altKm: number): { label: string; note: string } {
+  if (altKm < 2000) return { label: 'LEO', note: 'Low Earth orbit' };
+  if (altKm < 35000) return { label: 'MEO', note: 'Medium Earth orbit' };
+  if (altKm <= 36500) return { label: 'GEO', note: 'Geostationary belt' };
+  return { label: 'HEO', note: 'High / highly elliptical' };
+}
+
+/** Circular-orbit speed implied by the period; the point of it is scale, not precision. */
+function speedKmS(altKm: number, periodMinutes: number): number {
+  return (2 * Math.PI * (EARTH_RADIUS_KM + altKm)) / (periodMinutes * 60);
+}
+
+function period(minutes: number): string {
+  if (minutes < 100) return `${minutes.toFixed(1)} min`;
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes - h * 60);
+  return `${h}h ${String(m).padStart(2, '0')}m`;
+}
+
+/** Only a literal hex colour reaches an inline style. */
+function colorSafe(value: string | undefined): string {
+  return /^#[0-9a-fA-F]{3,8}$/.test(String(value ?? '')) ? String(value) : 'var(--cyan-primary)';
+}
+
+function Field({ label, value, color }: { label: string; value: string; color?: string }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[9px] font-mono tracking-[0.15em] text-[var(--text-muted)]">{label}</div>
+      <div
+        className="truncate text-[12px] font-mono tabular-nums text-[var(--text-primary)]"
+        style={color ? { color } : undefined}
+        title={value}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export default function SatelliteCard({ sat, onClose }: { sat: SatelliteDetail; onClose: () => void }) {
+  const accent = colorSafe(sat.color);
+  const shell = regime(sat.alt);
+
+  return (
+    <div
+      className="pointer-events-auto absolute left-2 right-2 top-16 z-[350] overflow-hidden rounded-xl border bg-[var(--bg-panel)] shadow-[0_10px_40px_rgba(0,0,0,0.6)] backdrop-blur-2xl md:left-[72px] md:right-auto md:top-[88px] md:w-[300px]"
+      style={{ borderColor: `${accent}55` }}
+      role="dialog"
+      aria-label={`Satellite ${sat.name}`}
+    >
+      {/* A rule in the satellite's own colour, matching its marker and its track. */}
+      <div className="h-[2px] w-full" style={{ background: accent }} />
+
+      <div className="flex items-start gap-2 px-3 pt-3">
+        <Satellite className="mt-[2px] h-4 w-4 flex-shrink-0" style={{ color: accent }} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[13px] font-bold leading-tight tracking-wide text-[var(--text-heading)]" title={sat.name}>
+            {sat.name}
+          </div>
+          <div className="truncate text-[10px] font-mono tracking-[0.12em] text-[var(--text-secondary)]">
+            {sat.mission || 'Unknown mission'}
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          className="-mr-1 -mt-1 flex-shrink-0 rounded-md p-1 text-[var(--text-muted)] transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50"
+          aria-label="Clear satellite selection"
+          title="Clear selection (Esc)"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-3 gap-y-2.5 px-3 py-3">
+        <Field label="ALTITUDE" value={`${Math.round(sat.alt).toLocaleString()} km`} color="var(--cyan-primary)" />
+        <Field label="ORBIT" value={shell.label} color={accent} />
+        <Field
+          label="PERIOD"
+          value={sat.periodMinutes ? period(sat.periodMinutes) : '—'}
+        />
+        <Field
+          label="SPEED"
+          value={sat.periodMinutes ? `${speedKmS(sat.alt, sat.periodMinutes).toFixed(2)} km/s` : '—'}
+        />
+        <Field label="LATITUDE" value={`${sat.lat.toFixed(3)}°`} />
+        <Field label="LONGITUDE" value={`${sat.lng.toFixed(3)}°`} />
+        <Field label="NORAD ID" value={sat.noradId || '—'} />
+        <Field label="CLASS" value={shell.note} />
+      </div>
+
+      {/* What the globe is showing, so a missing track reads as a known state
+          rather than as the selection having silently failed. */}
+      <div className="flex items-center gap-1.5 border-t border-[var(--border-secondary)] px-3 py-2 text-[9px] font-mono tracking-[0.12em] text-[var(--text-muted)]">
+        <Orbit className="h-3 w-3" />
+        {sat.track === 'loading' && <span>PLOTTING ORBIT…</span>}
+        {sat.track === 'ready' && <span style={{ color: accent }}>ORBIT TRACK ON GLOBE</span>}
+        {sat.track === 'unavailable' && <span>NO TRACK — TLE UNAVAILABLE</span>}
+      </div>
+
+      {sat.noradId && (
+        <a
+          href={`https://www.n2yo.com/satellite/?s=${encodeURIComponent(sat.noradId)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-center gap-1.5 border-t px-3 py-2.5 text-[10px] font-mono tracking-[0.15em] transition-colors"
+          style={{ borderColor: 'var(--border-secondary)', color: accent, background: `${accent}12` }}
+        >
+          TRACK ON N2YO <ExternalLink className="h-3 w-3" />
+        </a>
+      )}
+    </div>
+  );
+}

--- a/src/lib/orbit.test.ts
+++ b/src/lib/orbit.test.ts
@@ -105,6 +105,28 @@ describe('orbitPath', () => {
   it('returns nothing for a TLE it cannot read', () => {
     expect(orbitPath('', '', 10, AT)).toEqual([]);
   });
+
+  it('brackets a moment when started half a period before it', () => {
+    // What the orbit route relies on to put the satellite in the middle of its
+    // own track instead of at one end. Started at the moment itself, the marker
+    // sits on the first sample, and any staleness hangs it off the end of the
+    // line entirely.
+    const period = orbitalPeriodMinutes(ISS_2)!;
+    const path = orbitPath(ISS_1, ISS_2, 180, new Date(AT.getTime() - (period * 60_000) / 2));
+    const now = propagateTLE(ISS_1, ISS_2, AT)!;
+
+    let best = Infinity;
+    let bestIndex = -1;
+    path.forEach((p, i) => {
+      // Great-circle-ish separation is enough to find the closest sample.
+      const d = Math.hypot(p.lat - now.lat, wrapLongitude(p.lng - now.lng));
+      if (d < best) { best = d; bestIndex = i; }
+    });
+
+    const along = bestIndex / (path.length - 1);
+    expect(along).toBeGreaterThan(0.45);
+    expect(along).toBeLessThan(0.55);
+  });
 });
 
 describe('splitAtAntimeridian', () => {


### PR DESCRIPTION
Satellites are the one layer drawn off the surface, and that broke the popup they got.

## The readout was pointing at the sea

A MapLibre popup can only anchor to a ground coordinate. A bird at 35,786 km got a card pinned to the patch of ocean underneath it — pointing at empty water while the marker and its track sat well away, up the globe. Every other layer's popup lands on its own marker; this one could not, and no amount of tweaking the popup would fix it.

So the readout stops pretending to be attached. What ties it to the object is already on the globe and already correct: the selection ring the shader draws around the picked satellite, and the orbit track in the satellite's own colour. The card carries the numbers, in a fixed place that does not move while the satellite does.

It also stopped throwing data away. The orbit route already returned `periodMinutes` and the popup ignored it, so the card now shows the orbital regime, the period and the implied speed alongside altitude and position. And it says whether the track is plotting, drawn, or unavailable — a failed orbit fetch used to be completely silent.

## Closing now actually deselects

Ring, orbit and readout clear together — on the close button, on Escape, and on clicking empty sky. Closing the popup used to leave the satellite ringed with its orbit still drawn, which read as a selection that would not go away.

## The selection survives a refresh

It was held as an index into the array last handed to `setPoints`, and every poll rebuilds and re-filters that array. Left as a bare index, the highlight ring slides onto whichever satellite now sits in that slot, taking the readout with it. It is keyed on the NORAD id now, which also replaces the fragile index-based staleness check guarding late orbit replies.

## The orbit was never wrong — the two ends disagreed about the time

Checked against the catalogue, the track already passed within 0–3 km of the satellite's own reported position. The propagation was fine.

The fault was the clock. Markers are fetched once, when the layer is switched on, and never re-polled; the track was propagated from *now*. Twenty minutes in, a track started nine thousand kilometres from the marker it belonged to — which reads exactly like a broken orbit.

The client now sends the epoch its markers were propagated for, and the route draws around that instead of `now`. Anything implausible is ignored rather than trusted: a far-future `t` would propagate a TLE well outside the window it is accurate in and quietly draw a wrong orbit.

The revolution is also centred on the satellite rather than started at it. At one end it showed where the bird was going and nothing of where it came from, and any residual timing error hung the marker off the end of the line.

## Verification

Measured against the running server, across ISS, a Starlink, TDRS 3 (GEO) and a GLONASS — the marker now lands at **50% along its own track**, 0–3 km residual, where before it sat on the first sample:

```
ISS (ZARYA)             closest=3km  at point 90/181  (50% along)
STARLINK-1008           closest=2km  at point 90/181  (50% along)
TDRS 3                  closest=0km  at point 90/181  (50% along)
COSMOS 2433 [GLONASS-M] closest=1km  at point 90/181  (50% along)
```

`orbit.test.ts` pins the property the route relies on: propagating from half a period before a moment brackets that moment. 366 tests pass, `npm run build` compiles, lint is 3 findings below master (the old popup and a `colorSafe` helper it orphaned both went).

## Not verified

**The card has not been looked at.** The browser preview would not composite in my environment, so MapLibre never fired `load` and I could not render the map. Everything above is verified by measurement and by compiling, not by eye. The card's layout, placement and colours want a human look before this merges.

## Known, untouched

Satellite markers are still fetched once and never re-polled, so the dots do not move. That is what made the orbit anchoring necessary; fixing the polling itself is a separate change.

Generated with SIMPLIFAI — https://Simplifai-1.com
