### PR TITLE
fix(map): stop the scale bar stretching the bottom panel

### DIFF
--- a/src/components/ScaleBar.test.ts
+++ b/src/components/ScaleBar.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { scaleFor } from './ScaleBar';
+
+const OTTAWA_LAT = 45.5268;
+
+describe('scaleFor', () => {
+  it('picks a round step that fits inside the 100px budget', () => {
+    expect(scaleFor(3, OTTAWA_LAT)).toEqual({ barWidth: 73, label: '1000 km' });
+    expect(scaleFor(10, OTTAWA_LAT)).toEqual({ barWidth: 93, label: '10 km' });
+    expect(scaleFor(14, OTTAWA_LAT)).toEqual({ barWidth: 75, label: '500 m' });
+  });
+
+  it('stays narrow past zoom 16, where the step table used to run out', () => {
+    expect(scaleFor(17.8, OTTAWA_LAT)).toEqual({ barWidth: 42, label: '20 m' });
+    expect(scaleFor(22, OTTAWA_LAT)).toEqual({ barWidth: 76, label: '2 m' });
+  });
+
+  it('never stretches the bar beyond the bottom panel', () => {
+    for (let zoom = 0; zoom <= 24; zoom += 0.2) {
+      for (const latitude of [0, OTTAWA_LAT, 70]) {
+        expect(scaleFor(zoom, latitude).barWidth).toBeLessThan(400);
+      }
+    }
+  });
+
+  it('labels sub-kilometre steps in whole metres', () => {
+    for (let zoom = 13; zoom <= 24; zoom += 0.2) {
+      expect(scaleFor(zoom, OTTAWA_LAT).label).toMatch(/^\d+ (m|km)$/);
+    }
+  });
+});

--- a/src/components/ScaleBar.tsx
+++ b/src/components/ScaleBar.tsx
@@ -12,27 +12,30 @@ interface ScaleBarProps {
   latitude: number;
 }
 
-const SCALE_STEPS = [5000, 2000, 1000, 500, 200, 100, 50, 20, 10, 5, 2, 1, 0.5, 0.2, 0.1];
+const SCALE_STEPS = [5000, 2000, 1000, 500, 200, 100, 50, 20, 10, 5, 2, 1, 0.5, 0.2, 0.1, 0.05, 0.02, 0.01, 0.005, 0.002, 0.001];
+
+export function scaleFor(zoom: number, latitude: number): { barWidth: number; label: string } {
+  // Meters per pixel at given zoom and latitude
+  const metersPerPx = 156543.03392 * Math.cos(latitude * Math.PI / 180) / Math.pow(2, zoom);
+  const maxWidth = 100; // Max bar width in pixels
+  const maxMeters = metersPerPx * maxWidth;
+  const maxKm = maxMeters / 1000;
+
+  // Fall back to the smallest step: past ~z16 nothing in the table fits, and
+  // leaving it on the 5000 km head blew the bar out to millions of pixels.
+  let bestStep = SCALE_STEPS[SCALE_STEPS.length - 1];
+  for (const step of SCALE_STEPS) {
+    if (step <= maxKm) { bestStep = step; break; }
+  }
+
+  const barWidth = Math.max(24, Math.round((bestStep * 1000) / metersPerPx));
+  const label = bestStep >= 1 ? `${bestStep} km` : `${Math.round(bestStep * 1000)} m`;
+
+  return { barWidth, label };
+}
 
 export default function ScaleBar({ zoom, latitude }: ScaleBarProps) {
-  const scaleInfo = useMemo(() => {
-    // Meters per pixel at given zoom and latitude
-    const metersPerPx = 156543.03392 * Math.cos(latitude * Math.PI / 180) / Math.pow(2, zoom);
-    const maxWidth = 100; // Max bar width in pixels
-    const maxMeters = metersPerPx * maxWidth;
-    const maxKm = maxMeters / 1000;
-
-    // Find the best scale step
-    let bestStep = SCALE_STEPS[0];
-    for (const step of SCALE_STEPS) {
-      if (step <= maxKm) { bestStep = step; break; }
-    }
-
-    const barWidth = Math.max(24, Math.round((bestStep * 1000) / metersPerPx));
-    const label = bestStep >= 1 ? `${bestStep} km` : `${bestStep * 1000} m`;
-
-    return { barWidth, label };
-  }, [zoom, latitude]);
+  const scaleInfo = useMemo(() => scaleFor(zoom, latitude), [zoom, latitude]);
 
   return (
     <div className="flex items-center gap-1.5 pointer-events-none select-none">


### PR DESCRIPTION
Past zoom ~16.4 the scale bar ran the full width of the window, dragging the view controls' container along with it.

## Cause

`SCALE_STEPS` bottoms out at `0.1` km, and the loop takes the first step that fits inside the 100px budget. At street zoom nothing fits, so `bestStep` was never assigned and kept its initialiser — `SCALE_STEPS[0]`, the 5000 km head of the table. The bar was then drawn at `5000000 / metersPerPx`:

| zoom | bar width |
| --- | --- |
| 16.0 | 60px |
| 17.8 | **10,399,402px** |
| 20.0 | **47,783,105px** |
| 22.0 | **191,132,422px** |

## Fix

- Initialise `bestStep` to the *smallest* step rather than the largest, so overshooting the table degrades to the finest scale instead of the coarsest.
- Extend the table down to 1 m so there is something honest to fall back to.
- Round sub-kilometre labels — the new entries would otherwise print `50.000000000000007 m`, and `0.2` already had the same hazard.

Zoom 17.8 at latitude 45.5 now draws a 42px bar labelled `20 m`. Swept across z0–24 and latitudes 0/45.5/70, the bar never exceeds 313px, and that only past z23.6 — beyond the map's reach.

The step maths moves out to an exported `scaleFor`, matching how `DirectionsBar` keeps its pure helpers testable; the widths above are pinned by tests. Nothing else in the component changed.

## Verified

Ottawa, satellite, zoom 17.8 — the view from the report:

| | before | after |
| --- | --- | --- |
| bar width | 10,399,402px | 42px |
| label | `5000 km` | `20 m` |
| controls container | 1280px (full viewport) | 282px |
| page overflow | — | 0px |

414 tests pass, 4 of them new. Lint clean.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)

