### PR TITLE
feat(ui): Style Studio, live CCTV previews, and a calmer satellite readout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import FlightWatchPanel, { type WatchedFlight, type FlightTelemetry, type Aircra
 import type { NavProgress } from '@/lib/navigation';
 import ScaleBar from '@/components/ScaleBar';
 import ErrorBoundary from '@/components/ErrorBoundary';
+import { applySettings, loadSavedSettings } from '@/lib/style-tokens';
 import SharePanel from '@/components/SharePanel';
 import ViewPresets from '@/components/ViewPresets';
 import KeyboardShortcuts from '@/components/KeyboardShortcuts';
@@ -263,6 +264,13 @@ export default function Dashboard() {
   useEffect(() => {
     document.body.className = osirisTheme === 'core' ? '' : `theme-${osirisTheme}`;
   }, [osirisTheme]);
+
+  /* Style Studio overrides are inline on <body>, so they survive the theme
+     swap above and only need reapplying once per load. */
+  useEffect(() => {
+    const saved = loadSavedSettings();
+    if (saved) applySettings(saved);
+  }, []);
 
   const isMobile = useIsMobile();
   const startTime = useRef(Date.now());
@@ -1150,7 +1158,7 @@ export default function Dashboard() {
         style={{ left: isMobile ? '12px' : '120px' }}
       >
         {/* Unified Control Strip */}
-        <div className="flex items-center gap-[3px] p-[3px] pointer-events-auto rounded-[10px] border border-[var(--border-primary)] bg-[var(--bg-panel)] backdrop-blur-2xl shadow-[0_8px_32px_rgba(0,0,0,0.55)]">
+        <div className="flex items-center gap-[3px] p-[3px] pointer-events-auto rounded-xl border border-[var(--border-primary)] bg-[var(--bg-panel)] backdrop-blur-2xl shadow-[0_8px_32px_rgba(0,0,0,0.55)]">
           <ViewSegment layoutId="view-projection" active={mapProjection === 'globe'} onClick={() => setMapProjection('globe')} title="3D Globe" icon={Globe} label="3D" />
           <ViewSegment layoutId="view-projection" active={mapProjection === 'mercator'} onClick={() => setMapProjection('mercator')} title="2D Map" icon={MapPinned} label="2D" />
           <div className="w-px h-5 mx-1 bg-[var(--border-secondary)]" />

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -5,8 +5,9 @@ import { motion, AnimatePresence } from 'framer-motion';
 import {
   Plane, Satellite, Sun, AlertTriangle, Camera,
   CloudLightning, Ship, Network, Database, Ghost,
-  Flame, Tv, Radio, Mountain, Anchor, Megaphone
+  Flame, Tv, Radio, Mountain, Anchor, Megaphone, SlidersHorizontal
 } from 'lucide-react';
+import StyleStudio from './StyleStudio';
 
 interface LayerPanelProps {
   data: any;
@@ -180,6 +181,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
    * far edge closes the thing you were reaching for.
    */
   const [pinnedGroup, setPinnedGroup] = useState<string | null>(null);
+  const [studioOpen, setStudioOpen] = useState(false);
 
   useEffect(() => {
     if (!pinnedGroup) return;
@@ -259,9 +261,28 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
           </div>
         ))}
 
+        {/* MOBILE STYLE STUDIO */}
+        <div className="flex items-center justify-between mt-2 pt-3 border-t border-white/[0.06] px-1">
+          <span className="text-[10px] font-mono tracking-[0.2em] text-white/25 uppercase">Style Studio</span>
+          <button
+            onClick={() => setStudioOpen(o => !o)}
+            aria-pressed={studioOpen}
+            className="w-8 h-8 rounded-full flex items-center justify-center transition-all"
+            style={{
+              background: studioOpen ? 'var(--hover-accent)' : 'transparent',
+              boxShadow: studioOpen ? '0 0 12px var(--gold-glow)' : 'none',
+            }}
+          >
+            <SlidersHorizontal className="w-4 h-4" style={{ color: studioOpen ? 'var(--gold-primary)' : 'rgba(255,255,255,0.25)' }} />
+          </button>
+        </div>
+        <AnimatePresence>
+          {studioOpen && <StyleStudio isMobile onClose={() => setStudioOpen(false)} />}
+        </AnimatePresence>
+
         {/* MOBILE GHOST TOGGLE */}
         {setTheme && (
-          <div className="flex items-center justify-between mt-2 pt-3 border-t border-white/[0.06] px-1">
+          <div className="flex items-center justify-between pt-3 border-t border-white/[0.06] px-1">
             <span className="text-[10px] font-mono tracking-[0.2em] text-white/25 uppercase">Ghost Protocol</span>
             <button
               onClick={() => setTheme(theme === 'core' ? 'ghost' : 'core')}
@@ -428,6 +449,28 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
 
       {/* Subtle separator */}
       <div className="w-5 h-px bg-white/[0.06] my-2" />
+
+      {/* Style Studio */}
+      <button
+        onClick={() => setStudioOpen(o => !o)}
+        aria-pressed={studioOpen}
+        className="w-10 h-10 flex items-center justify-center rounded-lg transition-all duration-500 cursor-pointer"
+        style={{ background: studioOpen ? 'var(--hover-accent)' : 'transparent' }}
+        title="Style Studio"
+      >
+        <SlidersHorizontal
+          className="transition-all duration-500"
+          style={{
+            width: 15,
+            height: 15,
+            color: studioOpen ? 'var(--gold-primary)' : 'rgba(255,255,255,0.15)',
+            filter: studioOpen ? 'drop-shadow(0 0 6px var(--gold-glow))' : 'none',
+          }}
+        />
+      </button>
+      <AnimatePresence>
+        {studioOpen && <StyleStudio onClose={() => setStudioOpen(false)} />}
+      </AnimatePresence>
 
       {/* Ghost Protocol Toggle */}
       {setTheme && (

--- a/src/components/SatelliteCard.tsx
+++ b/src/components/SatelliteCard.tsx
@@ -70,9 +70,9 @@ function colorSafe(value: string | undefined): string {
 function Field({ label, value, color }: { label: string; value: string; color?: string }) {
   return (
     <div className="min-w-0">
-      <div className="text-[9px] font-mono tracking-[0.15em] text-[var(--text-muted)]">{label}</div>
+      <div className="text-[8px] font-mono tracking-[0.15em] text-[var(--text-muted)]">{label}</div>
       <div
-        className="truncate text-[12px] font-mono tabular-nums text-[var(--text-primary)]"
+        className="truncate text-[11px] font-mono tabular-nums text-[var(--text-primary)]"
         style={color ? { color } : undefined}
         title={value}
       >
@@ -88,21 +88,21 @@ export default function SatelliteCard({ sat, onClose }: { sat: SatelliteDetail; 
 
   return (
     <div
-      className="pointer-events-auto absolute left-2 right-2 top-16 z-[350] overflow-hidden rounded-xl border bg-[var(--bg-panel)] shadow-[0_10px_40px_rgba(0,0,0,0.6)] backdrop-blur-2xl md:left-[72px] md:right-auto md:top-[88px] md:w-[300px]"
-      style={{ borderColor: `${accent}55` }}
+      className="pointer-events-auto absolute left-2 right-2 top-16 z-[350] overflow-hidden rounded-lg border bg-[var(--bg-panel)] shadow-[0_6px_20px_rgba(0,0,0,0.45)] backdrop-blur-2xl md:left-[72px] md:right-auto md:top-[88px] md:w-[248px]"
+      style={{ borderColor: `${accent}33` }}
       role="dialog"
       aria-label={`Satellite ${sat.name}`}
     >
       {/* A rule in the satellite's own colour, matching its marker and its track. */}
-      <div className="h-[2px] w-full" style={{ background: accent }} />
+      <div className="h-px w-full" style={{ background: `${accent}99` }} />
 
-      <div className="flex items-start gap-2 px-3 pt-3">
-        <Satellite className="mt-[2px] h-4 w-4 flex-shrink-0" style={{ color: accent }} />
+      <div className="flex items-start gap-2 px-2.5 pt-2.5">
+        <Satellite className="mt-[2px] h-3.5 w-3.5 flex-shrink-0" style={{ color: accent }} />
         <div className="min-w-0 flex-1">
-          <div className="truncate text-[13px] font-bold leading-tight tracking-wide text-[var(--text-heading)]" title={sat.name}>
+          <div className="truncate text-[12px] font-bold leading-tight tracking-wide text-[var(--text-heading)]" title={sat.name}>
             {sat.name}
           </div>
-          <div className="truncate text-[10px] font-mono tracking-[0.12em] text-[var(--text-secondary)]">
+          <div className="truncate text-[9px] font-mono tracking-[0.12em] text-[var(--text-secondary)]">
             {sat.mission || 'Unknown mission'}
           </div>
         </div>
@@ -112,11 +112,11 @@ export default function SatelliteCard({ sat, onClose }: { sat: SatelliteDetail; 
           aria-label="Clear satellite selection"
           title="Clear selection (Esc)"
         >
-          <X className="h-3.5 w-3.5" />
+          <X className="h-3 w-3" />
         </button>
       </div>
 
-      <div className="grid grid-cols-2 gap-x-3 gap-y-2.5 px-3 py-3">
+      <div className="grid grid-cols-2 gap-x-2.5 gap-y-2 px-2.5 py-2.5">
         <Field label="ALTITUDE" value={`${Math.round(sat.alt).toLocaleString()} km`} color="var(--cyan-primary)" />
         <Field label="ORBIT" value={shell.label} color={accent} />
         <Field
@@ -135,8 +135,8 @@ export default function SatelliteCard({ sat, onClose }: { sat: SatelliteDetail; 
 
       {/* What the globe is showing, so a missing track reads as a known state
           rather than as the selection having silently failed. */}
-      <div className="flex items-center gap-1.5 border-t border-[var(--border-secondary)] px-3 py-2 text-[9px] font-mono tracking-[0.12em] text-[var(--text-muted)]">
-        <Orbit className="h-3 w-3" />
+      <div className="flex items-center gap-1.5 border-t border-[var(--border-secondary)] px-2.5 py-1.5 text-[8px] font-mono tracking-[0.12em] text-[var(--text-muted)]">
+        <Orbit className="h-2.5 w-2.5" />
         {sat.track === 'loading' && <span>PLOTTING ORBIT…</span>}
         {sat.track === 'ready' && <span style={{ color: accent }}>ORBIT TRACK ON GLOBE</span>}
         {sat.track === 'unavailable' && <span>NO TRACK — TLE UNAVAILABLE</span>}
@@ -147,10 +147,10 @@ export default function SatelliteCard({ sat, onClose }: { sat: SatelliteDetail; 
           href={`https://www.n2yo.com/satellite/?s=${encodeURIComponent(sat.noradId)}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center justify-center gap-1.5 border-t px-3 py-2.5 text-[10px] font-mono tracking-[0.15em] transition-colors"
-          style={{ borderColor: 'var(--border-secondary)', color: accent, background: `${accent}12` }}
+          className="flex items-center justify-center gap-1.5 border-t px-2.5 py-2 text-[9px] font-mono tracking-[0.15em] transition-colors"
+          style={{ borderColor: 'var(--border-secondary)', color: accent, background: `${accent}0a` }}
         >
-          TRACK ON N2YO <ExternalLink className="h-3 w-3" />
+          TRACK ON N2YO <ExternalLink className="h-2.5 w-2.5" />
         </a>
       )}
     </div>

--- a/src/components/StyleStudio.tsx
+++ b/src/components/StyleStudio.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { motion } from 'framer-motion';
+import { X, RotateCcw, Copy, Check, ClipboardPaste } from 'lucide-react';
+import {
+  applySettings,
+  FONT_MONO,
+  FONT_UI,
+  HEX_RE,
+  clearSettings,
+  loadSavedSettings,
+  PRESETS,
+  readTheme,
+  sanitize,
+  saveSettings,
+  shade,
+  type StyleSettings,
+} from '@/lib/style-tokens';
+
+/**
+ * Style Studio — the panel. All token maths lives in `@/lib/style-tokens`;
+ * this file is the controls and the wiring around them.
+ */
+
+/* ── Controls ── */
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-1.5">
+      <span className="text-[10px] font-mono tracking-[0.15em] uppercase text-white/40 shrink-0">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function Swatch({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <label className="relative flex items-center gap-2 cursor-pointer">
+      <span className="text-[10px] font-mono uppercase text-white/30 tabular-nums">{value}</span>
+      <span
+        className="w-7 h-7 rounded-md border border-white/15 shrink-0"
+        style={{ background: value, boxShadow: `0 0 10px ${value}55` }}
+      />
+      <input
+        type="color"
+        value={HEX_RE.test(value) ? value : '#000000'}
+        onChange={(e) => onChange(e.target.value)}
+        className="absolute inset-0 opacity-0 cursor-pointer"
+        aria-label={label}
+      />
+    </label>
+  );
+}
+
+function Slider({ label, value, min, max, step, onChange, format }: {
+  label: string; value: number; min: number; max: number; step: number;
+  onChange: (v: number) => void; format?: (v: number) => string;
+}) {
+  return (
+    <div className="flex items-center gap-2 flex-1 max-w-[150px]">
+      <input
+        type="range" min={min} max={max} step={step} value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        aria-label={label}
+        className="flex-1 h-1 appearance-none rounded-full bg-white/10 accent-[var(--gold-primary)] cursor-pointer"
+      />
+      <span className="text-[10px] font-mono tabular-nums text-white/40 w-9 text-right">
+        {format ? format(value) : value}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * A slider with an explicit AUTO state. AUTO means "emit no rule", which is
+ * how an untouched knob leaves the app's own styling intact.
+ */
+function AutoSlider({ label, value, min, max, step, whenEnabled, onChange, format }: {
+  label: string; value: number | null; min: number; max: number; step: number;
+  whenEnabled: number; onChange: (v: number | null) => void; format: (v: number) => string;
+}) {
+  const auto = value === null;
+  return (
+    <div className="flex items-center gap-1.5 flex-1 max-w-[168px]">
+      <button
+        onClick={() => onChange(auto ? whenEnabled : null)}
+        aria-pressed={auto}
+        title={auto ? `${label}: following the app's own styling` : `${label}: overridden`}
+        className={`px-1.5 py-0.5 rounded text-[8px] font-mono tracking-wider border transition-colors shrink-0 ${
+          auto
+            ? 'border-[var(--border-active)] bg-[var(--gold-primary)]/15 text-[var(--gold-light)]'
+            : 'border-white/10 text-white/30 hover:text-white/60'
+        }`}
+      >
+        AUTO
+      </button>
+      <input
+        type="range" min={min} max={max} step={step}
+        value={auto ? whenEnabled : value}
+        disabled={auto}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        aria-label={label}
+        className={`flex-1 h-1 appearance-none rounded-full bg-white/10 accent-[var(--gold-primary)] ${auto ? 'opacity-30 cursor-not-allowed' : 'cursor-pointer'}`}
+      />
+      <span className="text-[10px] font-mono tabular-nums text-white/40 w-9 text-right">
+        {auto ? 'auto' : format(value)}
+      </span>
+    </div>
+  );
+}
+
+function Segmented({ label, options, value, onChange }: {
+  label: string; options: { label: string; value: string }[]; value: string; onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1 justify-end" role="group" aria-label={label}>
+      {options.map(o => (
+        <button
+          key={o.label}
+          onClick={() => onChange(o.value)}
+          aria-pressed={value === o.value}
+          className={`px-2 py-1 rounded text-[9px] font-mono tracking-wider border transition-colors ${
+            value === o.value
+              ? 'border-[var(--border-active)] bg-[var(--gold-primary)]/15 text-[var(--gold-light)]'
+              : 'border-white/10 text-white/35 hover:text-white/60'
+          }`}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col">
+      <div className="text-[9px] font-mono tracking-[0.25em] uppercase text-white/25 border-b border-white/[0.07] pb-1 mb-1">
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function StyleStudio({ onClose, isMobile }: { onClose: () => void; isMobile?: boolean }) {
+  const [s, setS] = useState<StyleSettings | null>(null);
+  const [copied, setCopied] = useState(false);
+  const initialised = useRef(false);
+  /**
+   * Until the user actually changes something there is nothing to override.
+   * Without this, Reset would immediately re-apply a snapshot of the current
+   * theme as inline vars — which look identical but pin the palette, so the
+   * Ghost Protocol toggle would silently stop doing anything.
+   */
+  const dirty = useRef(false);
+
+  useEffect(() => {
+    if (initialised.current) return;
+    initialised.current = true;
+    const saved = loadSavedSettings();
+    if (saved) dirty.current = true;
+    setS(saved ?? readTheme());
+  }, []);
+
+  useEffect(() => {
+    if (!s || !dirty.current) return;
+    applySettings(s);
+    /* Debounced: a slider drag fires this on every frame. */
+    const t = setTimeout(() => {
+      saveSettings(s);
+    }, 250);
+    return () => clearTimeout(t);
+  }, [s]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  /* While clean, re-seed from the live theme so edits made after a theme
+     switch start from what is actually on screen. */
+  const edit = useCallback((patch: Partial<StyleSettings>) => {
+    setS(prev => {
+      const base = dirty.current && prev ? prev : readTheme();
+      return { ...base, ...patch };
+    });
+    dirty.current = true;
+  }, []);
+
+  const set = useCallback(<K extends keyof StyleSettings>(key: K, value: StyleSettings[K]) => {
+    edit({ [key]: value } as Partial<StyleSettings>);
+  }, [edit]);
+
+  /* The surface ramp follows the background unless a preset supplies its own. */
+  const setBg = useCallback((bg: string) => {
+    edit({ bg, bgPrimary: shade(bg, 0.03), bgSecondary: shade(bg, 0.07), bgTertiary: shade(bg, 0.12) });
+  }, [edit]);
+
+  const reset = () => {
+    dirty.current = false;
+    clearSettings();
+    applySettings(null);
+    setS(readTheme());
+  };
+
+  const copy = async () => {
+    if (!s) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(s, null, 2));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch { /* clipboard blocked */ }
+  };
+
+  const paste = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      edit(sanitize(JSON.parse(text), s ?? readTheme()));
+    } catch { /* not JSON, or clipboard blocked */ }
+  };
+
+  if (!s) return null;
+
+  /* Portalled to <body>: the rail that renders the trigger carries a
+     framer-motion transform, which would otherwise make this fixed panel
+     position against the rail instead of the viewport. */
+  return createPortal(
+    <motion.div
+      initial={{ opacity: 0, x: isMobile ? 0 : -12, y: isMobile ? 12 : 0 }}
+      animate={{ opacity: 1, x: 0, y: 0 }}
+      exit={{ opacity: 0, x: isMobile ? 0 : -12, y: isMobile ? 12 : 0 }}
+      transition={{ type: 'spring', stiffness: 320, damping: 30 }}
+      className={`z-[400] pointer-events-auto flex flex-col rounded-xl border border-[var(--border-primary)] shadow-[0_16px_48px_rgba(0,0,0,0.7)] ${
+        isMobile ? 'fixed inset-x-3 bottom-3 top-20' : 'fixed left-[58px] bottom-6 w-[340px] max-h-[min(78vh,720px)]'
+      }`}
+      style={{
+        background: 'rgba(6, 4, 14, 0.96)',
+        backdropFilter: 'blur(28px) saturate(1.2)',
+        WebkitBackdropFilter: 'blur(28px) saturate(1.2)',
+      }}
+      role="dialog"
+      aria-label="Style Studio"
+    >
+      <div className="flex items-center justify-between px-3 py-2.5 border-b border-white/[0.07] shrink-0">
+        <div className="flex flex-col">
+          <span className="text-[11px] font-mono tracking-[0.22em] uppercase text-[var(--gold-light)]">Style Studio</span>
+          <span className="text-[9px] font-mono tracking-[0.1em] uppercase text-white/25">Live UI tokens</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button onClick={paste} title="Paste a shared theme from the clipboard" aria-label="Paste theme" className="w-7 h-7 rounded-md flex items-center justify-center text-white/30 hover:text-white/70 hover:bg-white/5 transition-colors">
+            <ClipboardPaste className="w-3.5 h-3.5" />
+          </button>
+          <button onClick={copy} title="Copy this theme as JSON" aria-label="Copy theme" className="w-7 h-7 rounded-md flex items-center justify-center text-white/30 hover:text-white/70 hover:bg-white/5 transition-colors">
+            {copied ? <Check className="w-3.5 h-3.5 text-[var(--alert-green)]" /> : <Copy className="w-3.5 h-3.5" />}
+          </button>
+          <button onClick={reset} title="Reset to the active theme" aria-label="Reset" className="w-7 h-7 rounded-md flex items-center justify-center text-white/30 hover:text-white/70 hover:bg-white/5 transition-colors">
+            <RotateCcw className="w-3.5 h-3.5" />
+          </button>
+          <button onClick={onClose} title="Close" aria-label="Close Style Studio" className="w-7 h-7 rounded-md flex items-center justify-center text-white/30 hover:text-white/70 hover:bg-white/5 transition-colors">
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-3 py-2 flex flex-col gap-3">
+        <Section title="Preset">
+          <div className="grid grid-cols-3 gap-1 pt-1">
+            {PRESETS.map(p => (
+              <button
+                key={p.label}
+                onClick={() => edit(p.patch)}
+                className="flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-white/10 hover:border-[var(--border-active)] hover:bg-white/5 transition-colors"
+              >
+                <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: p.patch.accent, boxShadow: `0 0 6px ${p.patch.accent}` }} />
+                <span className="text-[9px] font-mono tracking-wider text-white/50">{p.label}</span>
+              </button>
+            ))}
+          </div>
+        </Section>
+
+        <Section title="Accent">
+          <Row label="Primary"><Swatch label="Primary accent" value={s.accent} onChange={v => set('accent', v)} /></Row>
+          <Row label="Secondary"><Swatch label="Secondary accent" value={s.accent2} onChange={v => set('accent2', v)} /></Row>
+          <Row label="Glow"><Slider label="Glow strength" value={s.glow} min={0} max={1} step={0.01} onChange={v => set('glow', v)} format={v => `${Math.round(v * 100)}%`} /></Row>
+        </Section>
+
+        <Section title="Signal">
+          <Row label="Critical"><Swatch label="Critical colour" value={s.alertRed} onChange={v => set('alertRed', v)} /></Row>
+          <Row label="Warning"><Swatch label="Warning colour" value={s.alertOrange} onChange={v => set('alertOrange', v)} /></Row>
+          <Row label="Nominal"><Swatch label="Nominal colour" value={s.alertGreen} onChange={v => set('alertGreen', v)} /></Row>
+          <Row label="Info"><Swatch label="Info colour" value={s.alertBlue} onChange={v => set('alertBlue', v)} /></Row>
+        </Section>
+
+        <Section title="Surface">
+          <Row label="Background"><Swatch label="Background colour" value={s.bg} onChange={setBg} /></Row>
+          <Row label="Panel"><Slider label="Panel opacity" value={s.panelAlpha} min={0.2} max={1} step={0.01} onChange={v => set('panelAlpha', v)} format={v => `${Math.round(v * 100)}%`} /></Row>
+          <Row label="Border"><Slider label="Border strength" value={s.borderAlpha} min={0} max={0.6} step={0.01} onChange={v => set('borderAlpha', v)} format={v => `${Math.round(v * 100)}%`} /></Row>
+          <Row label="Blur"><AutoSlider label="Backdrop blur" value={s.blur} min={0} max={64} step={1} whenEnabled={24} onChange={v => set('blur', v)} format={v => `${v}px`} /></Row>
+          <Row label="Radius"><Slider label="Corner radius" value={s.radius} min={0} max={2.5} step={0.05} onChange={v => set('radius', v)} format={v => `${v.toFixed(2)}x`} /></Row>
+        </Section>
+
+        <Section title="Text">
+          <Row label="Primary"><Swatch label="Primary text" value={s.textPrimary} onChange={v => set('textPrimary', v)} /></Row>
+          <Row label="Secondary"><Swatch label="Secondary text" value={s.textSecondary} onChange={v => set('textSecondary', v)} /></Row>
+          <Row label="Muted"><Swatch label="Muted text" value={s.textMuted} onChange={v => set('textMuted', v)} /></Row>
+          <Row label="Heading"><Swatch label="Heading text" value={s.textHeading} onChange={v => set('textHeading', v)} /></Row>
+        </Section>
+
+        <Section title="Typography">
+          <Row label="UI font"><Segmented label="UI font" options={FONT_UI} value={s.fontUi} onChange={v => set('fontUi', v)} /></Row>
+          <Row label="Mono font"><Segmented label="Mono font" options={FONT_MONO} value={s.fontMono} onChange={v => set('fontMono', v)} /></Row>
+          <Row label="Tracking"><AutoSlider label="Mono tracking" value={s.tracking} min={-0.05} max={0.4} step={0.005} whenEnabled={0.2} onChange={v => set('tracking', v)} format={v => `${v.toFixed(2)}em`} /></Row>
+        </Section>
+
+        <Section title="Motion & FX">
+          <Row label="Speed"><Slider label="Motion speed" value={s.motion} min={0} max={2} step={0.05} onChange={v => set('motion', v)} format={v => (v === 0 ? 'off' : `${v.toFixed(2)}x`)} /></Row>
+          <Row label="Scanlines"><Slider label="Scanline overlay" value={s.scanlines} min={0} max={0.2} step={0.005} onChange={v => set('scanlines', v)} format={v => (v === 0 ? 'off' : `${Math.round(v * 500)}%`)} /></Row>
+        </Section>
+
+        <p className="text-[9px] font-mono leading-relaxed text-white/20 pt-1 pb-1">
+          Saved to this browser. AUTO leaves the app&apos;s own styling alone. Reset restores the active theme.
+        </p>
+      </div>
+    </motion.div>,
+    document.body,
+  );
+}
+
+export default memo(StyleStudio);

--- a/src/lib/style-tokens.test.ts
+++ b/src/lib/style-tokens.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { buildCss, buildVars, DEFAULTS, sanitize, type StyleSettings } from './style-tokens';
+
+const settings = (o: Partial<StyleSettings> = {}): StyleSettings => ({ ...DEFAULTS, ...o });
+
+describe('sanitize', () => {
+  it('refuses colours that try to close the declaration and add rules', () => {
+    // Settings reach an injected <style> tag and body.style, so an unvalidated
+    // string pasted from the clipboard would be a CSS injection.
+    const hostile = { accent: 'red; } body { display: none !important } .x {' };
+    expect(sanitize(hostile, DEFAULTS).accent).toBe(DEFAULTS.accent);
+  });
+
+  it('refuses numbers smuggled in as strings with a CSS payload', () => {
+    const hostile = { blur: '12px; } * { visibility: hidden } .y {', tracking: '0.1em } body::before { content: "x" } .z {' };
+    const out = sanitize(hostile, DEFAULTS);
+    // parseFloat salvages the leading number; the payload never survives.
+    expect(out.blur).toBe(12);
+    expect(out.tracking).toBe(0.1);
+    expect(JSON.stringify(out)).not.toContain('visibility');
+    expect(JSON.stringify(out)).not.toContain('content');
+  });
+
+  it('rejects a font stack outside the offered list', () => {
+    const hostile = { fontUi: 'Comic Sans; } html { filter: invert(1) } x{' };
+    expect(sanitize(hostile, DEFAULTS).fontUi).toBe(DEFAULTS.fontUi);
+  });
+
+  it('clamps numbers to their control range', () => {
+    const out = sanitize({ radius: 9999, motion: -50, scanlines: 99, glow: 4, panelAlpha: 0 }, DEFAULTS);
+    expect(out.radius).toBe(2.5);
+    expect(out.motion).toBe(0);
+    expect(out.scanlines).toBe(0.2);
+    expect(out.glow).toBe(1);
+    expect(out.panelAlpha).toBe(0.2);
+  });
+
+  it('falls back for values that are not numbers at all', () => {
+    expect(sanitize({ panelAlpha: 'abc' }, DEFAULTS).panelAlpha).toBe(DEFAULTS.panelAlpha);
+    expect(sanitize({ textPrimary: 'javascript:alert(1)' }, DEFAULTS).textPrimary).toBe(DEFAULTS.textPrimary);
+  });
+
+  it('keeps null as null, because null is the AUTO state', () => {
+    // AUTO has to survive a save/load round trip or reopening the studio would
+    // silently start overriding blur and tracking.
+    const base = settings({ blur: 20, tracking: 0.1 });
+    expect(sanitize({ blur: null, tracking: null }, base).blur).toBeNull();
+    expect(sanitize({ blur: null, tracking: null }, base).tracking).toBeNull();
+  });
+
+  it('takes the base value when a key is absent', () => {
+    const base = settings({ blur: 20, accent: '#123456' });
+    const out = sanitize({}, base);
+    expect(out.blur).toBe(20);
+    expect(out.accent).toBe('#123456');
+  });
+
+  it('normalises the hex spellings a browser hands back', () => {
+    // getComputedStyle returns `rgba(var(--x), .2)` as 8-digit hex.
+    expect(sanitize({ accent: '#B388FF33' }, DEFAULTS).accent).toBe('#b388ff');
+    expect(sanitize({ accent: '#ABC' }, DEFAULTS).accent).toBe('#aabbcc');
+  });
+
+  it('survives junk input without throwing', () => {
+    expect(() => sanitize(null, DEFAULTS)).not.toThrow();
+    expect(() => sanitize('not an object', DEFAULTS)).not.toThrow();
+    expect(sanitize(null, DEFAULTS)).toEqual(DEFAULTS);
+  });
+});
+
+describe('buildCss', () => {
+  it('emits nothing when every knob is neutral', () => {
+    // The whole point: opening the studio and nudging a colour must not
+    // restyle radius, blur, tracking or motion as a side effect.
+    expect(buildCss(DEFAULTS)).toBe('');
+  });
+
+  it('emits only the block for the knob that changed', () => {
+    const css = buildCss(settings({ blur: 8 }));
+    expect(css).toContain('backdrop-filter: blur(8px)');
+    expect(css).not.toContain('border-radius');
+    expect(css).not.toContain('letter-spacing');
+    expect(css).not.toContain('transition-duration');
+  });
+
+  it('leaves tracking alone at AUTO and sets it when overridden', () => {
+    expect(buildCss(settings({ tracking: null }))).not.toContain('letter-spacing');
+    expect(buildCss(settings({ tracking: 0.2 }))).toContain('letter-spacing: 0.2em');
+  });
+
+  it('treats blur 0 as a real value, not as AUTO', () => {
+    // 0 means "no blur", which is a legitimate choice and must be emitted.
+    expect(buildCss(settings({ blur: 0 }))).toContain('blur(0px)');
+  });
+
+  it('scales the radius utilities but never the pill radius', () => {
+    const css = buildCss(settings({ radius: 2 }));
+    expect(css).toContain('.rounded-lg { border-radius: 16.0px; }');
+    expect(css).toContain('.rounded-full { border-radius: 9999px; }');
+  });
+
+  it('scopes every rule to the studio attribute', () => {
+    const css = buildCss(settings({ radius: 1.5, blur: 10, tracking: 0.1, motion: 0.5, scanlines: 0.1 }));
+    for (const line of css.split('\n')) {
+      if (line.trim().endsWith('{') || line.includes('} ')) {
+        expect(line.includes('body[data-studio="on"]') || line.trim() === '{').toBe(true);
+      }
+    }
+  });
+
+  it('cannot be escaped by a sanitised hostile payload', () => {
+    const hostile = sanitize(
+      { blur: '1px } body { display: none } .x {', tracking: '0.1em } body::before { content: "PWNED" } .z {' },
+      DEFAULTS,
+    );
+    const css = buildCss(hostile);
+    expect(css).not.toContain('PWNED');
+    expect(css).not.toContain('display: none');
+  });
+});
+
+describe('buildVars', () => {
+  it('derives the whole accent family from one colour', () => {
+    const v = buildVars(settings({ accent: '#ff8800', borderAlpha: 0.2, glow: 0.3 }));
+    expect(v['--gold-primary']).toBe('#ff8800');
+    expect(v['--gold-rgb']).toBe('255, 136, 0');
+    expect(v['--border-primary']).toBe('rgba(255, 136, 0, 0.2)');
+    expect(v['--gold-glow']).toBe('rgba(255, 136, 0, 0.3)');
+  });
+
+  it('keeps the active border stronger than the resting one', () => {
+    const v = buildVars(settings({ borderAlpha: 0.2 }));
+    expect(v['--border-active']).toBe('rgba(212, 175, 55, 0.48)');
+    expect(v['--border-secondary']).toBe('rgba(212, 175, 55, 0.09)');
+  });
+
+  it('never lets a derived alpha exceed 1', () => {
+    const v = buildVars(settings({ borderAlpha: 0.6 }));
+    expect(v['--border-active']).toBe('rgba(212, 175, 55, 1)');
+  });
+
+  it('uses the stored surface ramp rather than re-deriving it', () => {
+    // The themes' ramps are hue-shifted, not plain lightening, so a derived
+    // ramp would visibly flatten them the moment any control was touched.
+    const v = buildVars(settings({ bg: '#05000f', bgPrimary: '#08001a', bgSecondary: '#0d0025', bgTertiary: '#140033' }));
+    expect(v['--bg-void']).toBe('#05000f');
+    expect(v['--bg-primary']).toBe('#08001a');
+    expect(v['--bg-secondary']).toBe('#0d0025');
+    expect(v['--bg-tertiary']).toBe('#140033');
+  });
+
+  it('covers every custom property the themes define', () => {
+    // A token the studio forgets is a token Reset cannot clean up.
+    const names = Object.keys(buildVars(DEFAULTS));
+    for (const required of [
+      '--gold-rgb', '--gold-primary', '--gold-light', '--gold-dim', '--gold-glow',
+      '--cyan-rgb', '--cyan-primary', '--cyan-dim', '--cyan-glow',
+      '--alert-red', '--alert-orange', '--alert-green', '--alert-blue',
+      '--bg-void', '--bg-primary', '--bg-secondary', '--bg-tertiary', '--bg-panel', '--bg-panel-solid',
+      '--border-primary', '--border-secondary', '--border-active', '--border-cyan',
+      '--text-primary', '--text-secondary', '--text-muted', '--text-heading', '--text-gold', '--text-cyan',
+      '--scrollbar-thumb', '--scrollbar-thumb-hover', '--hover-accent',
+      '--font-hud', '--font-body',
+    ]) {
+      expect(names).toContain(required);
+    }
+  });
+});

--- a/src/lib/style-tokens.ts
+++ b/src/lib/style-tokens.ts
@@ -1,0 +1,371 @@
+/**
+ * Style Studio token engine — the pure half of the customisation feature.
+ *
+ * Two mechanisms, deliberately kept apart:
+ *
+ *  - Palette values become CSS custom properties on <body>. Inline styles beat
+ *    the `body.theme-*` rules in globals.css, so an override always wins over
+ *    the active theme.
+ *  - The few knobs no token covers (radius, blur, tracking, motion, scanlines)
+ *    are emitted as rules into one injected <style> tag.
+ *
+ * Every setting is seeded from the live theme and every injected rule is
+ * *conditional*, so touching one control changes only that control. Without
+ * that, editing an accent colour would also flatten the app's mono tracking
+ * and rewrite every backdrop blur to a single value.
+ */
+
+const STORAGE_KEY = 'osiris:style-studio';
+const STYLE_TAG_ID = 'osiris-style-studio';
+
+export interface StyleSettings {
+  accent: string;
+  accent2: string;
+  alertRed: string;
+  alertOrange: string;
+  alertGreen: string;
+  alertBlue: string;
+  bg: string;
+  bgPrimary: string;
+  bgSecondary: string;
+  bgTertiary: string;
+  panelAlpha: number;
+  borderAlpha: number;
+  textPrimary: string;
+  textSecondary: string;
+  textMuted: string;
+  textHeading: string;
+  fontUi: string;
+  fontMono: string;
+  glow: number;
+  /** null = leave the app's own value alone. */
+  tracking: number | null;
+  blur: number | null;
+  radius: number;
+  motion: number;
+  scanlines: number;
+}
+
+export const FONT_UI = [
+  { label: 'INTER', value: "'Inter', -apple-system, sans-serif" },
+  { label: 'MONO', value: "'JetBrains Mono', monospace" },
+  { label: 'SYSTEM', value: 'system-ui, -apple-system, sans-serif' },
+  { label: 'SERIF', value: "'Iowan Old Style', Georgia, serif" },
+];
+
+export const FONT_MONO = [
+  { label: 'JETBRAINS', value: "'JetBrains Mono', 'Courier New', monospace" },
+  { label: 'COURIER', value: "'Courier New', Courier, monospace" },
+  { label: 'CONSOLAS', value: "Consolas, 'SF Mono', Menlo, monospace" },
+  { label: 'INTER', value: "'Inter', sans-serif" },
+];
+
+/** Neutral baseline: also the shape used to enumerate every var we own. */
+export const DEFAULTS: StyleSettings = {
+  accent: '#d4af37',
+  accent2: '#00e5ff',
+  alertRed: '#ff3d3d',
+  alertOrange: '#ff9500',
+  alertGreen: '#00e676',
+  alertBlue: '#448aff',
+  bg: '#04040a',
+  bgPrimary: '#06060c',
+  bgSecondary: '#0c0e1a',
+  bgTertiary: '#121628',
+  panelAlpha: 0.88,
+  borderAlpha: 0.15,
+  textPrimary: '#e8e6e0',
+  textSecondary: '#9b978e',
+  textMuted: '#5c5a54',
+  textHeading: '#f5f0e0',
+  fontUi: FONT_UI[0].value,
+  fontMono: FONT_MONO[0].value,
+  glow: 0.3,
+  tracking: null,
+  blur: null,
+  radius: 1,
+  motion: 1,
+  scanlines: 0,
+};
+
+export type Preset = { label: string; patch: Partial<StyleSettings> };
+
+/** Presets carry a full surface ramp so they don't inherit the old one. */
+export const PRESETS: Preset[] = [
+  { label: 'HORUS', patch: { accent: '#d4af37', accent2: '#00e5ff', bg: '#04040a', bgPrimary: '#06060c', bgSecondary: '#0c0e1a', bgTertiary: '#121628', textPrimary: '#e8e6e0', textSecondary: '#9b978e', textMuted: '#5c5a54', textHeading: '#f5f0e0', glow: 0.3, scanlines: 0 } },
+  { label: 'PHANTOM', patch: { accent: '#b388ff', accent2: '#7c4dff', bg: '#05000f', bgPrimary: '#08001a', bgSecondary: '#0d0025', bgTertiary: '#140033', textPrimary: '#e1bee7', textSecondary: '#9575cd', textMuted: '#6a4c93', textHeading: '#b388ff', glow: 0.35, scanlines: 0 } },
+  { label: 'TERMINAL', patch: { accent: '#00ff9c', accent2: '#00b36b', bg: '#000a06', bgPrimary: '#001410', bgSecondary: '#00201a', bgTertiary: '#002d24', textPrimary: '#c8ffe4', textSecondary: '#5fbf95', textMuted: '#2e6b52', textHeading: '#7dffc4', glow: 0.4, scanlines: 0.05 } },
+  { label: 'CRIMSON', patch: { accent: '#ff4d5a', accent2: '#ff9500', bg: '#0c0204', bgPrimary: '#140407', bgSecondary: '#1e070b', bgTertiary: '#2a0a10', textPrimary: '#ffd9dd', textSecondary: '#c98089', textMuted: '#6e3a42', textHeading: '#ff8f97', glow: 0.35, scanlines: 0 } },
+  { label: 'ARCTIC', patch: { accent: '#8fd3ff', accent2: '#4fc3f7', bg: '#04080f', bgPrimary: '#070d18', bgSecondary: '#0b1524', bgTertiary: '#101f33', textPrimary: '#e3f2fd', textSecondary: '#90a4b8', textMuted: '#4a5d70', textHeading: '#c9e7ff', glow: 0.25, scanlines: 0 } },
+  { label: 'BLACKOUT', patch: { accent: '#9e9e9e', accent2: '#616161', bg: '#000000', bgPrimary: '#070707', bgSecondary: '#0e0e0e', bgTertiary: '#161616', textPrimary: '#e0e0e0', textSecondary: '#8a8a8a', textMuted: '#4a4a4a', textHeading: '#f0f0f0', glow: 0.08, scanlines: 0 } },
+];
+
+/* ── Colour helpers ── */
+export const HEX_RE = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+function hexToRgb(hex: string) {
+  const h = hex.replace('#', '');
+  const full = h.length === 3 ? h.split('').map(c => c + c).join('') : h;
+  const n = parseInt(full, 16);
+  return Number.isNaN(n) ? { r: 0, g: 0, b: 0 } : { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+function toHex(r: number, g: number, b: number) {
+  const p = (v: number) => Math.max(0, Math.min(255, Math.round(v))).toString(16).padStart(2, '0');
+  return `#${p(r)}${p(g)}${p(b)}`;
+}
+
+/** amount > 0 lightens toward white, < 0 darkens toward black. */
+export function shade(hex: string, amount: number) {
+  const { r, g, b } = hexToRgb(hex);
+  const t = amount > 0 ? 255 : 0;
+  const a = Math.abs(amount);
+  return toHex(r + (t - r) * a, g + (t - g) * a, b + (t - b) * a);
+}
+
+const rgbList = (hex: string) => { const { r, g, b } = hexToRgb(hex); return `${r}, ${g}, ${b}`; };
+const rgba = (hex: string, a: number) => { const { r, g, b } = hexToRgb(hex); return `rgba(${r}, ${g}, ${b}, ${Number(a.toFixed(3))})`; };
+
+/* ── Validation ──
+   Pasted JSON and stored JSON are both untrusted: numbers reach the injected
+   stylesheet as text, so anything unvalidated is a CSS injection. Colours are
+   normalised to 6-digit hex and fonts must match the offered stacks. */
+const clamp = (n: number, min: number, max: number) => Math.min(max, Math.max(min, n));
+
+function normHex(v: unknown, fallback: string) {
+  if (typeof v !== 'string') return fallback;
+  /* Browsers serialise `rgba(var(--x), a)` back as 8-digit hex, so accept an
+     alpha channel here and drop it — these fields are opaque colours. */
+  const t = v.trim().replace(/^(#(?:[0-9a-f]{6}))[0-9a-f]{2}$/i, '$1').replace(/^(#[0-9a-f]{3})[0-9a-f]$/i, '$1');
+  if (!HEX_RE.test(t)) return fallback;
+  const { r, g, b } = hexToRgb(t);
+  return toHex(r, g, b);
+}
+
+function normNum(v: unknown, fallback: number, min: number, max: number) {
+  const n = typeof v === 'number' ? v : parseFloat(String(v));
+  return Number.isFinite(n) ? clamp(n, min, max) : fallback;
+}
+
+function normNullableNum(v: unknown, fallback: number | null, min: number, max: number) {
+  if (v === null) return null;
+  if (v === undefined) return fallback;
+  const n = typeof v === 'number' ? v : parseFloat(String(v));
+  return Number.isFinite(n) ? clamp(n, min, max) : fallback;
+}
+
+function normFont(v: unknown, list: { value: string }[], fallback: string) {
+  return typeof v === 'string' && list.some(o => o.value === v) ? v : fallback;
+}
+
+export function sanitize(input: unknown, base: StyleSettings): StyleSettings {
+  const o = (input ?? {}) as Record<string, unknown>;
+  return {
+    accent: normHex(o.accent, base.accent),
+    accent2: normHex(o.accent2, base.accent2),
+    alertRed: normHex(o.alertRed, base.alertRed),
+    alertOrange: normHex(o.alertOrange, base.alertOrange),
+    alertGreen: normHex(o.alertGreen, base.alertGreen),
+    alertBlue: normHex(o.alertBlue, base.alertBlue),
+    bg: normHex(o.bg, base.bg),
+    bgPrimary: normHex(o.bgPrimary, base.bgPrimary),
+    bgSecondary: normHex(o.bgSecondary, base.bgSecondary),
+    bgTertiary: normHex(o.bgTertiary, base.bgTertiary),
+    panelAlpha: normNum(o.panelAlpha, base.panelAlpha, 0.2, 1),
+    borderAlpha: normNum(o.borderAlpha, base.borderAlpha, 0, 0.6),
+    textPrimary: normHex(o.textPrimary, base.textPrimary),
+    textSecondary: normHex(o.textSecondary, base.textSecondary),
+    textMuted: normHex(o.textMuted, base.textMuted),
+    textHeading: normHex(o.textHeading, base.textHeading),
+    fontUi: normFont(o.fontUi, FONT_UI, base.fontUi),
+    fontMono: normFont(o.fontMono, FONT_MONO, base.fontMono),
+    glow: normNum(o.glow, base.glow, 0, 1),
+    tracking: normNullableNum(o.tracking, base.tracking, -0.05, 0.4),
+    blur: normNullableNum(o.blur, base.blur, 0, 64),
+    radius: normNum(o.radius, base.radius, 0, 2.5),
+    motion: normNum(o.motion, base.motion, 0, 2),
+    scanlines: normNum(o.scanlines, base.scanlines, 0, 0.2),
+  };
+}
+
+/** Every design token the studio drives, derived from the settings. */
+export function buildVars(s: StyleSettings): Record<string, string> {
+  return {
+    '--gold-rgb': rgbList(s.accent),
+    '--gold-primary': s.accent,
+    '--gold-light': shade(s.accent, 0.35),
+    '--gold-dim': shade(s.accent, -0.45),
+    '--gold-glow': rgba(s.accent, s.glow),
+    '--text-gold': s.accent,
+    '--cyan-rgb': rgbList(s.accent2),
+    '--cyan-primary': s.accent2,
+    '--cyan-dim': shade(s.accent2, -0.5),
+    '--cyan-glow': rgba(s.accent2, s.glow * 0.6),
+    '--text-cyan': s.accent2,
+    '--alert-red': s.alertRed,
+    '--alert-orange': s.alertOrange,
+    '--alert-green': s.alertGreen,
+    '--alert-blue': s.alertBlue,
+    '--bg-void': s.bg,
+    '--bg-primary': s.bgPrimary,
+    '--bg-secondary': s.bgSecondary,
+    '--bg-tertiary': s.bgTertiary,
+    '--bg-panel': rgba(s.bg, s.panelAlpha),
+    '--bg-panel-solid': s.bgSecondary,
+    '--border-primary': rgba(s.accent, s.borderAlpha),
+    '--border-secondary': rgba(s.accent, s.borderAlpha * 0.45),
+    '--border-active': rgba(s.accent, Math.min(1, s.borderAlpha * 2.4)),
+    '--border-cyan': rgba(s.accent2, s.borderAlpha * 1.2),
+    '--hover-accent': rgba(s.accent, s.borderAlpha * 0.5),
+    '--scrollbar-thumb': rgba(s.accent, s.borderAlpha * 1.2),
+    '--scrollbar-thumb-hover': rgba(s.accent, s.borderAlpha * 2.4),
+    '--text-primary': s.textPrimary,
+    '--text-secondary': s.textSecondary,
+    '--text-muted': s.textMuted,
+    '--text-heading': s.textHeading,
+    '--font-body': s.fontUi,
+    '--font-hud': s.fontMono,
+  };
+}
+
+const VAR_NAMES = Object.keys(buildVars(DEFAULTS));
+
+/**
+ * The knobs no token covers. Each block is emitted only when it differs from
+ * the app's own styling, so an untouched knob leaves the design alone.
+ */
+export function buildCss(s: StyleSettings): string {
+  const at = 'body[data-studio="on"]';
+  const blocks: string[] = [];
+
+  if (s.radius !== 1) {
+    const r = (px: number) => `${(px * s.radius).toFixed(1)}px`;
+    blocks.push(
+      `${at} .rounded { border-radius: ${r(4)}; }
+${at} .rounded-md { border-radius: ${r(6)}; }
+${at} .rounded-lg { border-radius: ${r(8)}; }
+${at} .rounded-xl { border-radius: ${r(12)}; }
+${at} .rounded-2xl { border-radius: ${r(16)}; }
+${at} .rounded-full { border-radius: 9999px; }`,
+    );
+  }
+
+  if (s.blur !== null) {
+    blocks.push(
+      `${at} [class*="backdrop-blur"] {
+  backdrop-filter: blur(${s.blur}px) saturate(1.2);
+  -webkit-backdrop-filter: blur(${s.blur}px) saturate(1.2);
+}`,
+    );
+  }
+
+  if (s.tracking !== null) {
+    blocks.push(`${at} .font-mono { letter-spacing: ${s.tracking}em; }`);
+  }
+
+  if (s.motion !== 1) {
+    blocks.push(`${at} *, ${at} *::before, ${at} *::after { transition-duration: ${Math.round(600 * s.motion)}ms !important; }`);
+  }
+
+  if (s.scanlines > 0) {
+    blocks.push(
+      `${at}::after {
+  content: ''; position: fixed; inset: 0; pointer-events: none; z-index: 9998;
+  background-image: repeating-linear-gradient(0deg, rgba(255,255,255,${s.scanlines}) 0px, rgba(255,255,255,${s.scanlines}) 1px, transparent 1px, transparent 3px);
+}`,
+    );
+  }
+
+  return blocks.join('\n');
+}
+
+/**
+ * Pull the alpha channel out of a token value. Chrome serialises a computed
+ * `rgba(var(--gold-rgb), 0.2)` as `#b388ff33`, so both spellings have to work
+ * or every alpha-derived setting silently falls back to its default.
+ */
+function parseAlpha(value: string, fallback: number) {
+  const v = value.trim();
+  const fn = v.match(/rgba?\([^)]*[,/]\s*([0-9.]+%?)\s*\)/);
+  if (fn) {
+    const raw = fn[1];
+    const n = parseFloat(raw);
+    if (Number.isFinite(n)) return clamp(raw.endsWith('%') ? n / 100 : n, 0, 1);
+  }
+  const hex8 = v.match(/^#(?:[0-9a-f]{6})([0-9a-f]{2})$/i);
+  if (hex8) return clamp(parseInt(hex8[1], 16) / 255, 0, 1);
+  const hex4 = v.match(/^#(?:[0-9a-f]{3})([0-9a-f])$/i);
+  if (hex4) return clamp(parseInt(hex4[1] + hex4[1], 16) / 255, 0, 1);
+  return fallback;
+}
+
+/** Seed every setting from whatever the active theme currently computes to. */
+export function readTheme(): StyleSettings {
+  if (typeof document === 'undefined') return DEFAULTS;
+  const cs = getComputedStyle(document.body);
+  const v = (name: string, fallback: string) => (cs.getPropertyValue(name).trim() || fallback);
+  const hex = (name: string, fallback: string) => normHex(v(name, fallback), fallback);
+  return {
+    ...DEFAULTS,
+    accent: hex('--gold-primary', DEFAULTS.accent),
+    accent2: hex('--cyan-primary', DEFAULTS.accent2),
+    alertRed: hex('--alert-red', DEFAULTS.alertRed),
+    alertOrange: hex('--alert-orange', DEFAULTS.alertOrange),
+    alertGreen: hex('--alert-green', DEFAULTS.alertGreen),
+    alertBlue: hex('--alert-blue', DEFAULTS.alertBlue),
+    bg: hex('--bg-void', DEFAULTS.bg),
+    bgPrimary: hex('--bg-primary', DEFAULTS.bgPrimary),
+    bgSecondary: hex('--bg-secondary', DEFAULTS.bgSecondary),
+    bgTertiary: hex('--bg-tertiary', DEFAULTS.bgTertiary),
+    panelAlpha: parseAlpha(v('--bg-panel', ''), DEFAULTS.panelAlpha),
+    borderAlpha: parseAlpha(v('--border-primary', ''), DEFAULTS.borderAlpha),
+    textPrimary: hex('--text-primary', DEFAULTS.textPrimary),
+    textSecondary: hex('--text-secondary', DEFAULTS.textSecondary),
+    textMuted: hex('--text-muted', DEFAULTS.textMuted),
+    textHeading: hex('--text-heading', DEFAULTS.textHeading),
+    glow: parseAlpha(v('--gold-glow', ''), DEFAULTS.glow),
+  };
+}
+
+/** Push settings onto <body>, or strip every trace when passed null. */
+export function applySettings(s: StyleSettings | null) {
+  const body = document.body;
+  if (!s) {
+    for (const name of VAR_NAMES) body.style.removeProperty(name);
+    body.removeAttribute('data-studio');
+    document.getElementById(STYLE_TAG_ID)?.remove();
+    return;
+  }
+  for (const [name, value] of Object.entries(buildVars(s))) body.style.setProperty(name, value);
+  body.setAttribute('data-studio', 'on');
+  const css = buildCss(s);
+  let tag = document.getElementById(STYLE_TAG_ID);
+  if (!css) { tag?.remove(); return; }
+  if (!tag) {
+    tag = document.createElement('style');
+    tag.id = STYLE_TAG_ID;
+    document.head.appendChild(tag);
+  }
+  tag.textContent = css;
+}
+
+/** Persist the current customisation. Silently a no-op in private mode. */
+export function saveSettings(s: StyleSettings) {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(s)); } catch { /* private mode */ }
+}
+
+/** Forget the stored customisation. */
+export function clearSettings() {
+  try { localStorage.removeItem(STORAGE_KEY); } catch { /* private mode */ }
+}
+
+/** Reapply saved customisation on load, before the studio is ever opened. */
+export function loadSavedSettings(): StyleSettings | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return sanitize(JSON.parse(raw), readTheme());
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Three things, all verified against the live dev server.

---

## 1. Live CCTV previews on the map

Past **zoom 13**, the nearest cameras in view stop being dots and start showing what they see: a small live frame pinned above each marker, captioned with the camera's name. Clicking a tile opens the full viewer as before.

**Only still-image cameras qualify.** Of the ~19,000 in the catalogue the overwhelming majority are JPEG snapshot feeds, costing one request per refresh. The 675 MP4 / 75 HLS / 49 iframe cameras would each need a decoder or an embed, and eight of those on screen at once is a different feature with a much worse frame budget. They still open on click.

Bounded on every axis that could hurt: at most **8 tiles**, chosen nearest the centre of the screen and rejected if they would land on one already taken; refreshed every **15s** on staggered timers so they do not all hit their origin on the same tick. Positions are written straight to the DOM on map `move`, so panning does not re-render React sixty times a second — which cameras are shown recomputes only when the map settles.

`moveend` alone does not work as the trigger: arriving somewhere fires it *before* the source tiles for that view are parsed, so the query comes back empty and nothing would ever ask again. `idle` and `sourcedata` cover the frame after rendering settles, and the camera list refreshing under a stationary map. A tile that would clip off the top flips below its marker, and the overlay sits under the app's own chrome rather than over it.

Checked at Southwark / London Bridge, z14.2: tiles for TOOLEY ST/BOSS ST, BOROUGH HIGH ST/SOUTHWARK ST, BLACKFRIARS RD/DOLBEN ST and others. Anchoring is pixel-exact — every tile centred on its dot (dx = 0), exactly 16px above it. Zoom gate 8 → 0 → 8 across z14.2 / z12.5 / z14.2. Click opened the live TfL feed. Toggling the CCTV layer off clears every tile.

---

## 2. Style Studio

A live editor for the design tokens, opened from the rail above the Ghost Protocol toggle.

| Section | Controls |
|---|---|
| Preset | Horus, Phantom, Terminal, Crimson, Arctic, Blackout |
| Accent | primary, secondary, glow strength |
| Signal | critical / warning / nominal / info |
| Surface | background, panel opacity, border strength, blur, corner radius |
| Text | primary, secondary, muted, heading |
| Typography | UI font, mono font, mono tracking |
| Motion & FX | transition speed (down to off), scanline overlay |

One accent pick derives the whole family — 34 tokens from ~20 inputs. Themes copy and paste as JSON; customisation persists per browser.

Palette values are inline custom properties on `<body>`, which outrank the `body.theme-*` rules, so an override always wins over the active theme. The few knobs no token covers go into one injected `<style>` tag.

**Touching one control changes only that control.** In an earlier cut, editing *only* the accent also collapsed every mono `tracking-[0.2em]` to zero and forced blur from 40px to 24px, because all knobs applied together. Every setting is now seeded from the live theme and every injected rule is conditional; blur and tracking have an explicit **AUTO** state meaning "emit nothing". With everything neutral the stylesheet is empty and the tag is removed.

Two things this had to get right:

- **Reset has to stay reset.** Re-applying a snapshot of the theme looks identical but pins the palette, which would leave the Ghost Protocol toggle silently doing nothing. Nothing is written until the user actually changes something.
- **Stored and pasted JSON are untrusted** and reach an injected stylesheet, so `sanitize` normalises colours, clamps numbers and whitelists fonts. Tests cover payloads like `red; } body { display: none } .x {`.

Token maths lives in `src/lib/style-tokens.ts` (pure, no React) with **21 tests**; the panel is just controls, portalled to `<body>` because the rail carries a framer-motion transform. Worth recording: browsers serialise a computed `rgba(var(--x), a)` back as 8-digit hex, so reading only the `rgba()` spelling made border strength and panel opacity silently fall back to defaults on open.

---

## 3. Satellite readout, smaller and quieter

300×293 → **248×254**:

| | before | after |
|---|---|---|
| Top accent rule | 2px solid, full strength | 1px hairline at 60% alpha |
| Border | accent @ 33% | accent @ 20% |
| Drop shadow | `0 10px 40px` /60% | `0 6px 20px` /45% |
| Link wash | accent @ 7% | accent @ 4% |

Type and padding drop a step throughout. The colour rule stays — it ties the card to its marker and orbit track — just at hairline weight.

---

## Also

The map **opens in core again, not phantom**. Phantom stays one click away on the Ghost Protocol toggle, and the Style Studio seeds from whichever theme is active.

## Verification

`npm run build` compiles and `/` still prerenders statically; `tsc --noEmit` clean; **410 tests pass** (26 files); eslint clean on every touched file.

## Known interaction

While a custom palette is active, the Ghost Protocol toggle flips the body class but the visible palette does not change — the studio's inline vars outrank it by design. Reset restores theme control. Happy to make the theme toggle clear overrides, or re-seed the studio from the newly picked theme, if that reads better.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
