### PR TITLE
feat(map): rebuild the CCTV close-up, and put the map's own colours in the Style Studio

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,6 +38,22 @@
   --accent-weather: #E040FB;
   --accent-nuclear: #76FF03;
 
+  /* ── Map Layers ──
+     What the map itself draws with. Mirrored in src/lib/map-palette.ts, which
+     reads these back; the two copies are pinned together by its tests. */
+  --map-cctv: #00e676;
+  --map-sat-comms: #00e676;
+  --map-sat-military: #ff3d3d;
+  --map-sat-navigation: #448aff;
+  --map-sat-earth: #90ee90;
+  --map-sat-science: #ffd700;
+  --map-sat-other: #00e5ff;
+  --map-flight-civil: #00e5ff;
+  --map-flight-private: #ffd700;
+  --map-flight-gov: #ff9500;
+  --map-flight-military: #ff0000;
+  --map-flight-unknown: #546e7a;
+
   /* ── Borders ── */
   --border-primary: rgba(var(--gold-rgb), 0.15);
   --border-secondary: rgba(var(--gold-rgb), 0.08);
@@ -115,6 +131,15 @@ body.theme-ghost {
   --scrollbar-thumb: rgba(179, 136, 255, 0.25);
   --scrollbar-thumb-hover: rgba(179, 136, 255, 0.5);
   --hover-accent: rgba(179, 136, 255, 0.1);
+
+  /* Phantom pulls the map's own layers into the violet range too. The
+     satellite entries are deliberately left alone: they are the signal that
+     nobody has overridden that category, so the feed's mission colours show. */
+  --map-cctv: #b388ff;
+  --map-flight-civil: #b388ff;
+  --map-flight-private: #ce93d8;
+  --map-flight-gov: #d500f9;
+  --map-flight-unknown: #b388ff;
 }
 
 @theme inline {
@@ -599,6 +624,33 @@ html:has(.docs-root) body {
 .pulse-ring--alert::before,
 .pulse-ring--alert::after {
   border-color: var(--alert-red);
+}
+
+/* ─────────────────────────────────────────────────────────────
+   CCTV MAP PREVIEWS
+   The live frames pinned to camera markers past zoom 13.
+   ───────────────────────────────────────────────────────────── */
+.cctv-tile {
+  transform-origin: 50% 100%;
+  transition: transform 0.18s cubic-bezier(0.16, 1, 0.3, 1), filter 0.18s ease;
+}
+.cctv-tile:hover,
+.cctv-tile:focus-visible {
+  /* Lifting rather than scaling: a scaled tile resamples the frame inside it,
+     and at this size that reads as the camera going soft. */
+  transform: translateY(-3px);
+  filter: brightness(1.12) drop-shadow(0 0 10px color-mix(in srgb, var(--map-cctv) 30%, transparent));
+}
+
+/* `place()` writes data-flip on the wrapper once it knows whether the tile
+   had room above its marker. Only the stem on the marker's side is drawn. */
+[data-flip="above"] .cctv-stem-up,
+[data-flip="below"] .cctv-stem-down,
+[data-flip="none"] .cctv-stem { display: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .cctv-tile { transition: none; }
+  .cctv-tile:hover, .cctv-tile:focus-visible { transform: none; }
 }
 
 /* ─────────────────────────────────────────────────────────────

--- a/src/components/CctvPreviews.tsx
+++ b/src/components/CctvPreviews.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { Maximize2 } from 'lucide-react';
 import type { Map as MlMap } from 'maplibre-gl';
 
 /**
@@ -23,15 +24,57 @@ import type { Map as MlMap } from 'maplibre-gl';
 
 const MIN_ZOOM = 13;
 const MAX_TILES = 8;
-const TILE_W = 132;
-const IMG_H = 78;
-const LABEL_H = 16;
-/** Clearance between the bottom of a tile and the marker it belongs to. */
-const GAP = 16;
+const TILE_W = 176;
+/** 16:9, so a frame is not letterboxed inside its own container. */
+const IMG_H = 99;
+const LABEL_H = 20;
+/** Clearance between the bottom of a tile and the marker it belongs to — the
+ *  connector that ties the two together is drawn across it. */
+const GAP = 26;
 const TILE_H = IMG_H + LABEL_H;
 const REFRESH_MS = 15000;
 /** Keeps a tile clear of the viewport edge, and of the layer rail on the left. */
-const EDGE = 56;
+const EDGE = 60;
+/** More at the top and bottom, where the app's own chrome is: the header at one
+ *  end, the view controls and the ticker at the other. All of it draws over the
+ *  previews, so a tile placed underneath is simply hidden. */
+const EDGE_TOP = 96;
+const EDGE_BOTTOM = 156;
+
+/**
+ * Where the tile for a marker at `pt` ends up.
+ *
+ * Shared by the two passes deliberately. Which cameras get a tile is decided
+ * when the map settles and the tiles are then repositioned on every frame of a
+ * pan, and if those two disagreed about where a tile lands, the overlap check
+ * would be run against coordinates nothing is ever drawn at — which is what let
+ * a tile clamped back inside the viewport come to rest on top of its neighbour.
+ */
+function layout(pt: { x: number; y: number }, width: number, height: number) {
+  const maxX = width - TILE_W - EDGE;
+  const maxY = height - TILE_H - EDGE_BOTTOM;
+  /* Above the marker by default; below it when there is no room, so a camera
+     near the top of the screen still gets a visible tile. */
+  const above = pt.y - TILE_H - GAP;
+  const flipped = above < EDGE_TOP;
+  const wantX = pt.x - TILE_W / 2;
+  const wantY = flipped ? pt.y + GAP : above;
+  const x = Math.min(Math.max(wantX, EDGE), Math.max(EDGE, maxX));
+  const y = Math.min(Math.max(wantY, EDGE_TOP), Math.max(EDGE_TOP, maxY));
+  return {
+    x,
+    y,
+    flipped,
+    /* The connector is drawn straight down (or up) from the middle of the tile,
+       which is only where the marker is if the tile sits where it wanted to. */
+    anchored: Math.abs(x - wantX) < 1 && Math.abs(y - wantY) < 1,
+  };
+}
+
+/** Whatever the camera layer is currently drawn in — see lib/map-palette. */
+const CAM = 'var(--map-cctv)';
+/** color-mix keeps every tint tied to that property, not to a frozen hex. */
+const cam = (pct: number) => `color-mix(in srgb, ${CAM} ${pct}%, transparent)`;
 
 export interface PreviewCamera {
   id: string;
@@ -52,8 +95,8 @@ function freshen(url: string): string {
   return url.includes('?') ? `${url}&_t=${Date.now()}` : `${url}?_t=${Date.now()}`;
 }
 
-function Tile({ cam, onOpen }: { cam: PreviewCamera; onOpen: (cam: PreviewCamera) => void }) {
-  const [src, setSrc] = useState(() => freshen(cam.feed_url));
+function Tile({ cam: camera, onOpen }: { cam: PreviewCamera; onOpen: (cam: PreviewCamera) => void }) {
+  const [src, setSrc] = useState(() => freshen(camera.feed_url));
   const [failed, setFailed] = useState(false);
   const [loaded, setLoaded] = useState(false);
 
@@ -63,15 +106,15 @@ function Tile({ cam, onOpen }: { cam: PreviewCamera; onOpen: (cam: PreviewCamera
     /* Staggered, so eight tiles do not all hit their origin on the same tick. */
     let interval: ReturnType<typeof setInterval> | undefined;
     const first = setTimeout(() => {
-      setSrc(freshen(cam.feed_url));
-      interval = setInterval(() => setSrc(freshen(cam.feed_url)), REFRESH_MS);
+      setSrc(freshen(camera.feed_url));
+      interval = setInterval(() => setSrc(freshen(camera.feed_url)), REFRESH_MS);
     }, REFRESH_MS + Math.random() * 2000);
 
     return () => {
       clearTimeout(first);
       if (interval) clearInterval(interval);
     };
-  }, [cam.feed_url]);
+  }, [camera.feed_url]);
 
   /* A camera that will not load is worse than no tile: it is a broken box
      sitting over the map claiming to be a feed. */
@@ -79,41 +122,123 @@ function Tile({ cam, onOpen }: { cam: PreviewCamera; onOpen: (cam: PreviewCamera
 
   return (
     <button
-      onClick={() => onOpen(cam)}
-      title={cam.name}
-      className="group block w-full text-left transition-transform duration-200 hover:scale-[1.06] focus:outline-none"
+      onClick={() => onOpen(camera)}
+      title={camera.name}
+      className="cctv-tile group block w-full text-left focus:outline-none"
       style={{ width: TILE_W }}
     >
       <div
-        className="relative overflow-hidden border bg-black/80"
-        style={{ height: IMG_H, borderColor: 'rgba(0,230,118,0.35)' }}
+        className="relative overflow-hidden bg-black"
+        style={{
+          height: IMG_H,
+          border: `1px solid ${cam(40)}`,
+          boxShadow: '0 6px 20px rgba(0,0,0,0.65)',
+        }}
       >
         {/* eslint-disable-next-line @next/next/no-img-element -- remote camera frames, no loader */}
         <img
           src={src}
-          alt={cam.name}
+          alt={camera.name}
           width={TILE_W}
           height={IMG_H}
-          className="h-full w-full object-cover transition-opacity duration-300"
-          style={{ opacity: loaded ? 0.92 : 0 }}
+          className="h-full w-full object-cover transition-opacity duration-500"
+          style={{ opacity: loaded ? 1 : 0 }}
           onLoad={() => setLoaded(true)}
           onError={() => setFailed(true)}
           draggable={false}
         />
+
+        {/* Two cosmetic passes over the picture: scanlines, for the same CRT
+            read the full viewer already has, and an inner vignette so a bright
+            frame does not bleed into the map at its edges. */}
+        <div
+          className="pointer-events-none absolute inset-0"
+          style={{ backgroundImage: 'repeating-linear-gradient(0deg, rgba(0,0,0,0.22) 0px, rgba(0,0,0,0.22) 1px, transparent 1px, transparent 3px)' }}
+        />
+        <div className="pointer-events-none absolute inset-0 shadow-[inset_0_0_22px_rgba(0,0,0,0.85)]" />
+
+        {/* Corner brackets. They make the frame read as an instrument rather
+            than a thumbnail, and they hold that read over any picture. */}
+        {[
+          'left-0 top-0 border-l border-t',
+          'right-0 top-0 border-r border-t',
+          'left-0 bottom-0 border-l border-b',
+          'right-0 bottom-0 border-r border-b',
+        ].map(pos => (
+          <span
+            key={pos}
+            className={`pointer-events-none absolute h-2.5 w-2.5 ${pos}`}
+            style={{ borderColor: cam(80) }}
+          />
+        ))}
+
+        <div className="pointer-events-none absolute left-1.5 top-1.5 flex items-center gap-1 bg-black/70 px-1 py-[1px]">
+          <span className="h-1 w-1 rounded-full bg-[var(--alert-red)] animate-pulse" />
+          <span className="font-mono text-[7px] tracking-[0.18em] text-white/75">LIVE</span>
+        </div>
+
+        {/* Hover only: the tile is already a button, this says what it opens. */}
+        <div
+          className="pointer-events-none absolute right-1.5 top-1.5 flex items-center gap-1 bg-black/70 px-1 py-[1px] opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+          style={{ color: CAM }}
+        >
+          <Maximize2 className="h-2 w-2" />
+          <span className="font-mono text-[7px] tracking-[0.18em]">OPEN</span>
+        </div>
+
         {!loaded && (
-          <div className="absolute inset-0 flex items-center justify-center text-[7px] font-mono tracking-[0.2em] text-white/30">
-            LINKING
+          <div className="absolute inset-0 overflow-hidden bg-black">
+            <div
+              className="absolute inset-x-0 h-8"
+              style={{
+                background: `linear-gradient(to bottom, transparent, ${cam(18)}, transparent)`,
+                animation: 'scan-line-sweep 1.8s ease-in-out infinite',
+              }}
+            />
+            <div className="absolute inset-0 flex items-center justify-center font-mono text-[7px] tracking-[0.25em] text-white/30">
+              LINKING
+            </div>
           </div>
         )}
-        <div className="pointer-events-none absolute inset-0 border border-white/5 group-hover:border-white/20" />
       </div>
+
       <div
-        className="flex items-center gap-1 truncate border border-t-0 bg-black/85 px-1.5 font-mono text-[8px] uppercase tracking-[0.12em]"
-        style={{ height: LABEL_H, borderColor: 'rgba(0,230,118,0.35)', color: 'var(--alert-green)' }}
+        className="flex items-center gap-1.5 truncate bg-black/90 px-1.5 font-mono text-[8px] uppercase tracking-[0.12em]"
+        style={{
+          height: LABEL_H,
+          border: `1px solid ${cam(40)}`,
+          borderTop: 'none',
+          color: CAM,
+        }}
       >
-        <span className="truncate">{cam.name}</span>
+        <span className="h-1 w-1 shrink-0 rounded-full" style={{ background: CAM, boxShadow: `0 0 5px ${CAM}` }} />
+        <span className="truncate">{camera.name}</span>
       </div>
     </button>
+  );
+}
+
+/**
+ * The line from a tile to the marker it belongs to.
+ *
+ * Without one, eight frames float over the map with nothing saying which
+ * camera each belongs to — at this zoom the dots are dense enough that the
+ * nearest one is a guess. Which end it hangs from is decided by `place()`,
+ * since only that knows whether the tile had room above its marker; both are
+ * rendered and globals.css hides the one that does not apply.
+ */
+function Connector() {
+  return (
+    <>
+      <span
+        className="cctv-stem cctv-stem-down pointer-events-none absolute left-1/2 w-px"
+        style={{ top: TILE_H, height: GAP - 5, background: `linear-gradient(to bottom, ${cam(70)}, ${cam(10)})` }}
+      />
+      <span
+        className="cctv-stem cctv-stem-up pointer-events-none absolute left-1/2 w-px"
+        style={{ bottom: TILE_H, height: GAP - 5, background: `linear-gradient(to top, ${cam(70)}, ${cam(10)})` }}
+      />
+    </>
   );
 }
 
@@ -147,7 +272,7 @@ function CctvPreviews({ mapRef, active, onOpen }: {
     const cy = canvas.clientHeight / 2;
 
     const seen = new Set<string>();
-    const candidates: { cam: PreviewCamera; x: number; y: number; d: number }[] = [];
+    const candidates: { cam: PreviewCamera; box: ReturnType<typeof layout>; d: number }[] = [];
 
     for (const f of feats) {
       const p = (f.properties ?? {}) as Record<string, unknown>;
@@ -177,8 +302,7 @@ function CctvPreviews({ mapRef, active, onOpen }: {
           stream_type: p.stream_type ? String(p.stream_type) : undefined,
           external_url: p.external_url ? String(p.external_url) : undefined,
         },
-        x: pt.x,
-        y: pt.y,
+        box: layout(pt, canvas.clientWidth, canvas.clientHeight),
         d: (pt.x - cx) ** 2 + (pt.y - cy) ** 2,
       });
     }
@@ -190,7 +314,7 @@ function CctvPreviews({ mapRef, active, onOpen }: {
     const picked: typeof candidates = [];
     for (const c of candidates) {
       if (picked.length >= MAX_TILES) break;
-      const clash = picked.some(p => Math.abs(p.x - c.x) < TILE_W + 10 && Math.abs(p.y - c.y) < TILE_H + GAP + 10);
+      const clash = picked.some(p => Math.abs(p.box.x - c.box.x) < TILE_W + 8 && Math.abs(p.box.y - c.box.y) < TILE_H + GAP);
       if (!clash) picked.push(c);
     }
 
@@ -232,18 +356,15 @@ function CctvPreviews({ mapRef, active, onOpen }: {
     if (!map) return;
     const place = () => {
       const canvas = map.getCanvas();
-      const maxX = canvas.clientWidth - TILE_W - EDGE;
-      const maxY = canvas.clientHeight - TILE_H - EDGE;
       for (const cam of cams) {
         const el = nodes.current.get(cam.id);
         if (!el) continue;
-        const pt = map.project([cam.lng, cam.lat]);
-        /* Above the marker by default; below it when there is no room, so a
-           camera near the top of the screen still gets a visible tile. */
-        const above = pt.y - TILE_H - GAP;
-        const y = above < EDGE ? pt.y + GAP : above;
-        const x = pt.x - TILE_W / 2;
-        el.style.transform = `translate3d(${Math.round(Math.min(Math.max(x, EDGE), Math.max(EDGE, maxX)))}px, ${Math.round(Math.min(Math.max(y, EDGE), Math.max(EDGE, maxY)))}px, 0)`;
+        const box = layout(map.project([cam.lng, cam.lat]), canvas.clientWidth, canvas.clientHeight);
+        /* A tile pushed back inside the viewport has been moved off its marker,
+           so its connector would point at empty map. Drop the line rather than
+           draw something untrue. */
+        el.dataset.flip = !box.anchored ? 'none' : box.flipped ? 'below' : 'above';
+        el.style.transform = `translate3d(${Math.round(box.x)}px, ${Math.round(box.y)}px, 0)`;
       }
     };
     place();
@@ -259,10 +380,12 @@ function CctvPreviews({ mapRef, active, onOpen }: {
         <div
           key={cam.id}
           ref={el => { nodes.current.set(cam.id, el); }}
+          data-flip="above"
           className="pointer-events-auto absolute left-0 top-0 will-change-transform"
           style={{ width: TILE_W }}
         >
           <Tile cam={cam} onOpen={onOpen} />
+          <Connector />
         </div>
       ))}
     </div>

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -4,6 +4,8 @@ import { buildGeometry, closeRing, drawReducer, initialDrawState, measure, type 
 import { useEffect, useRef, useState, useCallback, memo } from 'react';
 import maplibregl from 'maplibre-gl';
 import { createSatelliteLayer, parseColor, type SatPoint } from '@/lib/satellite-layer';
+import { MAP_DEFAULTS, MAP_PALETTE_KEYS, readMapPalette, satColorFor, type MapPalette } from '@/lib/map-palette';
+import { STYLE_EVENT } from '@/lib/style-tokens';
 import SatelliteCard, { type SatelliteDetail } from '@/components/SatelliteCard';
 import CctvPreviews, { type PreviewCamera } from '@/components/CctvPreviews';
 
@@ -96,6 +98,15 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
   const [mapReady, setMapReady] = useState(false);
+  /**
+   * What the map's own layers draw with, mirrored out of the `--map-*` custom
+   * properties. Held in state rather than read at each use so a change re-runs
+   * the recolour effects; held in a ref as well for the click handlers, which
+   * are registered once on load and would otherwise close over the first value.
+   */
+  const [palette, setPalette] = useState<MapPalette>(MAP_DEFAULTS);
+  const paletteRef = useRef(palette);
+  useEffect(() => { paletteRef.current = palette; }, [palette]);
   const prevStyleRef = useRef(mapStyle);
   const prevDrawnPolygonsRef = useRef<string[]>([]);
   const prevArcgisLayersRef = useRef<string[]>([]);
@@ -267,18 +278,24 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       const isGhost = theme === 'ghost';
       const phantomPurple = '#B388FF';
       const phantomDark = '#1A0040';
-      const cameraColor = isGhost ? '#B388FF' : '#00E676';
-      const flightCom = isGhost ? phantomPurple : '#00E5FF';
-      const flightPriv = isGhost ? phantomPurple : '#FFD700';
-      const flightGov = isGhost ? phantomPurple : '#FF9500';
-      const flightMil = isGhost ? phantomPurple : '#FF3D3D';
+      /* The first paint reads the same `--map-*` properties the recolour
+         effects below push in later. Deriving them from `theme` here as well
+         is what let the two drift: the effect's ghost palette was four
+         distinct violets, this block's was one, and whichever ran last won. */
+      const bootStyle = getComputedStyle(document.body);
+      const boot = readMapPalette(name => bootStyle.getPropertyValue(name));
+      const cameraColor = boot.cctv;
+      const flightCom = boot.flightCivil;
+      const flightPriv = boot.flightPrivate;
+      const flightGov = boot.flightGov;
+      const flightMil = boot.flightMilitary;
 
       // Create icons — OSIRIS Unified Palette
       createIcon(map, 'plane-cyan', flightCom, 24);   
       createIcon(map, 'plane-green', flightPriv, 24);   
       createIcon(map, 'plane-pink', flightGov, 24);    
       createIcon(map, 'plane-red', flightMil, 24);     
-      createIcon(map, 'plane-grey', isGhost ? phantomPurple : '#546E7A', 24);    
+      createIcon(map, 'plane-grey', boot.flightUnknown, 24);
       createDot(map, 'dot-gold', isGhost ? phantomPurple : '#D4AF37', 8);
       createDot(map, 'dot-red', isGhost ? phantomPurple : '#D32F2F', 10);
       createDot(map, 'dot-orange', isGhost ? phantomPurple : '#E65100', 10);
@@ -980,7 +997,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
             if (!d?.segments?.length) { mark('unavailable'); return; }
             layer.setOrbit(
               d.segments.map((seg: number[][]) => seg.map(([lng, lat, altKm]) => ({ lng, lat, altKm }))),
-              parseColor(p.color),
+              parseColor(satColorFor(p.category, p.color, paletteRef.current)),
             );
             mark('ready', typeof d.periodMinutes === 'number' ? d.periodMinutes : null);
           })
@@ -1509,20 +1526,34 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     setGeo('military', activeLayers.military ? toFeatures(data.military_flights) : []);
   }, [mapReady, data.commercial_flights, data.private_flights, data.private_jets, data.military_flights, activeLayers.flights, activeLayers.private, activeLayers.jets, activeLayers.military]);
 
+  /**
+   * Pull the palette out of the document whenever it can have changed.
+   *
+   * Two triggers, and they need different timing. The Style Studio writes the
+   * properties and then dispatches, so reading straight away is correct. A
+   * theme switch flips a class on <body> from an effect in the page component
+   * — a parent, so it runs *after* this one — and reading now would return the
+   * outgoing theme. The extra frame covers that case.
+   */
+  useEffect(() => {
+    const read = () => {
+      const cs = getComputedStyle(document.body);
+      const next = readMapPalette(name => cs.getPropertyValue(name));
+      setPalette(prev => (MAP_PALETTE_KEYS.every(k => prev[k] === next[k]) ? prev : next));
+    };
+    read();
+    const raf = requestAnimationFrame(read);
+    window.addEventListener(STYLE_EVENT, read);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener(STYLE_EVENT, read);
+    };
+  }, [theme]);
+
     // Update aircraft icon colors dynamically on theme switch
     useEffect(() => {
       if (!mapReady || !mapRef.current) return;
       const map = mapRef.current;
-      
-      const isGhost = theme === 'ghost';
-      const phantomPurple = '#B388FF';
-      const ghostPriv = '#CE93D8';
-      const ghostGov = '#D500F9';
-
-      const flightCom = isGhost ? phantomPurple : '#00E5FF';
-      const flightPriv = isGhost ? ghostPriv : '#FFD700';
-      const flightGov = isGhost ? ghostGov : '#FF9500';
-      const flightMil = '#FF0000';
 
       const updateMapIcon = (id: string, color: string, size: number) => {
         if (!map.hasImage(id)) return;
@@ -1547,12 +1578,21 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         map.updateImage(id, { width: size, height: size, data: new Uint8Array(ctx.getImageData(0, 0, size, size).data) });
       };
 
-      updateMapIcon('plane-cyan', flightCom, 24);
-      updateMapIcon('plane-green', flightPriv, 24);
-      updateMapIcon('plane-pink', flightGov, 24);
-      updateMapIcon('plane-red', flightMil, 24);
-      updateMapIcon('plane-grey', isGhost ? phantomPurple : '#546E7A', 24);
-    }, [mapReady, theme]);
+      updateMapIcon('plane-cyan', palette.flightCivil, 24);
+      updateMapIcon('plane-green', palette.flightPrivate, 24);
+      updateMapIcon('plane-pink', palette.flightGov, 24);
+      updateMapIcon('plane-red', palette.flightMilitary, 24);
+      updateMapIcon('plane-grey', palette.flightUnknown, 24);
+    }, [mapReady, palette]);
+
+    /* Cameras are circles and a label, so no image to rebuild — the colour is
+       a paint property on each. */
+    useEffect(() => {
+      if (!mapReady || !mapRef.current) return;
+      const map = mapRef.current;
+      if (map.getLayer('cctv-dots')) map.setPaintProperty('cctv-dots', 'circle-color', palette.cctv);
+      if (map.getLayer('cctv-label')) map.setPaintProperty('cctv-label', 'text-color', palette.cctv);
+    }, [mapReady, palette.cctv]);
 
   // ── DECOUPLED LAYER RENDERERS (Performance Optimized) ──
 
@@ -1566,11 +1606,11 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     lng: s.lng,
     lat: s.lat,
     altKm: s.alt,
-    color: parseColor(s.color),
+    color: parseColor(satColorFor(s.category, s.color, palette)),
     // Stations are the ones an operator is usually looking for, so they get
     // to be findable in a field of several hundred identical dots.
     size: s.category === 'science' || /ISS|TIANGONG/i.test(s.name || '') ? 2.2 : 1,
-  })), []);
+  })), [palette]);
 
   /**
    * Re-points the selection at the same satellite after a refresh.
@@ -1602,7 +1642,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     
     // If 'All Satellites' is on, show everything
     if (al.satellites) {
-      setGeo('satellites', sats.map((s: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [s.lng, s.lat] }, properties: { name: s.name, color: s.color, mission: s.mission, alt: s.alt, noradId: s.noradId, category: s.category } })));
+      setGeo('satellites', sats.map((s: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [s.lng, s.lat] }, properties: { name: s.name, color: satColorFor(s.category, s.color, palette), mission: s.mission, alt: s.alt, noradId: s.noradId, category: s.category } })));
       satRowsRef.current = sats;
       satLayerRef.current?.setPoints(toSatPoints(sats));
       resyncSatSelection(sats);
@@ -1626,7 +1666,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     }
     
     const filtered = sats.filter((s: any) => enabledCategories.includes(s.category));
-    setGeo('satellites', filtered.map((s: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [s.lng, s.lat] }, properties: { name: s.name, color: s.color, mission: s.mission, alt: s.alt, noradId: s.noradId, category: s.category } })));
+    setGeo('satellites', filtered.map((s: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [s.lng, s.lat] }, properties: { name: s.name, color: satColorFor(s.category, s.color, palette), mission: s.mission, alt: s.alt, noradId: s.noradId, category: s.category } })));
     satRowsRef.current = filtered;
     satLayerRef.current?.setPoints(toSatPoints(filtered));
     resyncSatSelection(filtered);

--- a/src/components/StyleStudio.tsx
+++ b/src/components/StyleStudio.tsx
@@ -3,7 +3,8 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
-import { X, RotateCcw, Copy, Check, ClipboardPaste } from 'lucide-react';
+import { X, RotateCcw, Copy, Check, ClipboardPaste, Undo2 } from 'lucide-react';
+import { MAP_DEFAULTS, type MapPaletteKey } from '@/lib/map-palette';
 import {
   applySettings,
   FONT_MONO,
@@ -28,7 +29,7 @@ import {
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex items-center justify-between gap-3 py-1.5">
-      <span className="text-[10px] font-mono tracking-[0.15em] uppercase text-white/40 shrink-0">{label}</span>
+      <span className="text-[10px] font-mono tracking-[0.15em] uppercase text-white/40 truncate">{label}</span>
       {children}
     </div>
   );
@@ -63,7 +64,7 @@ function Slider({ label, value, min, max, step, onChange, format }: {
         type="range" min={min} max={max} step={step} value={value}
         onChange={(e) => onChange(parseFloat(e.target.value))}
         aria-label={label}
-        className="flex-1 h-1 appearance-none rounded-full bg-white/10 accent-[var(--gold-primary)] cursor-pointer"
+        className="min-w-0 flex-1 h-1 appearance-none rounded-full bg-white/10 accent-[var(--gold-primary)] cursor-pointer"
       />
       <span className="text-[10px] font-mono tabular-nums text-white/40 w-9 text-right">
         {format ? format(value) : value}
@@ -101,7 +102,7 @@ function AutoSlider({ label, value, min, max, step, whenEnabled, onChange, forma
         disabled={auto}
         onChange={(e) => onChange(parseFloat(e.target.value))}
         aria-label={label}
-        className={`flex-1 h-1 appearance-none rounded-full bg-white/10 accent-[var(--gold-primary)] ${auto ? 'opacity-30 cursor-not-allowed' : 'cursor-pointer'}`}
+        className={`min-w-0 flex-1 h-1 appearance-none rounded-full bg-white/10 accent-[var(--gold-primary)] ${auto ? 'opacity-30 cursor-not-allowed' : 'cursor-pointer'}`}
       />
       <span className="text-[10px] font-mono tabular-nums text-white/40 w-9 text-right">
         {auto ? 'auto' : format(value)}
@@ -129,6 +130,44 @@ function Segmented({ label, options, value, onChange }: {
           {o.label}
         </button>
       ))}
+    </div>
+  );
+}
+
+/** Groups rows inside a section without starting a new one. */
+function SubHead({ label, note }: { label: string; note?: string }) {
+  return (
+    <div className="pt-2.5 pb-0.5">
+      <div className="text-[9px] font-mono tracking-[0.2em] uppercase text-white/30">{label}</div>
+      {note && <div className="text-[8px] font-mono leading-snug text-white/20 pt-0.5">{note}</div>}
+    </div>
+  );
+}
+
+/**
+ * A colour with a default it can be sent back to.
+ *
+ * The satellite swatches need this more than most: sitting on the default is
+ * not just a colour, it is what keeps each satellite's own mission colour, so
+ * getting back to it has to be possible without resetting the whole theme.
+ */
+function ResettableSwatch({ label, value, fallback, onChange }: {
+  label: string; value: string; fallback: string; onChange: (v: string) => void;
+}) {
+  const changed = value.toLowerCase() !== fallback.toLowerCase();
+  return (
+    <div className="flex items-center gap-1.5">
+      <button
+        onClick={() => onChange(fallback)}
+        title={`Restore the default ${label.toLowerCase()}`}
+        aria-label={`Restore default ${label}`}
+        className={`w-5 h-5 rounded flex items-center justify-center transition-opacity ${
+          changed ? 'text-white/35 hover:text-white/80 hover:bg-white/5' : 'opacity-0 pointer-events-none'
+        }`}
+      >
+        <Undo2 className="w-3 h-3" />
+      </button>
+      <Swatch label={label} value={value} onChange={onChange} />
     </div>
   );
 }
@@ -182,16 +221,22 @@ function StyleStudio({ onClose, isMobile }: { onClose: () => void; isMobile?: bo
 
   /* While clean, re-seed from the live theme so edits made after a theme
      switch start from what is actually on screen. */
-  const edit = useCallback((patch: Partial<StyleSettings>) => {
+  const edit = useCallback((patch: Partial<StyleSettings> | ((base: StyleSettings) => Partial<StyleSettings>)) => {
     setS(prev => {
       const base = dirty.current && prev ? prev : readTheme();
-      return { ...base, ...patch };
+      return { ...base, ...(typeof patch === 'function' ? patch(base) : patch) };
     });
     dirty.current = true;
   }, []);
 
   const set = useCallback(<K extends keyof StyleSettings>(key: K, value: StyleSettings[K]) => {
     edit({ [key]: value } as Partial<StyleSettings>);
+  }, [edit]);
+
+  /* One layer colour at a time — the rest of the palette has to come from the
+     seeded base, not from a render-time copy that may predate a theme switch. */
+  const setMap = useCallback((key: MapPaletteKey, value: string) => {
+    edit(base => ({ map: { ...base.map, [key]: value } }));
   }, [edit]);
 
   /* The surface ramp follows the background unless a preset supplies its own. */
@@ -294,6 +339,26 @@ function StyleStudio({ onClose, isMobile }: { onClose: () => void; isMobile?: bo
           <Row label="Info"><Swatch label="Info colour" value={s.alertBlue} onChange={v => set('alertBlue', v)} /></Row>
         </Section>
 
+        <Section title="Map layers">
+          <SubHead label="Cameras" />
+          <Row label="Dots &amp; labels"><ResettableSwatch label="Camera colour" value={s.map.cctv} fallback={MAP_DEFAULTS.cctv} onChange={v => setMap('cctv', v)} /></Row>
+
+          <SubHead label="Satellites" note="Default keeps each satellite's own mission colour. Change one and it takes over that whole category." />
+          <Row label="Comms"><ResettableSwatch label="Comms satellites" value={s.map.satComms} fallback={MAP_DEFAULTS.satComms} onChange={v => setMap('satComms', v)} /></Row>
+          <Row label="Military"><ResettableSwatch label="Military satellites" value={s.map.satMilitary} fallback={MAP_DEFAULTS.satMilitary} onChange={v => setMap('satMilitary', v)} /></Row>
+          <Row label="Navigation"><ResettableSwatch label="Navigation satellites" value={s.map.satNavigation} fallback={MAP_DEFAULTS.satNavigation} onChange={v => setMap('satNavigation', v)} /></Row>
+          <Row label="Earth obs"><ResettableSwatch label="Earth observation satellites" value={s.map.satEarth} fallback={MAP_DEFAULTS.satEarth} onChange={v => setMap('satEarth', v)} /></Row>
+          <Row label="Science"><ResettableSwatch label="Science satellites" value={s.map.satScience} fallback={MAP_DEFAULTS.satScience} onChange={v => setMap('satScience', v)} /></Row>
+          <Row label="Other"><ResettableSwatch label="Other satellites" value={s.map.satOther} fallback={MAP_DEFAULTS.satOther} onChange={v => setMap('satOther', v)} /></Row>
+
+          <SubHead label="Aircraft" />
+          <Row label="Civil"><ResettableSwatch label="Civil aircraft" value={s.map.flightCivil} fallback={MAP_DEFAULTS.flightCivil} onChange={v => setMap('flightCivil', v)} /></Row>
+          <Row label="Private"><ResettableSwatch label="Private aircraft" value={s.map.flightPrivate} fallback={MAP_DEFAULTS.flightPrivate} onChange={v => setMap('flightPrivate', v)} /></Row>
+          <Row label="Government"><ResettableSwatch label="Government aircraft" value={s.map.flightGov} fallback={MAP_DEFAULTS.flightGov} onChange={v => setMap('flightGov', v)} /></Row>
+          <Row label="Military"><ResettableSwatch label="Military aircraft" value={s.map.flightMilitary} fallback={MAP_DEFAULTS.flightMilitary} onChange={v => setMap('flightMilitary', v)} /></Row>
+          <Row label="Unknown"><ResettableSwatch label="Unknown aircraft" value={s.map.flightUnknown} fallback={MAP_DEFAULTS.flightUnknown} onChange={v => setMap('flightUnknown', v)} /></Row>
+        </Section>
+
         <Section title="Surface">
           <Row label="Background"><Swatch label="Background colour" value={s.bg} onChange={setBg} /></Row>
           <Row label="Panel"><Slider label="Panel opacity" value={s.panelAlpha} min={0.2} max={1} step={0.01} onChange={v => set('panelAlpha', v)} format={v => `${Math.round(v * 100)}%`} /></Row>
@@ -318,10 +383,13 @@ function StyleStudio({ onClose, isMobile }: { onClose: () => void; isMobile?: bo
         <Section title="Motion & FX">
           <Row label="Speed"><Slider label="Motion speed" value={s.motion} min={0} max={2} step={0.05} onChange={v => set('motion', v)} format={v => (v === 0 ? 'off' : `${v.toFixed(2)}x`)} /></Row>
           <Row label="Scanlines"><Slider label="Scanline overlay" value={s.scanlines} min={0} max={0.2} step={0.005} onChange={v => set('scanlines', v)} format={v => (v === 0 ? 'off' : `${Math.round(v * 500)}%`)} /></Row>
+          <Row label="Grain"><Slider label="Film grain overlay" value={s.grain} min={0} max={0.3} step={0.005} onChange={v => set('grain', v)} format={v => (v === 0 ? 'off' : `${Math.round(v * 333)}%`)} /></Row>
+          <Row label="Vignette"><Slider label="Edge vignette" value={s.vignette} min={0} max={1} step={0.01} onChange={v => set('vignette', v)} format={v => (v === 0 ? 'off' : `${Math.round(v * 100)}%`)} /></Row>
         </Section>
 
         <p className="text-[9px] font-mono leading-relaxed text-white/20 pt-1 pb-1">
-          Saved to this browser. AUTO leaves the app&apos;s own styling alone. Reset restores the active theme.
+          Saved to this browser. AUTO leaves the app&apos;s own styling alone, and presets do not touch the map
+          layers &mdash; those carry meaning, not just a look. Reset restores the active theme.
         </p>
       </div>
     </motion.div>,

--- a/src/lib/map-palette.test.ts
+++ b/src/lib/map-palette.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import {
+  MAP_DEFAULTS,
+  MAP_PALETTE_KEYS,
+  MAP_VARS,
+  readMapPalette,
+  satColorFor,
+  type MapPalette,
+} from './map-palette';
+
+const palette = (o: Partial<MapPalette> = {}): MapPalette => ({ ...MAP_DEFAULTS, ...o });
+
+describe('satColorFor', () => {
+  it('keeps the feed\'s own mission colour while the category is untouched', () => {
+    // Weather and Earth Observation are both earth_obs but arrive as different
+    // colours; nobody who never opens the studio should lose that.
+    expect(satColorFor('earth_obs', '#87ceeb', palette())).toBe('#87ceeb');
+    expect(satColorFor('earth_obs', '#90ee90', palette())).toBe('#90ee90');
+  });
+
+  it('takes over the whole category once that swatch is moved', () => {
+    const p = palette({ satEarth: '#ff00ff' });
+    expect(satColorFor('earth_obs', '#87ceeb', p)).toBe('#ff00ff');
+    expect(satColorFor('earth_obs', '#90ee90', p)).toBe('#ff00ff');
+    // and leaves every other category alone
+    expect(satColorFor('military', '#ff3d3d', p)).toBe('#ff3d3d');
+  });
+
+  it('ignores the case the default is written in', () => {
+    expect(satColorFor('military', '#abcdef', palette({ satMilitary: '#FF3D3D' }))).toBe('#abcdef');
+  });
+
+  it('files an unknown or missing category under other', () => {
+    const p = palette({ satOther: '#123456' });
+    expect(satColorFor('debris', '#00e5ff', p)).toBe('#123456');
+    expect(satColorFor(undefined, '#00e5ff', p)).toBe('#123456');
+  });
+
+  it('still returns a colour when the feed supplies none', () => {
+    expect(satColorFor('comms', undefined, palette())).toBe(MAP_DEFAULTS.satComms);
+    expect(satColorFor('comms', '', palette())).toBe(MAP_DEFAULTS.satComms);
+  });
+});
+
+describe('readMapPalette', () => {
+  it('reads every entry, trimming what getComputedStyle returns', () => {
+    const out = readMapPalette(name => (name === '--map-cctv' ? '  #ff0000 ' : ''));
+    expect(out.cctv).toBe('#ff0000');
+  });
+
+  it('canonicalises so two spellings of one colour compare equal', () => {
+    // satColorFor decides "untouched" by comparing against MAP_DEFAULTS, so a
+    // shorthand or upper-case value must not read as a customisation.
+    expect(readMapPalette(() => '#0F0').cctv).toBe('#00ff00');
+    expect(readMapPalette(() => '#00E676').cctv).toBe('#00e676');
+  });
+
+  it('falls back for anything missing or not a colour', () => {
+    // An unresolved var() or a stylesheet that has not loaded yields ''.
+    expect(readMapPalette(() => '').satMilitary).toBe(MAP_DEFAULTS.satMilitary);
+    expect(readMapPalette(() => 'red; } * { display: none }').cctv).toBe(MAP_DEFAULTS.cctv);
+    // Keywords and rgb() need a parser; without a DOM there is none, so they
+    // fall back here. In the browser they resolve — which is the point: the
+    // CSS build rewrites #ff0000 to `red` on its way to getComputedStyle.
+    expect(readMapPalette(() => 'rgb(1,2,3)').cctv).toBe(MAP_DEFAULTS.cctv);
+  });
+});
+
+describe('globals.css', () => {
+  const css = readFileSync(new URL('../app/globals.css', import.meta.url), 'utf8');
+
+  /** The value `--name: ` is declared with, at its first (i.e. :root) mention. */
+  const declared = (name: string): string | null => {
+    const at = css.indexOf(name + ':');
+    if (at < 0) return null;
+    return css.slice(at + name.length + 1, css.indexOf(';', at)).trim().toLowerCase();
+  };
+
+  it('declares every property the palette reads', () => {
+    for (const key of MAP_PALETTE_KEYS) {
+      expect(declared(MAP_VARS[key]), MAP_VARS[key]).not.toBeNull();
+    }
+  });
+
+  it('agrees with MAP_DEFAULTS, which satColorFor compares against', () => {
+    // The two copies cannot import each other, and a silent drift would make
+    // every satellite category read as "customised" and flatten the map.
+    for (const key of MAP_PALETTE_KEYS) {
+      expect(declared(MAP_VARS[key]), MAP_VARS[key]).toBe(MAP_DEFAULTS[key]);
+    }
+  });
+
+  it('leaves the satellite categories at their defaults in the ghost theme', () => {
+    // Overriding them there would permanently suppress the feed's own colours.
+    const ghost = css.slice(css.indexOf('body.theme-ghost'), css.indexOf('@theme inline'));
+    for (const key of MAP_PALETTE_KEYS.filter(k => k.startsWith('sat'))) {
+      expect(ghost, MAP_VARS[key] + ' overridden in ghost').not.toContain(MAP_VARS[key]);
+    }
+  });
+});

--- a/src/lib/map-palette.ts
+++ b/src/lib/map-palette.ts
@@ -1,0 +1,148 @@
+/**
+ * OSIRIS — map layer palette.
+ *
+ * The colours the *map* draws with, as opposed to the chrome around it: camera
+ * dots, satellites, aircraft. They live as `--map-*` custom properties beside
+ * the rest of the design tokens, so the two themes set them in globals.css and
+ * the Style Studio overrides them the same way it overrides everything else.
+ *
+ * Everything here is pure. Reading the properties off the document is the
+ * caller's job — `readMapPalette` takes the lookup as an argument.
+ */
+
+export interface MapPalette {
+  cctv: string;
+  satComms: string;
+  satMilitary: string;
+  satNavigation: string;
+  satEarth: string;
+  satScience: string;
+  satOther: string;
+  flightCivil: string;
+  flightPrivate: string;
+  flightGov: string;
+  flightMilitary: string;
+  flightUnknown: string;
+}
+
+export type MapPaletteKey = keyof MapPalette;
+
+/** Custom property backing each entry. Must match the block in globals.css. */
+export const MAP_VARS: Record<MapPaletteKey, string> = {
+  cctv: '--map-cctv',
+  satComms: '--map-sat-comms',
+  satMilitary: '--map-sat-military',
+  satNavigation: '--map-sat-navigation',
+  satEarth: '--map-sat-earth',
+  satScience: '--map-sat-science',
+  satOther: '--map-sat-other',
+  flightCivil: '--map-flight-civil',
+  flightPrivate: '--map-flight-private',
+  flightGov: '--map-flight-gov',
+  flightMilitary: '--map-flight-military',
+  flightUnknown: '--map-flight-unknown',
+};
+
+/**
+ * The core theme's values, and the fallback when a property is missing.
+ *
+ * The satellite entries double as the "untouched" marker — see `satColorFor`.
+ * They are duplicated in globals.css because CSS cannot import them; the test
+ * suite pins the two copies together.
+ */
+export const MAP_DEFAULTS: MapPalette = {
+  cctv: '#00e676',
+  satComms: '#00e676',
+  satMilitary: '#ff3d3d',
+  satNavigation: '#448aff',
+  satEarth: '#90ee90',
+  satScience: '#ffd700',
+  satOther: '#00e5ff',
+  flightCivil: '#00e5ff',
+  flightPrivate: '#ffd700',
+  flightGov: '#ff9500',
+  flightMilitary: '#ff0000',
+  flightUnknown: '#546e7a',
+};
+
+export const MAP_PALETTE_KEYS = Object.keys(MAP_DEFAULTS) as MapPaletteKey[];
+
+/** The sub-layers the catalogue is filtered by, in panel order. */
+const SAT_CATEGORY: Record<string, MapPaletteKey> = {
+  comms: 'satComms',
+  military: 'satMilitary',
+  navigation: 'satNavigation',
+  earth_obs: 'satEarth',
+  science: 'satScience',
+  other: 'satOther',
+};
+
+/**
+ * Colour for one satellite.
+ *
+ * The catalogue classifies by *mission*, which is finer than the six categories
+ * the map filters by: Weather and Earth Observation are both `earth_obs` but
+ * arrive as different colours. Flattening every satellite onto its category
+ * would throw that away for everyone who never opens the Style Studio, so the
+ * category colour is applied only once it has been moved off its default — an
+ * untouched palette leaves the feed's own colours exactly as they were.
+ */
+export function satColorFor(category: string | undefined, missionColor: string | undefined, palette: MapPalette): string {
+  const key = SAT_CATEGORY[category ?? ''] ?? 'satOther';
+  const chosen = palette[key];
+  const untouched = chosen.toLowerCase() === MAP_DEFAULTS[key].toLowerCase();
+  return (untouched && missionColor) || chosen;
+}
+
+const HEX = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/** Expand shorthand and lowercase, so two spellings of a colour compare equal. */
+function canonical(hex: string): string {
+  const h = hex.slice(1).toLowerCase();
+  return '#' + (h.length === 3 ? h.split('').map(c => c + c).join('') : h);
+}
+
+/**
+ * Resolve a colour the CSS build may have rewritten.
+ *
+ * Lightning CSS minifies hex to a keyword wherever that is shorter, so
+ * `--map-flight-military: #ff0000` comes back out of getComputedStyle as
+ * `red`. Comparing that against the defaults would report the category as
+ * customised and quietly discard the mission colours, so the value has to be
+ * parsed rather than pattern-matched. A 2d context is the browser's own
+ * parser; assigning a colour and reading it back yields `#rrggbb`.
+ *
+ * Two seeds and an agreement check, because a value the parser rejects leaves
+ * `fillStyle` at whatever it already held — with one seed, garbage would come
+ * back as that seed rather than as a rejection.
+ */
+let probe: CanvasRenderingContext2D | null | undefined;
+function parseColorValue(value: string): string | null {
+  if (probe === undefined) {
+    probe = typeof document === 'undefined' ? null : document.createElement('canvas').getContext('2d');
+  }
+  if (!probe) return null;
+  probe.fillStyle = '#000000';
+  probe.fillStyle = value;
+  const a = probe.fillStyle;
+  probe.fillStyle = '#ffffff';
+  probe.fillStyle = value;
+  const b = probe.fillStyle;
+  return a === b && typeof a === 'string' && HEX.test(a) ? canonical(a) : null;
+}
+
+/**
+ * Read the palette out of a resolved-style lookup, e.g. `getComputedStyle`.
+ *
+ * Anything that is not a colour — an unresolved var(), a stylesheet that has
+ * not loaded, a string pasted in to escape the declaration — falls back rather
+ * than reaching a paint property.
+ */
+export function readMapPalette(lookup: (varName: string) => string): MapPalette {
+  const out = {} as MapPalette;
+  for (const key of MAP_PALETTE_KEYS) {
+    const raw = (lookup(MAP_VARS[key]) || '').trim();
+    out[key] = (HEX.test(raw) ? canonical(raw) : parseColorValue(raw)) ?? MAP_DEFAULTS[key];
+  }
+  return out;
+}

--- a/src/lib/style-tokens.test.ts
+++ b/src/lib/style-tokens.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildCss, buildVars, DEFAULTS, sanitize, type StyleSettings } from './style-tokens';
+import { MAP_DEFAULTS, MAP_PALETTE_KEYS, MAP_VARS } from './map-palette';
 
 const settings = (o: Partial<StyleSettings> = {}): StyleSettings => ({ ...DEFAULTS, ...o });
 
@@ -164,5 +165,68 @@ describe('buildVars', () => {
     ]) {
       expect(names).toContain(required);
     }
+  });
+});
+
+describe('map palette', () => {
+  it('emits every map property so the map can read them back', () => {
+    const v = buildVars(settings());
+    for (const key of MAP_PALETTE_KEYS) {
+      expect(v[MAP_VARS[key]]).toBe(MAP_DEFAULTS[key]);
+    }
+  });
+
+  it('carries an edited layer colour through to its property', () => {
+    const v = buildVars(settings({ map: { ...MAP_DEFAULTS, cctv: '#ff00ff' } }));
+    expect(v['--map-cctv']).toBe('#ff00ff');
+    expect(v['--map-sat-military']).toBe(MAP_DEFAULTS.satMilitary);
+  });
+
+  it('sanitises map colours like every other colour', () => {
+    // These land on body.style as text, so the same injection rules apply.
+    const hostile = { map: { cctv: 'red; } body { display: none } .x {', satEarth: '#0f0' } };
+    const out = sanitize(hostile, DEFAULTS);
+    expect(out.map.cctv).toBe(MAP_DEFAULTS.cctv);
+    expect(out.map.satEarth).toBe('#00ff00');
+    expect(JSON.stringify(out)).not.toContain('display');
+  });
+
+  it('survives a stored theme written before the map section existed', () => {
+    const out = sanitize({ accent: '#ffffff' }, DEFAULTS);
+    expect(out.map).toEqual(MAP_DEFAULTS);
+  });
+});
+
+describe('screen overlays', () => {
+  it('emits nothing while scanlines, vignette and grain are all off', () => {
+    expect(buildCss(settings())).not.toContain('::after');
+  });
+
+  it('stacks them into one pseudo-element rather than overwriting', () => {
+    // Two ::after rules would not compose — the later one simply wins.
+    const css = buildCss(settings({ scanlines: 0.04, vignette: 0.5, grain: 0.1 }));
+    expect(css.match(/::after/g)).toHaveLength(1);
+    expect(css).toContain('repeating-linear-gradient');
+    expect(css).toContain('radial-gradient');
+    expect(css).toContain('data:image/svg+xml');
+  });
+
+  it('leaves out the layers that are off', () => {
+    const css = buildCss(settings({ vignette: 0.4 }));
+    expect(css).toContain('radial-gradient');
+    expect(css).not.toContain('repeating-linear-gradient');
+    expect(css).not.toContain('data:image/svg+xml');
+  });
+
+  it('percent-encodes the grain tile so it cannot break out of the url()', () => {
+    const css = buildCss(settings({ grain: 0.2 }));
+    expect(css).not.toContain('<svg');
+    expect(css).toContain('%3Csvg');
+  });
+
+  it('clamps the new knobs', () => {
+    const out = sanitize({ vignette: 12, grain: -3 }, DEFAULTS);
+    expect(out.vignette).toBe(1);
+    expect(out.grain).toBe(0);
   });
 });

--- a/src/lib/style-tokens.ts
+++ b/src/lib/style-tokens.ts
@@ -15,6 +15,14 @@
  * and rewrite every backdrop blur to a single value.
  */
 
+import {
+  MAP_DEFAULTS,
+  MAP_PALETTE_KEYS,
+  MAP_VARS,
+  readMapPalette,
+  type MapPalette,
+} from './map-palette';
+
 const STORAGE_KEY = 'osiris:style-studio';
 const STYLE_TAG_ID = 'osiris-style-studio';
 
@@ -44,6 +52,10 @@ export interface StyleSettings {
   radius: number;
   motion: number;
   scanlines: number;
+  vignette: number;
+  grain: number;
+  /** Colours the map itself draws with — see ./map-palette. */
+  map: MapPalette;
 }
 
 export const FONT_UI = [
@@ -86,6 +98,9 @@ export const DEFAULTS: StyleSettings = {
   radius: 1,
   motion: 1,
   scanlines: 0,
+  vignette: 0,
+  grain: 0,
+  map: MAP_DEFAULTS,
 };
 
 export type Preset = { label: string; patch: Partial<StyleSettings> };
@@ -185,7 +200,18 @@ export function sanitize(input: unknown, base: StyleSettings): StyleSettings {
     radius: normNum(o.radius, base.radius, 0, 2.5),
     motion: normNum(o.motion, base.motion, 0, 2),
     scanlines: normNum(o.scanlines, base.scanlines, 0, 0.2),
+    vignette: normNum(o.vignette, base.vignette, 0, 1),
+    grain: normNum(o.grain, base.grain, 0, 0.3),
+    map: normMap(o.map, base.map),
   };
+}
+
+/** Same treatment as every other colour: these reach body.style as text. */
+function normMap(v: unknown, base: MapPalette): MapPalette {
+  const o = (v ?? {}) as Record<string, unknown>;
+  const out = {} as MapPalette;
+  for (const key of MAP_PALETTE_KEYS) out[key] = normHex(o[key], base[key]);
+  return out;
 }
 
 /** Every design token the studio drives, derived from the settings. */
@@ -225,6 +251,7 @@ export function buildVars(s: StyleSettings): Record<string, string> {
     '--text-heading': s.textHeading,
     '--font-body': s.fontUi,
     '--font-hud': s.fontMono,
+    ...Object.fromEntries(MAP_PALETTE_KEYS.map(k => [MAP_VARS[k], s.map[k]])),
   };
 }
 
@@ -267,11 +294,28 @@ ${at} .rounded-full { border-radius: 9999px; }`,
     blocks.push(`${at} *, ${at} *::before, ${at} *::after { transition-duration: ${Math.round(600 * s.motion)}ms !important; }`);
   }
 
+  /* Scanlines, vignette and grain share one pseudo-element: a second ::after
+     would replace the first rather than stack with it. Each layer is added
+     only when its own knob is up, so an unused one composes to nothing. */
+  const overlays: string[] = [];
   if (s.scanlines > 0) {
+    overlays.push(`repeating-linear-gradient(0deg, rgba(255,255,255,${s.scanlines}) 0px, rgba(255,255,255,${s.scanlines}) 1px, transparent 1px, transparent 3px)`);
+  }
+  if (s.grain > 0) {
+    /* An SVG turbulence tile, repeated. No request, and the browser rasterises
+       it once; a canvas would have to be regenerated on every edit. */
+    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='140' height='140'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/></filter><rect width='140' height='140' filter='url(%23n)' opacity='${s.grain}'/></svg>`;
+    overlays.push(`url("data:image/svg+xml,${encodeURIComponent(svg).replace(/'/g, '%27')}")`);
+  }
+  if (s.vignette > 0) {
+    overlays.push(`radial-gradient(ellipse at center, transparent 40%, rgba(0,0,0,${s.vignette}) 100%)`);
+  }
+
+  if (overlays.length) {
     blocks.push(
       `${at}::after {
   content: ''; position: fixed; inset: 0; pointer-events: none; z-index: 9998;
-  background-image: repeating-linear-gradient(0deg, rgba(255,255,255,${s.scanlines}) 0px, rgba(255,255,255,${s.scanlines}) 1px, transparent 1px, transparent 3px);
+  background-image: ${overlays.join(', ')};
 }`,
     );
   }
@@ -324,7 +368,22 @@ export function readTheme(): StyleSettings {
     textMuted: hex('--text-muted', DEFAULTS.textMuted),
     textHeading: hex('--text-heading', DEFAULTS.textHeading),
     glow: parseAlpha(v('--gold-glow', ''), DEFAULTS.glow),
+    map: readMapPalette(name => cs.getPropertyValue(name)),
   };
+}
+
+/**
+ * Fired after the tokens on <body> change.
+ *
+ * The map draws in WebGL from paint properties, not from CSS, so a custom
+ * property landing on <body> means nothing to it until something re-reads the
+ * palette and pushes it in. An event keeps that one-way: the token engine has
+ * no idea the map exists.
+ */
+export const STYLE_EVENT = 'osiris:style';
+
+function announce() {
+  if (typeof window !== 'undefined') window.dispatchEvent(new CustomEvent(STYLE_EVENT));
 }
 
 /** Push settings onto <body>, or strip every trace when passed null. */
@@ -334,19 +393,21 @@ export function applySettings(s: StyleSettings | null) {
     for (const name of VAR_NAMES) body.style.removeProperty(name);
     body.removeAttribute('data-studio');
     document.getElementById(STYLE_TAG_ID)?.remove();
+    announce();
     return;
   }
   for (const [name, value] of Object.entries(buildVars(s))) body.style.setProperty(name, value);
   body.setAttribute('data-studio', 'on');
   const css = buildCss(s);
   let tag = document.getElementById(STYLE_TAG_ID);
-  if (!css) { tag?.remove(); return; }
+  if (!css) { tag?.remove(); announce(); return; }
   if (!tag) {
     tag = document.createElement('style');
     tag.id = STYLE_TAG_ID;
     document.head.appendChild(tag);
   }
   tag.textContent = css;
+  announce();
 }
 
 /** Persist the current customisation. Silently a no-op in private mode. */


### PR DESCRIPTION
Two things, joined by one mechanism: the colours the map draws with now live as `--map-*` custom properties beside the rest of the design tokens, which is what lets both the previews and the Style Studio read them.

## The close-up

Past zoom 13 the nearest cameras show a live frame instead of a dot. Those frames were 132x78 thumbnails on a hardcoded green border, floating over the map with nothing tying them to a marker.

- **176x99, which is 16:9**, so a frame is not letterboxed by its own container
- **corner brackets, a LIVE pill, an inner vignette and scanlines**, so a tile reads as an instrument rather than a thumbnail — over any picture
- **a connector to the marker it belongs to.** At this zoom the dots are dense enough that "which camera is this" was a guess
- **lift on hover instead of scale.** A scaled tile resamples the frame inside it, and at this size that reads as the camera going soft. Hover also names what a click does
- the loading state is a sweep rather than a word on a black box

Two placement bugs came out of enlarging them.

| | before | after |
| --- | --- | --- |
| tile-on-tile overlaps | yes | 0 |
| tiles behind the view controls | yes | 0 |

Which cameras get a tile is decided when the map settles; the tiles are then repositioned on every frame of a pan. Those two passes each had their own idea of where a tile goes, so the overlap check ran against coordinates nothing was ever drawn at, and a tile clamped back inside the viewport could come to rest on its neighbour. They now share one `layout()`. Tiles also kept the same clearance on all four edges, which put them under the header and behind the view controls — the top and bottom insets now account for the chrome that draws over them.

A tile pushed off its marker by that clamping drops its connector rather than pointing at empty map.

## The colours

`--map-*` covers cameras, six satellite categories and five aircraft classes, set per theme in `globals.css` and overridable from a new **Map layers** section in the Style Studio.

Cameras are a paint property on two layers; aircraft icons are canvas images rebuilt through `updateImage`, which the theme switch already did. Both were deriving their colours from the `theme` prop in two places that disagreed — the ghost palette was four distinct violets in the effect and one flat purple at map load, and whichever ran last won. Both now read the properties.

Satellites are the awkward one. The catalogue classifies by *mission*, which is finer than the six categories the map filters by: Weather and Earth Observation are both `earth_obs` but arrive as different colours. Flattening every satellite onto its category would throw that away for everyone who never opens the studio, so **a category colour applies only once it has been moved off its default**, and each swatch has its own restore control to get back there.

That comparison is why the read canonicalises rather than pattern-matching: Lightning CSS rewrites `#ff0000` to `red` on its way into the stylesheet, so what comes back out of `getComputedStyle` is not what `globals.css` was written with. The defaults are duplicated in CSS and TS because CSS cannot import them; a test pins the two copies together.

**Presets deliberately leave the map alone.** Those colours carry meaning — military against civil, one category against another — and collapsing them onto an accent is a downgrade, not a restyle.

Also in the studio: **vignette** and **film grain**, sharing the one `::after` the scanlines already used, since a second would replace it rather than stack with it. And the sliders no longer push the panel wider than itself — a range input has an intrinsic minimum width, so `flex-1` alone could not shrink it and every label was clipped on the left.

## Verified in the browser

Downtown Ottawa, zoom 15.6, 8 tiles:

- camera colour to `#ff00ff` repainted the dots, the labels and the preview tiles together
- military satellites to white across all 18,848 on screen; fires stayed red
- civil aircraft to `#ff8800` — the icon bitmap went `[0,229,255]` to `[255,136,0]`
- Ghost Protocol still drives all of it: `#b388ff` cameras, four distinct violets for aircraft, satellites left on their mission colours
- Reset leaves 0 inline vars on `<body>` and removes the injected style tag

434 tests pass, 11 of them new. Lint clean, production build OK.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
