### PR TITLE
feat(map): default to phantom mode and rebuild the view controls

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -97,6 +97,36 @@ function getYouTubeWatchUrl(url: string): string {
   return url;
 }
 
+function ViewSegment({ active, onClick, title, icon: Icon, label, layoutId }: {
+  active: boolean;
+  onClick: () => void;
+  title: string;
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  layoutId: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      aria-pressed={active}
+      className={`relative flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[10px] font-mono font-medium tracking-[0.18em] transition-colors duration-200 ${
+        active ? 'text-[var(--gold-light)]' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+      }`}
+    >
+      {active && (
+        <motion.span
+          layoutId={layoutId}
+          transition={{ type: 'spring', stiffness: 420, damping: 34 }}
+          className="absolute inset-0 rounded-md border border-[var(--border-active)] bg-[var(--gold-primary)]/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_0_14px_var(--gold-glow)]"
+        />
+      )}
+      <Icon className="w-3.5 h-3.5 relative z-10" />
+      <span className="hidden md:inline relative z-10">{label}</span>
+    </button>
+  );
+}
+
 export default function Dashboard() {
   const dataRef = useRef<any>({});
   const [dataVersion, setDataVersion] = useState(0);
@@ -228,7 +258,7 @@ export default function Dashboard() {
   const [scanTargets, setScanTargets] = useState<any[]>([]);
   const [drawnPolygons, setDrawnPolygons] = useState<DrawnShape[]>([]);
   const [demoMode, setDemoMode] = useState(false);
-  const [osirisTheme, setOsirisTheme] = useState<'core'|'ghost'>('core');
+  const [osirisTheme, setOsirisTheme] = useState<'core'|'ghost'>('ghost');
 
   useEffect(() => {
     document.body.className = osirisTheme === 'core' ? '' : `theme-${osirisTheme}`;
@@ -1120,64 +1150,12 @@ export default function Dashboard() {
         style={{ left: isMobile ? '12px' : '120px' }}
       >
         {/* Unified Control Strip */}
-        <div className="flex items-center gap-1.5 pointer-events-auto">
-          {/* Projection Toggle (Globe / 2D) */}
-          <div className="flex items-center rounded-xl overflow-hidden border border-[var(--border-primary)] bg-[var(--bg-panel)] backdrop-blur-2xl shadow-[0_4px_24px_rgba(0,0,0,0.5)]">
-            <button
-              onClick={() => setMapProjection('globe')}
-              className={`flex items-center gap-1.5 px-3 py-2 text-[10px] font-mono tracking-wider transition-all duration-200 ${
-                mapProjection === 'globe'
-                  ? 'bg-[var(--cyan-primary)]/15 text-[var(--cyan-primary)]'
-                  : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
-              }`}
-              title="3D Globe"
-            >
-              <Globe className="w-3.5 h-3.5" />
-              <span className="hidden md:inline">3D</span>
-            </button>
-            <div className="w-px h-4 bg-[var(--border-primary)]" />
-            <button
-              onClick={() => setMapProjection('mercator')}
-              className={`flex items-center gap-1.5 px-3 py-2 text-[10px] font-mono tracking-wider transition-all duration-200 ${
-                mapProjection === 'mercator'
-                  ? 'bg-[var(--gold-primary)]/15 text-[var(--gold-primary)]'
-                  : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
-              }`}
-              title="2D Map"
-            >
-              <MapPinned className="w-3.5 h-3.5" />
-              <span className="hidden md:inline">2D</span>
-            </button>
-          </div>
-
-          {/* Style Toggle (Night / Satellite) */}
-          <div className="flex items-center rounded-xl overflow-hidden border border-[var(--border-primary)] bg-[var(--bg-panel)] backdrop-blur-2xl shadow-[0_4px_24px_rgba(0,0,0,0.5)]">
-            <button
-              onClick={() => setMapStyle('dark')}
-              className={`flex items-center gap-1.5 px-3 py-2 text-[10px] font-mono tracking-wider transition-all duration-200 ${
-                mapStyle === 'dark'
-                  ? 'bg-[var(--cyan-primary)]/15 text-[var(--cyan-primary)]'
-                  : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
-              }`}
-              title="Night Mode"
-            >
-              <Moon className="w-3.5 h-3.5" />
-              <span className="hidden md:inline">MAP</span>
-            </button>
-            <div className="w-px h-4 bg-[var(--border-primary)]" />
-            <button
-              onClick={() => setMapStyle('satellite')}
-              className={`flex items-center gap-1.5 px-3 py-2 text-[10px] font-mono tracking-wider transition-all duration-200 ${
-                mapStyle === 'satellite'
-                  ? 'bg-[var(--alert-green)]/15 text-[var(--alert-green)]'
-                  : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
-              }`}
-              title="Satellite View"
-            >
-              <Satellite className="w-3.5 h-3.5" />
-              <span className="hidden md:inline">SAT</span>
-            </button>
-          </div>
+        <div className="flex items-center gap-[3px] p-[3px] pointer-events-auto rounded-[10px] border border-[var(--border-primary)] bg-[var(--bg-panel)] backdrop-blur-2xl shadow-[0_8px_32px_rgba(0,0,0,0.55)]">
+          <ViewSegment layoutId="view-projection" active={mapProjection === 'globe'} onClick={() => setMapProjection('globe')} title="3D Globe" icon={Globe} label="3D" />
+          <ViewSegment layoutId="view-projection" active={mapProjection === 'mercator'} onClick={() => setMapProjection('mercator')} title="2D Map" icon={MapPinned} label="2D" />
+          <div className="w-px h-5 mx-1 bg-[var(--border-secondary)]" />
+          <ViewSegment layoutId="view-style" active={mapStyle === 'dark'} onClick={() => setMapStyle('dark')} title="Night Mode" icon={Moon} label="MAP" />
+          <ViewSegment layoutId="view-style" active={mapStyle === 'satellite'} onClick={() => setMapStyle('satellite')} title="Satellite View" icon={Satellite} label="SAT" />
         </div>
 
         {/* Scale Bar */}


### PR DESCRIPTION
Ghost Protocol is now the theme the map opens in, and the projection and basemap toggles become one segmented instrument instead of two pills.

### Phantom mode on by default

`osirisTheme` now initialises to `'ghost'`, so `theme-ghost` is stamped on `<body>` at load and the whole violet palette is live without touching the toggle. The Ghost Protocol switch in the layer panel still works in both directions.

### View controls, rebuilt

The old strip had four buttons in two `rounded-xl` pills, each active state a flat tint block with a hard vertical edge, and four unrelated accent colours (cyan for 3D, gold for 2D, cyan for MAP, green for SAT). Inactive labels sat on `--text-muted`, which is `#4A148C` in ghost — effectively invisible.

- both pills merged into one shell with a hairline divider between the projection and basemap banks
- `ViewSegment` extracted; the active segment is a `motion.span` with a `layoutId`, so the selection slides between segments on a spring instead of the tint snapping. One `layoutId` per bank, so indicators never cross the divider
- per-button accents replaced with the theme accent (`--gold-primary` / `--border-active` / `--gold-glow`), so the strip follows whichever theme is active
- inactive labels lifted to `--text-secondary`, hover to `--text-primary`
- `aria-pressed` added to each segment, which the old markup lacked

60 lines of duplicated button markup collapse to 7.

### Verification

Checked against the dev server. CSS transitions were temporarily suppressed while measuring, since a non-compositing browser pane freezes them mid-interpolation and reports stale colours.

- computed values resolve to the phantom palette: active label `rgb(209,196,233)`, inactive `rgb(149,117,205)`, shell border `rgba(179,136,255,0.2)` on `rgba(8,0,26,0.92)`, indicator glow `rgba(179,136,255,0.3)`
- clicking SAT and 2D flipped `aria-pressed` and moved the indicator to exactly one segment per bank; clicking back restored the defaults
- no console warnings from the shared `layoutId`s
- `npx tsc --noEmit` clean

No screenshot — the browser pane isn't displayed in this environment, so the page never composites frames.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
