### PR TITLE
Optional Lattice tracks (default off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,15 @@
 # ═══════════════════════════════════════════════════════════════════════════
-#  OSIRIS — Environment Template
+#  OSIRIS - Environment Template
 #  Copy this file to `.env` (or `.env.local`) and fill in values as needed.
 #
-#  IMPORTANT — read before filling anything in:
+#  IMPORTANT - read before filling anything in:
 #  OSIRIS works fully WITHOUT any third-party API keys. Aviation, maritime,
 #  satellites, fires, earthquakes, weather, news, CVEs, etc. all use public
 #  keyless feeds (adsb.lol, celestrak.org, NASA FIRMS open CSV, USGS, …).
 #
 #  As of this revision the application code only actually reads SCANNER_URL
 #  and SCANNER_KEY. The other keys below are OPTIONAL and reserved for higher
-#  rate limits / future data sources — set them only if you extend the code or
+#  rate limits / future data sources - set them only if you extend the code or
 #  hit rate limits on the public feeds.
 # ═══════════════════════════════════════════════════════════════════════════
 
@@ -32,7 +32,7 @@ SCANNER_KEY=
 #  NET & EVENT INTEL (https://radar.cloudflare.com/).
 #  Free: any Cloudflare account → My Profile → API Tokens → Create Token →
 #  Custom token with permission "Account · Radar · Read".
-#  Leave empty to disable — /api/cloudflare-radar returns 503 and both layer
+#  Leave empty to disable - /api/cloudflare-radar returns 503 and both layer
 #  toggles stay hidden in the UI. The GDELT Events layer is unaffected and
 #  needs no key.
 # ─────────────────────────────────────────────────────────────────────────
@@ -62,8 +62,8 @@ LATTICE_ENV_TOKEN=
 #  mempool.space, Blockscout and the public Solana RPC.
 #
 #  These only deepen it; /api/osint/crypto?probe=1 reports which are active:
-#    ETHERSCAN_API_KEY  https://etherscan.io/apis  — internal txs, richer ETH
-#    HELIUS_API_KEY     https://helius.dev         — parsed Solana transfers.
+#    ETHERSCAN_API_KEY  https://etherscan.io/apis  - internal txs, richer ETH
+#    HELIUS_API_KEY     https://helius.dev         - parsed Solana transfers.
 #                       Without it, SOL transfer amounts and counterparties
 #                       stay blank: the public RPC lists signatures only.
 # ─────────────────────────────────────────────────────────────────────────
@@ -72,10 +72,10 @@ HELIUS_API_KEY=
 
 
 # ─────────────────────────────────────────────────────────────────────────
-#  OPTIONAL DATA-SOURCE KEYS  (not read by current code — future / upgrades)
+#  OPTIONAL DATA-SOURCE KEYS  (not read by current code - future / upgrades)
 # ─────────────────────────────────────────────────────────────────────────
 
-# NASA FIRMS — active wildfire hotspots.
+# NASA FIRMS - active wildfire hotspots.
 # Free, instant. Enter an email at the page below and the MAP_KEY is emailed
 # to you (looks like 'abcdef1234567890abcdef1234567890'). Limit: 5000 req /
 # 10 min. The app already uses the keyless FIRMS CSV; a key only matters if
@@ -83,7 +83,7 @@ HELIUS_API_KEY=
 #   Get it: https://firms.modaps.eosdis.nasa.gov/api/map_key/
 FIRMS_API_KEY=
 
-# OpenSky Network — aviation (higher rate limits than the keyless feed).
+# OpenSky Network - aviation (higher rate limits than the keyless feed).
 # Free account. Since March 2025 OpenSky uses OAuth2 (username/password auth
 # is dropped). Create an account, open the Account page, create a new API
 # client, and copy the client_id / client_secret.
@@ -91,13 +91,13 @@ FIRMS_API_KEY=
 OPENSKY_CLIENT_ID=
 OPENSKY_CLIENT_SECRET=
 
-# N2YO — satellite tracking / pass predictions.
+# N2YO - satellite tracking / pass predictions.
 # Free. Register, then Profile page → scroll down → "generate API key".
 # The key cannot be changed once issued. Limit: 1000 req / hour.
 #   Get it: https://www.n2yo.com/login/register/  (then Profile)
 N2YO_API_KEY=
 
-# aisstream.io — live maritime AIS vessel positions via WebSocket.
+# aisstream.io - live maritime AIS vessel positions via WebSocket.
 # Free. Register, then create a key on the API Keys page. Used in the
 # subscription message to wss://stream.aisstream.io/v0/stream.
 #   Get it: https://aisstream.io/  (sign up → API Keys)
@@ -118,7 +118,7 @@ OSIRIS_PORT=3000
 #   osintdefender,insiderpaper,aljazeeraenglish,nexta_live,war_monitor
 # OSIRIS_TELEGRAM_CHANNELS=
 
-# Set by the Docker image already — override only if needed.
+# Set by the Docker image already - override only if needed.
 # NODE_ENV=production
 # PORT=3000
 # HOSTNAME=0.0.0.0

--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,8 @@ CLOUDFLARE_API_TOKEN=
 #  Connector: https://github.com/Polybolos-Institute/osiris-lattice
 #  Independent sample, not an Anduril product. Local mock:
 #    https://github.com/Polybolos-Institute/anduril-mock-lattice
+#  If you want a live Lattice sandbox, join the developer program:
+#    https://www.anduril.com/lattice/lattice-sdk
 #  LATTICE_ENV_TOKEN is the Sandboxes Bearer (not the Lattice UI password).
 # ─────────────────────────────────────────────────────────────────────────
 LATTICE_ENABLED=0

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,22 @@ CLOUDFLARE_API_TOKEN=
 
 
 # ─────────────────────────────────────────────────────────────────────────
+#  ANDURIL LATTICE  (optional; default off)
+#  Map layer "Lattice Tracks" stays hidden until LATTICE_ENABLED=1 and the
+#  four credentials below are set. Uses /api/v1/oauth/token + entity stream.
+#  Connector: https://github.com/Polybolos-Institute/osiris-lattice
+#  Independent sample, not an Anduril product. Local mock:
+#    https://github.com/Polybolos-Institute/anduril-mock-lattice
+#  LATTICE_ENV_TOKEN is the Sandboxes Bearer (not the Lattice UI password).
+# ─────────────────────────────────────────────────────────────────────────
+LATTICE_ENABLED=0
+LATTICE_ENDPOINT=
+LATTICE_CLIENT_ID=
+LATTICE_CLIENT_SECRET=
+LATTICE_ENV_TOKEN=
+
+
+# ─────────────────────────────────────────────────────────────────────────
 #  CHAIN INTEL  ── optional; the RECON "CHAIN INTEL" tab works without these ──
 #  Baseline wallet forensics (BTC/ETH/SOL balance, transaction history,
 #  counterparties, OFAC SDN screening, risk scoring) is fully keyless via

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -27,18 +27,18 @@ Open <http://localhost:3000>.
 
 What the compose file does:
 
-- **`build:`** — compose builds the image locally from the `Dockerfile`, so
+- **`build:`** - compose builds the image locally from the `Dockerfile`, so
   you always run the code you just cloned. To run the prebuilt registry image
   instead, add `image: ghcr.io/simplifaisoul/osiris:latest` to the `osiris`
   service and drop the `build:` block.
-- **`env_file: .env` (`required: false`)** — if a `.env` file exists its
+- **`env_file: .env` (`required: false`)** - if a `.env` file exists its
   values are injected into the container; if it's missing, OSIRIS still starts
   with the keyless feeds.
-- **`ports: ${OSIRIS_PORT:-3000}:3000`** — the web UI. The container always
+- **`ports: ${OSIRIS_PORT:-3000}:3000`** - the web UI. The container always
   listens on 3000; the published **host** port is `OSIRIS_PORT` (default
   `3000`). Set `OSIRIS_PORT` in `.env` to remap it, e.g. `OSIRIS_PORT=3005`
-  when 3000 is already in use — no need to edit the compose file.
-- **`restart: unless-stopped`** — survives reboots.
+  when 3000 is already in use - no need to edit the compose file.
+- **`restart: unless-stopped`** - survives reboots.
 
 Common commands:
 
@@ -61,7 +61,7 @@ docker run -d --name osiris \
   ghcr.io/simplifaisoul/osiris:latest
 ```
 
-The package is public — no `docker login` is required to pull it.
+The package is public - no `docker login` is required to pull it.
 
 ### Plain `docker run`
 
@@ -124,17 +124,17 @@ rest of OSIRIS works normally. Generate a key with `openssl rand -hex 32`.
 ### Optional keys (reserved / for higher rate limits)
 
 These are documented for completeness and forward-compatibility. The current
-data routes use **keyless** public feeds, so these are not consumed yet — set
+data routes use **keyless** public feeds, so these are not consumed yet - set
 them only if you extend the relevant route or hit rate limits.
 
 | Variable | Service | How to get it (all free) |
 |----------|---------|--------------------------|
-| `FIRMS_API_KEY` | NASA FIRMS active fires | Enter an email at <https://firms.modaps.eosdis.nasa.gov/api/map_key/> — the `MAP_KEY` is emailed instantly. Limit 5000 req / 10 min. |
+| `FIRMS_API_KEY` | NASA FIRMS active fires | Enter an email at <https://firms.modaps.eosdis.nasa.gov/api/map_key/> - the `MAP_KEY` is emailed instantly. Limit 5000 req / 10 min. |
 | `OPENSKY_CLIENT_ID` / `OPENSKY_CLIENT_SECRET` | OpenSky aviation | Create an account at <https://opensky-network.org/>, open **Account → API client**, create a client and copy id/secret. **OAuth2 only since March 2025** (username/password auth removed). |
 | `N2YO_API_KEY` | N2YO satellites | Register at <https://www.n2yo.com/login/register/>, then **Profile → generate API key**. Limit 1000 req / hour; key can't be regenerated. |
 | `AIS_API_KEY` | aisstream.io maritime | Sign up at <https://aisstream.io/>, create a key on the **API Keys** page. Used over `wss://stream.aisstream.io/v0/stream`. |
 
-> Keep `.env` out of version control — it is already in `.gitignore`. Only
+> Keep `.env` out of version control - it is already in `.gitignore`. Only
 > `.env.template` (no secrets) is committed.
 
 ### Optional runtime overrides

--- a/README.md
+++ b/README.md
@@ -44,16 +44,6 @@ Osiris is a production-grade OSINT platform that provides situational awareness 
 
 ---
 
-## Optional: Lattice ontology layer
-
-Stock Osiris is untyped OSINT (public dots). With env opt-in, Osiris can also display **Anduril Lattice** entities **without throwing away type**.
-
-Lattice already stores `platformType`, `specificType`, disposition, environment, and provenance. That is an operational ontology: a shared catalog of what each object is, including explicit unknown. Osiris becomes a Lattice-capable COP: inspect those fields on the map, fail closed (do not invent combat class), connect and disconnect without killing the rest of the dashboard.
-
-It does not clone Lattice C2 and it does not engage. Details, capabilities, and limits: **[docs/LATTICE.md](docs/LATTICE.md)**. Connector source: [osiris-lattice](https://github.com/Polybolos-Institute/osiris-lattice).
-
----
-
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -54,37 +54,31 @@ It does not clone Lattice C2 and it does not engage. Details, capabilities, and 
 
 ---
 
----
-
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────┐
-│                  OSIRIS CLIENT                   │
-│  ┌──────────┐  ┌──────────┐  ┌───────────────┐ │
-│  │ MapLibre  │  │  HUD     │  │  RECON Toolkit│ │
-│  │  GL (GPU) │  │ Panels   │  │  Port Scan    │ │
-│  │  WebGL    │  │ Layers   │  │  DNS / WHOIS  │ │
-│  │  Render   │  │ Controls │  │  Vuln Scanner │ │
-│  └──────────┘  └──────────┘  └───────────────┘ │
-├─────────────────────────────────────────────────┤
-│               NEXT.JS API ROUTES                 │
-│  /api/flights         /api/earthquakes          │
-│  /api/cctv            /api/news                 │
-│  /api/fires           /api/maritime             │
-│  /api/gdelt           /api/satellites           │
-│  /api/weather         /api/scanner              │
-│  /api/sentinel        /api/telegram-feed        │
-│  /api/lattice         (optional; default off)   │
-│  /api/osint/*  (whois, dns, ip, cve, sanctions, │
-│                 crypto, sweep, threats, …)      │
-├─────────────────────────────────────────────────┤
-│              EXTERNAL DATA SOURCES               │
-│  OpenSky · USGS · NASA · NOAA · TfL · NVD      │
-│  GDACS · EONET · FIRMS · N2YO · RSS Feeds      │
-│  blockstream.info · Blockscout · OpenSanctions  │
-│  t.me public previews                            │
-└─────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────┐
+│                             OSIRIS CLIENT                               │
+│  ┌────────────┐  ┌────────────┐  ┌─────────────────┐                    │
+│  │ MapLibre   │  │ HUD        │  │ RECON Toolkit   │                    │
+│  │ GL (GPU)   │  │ Panels     │  │ Port Scan       │                    │
+│  │ WebGL      │  │ Layers     │  │ DNS / WHOIS     │                    │
+│  │ Render     │  │ Controls   │  │ Vuln Scanner    │                    │
+│  └────────────┘  └────────────┘  └─────────────────┘                    │
+├─────────────────────────────────────────────────────────────────────────┤
+│                          NEXT.JS API ROUTES                             │
+│  /api/flights       /api/earthquakes     /api/cctv                      │
+│  /api/news          /api/fires           /api/maritime                  │
+│  /api/gdelt         /api/satellites      /api/weather                   │
+│  /api/scanner       /api/sentinel        /api/telegram-feed             │
+│  /api/lattice       (optional; default off)                             │
+│  /api/osint/*       whois, dns, ip, cve, sanctions, crypto, ...         │
+├─────────────────────────────────────────────────────────────────────────┤
+│                        EXTERNAL DATA SOURCES                            │
+│  OpenSky  USGS  NASA  NOAA  TfL  NVD  GDACS  EONET                      │
+│  FIRMS  N2YO  RSS  blockstream.info  Blockscout  OpenSanctions          │
+│  t.me public previews                                                   │
+└─────────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -93,19 +87,19 @@ It does not clone Lattice C2 and it does not engage. Details, capabilities, and 
 
 ### Intelligence Layers
 - **16 toggleable data layers** with real-time entity counts
-- **GPU-accelerated rendering** — all map data rendered via WebGL, not DOM
-- **Progressive loading** — data fetched on-demand when layers are activated
-- **Viewport-aware** — only loads relevant data for the visible region
+- **GPU-accelerated rendering** - all map data rendered via WebGL, not DOM
+- **Progressive loading** - data fetched on-demand when layers are activated
+- **Viewport-aware** - only loads relevant data for the visible region
 
 ### RECON Toolkit
-- **Port Scanner** — TCP connect scan with service fingerprinting
-- **DNS Lookup** — Full record resolution (A, AAAA, MX, NS, TXT, CNAME)
-- **WHOIS** — Domain/IP registration data (auto-cross-checked against OFAC SDN)
-- **SSL/TLS Inspector** — Certificate chain analysis
-- **IP Intelligence** — Geolocation, ASN, threat reputation (auto-cross-checked against OFAC SDN)
-- **Vulnerability Scanner** — CVE lookup against NVD database
-- **Crypto Wallet Trace** — BTC + ETH lookup (balance, tx history, OFAC SDN sanctions flag)
-- **OFAC Sanctions Search** — query persons, organizations, vessels and aircraft against the US OFAC SDN list
+- **Port Scanner** - TCP connect scan with service fingerprinting
+- **DNS Lookup** - Full record resolution (A, AAAA, MX, NS, TXT, CNAME)
+- **WHOIS** - Domain/IP registration data (auto-cross-checked against OFAC SDN)
+- **SSL/TLS Inspector** - Certificate chain analysis
+- **IP Intelligence** - Geolocation, ASN, threat reputation (auto-cross-checked against OFAC SDN)
+- **Vulnerability Scanner** - CVE lookup against NVD database
+- **Crypto Wallet Trace** - BTC + ETH lookup (balance, tx history, OFAC SDN sanctions flag)
+- **OFAC Sanctions Search** - query persons, organizations, vessels and aircraft against the US OFAC SDN list
 
 ### Live Broadcast Network
 - **25+ live 24/7 news streams** from global broadcasters
@@ -113,7 +107,7 @@ It does not clone Lattice C2 and it does not engage. Details, capabilities, and 
 - Feeds from NBC, CBS, ABC, Sky News, Al Jazeera, France 24, NHK, WION, and more
 
 ### Telegram OSINT Layer
-- **Public-channel feed** scraped from the unauthenticated `t.me/s/<channel>` web preview — no Bot API token, no MTProto
+- **Public-channel feed** scraped from the unauthenticated `t.me/s/<channel>` web preview - no Bot API token, no MTProto
 - Default curated set of 5 channels (EN + RU/UA war reporting), overridable via `OSIRIS_TELEGRAM_CHANNELS`
 - Posts are geoparsed against a multilingual place dictionary (EN + Cyrillic + Arabic) and plotted on the map
 - Click any cyan dot to read the post and jump to the original on Telegram
@@ -122,12 +116,12 @@ It does not clone Lattice C2 and it does not engage. Details, capabilities, and 
 - **BTC** lookups via [blockstream.info](https://blockstream.info) (Esplora API, keyless)
 - **ETH** lookups via [Blockscout](https://github.com/blockscout/blockscout)'s public ETH instance (`eth.blockscout.com`, keyless)
 - Every lookup is cross-checked against the OFAC SDN sanctioned-address list (mirrored from [`0xB10C/ofac-sanctioned-digital-currency-addresses`](https://github.com/0xB10C/ofac-sanctioned-digital-currency-addresses))
-- Sanctioned wallets surface a red **SANCTIONED — OFAC SDN** badge in the RECON panel
+- Sanctioned wallets surface a red **SANCTIONED - OFAC SDN** badge in the RECON panel
 
 ### OFAC SDN Cross-Check
-- Standalone `SANCTIONS` tab in the RECON toolkit — full-text search across persons, organisations, vessels and aircraft
+- Standalone `SANCTIONS` tab in the RECON toolkit - full-text search across persons, organisations, vessels and aircraft
 - WHOIS and IP-intel routes auto-cross-check registrant / ASN-owner names against the SDN list and surface an inline alert
-- Data sourced from [OpenSanctions](https://www.opensanctions.org) (CC-BY 4.0) — keyless, ~7 MB cached in-memory for 24h
+- Data sourced from [OpenSanctions](https://www.opensanctions.org) (CC-BY 4.0) - keyless, ~7 MB cached in-memory for 24h
 
 ### Conflict Zone Monitoring
 - **13 active conflict/tension zones** with severity-coded warning markers
@@ -159,7 +153,7 @@ Open [http://localhost:3000](http://localhost:3000)
 ```bash
 git clone https://github.com/simplifaisoul/osiris.git
 cd osiris
-cp .env.template .env     # optional — configure keys / port
+cp .env.template .env     # optional - configure keys / port
 docker compose up -d
 ```
 
@@ -169,20 +163,20 @@ carries CasaOS app metadata (`x-casaos:`) for one-click install on
 [CasaOS](https://casaos.io). See **[DOCKER.md](DOCKER.md)** for the full Docker,
 CasaOS and API-key guide.
 
-**Prebuilt image (GHCR)** — skip the build and pull it directly:
+**Prebuilt image (GHCR)** - skip the build and pull it directly:
 
 ```bash
 docker pull ghcr.io/simplifaisoul/osiris:latest
 docker run -d -p 3000:3000 --env-file .env ghcr.io/simplifaisoul/osiris:latest
 ```
 
-**Custom port** — the container always listens on `3000`; set `OSIRIS_PORT` in
+**Custom port** - the container always listens on `3000`; set `OSIRIS_PORT` in
 `.env` to change the published host port (e.g. `OSIRIS_PORT=3005`) without
 editing the compose file.
 
 ### Environment Variables
 
-OSIRIS works **partially without any API keys** — all core feeds use public,
+OSIRIS works **partially without any API keys** - all core feeds use public,
 keyless sources. Copy [`.env.template`](.env.template) to `.env` and set only
 what you need:
 
@@ -191,15 +185,15 @@ what you need:
 OSIRIS_PORT=3000
 
 # RECON scanner backend (the only vars the current code reads).
-# SCANNER_KEY must match the backend's OSIRIS_KEY — generate with: openssl rand -hex 32
+# SCANNER_KEY must match the backend's OSIRIS_KEY - generate with: openssl rand -hex 32
 SCANNER_URL=
 SCANNER_KEY=
 
 # Optional, for higher rate limits / future sources (see DOCKER.md for signup links)
-FIRMS_API_KEY=                # NASA FIRMS  — firms.modaps.eosdis.nasa.gov/api/map_key/
-OPENSKY_CLIENT_ID=            # OpenSky OAuth2 (since Mar 2025) — opensky-network.org
+FIRMS_API_KEY=                # NASA FIRMS  - firms.modaps.eosdis.nasa.gov/api/map_key/
+OPENSKY_CLIENT_ID=            # OpenSky OAuth2 (since Mar 2025) - opensky-network.org
 OPENSKY_CLIENT_SECRET=
-N2YO_API_KEY=                 # N2YO satellites — n2yo.com (Profile → API key)
+N2YO_API_KEY=                 # N2YO satellites - n2yo.com (Profile → API key)
 AIS_API_KEY=                 # aisstream.io maritime
 
 # Optional Anduril Lattice tracks (default off). Hidden until LATTICE_ENABLED=1.
@@ -212,7 +206,7 @@ AIS_API_KEY=                 # aisstream.io maritime
 ```
 
 > Without `SCANNER_URL`/`SCANNER_KEY` the RECON toolkit returns `503`; every
-> other layer works out of the box. `.env` is gitignored — only the template is committed.
+> other layer works out of the box. `.env` is gitignored - only the template is committed.
 
 ---
 
@@ -244,7 +238,7 @@ AIS_API_KEY=                 # aisstream.io maritime
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT - see [LICENSE](LICENSE) for details.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ N2YO_API_KEY=                 # N2YO satellites - n2yo.com (Profile → API key)
 AIS_API_KEY=                 # aisstream.io maritime
 
 # Optional Anduril Lattice tracks (default off). Hidden until LATTICE_ENABLED=1.
-# See .env.example. Connector: https://github.com/Polybolos-Institute/osiris-lattice
+# If you want a live Lattice sandbox, join the developer program:
+#   https://www.anduril.com/lattice/lattice-sdk
+# See docs/LATTICE.md and .env.example. Connector: https://github.com/Polybolos-Institute/osiris-lattice
 # LATTICE_ENABLED=0
 # LATTICE_ENDPOINT=
 # LATTICE_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ Osiris is a production-grade OSINT platform that provides situational awareness 
 | **Crypto** | BTC + ETH Wallet Tracing, OFAC SDN Match | blockstream.info, Blockscout, OpenSanctions |
 | **Sanctions** | Person / Org / Vessel SDN Search | OpenSanctions (US OFAC SDN mirror) |
 | **Telegram OSINT** | Geoparsed Posts from Public Channels | `t.me/s/<channel>` web preview |
+| **Lattice (optional)** | Typed live tracks + ontology | Anduril Lattice env or mock; default off |
+
+---
+
+## Optional: Lattice ontology layer
+
+Stock Osiris is untyped OSINT (public dots). With env opt-in, Osiris can also display **Anduril Lattice** entities **without throwing away type**.
+
+Lattice already stores `platformType`, `specificType`, disposition, environment, and provenance. That is an operational ontology: a shared catalog of what each object is, including explicit unknown. Osiris becomes a Lattice-capable COP: inspect those fields on the map, fail closed (do not invent combat class), connect and disconnect without killing the rest of the dashboard.
+
+It does not clone Lattice C2 and it does not engage. Details, capabilities, and limits: **[docs/LATTICE.md](docs/LATTICE.md)**. Connector source: [osiris-lattice](https://github.com/Polybolos-Institute/osiris-lattice).
+
+---
 
 ---
 
@@ -62,6 +75,7 @@ Osiris is a production-grade OSINT platform that provides situational awareness 
 │  /api/gdelt           /api/satellites           │
 │  /api/weather         /api/scanner              │
 │  /api/sentinel        /api/telegram-feed        │
+│  /api/lattice         (optional; default off)   │
 │  /api/osint/*  (whois, dns, ip, cve, sanctions, │
 │                 crypto, sweep, threats, …)      │
 ├─────────────────────────────────────────────────┤
@@ -187,6 +201,14 @@ OPENSKY_CLIENT_ID=            # OpenSky OAuth2 (since Mar 2025) — opensky-netw
 OPENSKY_CLIENT_SECRET=
 N2YO_API_KEY=                 # N2YO satellites — n2yo.com (Profile → API key)
 AIS_API_KEY=                 # aisstream.io maritime
+
+# Optional Anduril Lattice tracks (default off). Hidden until LATTICE_ENABLED=1.
+# See .env.example. Connector: https://github.com/Polybolos-Institute/osiris-lattice
+# LATTICE_ENABLED=0
+# LATTICE_ENDPOINT=
+# LATTICE_CLIENT_ID=
+# LATTICE_CLIENT_SECRET=
+# LATTICE_ENV_TOKEN=
 ```
 
 > Without `SCANNER_URL`/`SCANNER_KEY` the RECON toolkit returns `503`; every

--- a/docs/LATTICE.md
+++ b/docs/LATTICE.md
@@ -1,0 +1,51 @@
+# Optional Lattice layer (ontology COP)
+
+This Osiris tree vendors [osiris-lattice](https://github.com/Polybolos-Institute/osiris-lattice) under `src/lib/lattice/`. The layer is **default off**. Stock Osiris is unchanged until you set `LATTICE_ENABLED=1` and OAuth env vars.
+
+Read the full argument there: [OSIRIS_ONTOLOGY.md](https://github.com/Polybolos-Institute/osiris-lattice/blob/main/docs/OSIRIS_ONTOLOGY.md)
+
+## What this is trying to do
+
+Osiris is already a global OSINT map. Public flights, cameras, hazards, news. Those dots are usually **untyped**: a lat/lon and a homegrown label.
+
+Anduril Lattice already types the live world: `platformType`, `specificType`, disposition, environment, provenance, entityId. That is an operational **ontology** (shared catalog of what each object is), not a research knowledge graph.
+
+This optional layer lets Osiris **sit on that catalog**:
+
+- Connect to a Lattice env (or [anduril-mock-lattice](https://github.com/Polybolos-Institute/anduril-mock-lattice)).
+- Draw tracks **without stripping ontology**. Click a point: platform, subtype, disposition, environment, fail-closed class (or explicit unknown).
+- Disconnect with `LATTICE_ENABLED=0`. Every other Osiris layer keeps running. Credentials can stay in env.
+- Never invent `SMALL_UAS` (or any combat class) for an empty or unknown Lattice type.
+
+That is how open Osiris becomes a serious platform for people developing on Lattice: OSINT plus a typed common picture. It is **not** a Lattice C2 clone and **not** an engagement engine. ROE and authority stay in whatever C2 you already run.
+
+## Capabilities in this PR
+
+| You get | You do not get |
+|---------|----------------|
+| Hidden layer until configured (same pattern as Cloudflare Radar) | Layer on by default |
+| `GET /api/lattice?probe=1` | Secrets in git |
+| `GET /api/lattice` FeatureCollection with ontology on properties | Mapping into a private engage ICD |
+| Map dots + click inspector | Tasking / missions / Anduril UI clone |
+| Fail-closed unknown | Osiris deciding friend/foe as a legal finding |
+
+## Connect
+
+See `.env.example` section **ANDURIL LATTICE**. Required:
+
+- `LATTICE_ENABLED=1`
+- `LATTICE_ENDPOINT` (host:port)
+- `LATTICE_CLIENT_ID` / `LATTICE_CLIENT_SECRET`
+- `LATTICE_ENV_TOKEN` (Sandboxes Bearer, not the Lattice UI password)
+
+Then NETWORK INTEL shows **Lattice Tracks**. Probe is `GET /api/lattice?probe=1`.
+
+## Disconnect
+
+`LATTICE_ENABLED=0` or unset credentials. Probe returns `configured: false`. Toggle stays hidden. Osiris OSINT is unaffected.
+
+## Independent sample
+
+Anduril and Lattice are trademarks of Anduril Industries. This is an independent optional integration, not an Anduril product.
+
+Thank you to [simplifaisoul](https://github.com/simplifaisoul) for Osiris (MIT).

--- a/docs/LATTICE.md
+++ b/docs/LATTICE.md
@@ -15,6 +15,8 @@ NETWORK INTEL then shows **Lattice Tracks**. Probe: `GET /api/lattice?probe=1`. 
 
 Local mock: [anduril-mock-lattice](https://github.com/Polybolos-Institute/anduril-mock-lattice).
 
+If you want a live Anduril Lattice sandbox, join the Lattice developer program here: [https://www.anduril.com/lattice/lattice-sdk](https://www.anduril.com/lattice/lattice-sdk). Osiris does not require that. The local mock works without it.
+
 ## Disable
 
 `LATTICE_ENABLED=0` or unset credentials. Probe returns `configured: false`. Toggle stays hidden.

--- a/docs/LATTICE.md
+++ b/docs/LATTICE.md
@@ -1,51 +1,28 @@
-# Optional Lattice layer (ontology COP)
+# Optional Lattice layer
 
-This Osiris tree vendors [osiris-lattice](https://github.com/Polybolos-Institute/osiris-lattice) under `src/lib/lattice/`. The layer is **default off**. Stock Osiris is unchanged until you set `LATTICE_ENABLED=1` and OAuth env vars.
+Vendored from [osiris-lattice](https://github.com/Polybolos-Institute/osiris-lattice) at `src/lib/lattice/`. Default off.
 
-Read the full argument there: [OSIRIS_ONTOLOGY.md](https://github.com/Polybolos-Institute/osiris-lattice/blob/main/docs/OSIRIS_ONTOLOGY.md)
+## Enable
 
-## What this is trying to do
-
-Osiris is already a global OSINT map. Public flights, cameras, hazards, news. Those dots are usually **untyped**: a lat/lon and a homegrown label.
-
-Anduril Lattice already types the live world: `platformType`, `specificType`, disposition, environment, provenance, entityId. That is an operational **ontology** (shared catalog of what each object is), not a research knowledge graph.
-
-This optional layer lets Osiris **sit on that catalog**:
-
-- Connect to a Lattice env (or [anduril-mock-lattice](https://github.com/Polybolos-Institute/anduril-mock-lattice)).
-- Draw tracks **without stripping ontology**. Click a point: platform, subtype, disposition, environment, fail-closed class (or explicit unknown).
-- Disconnect with `LATTICE_ENABLED=0`. Every other Osiris layer keeps running. Credentials can stay in env.
-- Never invent `SMALL_UAS` (or any combat class) for an empty or unknown Lattice type.
-
-That is how open Osiris becomes a serious platform for people developing on Lattice: OSINT plus a typed common picture. It is **not** a Lattice C2 clone and **not** an engagement engine. ROE and authority stay in whatever C2 you already run.
-
-## Capabilities in this PR
-
-| You get | You do not get |
-|---------|----------------|
-| Hidden layer until configured (same pattern as Cloudflare Radar) | Layer on by default |
-| `GET /api/lattice?probe=1` | Secrets in git |
-| `GET /api/lattice` FeatureCollection with ontology on properties | Mapping into a private engage ICD |
-| Map dots + click inspector | Tasking / missions / Anduril UI clone |
-| Fail-closed unknown | Osiris deciding friend/foe as a legal finding |
-
-## Connect
-
-See `.env.example` section **ANDURIL LATTICE**. Required:
+`.env.example` section **ANDURIL LATTICE**:
 
 - `LATTICE_ENABLED=1`
-- `LATTICE_ENDPOINT` (host:port)
+- `LATTICE_ENDPOINT`
 - `LATTICE_CLIENT_ID` / `LATTICE_CLIENT_SECRET`
 - `LATTICE_ENV_TOKEN` (Sandboxes Bearer, not the Lattice UI password)
 
-Then NETWORK INTEL shows **Lattice Tracks**. Probe is `GET /api/lattice?probe=1`.
+NETWORK INTEL then shows **Lattice Tracks**. Probe: `GET /api/lattice?probe=1`. Entities: `GET /api/lattice`.
 
-## Disconnect
+Local mock: [anduril-mock-lattice](https://github.com/Polybolos-Institute/anduril-mock-lattice).
 
-`LATTICE_ENABLED=0` or unset credentials. Probe returns `configured: false`. Toggle stays hidden. Osiris OSINT is unaffected.
+## Disable
 
-## Independent sample
+`LATTICE_ENABLED=0` or unset credentials. Probe returns `configured: false`. Toggle stays hidden.
 
-Anduril and Lattice are trademarks of Anduril Industries. This is an independent optional integration, not an Anduril product.
+Empty or unknown Lattice types are left unknown. This layer does not task, mission, or engage.
+
+## Note
+
+Anduril and Lattice are trademarks of Anduril Industries. Independent optional integration, not an Anduril product.
 
 Thank you to [simplifaisoul](https://github.com/simplifaisoul) for Osiris (MIT).

--- a/src/app/api/lattice/route.ts
+++ b/src/app/api/lattice/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { configFromEnv, snapshotLattice } from '@/lib/lattice';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Optional Anduril Lattice entity layer.
+ * Default off. Requires LATTICE_ENABLED=1 plus sandbox OAuth env vars.
+ * Connector: https://github.com/Polybolos-Institute/osiris-lattice
+ * Independent sample, not an Anduril product.
+ */
+
+function latticeExplicitlyEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const flag = env.LATTICE_ENABLED?.trim().toLowerCase();
+  return flag === '1' || flag === 'true';
+}
+
+function isConfigured(): boolean {
+  return latticeExplicitlyEnabled() && configFromEnv() !== null;
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  if (searchParams.get('probe') === '1') {
+    return NextResponse.json({
+      configured: isConfigured(),
+      source: 'Anduril Lattice (optional)',
+    });
+  }
+
+  if (!isConfigured()) {
+    return NextResponse.json(
+      {
+        type: 'FeatureCollection',
+        features: [],
+        total_entities: 0,
+        connected: false,
+        configured: false,
+        error: 'Lattice not configured',
+        hint: 'Set LATTICE_ENABLED=1 and LATTICE_ENDPOINT / LATTICE_CLIENT_ID / LATTICE_CLIENT_SECRET / LATTICE_ENV_TOKEN',
+      },
+      { status: 503 },
+    );
+  }
+
+  const collection = await snapshotLattice({ enabled: true });
+  const status = collection.connected ? 200 : 502;
+  return NextResponse.json(
+    { ...collection, configured: true },
+    { status, headers: { 'Cache-Control': 'no-store' } },
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -312,6 +312,7 @@ export default function Dashboard() {
     gdelt_events: false,
     cf_outages: false,
     cf_attacks: false,
+    lattice: false,
   });
   // Server-side capability flags — gate layers that need credentials.
   const [capabilities, setCapabilities] = useState<Record<string, boolean>>({});
@@ -346,6 +347,11 @@ export default function Dashboard() {
     fetch('/api/cloudflare-radar?probe=1')
       .then(r => (r.ok ? r.json() : null))
       .then(p => { if (p) setCapabilities(c => ({ ...c, cloudflare: !!p.configured })); })
+      .catch(() => { /* leave the layer hidden */ });
+
+    fetch('/api/lattice?probe=1')
+      .then(r => (r.ok ? r.json() : null))
+      .then(p => { if (p) setCapabilities(c => ({ ...c, lattice: !!p.configured })); })
       .catch(() => { /* leave the layer hidden */ });
 
     // Delay geolocation until map is ready (after splash screen clears)
@@ -719,6 +725,10 @@ export default function Dashboard() {
       }));
     }
 
+    if ((activeLayers as any).lattice) {
+      loadLayerOnce('lattice', '/api/lattice', d => ({ lattice_entities: d.features ?? [] }));
+    }
+
 
   }, [activeLayers]);
 
@@ -744,6 +754,9 @@ export default function Dashboard() {
         fetchEndpoint('/api/cyber-attacks', d => ({ cyber_attacks: d.attacks }));
         layerFetchedRef.current.add('cyber_attacks');
       }, 10000)); // 10s — rapid refresh
+    }
+    if ((activeLayers as any).lattice) {
+      intervals.push(setInterval(() => fetchEndpoint('/api/lattice', d => ({ lattice_entities: d.features ?? [] })), 30000));
     }
     return () => intervals.forEach(clearInterval);
   }, [activeLayers, fetchEndpoint]);

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -141,7 +141,7 @@ const LAYER_GROUPS: LayerGroupDef[] = [
 /* ── Minimal Toggle Switch ── */
 /**
  * Presentational only. The row around it is the button, and a button inside a
- * button is invalid HTML — the browser reparents it, which breaks hydration and
+ * button is invalid HTML - the browser reparents it, which breaks hydration and
  * silently drops the click handler on the inner control.
  */
 function ToggleSwitch({ active }: { active: boolean }) {
@@ -178,7 +178,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
   const [hoveredGroup, setHoveredGroup] = useState<string | null>(null);
   /**
    * A pinned group stays open when the pointer leaves. Hover-only flyouts are
-   * fine to glance at and impossible to work in — reaching for a toggle at the
+   * fine to glance at and impossible to work in - reaching for a toggle at the
    * far edge closes the thing you were reaching for.
    */
   const [pinnedGroup, setPinnedGroup] = useState<string | null>(null);
@@ -193,7 +193,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
 
   const toggle = (key: string) => setActiveLayers((prev: any) => ({ ...prev, [key]: !prev[key] }));
 
-  /** Switch a whole group at once — off if any are on, otherwise all on. */
+  /** Switch a whole group at once - off if any are on, otherwise all on. */
   const toggleGroup = (layers: LayerDef[]) => {
     const anyOn = layers.some(l => activeLayers[l.key]);
     setActiveLayers((prev: any) => {
@@ -337,7 +337,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
               <button
                 onClick={() => setPinnedGroup(isPinned ? null : group.label)}
                 aria-expanded={isOpen}
-                aria-label={`${group.fullLabel}${activeCount ? ` — ${activeCount} active` : ''}`}
+                aria-label={`${group.fullLabel}${activeCount ? ` - ${activeCount} active` : ''}`}
                 title={group.fullLabel}
                 className="relative w-10 h-10 flex items-center justify-center cursor-pointer rounded-lg transition-all duration-300 focus:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
                 style={{

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -115,6 +115,7 @@ const LAYER_GROUPS: LayerGroupDef[] = [
     layers: [
       { key: 'malware', label: 'Live Malware', dataKey: 'malware_threats' },
       { key: 'cyber_attacks', label: 'Live Attacks', dataKey: 'cyber_attacks' },
+      { key: 'lattice', label: 'Lattice Tracks', dataKey: 'lattice_entities', requires: 'lattice' },
     ],
   },
   {

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -286,7 +286,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       createDot(map, 'dot-fire', isGhost ? phantomPurple : '#E65100', 10);
       createDot(map, 'dot-cctv', cameraColor, 10);
 
-      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'malware-nodes', 'network-mesh', 'cyber-arcs', 'cyber-heads', 'cyber-impacts', 'gdelt-events', 'cf-outages', 'cf-attacks'];
+      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'malware-nodes', 'network-mesh', 'cyber-arcs', 'cyber-heads', 'cyber-impacts', 'gdelt-events', 'cf-outages', 'cf-attacks', 'lattice'];
       sources.forEach(s => map.addSource(s, { type: 'geojson', data: EMPTY_FC }));
 
       // ── FLIGHT ROUTE VISUALIZATION SOURCES & LAYERS ──
@@ -484,6 +484,17 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         'text-size': 9, 'text-font': ['JetBrains Mono Bold', 'Open Sans Bold'],
         'text-offset': [0, 1.6], 'text-allow-overlap': false,
       }, paint: { 'text-color': '#FF6B6B', 'text-halo-color': '#000', 'text-halo-width': 1.5, 'text-opacity': 0.9 }});
+
+      /* Optional Lattice tracks. Hidden until LATTICE_ENABLED=1. Ontology fields stay on the feature. */
+      map.addLayer({ id: 'lattice-glow', type: 'circle', source: 'lattice', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,10, 5,16, 10,24],
+        'circle-color': '#00d4ff', 'circle-opacity': 0.12, 'circle-blur': 1,
+      }});
+      map.addLayer({ id: 'lattice-dots', type: 'circle', source: 'lattice', paint: {
+        'circle-radius': ['interpolate',['linear'],['zoom'], 1,4, 5,6, 10,9],
+        'circle-color': '#00d4ff', 'circle-opacity': 0.9,
+        'circle-stroke-width': 1.5, 'circle-stroke-color': '#000000', 'circle-stroke-opacity': 0.7,
+      }});
 
       // Weather Events (NASA EONET) — deep violet
       map.addLayer({ id: 'weather-glow', type: 'circle', source: 'weather', paint: {
@@ -928,7 +939,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       'gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots',
       'balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots',
       'sdk-sea','sdk-air','sdk-intel','malware-dots','cyber-heads','gdelt-events-dots',
-      'cf-outage-dots','cf-attack-dots','flight-dots','military-dots','jet-dots','private-dots']);
+      'cf-outage-dots','cf-attack-dots','lattice-dots','flight-dots','military-dots','jet-dots','private-dots']);
 
     // Satellites are picked on the GPU: the pick pass runs the same vertex
     // shader as the visible one, so the target is always exactly where the
@@ -1129,6 +1140,26 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       </div>`);
     });
 
+    map.on('click', 'lattice-dots', e => {
+      if (!e.features?.length) return;
+      const p = e.features[0].properties as any;
+      const coords = (e.features[0].geometry as any).coordinates;
+      const closed = p.failClosedClass ? htmlEsc(p.failClosedClass) : 'unknown (fail closed)';
+      popup(coords, `
+      <div style="${pStyle}border:1px solid rgba(0,212,255,0.35);min-width:240px;">
+        <div style="color:#00d4ff;font-size:10px;font-weight:700;letter-spacing:0.15em;margin-bottom:8px;">LATTICE</div>
+        <div style="color:#E8E6E0;font-size:12px;font-weight:700;margin-bottom:8px;">${htmlEsc(p.name || p.id)}</div>
+        <div style="display:grid;grid-template-columns:auto 1fr;gap:3px 10px;font-size:10px;color:#9B978E;">
+          <span style="opacity:0.6;">Platform</span><span style="color:#E8E6E0;">${htmlEsc(p.platformType || '—')}</span>
+          <span style="opacity:0.6;">Specific</span><span style="color:#E8E6E0;">${htmlEsc(p.specificType || '—')}</span>
+          <span style="opacity:0.6;">Disposition</span><span style="color:#E8E6E0;">${htmlEsc(p.disposition || '—')}</span>
+          <span style="opacity:0.6;">Environment</span><span style="color:#E8E6E0;">${htmlEsc(p.environment || '—')}</span>
+          <span style="opacity:0.6;">Class</span><span style="color:#E8E6E0;">${closed}</span>
+        </div>
+        <div style="margin-top:8px;font-size:9px;color:#5C5A54;">Optional Lattice layer · ontology passed through</div>
+      </div>`);
+    });
+
     // ── GDELT Conflicts (with source article) ──
     map.on('click', 'gdelt-dots', e => {
       if (!e.features?.length) return;
@@ -1241,7 +1272,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     });
 
     // ── Generic hover for clickables ──
-    ['conflict-icons','cctv-dots','eq-circles','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo','malware-dots','cyber-heads','gdelt-events-dots','cf-outage-dots','cf-attack-dots'].forEach(layer => {
+    ['conflict-icons','cctv-dots','eq-circles','fires-heat','gdelt-dots','weather-dots','infra-dots','maritime-dots','choke-dots','news-dots','balloon-dots','rad-dots','ship-dots','sweep-device-dots','scan-targets-dots','sdk-sea','sdk-sea-glow','sdk-sea-atmo','sdk-air','sdk-air-glow','sdk-air-atmo','sdk-intel','sdk-intel-glow','sdk-intel-atmo','malware-dots','cyber-heads','gdelt-events-dots','cf-outage-dots','cf-attack-dots','lattice-dots'].forEach(layer => {
       map.on('mouseenter', layer, () => { map.getCanvas().style.cursor = 'pointer'; });
       map.on('mouseleave', layer, () => { map.getCanvas().style.cursor = ''; });
     });
@@ -1680,6 +1711,12 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     })) : []);
   }, [mapReady, data.cf_attack_origins, (activeLayers as any).cf_attacks, setGeo]);
 
+  useEffect(() => {
+    if (!mapReady) return;
+    const al = activeLayers as any;
+    setGeo('lattice', al.lattice && Array.isArray(data.lattice_entities) ? data.lattice_entities : []);
+  }, [mapReady, data.lattice_entities, (activeLayers as any).lattice, setGeo]);
+
   // Malware Threats
   useEffect(() => {
     if (!mapReady) return;
@@ -1956,6 +1993,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     setVis(['gdelt-events-dots'], (activeLayers as any).gdelt_events);
     setVis(['cf-outage-halo','cf-outage-dots','cf-outage-label'], (activeLayers as any).cf_outages);
     setVis(['cf-attack-dots','cf-attack-label'], (activeLayers as any).cf_attacks);
+    setVis(['lattice-glow','lattice-dots'], (activeLayers as any).lattice);
 
     setVis(['malware-glow','malware-dots','malware-label'], activeLayers.malware);
     setVis(['network-mesh-atmo', 'network-mesh-glow', 'network-mesh-core'], activeLayers.internet_outages || activeLayers.malware);

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -485,7 +485,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         'text-offset': [0, 1.6], 'text-allow-overlap': false,
       }, paint: { 'text-color': '#FF6B6B', 'text-halo-color': '#000', 'text-halo-width': 1.5, 'text-opacity': 0.9 }});
 
-      /* Optional Lattice tracks. Hidden until LATTICE_ENABLED=1. Ontology fields stay on the feature. */
+      /* Optional Lattice tracks. Hidden until LATTICE_ENABLED=1. */
       map.addLayer({ id: 'lattice-glow', type: 'circle', source: 'lattice', paint: {
         'circle-radius': ['interpolate',['linear'],['zoom'], 1,10, 5,16, 10,24],
         'circle-color': '#00d4ff', 'circle-opacity': 0.12, 'circle-blur': 1,

--- a/src/lib/lattice/SOURCE.md
+++ b/src/lib/lattice/SOURCE.md
@@ -1,0 +1,6 @@
+Vendored from https://github.com/Polybolos-Institute/osiris-lattice (MIT).
+
+Optional Anduril Lattice connector. Independent sample, not an Anduril product.
+Does not map types into a C2 or engagement ICD. Unknown labels stay unknown.
+
+Update from upstream when the connector changes; keep this directory small.

--- a/src/lib/lattice/config.ts
+++ b/src/lib/lattice/config.ts
@@ -1,0 +1,65 @@
+/**
+ * Lattice connection config. No secrets in this file.
+ * LATTICE_ENV_TOKEN and LATTICE_SANDBOX_TOKEN are the same credential
+ * (Sandboxes Bearer). ENV_TOKEN is the name used by other doors.
+ */
+
+export type LatticeConfig = {
+  endpoint: string;
+  clientId: string;
+  clientSecret: string;
+  sandboxToken: string;
+  enabled: boolean;
+  streamTimeoutMs: number;
+};
+
+function firstEnv(env: NodeJS.ProcessEnv, names: string[]): string {
+  for (const name of names) {
+    const v = env[name]?.trim();
+    if (v) return v;
+  }
+  return "";
+}
+
+export function latticeBaseUrl(endpoint: string): string {
+  let host = endpoint.trim();
+  let scheme = "https";
+  if (host.startsWith("http://")) {
+    scheme = "http";
+    host = host.slice("http://".length);
+  } else if (host.startsWith("https://")) {
+    host = host.slice("https://".length);
+  }
+  host = host.replace(/\/+$/, "");
+  const bare = host.split(":")[0]?.toLowerCase() ?? "";
+  if (scheme === "https" && (bare === "127.0.0.1" || bare === "localhost" || bare === "::1")) {
+    scheme = "http";
+  }
+  return `${scheme}://${host}`;
+}
+
+export function configFromEnv(env: NodeJS.ProcessEnv = process.env): LatticeConfig | null {
+  const endpoint = firstEnv(env, ["LATTICE_ENDPOINT"]);
+  const clientId = firstEnv(env, ["LATTICE_CLIENT_ID"]);
+  const clientSecret = firstEnv(env, ["LATTICE_CLIENT_SECRET"]);
+  const sandboxToken = firstEnv(env, ["LATTICE_ENV_TOKEN", "LATTICE_SANDBOX_TOKEN"]);
+  if (!endpoint || !clientId || !clientSecret || !sandboxToken) return null;
+
+  const enabledRaw = firstEnv(env, ["LATTICE_ENABLED"]);
+  const enabled = enabledRaw === "" ? true : enabledRaw !== "0" && enabledRaw.toLowerCase() !== "false";
+  const timeoutRaw = firstEnv(env, ["LATTICE_STREAM_TIMEOUT_MS"]);
+  const streamTimeoutMs = timeoutRaw ? Number(timeoutRaw) : 8000;
+
+  return {
+    endpoint,
+    clientId,
+    clientSecret,
+    sandboxToken,
+    enabled,
+    streamTimeoutMs: Number.isFinite(streamTimeoutMs) && streamTimeoutMs > 0 ? streamTimeoutMs : 8000,
+  };
+}
+
+export function isConfigured(config: LatticeConfig | null): config is LatticeConfig {
+  return config !== null;
+}

--- a/src/lib/lattice/index.ts
+++ b/src/lib/lattice/index.ts
@@ -1,0 +1,50 @@
+import { configFromEnv, type LatticeConfig } from './config';
+import { fetchAccessToken, streamEntities } from './latticeClient';
+import {
+  disconnectedCollection,
+  entitiesToFeatureCollection,
+  type LatticeFeatureCollection,
+} from './toGeoJSON';
+
+export type SnapshotOptions = {
+  config?: LatticeConfig | null;
+  enabled?: boolean;
+};
+
+/**
+ * One-shot COP snapshot: token + short entity stream + GeoJSON.
+ * If disabled or unconfigured, returns an empty collection (disconnect).
+ * Does not map Lattice types into any engagement ICD.
+ */
+export async function snapshotLattice(options: SnapshotOptions = {}): Promise<LatticeFeatureCollection> {
+  const config = options.config === undefined ? configFromEnv() : options.config;
+  const enabled = options.enabled ?? config?.enabled ?? false;
+  if (!enabled) return disconnectedCollection("Lattice disconnected");
+  if (!config) return disconnectedCollection("Lattice not configured");
+
+  try {
+    const token = await fetchAccessToken(config);
+    const entities = await streamEntities(config, token);
+    return entitiesToFeatureCollection(entities);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Lattice fetch failed";
+    return { ...disconnectedCollection(message), connected: false };
+  }
+}
+
+export { configFromEnv, latticeBaseUrl, isConfigured } from './config';
+export type { LatticeConfig } from './config';
+export {
+  failClosedClassLabel,
+  isGenericPlatformType,
+  isUnknownClassLabel,
+  resolveOntologyClassLabel,
+} from './ontology';
+export type { LatticeEntity, LatticeMilView, LatticeOntology, LatticeProvenance } from './ontology';
+export { fetchAccessToken, getEntity, parseNdjsonEntities, putEntity, streamEntities } from './latticeClient';
+export {
+  disconnectedCollection,
+  entitiesToFeatureCollection,
+  entityToFeature,
+} from './toGeoJSON';
+export type { LatticeFeature, LatticeFeatureCollection, LatticeFeatureProperties } from './toGeoJSON';

--- a/src/lib/lattice/index.ts
+++ b/src/lib/lattice/index.ts
@@ -12,9 +12,7 @@ export type SnapshotOptions = {
 };
 
 /**
- * One-shot COP snapshot: token + short entity stream + GeoJSON.
- * If disabled or unconfigured, returns an empty collection (disconnect).
- * Does not map Lattice types into any engagement ICD.
+ * Token, short entity stream, GeoJSON. Empty collection if disabled or unconfigured.
  */
 export async function snapshotLattice(options: SnapshotOptions = {}): Promise<LatticeFeatureCollection> {
   const config = options.config === undefined ? configFromEnv() : options.config;

--- a/src/lib/lattice/latticeClient.ts
+++ b/src/lib/lattice/latticeClient.ts
@@ -1,0 +1,112 @@
+import { latticeBaseUrl, type LatticeConfig } from './config';
+import type { LatticeEntity } from './ontology';
+
+function sandboxHeaders(config: LatticeConfig, extra?: Record<string, string>): Record<string, string> {
+  return {
+    "Anduril-Sandbox-Authorization": `Bearer ${config.sandboxToken}`,
+    ...extra,
+  };
+}
+
+export async function fetchAccessToken(config: LatticeConfig): Promise<string> {
+  const url = `${latticeBaseUrl(config.endpoint)}/api/v1/oauth/token`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: sandboxHeaders(config, {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    }),
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Lattice OAuth HTTP ${res.status}: ${body.slice(0, 240)}`);
+  }
+  const data = (await res.json()) as { access_token?: string };
+  if (typeof data.access_token !== "string" || !data.access_token) {
+    throw new Error("Lattice OAuth response missing access_token");
+  }
+  return data.access_token;
+}
+
+export function parseNdjsonEntities(raw: string): LatticeEntity[] {
+  const out: LatticeEntity[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const event = JSON.parse(trimmed) as { entity?: LatticeEntity; heartbeat?: unknown };
+      if (event.entity) out.push(event.entity);
+    } catch {
+      // skip malformed line
+    }
+  }
+  return out;
+}
+
+export async function streamEntities(config: LatticeConfig, accessToken: string): Promise<LatticeEntity[]> {
+  const url = `${latticeBaseUrl(config.endpoint)}/api/v1/entities/stream`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      ...sandboxHeaders(config, {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/x-ndjson, application/json",
+      }),
+    },
+    body: JSON.stringify({ heartbeatIntervalMs: 5000, preExistingOnly: false }),
+    signal: AbortSignal.timeout(config.streamTimeoutMs),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Lattice stream HTTP ${res.status}: ${body.slice(0, 240)}`);
+  }
+  const raw = await res.text();
+  return parseNdjsonEntities(raw);
+}
+
+export async function putEntity(
+  config: LatticeConfig,
+  accessToken: string,
+  entity: LatticeEntity,
+): Promise<LatticeEntity> {
+  const url = `${latticeBaseUrl(config.endpoint)}/api/v1/entities`;
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: sandboxHeaders(config, {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    }),
+    body: JSON.stringify(entity),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Lattice PUT HTTP ${res.status}: ${body.slice(0, 240)}`);
+  }
+  return (await res.json()) as LatticeEntity;
+}
+
+export async function getEntity(
+  config: LatticeConfig,
+  accessToken: string,
+  entityId: string,
+): Promise<LatticeEntity> {
+  const url = `${latticeBaseUrl(config.endpoint)}/api/v1/entities/${encodeURIComponent(entityId)}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: sandboxHeaders(config, {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/json",
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Lattice GET HTTP ${res.status}: ${body.slice(0, 240)}`);
+  }
+  return (await res.json()) as LatticeEntity;
+}

--- a/src/lib/lattice/ontology.ts
+++ b/src/lib/lattice/ontology.ts
@@ -1,0 +1,80 @@
+/** Lattice ontology helpers. Not an engagement ICD. Do not invent combat class. */
+
+export type LatticeOntology = {
+  template?: string;
+  platformType?: string;
+  specificType?: string;
+};
+
+export type LatticeMilView = {
+  disposition?: string;
+  environment?: string;
+};
+
+export type LatticeProvenance = {
+  dataType?: string;
+  integrationName?: string;
+};
+
+export type LatticeEntity = {
+  entityId?: string;
+  aliases?: { name?: string };
+  location?: {
+    position?: {
+      latitudeDegrees?: number;
+      longitudeDegrees?: number;
+      altitudeHaeMeters?: number;
+    };
+    velocity?: {
+      speedMps?: number;
+      headingDegrees?: number;
+    };
+  };
+  milView?: LatticeMilView;
+  ontology?: LatticeOntology;
+  provenance?: LatticeProvenance;
+  isLive?: boolean;
+};
+
+function normalizeKey(raw: string): string {
+  let s = raw.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+  s = s.replace(/^_+|_+$/g, "").replace(/_+/g, "_");
+  return s;
+}
+
+const GENERIC_PLATFORM = new Set(["air_vehicle", "object_class_air_vehicle"]);
+const UNKNOWN_KEYS = new Set([
+  "unknown",
+  "unknown_air_vehicle",
+  "unknown_vehicle",
+  "unknownairtrack",
+  "unknown_air_track",
+]);
+
+export function isGenericPlatformType(platformType: string): boolean {
+  return GENERIC_PLATFORM.has(normalizeKey(platformType));
+}
+
+export function isUnknownClassLabel(label: string): boolean {
+  const key = normalizeKey(label);
+  return key.length === 0 || UNKNOWN_KEYS.has(key);
+}
+
+/** platformType first; specificType only when platform is empty or generic. */
+export function resolveOntologyClassLabel(ontology?: LatticeOntology): string {
+  const platform = ontology?.platformType?.trim() ?? "";
+  const specific = ontology?.specificType?.trim() ?? "";
+  if (platform && !isGenericPlatformType(platform)) return platform;
+  if (specific) return specific;
+  return platform;
+}
+
+/**
+ * Fail closed: empty or unknown labels return null.
+ * Never substitute SMALL_UAS or any combat class.
+ */
+export function failClosedClassLabel(ontology?: LatticeOntology): string | null {
+  const label = resolveOntologyClassLabel(ontology);
+  if (!label || isUnknownClassLabel(label)) return null;
+  return label;
+}

--- a/src/lib/lattice/ontology.ts
+++ b/src/lib/lattice/ontology.ts
@@ -1,4 +1,4 @@
-/** Lattice ontology helpers. Not an engagement ICD. Do not invent combat class. */
+/** Lattice platformType / specificType helpers. Unknown stays unknown. */
 
 export type LatticeOntology = {
   template?: string;
@@ -69,10 +69,7 @@ export function resolveOntologyClassLabel(ontology?: LatticeOntology): string {
   return platform;
 }
 
-/**
- * Fail closed: empty or unknown labels return null.
- * Never substitute SMALL_UAS or any combat class.
- */
+/** Empty or unknown labels return null. */
 export function failClosedClassLabel(ontology?: LatticeOntology): string | null {
   const label = resolveOntologyClassLabel(ontology);
   if (!label || isUnknownClassLabel(label)) return null;

--- a/src/lib/lattice/toGeoJSON.ts
+++ b/src/lib/lattice/toGeoJSON.ts
@@ -1,0 +1,99 @@
+import type { LatticeEntity } from './ontology';
+import { failClosedClassLabel, resolveOntologyClassLabel } from './ontology';
+
+export type LatticeFeatureProperties = {
+  id: string;
+  name: string;
+  source: "LATTICE";
+  lat: number;
+  lon: number;
+  heading: number;
+  speed: number;
+  platformType: string;
+  specificType: string;
+  ontologyTemplate: string;
+  ontologyLabel: string;
+  failClosedClass: string | null;
+  disposition: string;
+  environment: string;
+  provenanceDataType: string;
+  provenanceIntegration: string;
+};
+
+export type LatticeFeature = {
+  type: "Feature";
+  geometry: { type: "Point"; coordinates: [number, number] };
+  properties: LatticeFeatureProperties;
+};
+
+export type LatticeFeatureCollection = {
+  type: "FeatureCollection";
+  features: LatticeFeature[];
+  total_entities: number;
+  connected: boolean;
+  error: string | null;
+};
+
+export function disconnectedCollection(error: string): LatticeFeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: [],
+    total_entities: 0,
+    connected: false,
+    error,
+  };
+}
+
+export function entityToFeature(entity: LatticeEntity): LatticeFeature | null {
+  const id = entity.entityId?.trim() ?? "";
+  const pos = entity.location?.position ?? {};
+  const lat = pos.latitudeDegrees;
+  const lon = pos.longitudeDegrees;
+  if (typeof lat !== "number" || typeof lon !== "number" || !Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return null;
+  }
+
+  const ontology = entity.ontology;
+  const name = entity.aliases?.name?.trim() || id;
+  const vel = entity.location?.velocity ?? {};
+
+  return {
+    type: "Feature",
+    geometry: { type: "Point", coordinates: [lon, lat] },
+    properties: {
+      id,
+      name,
+      source: "LATTICE",
+      lat,
+      lon,
+      heading: vel.headingDegrees ?? 0,
+      speed: vel.speedMps ?? 0,
+      platformType: ontology?.platformType?.trim() ?? "",
+      specificType: ontology?.specificType?.trim() ?? "",
+      ontologyTemplate: ontology?.template?.trim() ?? "",
+      ontologyLabel: resolveOntologyClassLabel(ontology),
+      failClosedClass: failClosedClassLabel(ontology),
+      disposition: entity.milView?.disposition?.trim() ?? "",
+      environment: entity.milView?.environment?.trim() ?? "",
+      provenanceDataType: entity.provenance?.dataType?.trim() ?? "",
+      provenanceIntegration: entity.provenance?.integrationName?.trim() ?? "",
+    },
+  };
+}
+
+export function entitiesToFeatureCollection(entities: LatticeEntity[]): LatticeFeatureCollection {
+  const byId = new Map<string, LatticeFeature>();
+  for (const entity of entities) {
+    const feature = entityToFeature(entity);
+    if (!feature) continue;
+    if (feature.properties.id) byId.set(feature.properties.id, feature);
+  }
+  const features = [...byId.values()];
+  return {
+    type: "FeatureCollection",
+    features,
+    total_entities: features.length,
+    connected: true,
+    error: null,
+  };
+}


### PR DESCRIPTION
Optional Anduril Lattice tracks. Default off.

Vendors https://github.com/Polybolos-Institute/osiris-lattice under src/lib/lattice/.

Enable with LATTICE_ENABLED=1 plus LATTICE_ENDPOINT, LATTICE_CLIENT_ID, LATTICE_CLIENT_SECRET, LATTICE_ENV_TOKEN (Sandboxes Bearer).

- GET /api/lattice?probe=1
- GET /api/lattice GeoJSON
- NETWORK INTEL: Lattice Tracks
- LATTICE_ENABLED=0 disconnects. Other layers unchanged.

Empty or unknown Lattice types stay unknown. Independent sample. Not an Anduril product.

Docs in this PR: docs/LATTICE.md

## Test plan
- [ ] Fresh clone, no Lattice env: app boots; Lattice toggle absent; /api/lattice?probe=1 is { configured: false }
- [ ] With mock Lattice plus env: probe true; layer appears; click shows platformType
- [ ] LATTICE_ENABLED=0: layer gone again; flights/news still work