### PR TITLE
feat(cctv): give video cameras a preview tile, not just snapshots

### DIFF
--- a/src/components/CctvPreviews.tsx
+++ b/src/components/CctvPreviews.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Maximize2 } from 'lucide-react';
+import { freshen, previewMedia, refreshInterval, VIDEO_KINDS, type PreviewKind } from '@/lib/camera-preview';
 import type { Map as MlMap } from 'maplibre-gl';
 
 /**
@@ -11,11 +12,12 @@ import type { Map as MlMap } from 'maplibre-gl';
  * dots and start showing what they see: a small live frame pinned above each
  * marker, captioned with the camera's name.
  *
- * Only still-image cameras qualify. The catalogue is ~19,000 strong and the
- * overwhelming majority are JPEG snapshot feeds, which cost one request per
- * refresh; the handful of HLS/MP4/iframe cameras would each need a decoder or
- * an embed, and eight of those on screen at once would be a different feature
- * with a much worse frame budget. Those still open normally on click.
+ * Most of the ~19,000 are JPEG snapshot feeds, which cost one request per
+ * refresh. The ones that are video get a tile too — Quebec 511 alone is 675
+ * MP4 cameras, and leaving them as dots read as "no camera here" rather than
+ * "this one needs a player" — but no more than MAX_VIDEO_TILES play at once,
+ * because decoding is what the frame budget actually goes on. Beyond that a
+ * video camera stays a dot and opens on click, as embeds always do.
  *
  * Positions are written straight to the DOM on every map `move`, so panning
  * does not re-render React 60 times a second. Which cameras are shown is
@@ -32,7 +34,8 @@ const LABEL_H = 20;
  *  connector that ties the two together is drawn across it. */
 const GAP = 26;
 const TILE_H = IMG_H + LABEL_H;
-const REFRESH_MS = 15000;
+/** Simultaneously decoding tiles. Snapshots fill whatever is left of MAX_TILES. */
+const MAX_VIDEO_TILES = 4;
 /** Keeps a tile clear of the viewport edge, and of the layer rail on the left. */
 const EDGE = 60;
 /** More at the top and bottom, where the app's own chrome is: the header at one
@@ -88,33 +91,138 @@ export interface PreviewCamera {
   stream_url?: string;
   stream_type?: string;
   external_url?: string;
+  /** Resolved once during selection — see lib/camera-preview. */
+  media: { kind: PreviewKind; url: string };
 }
 
-/** Cache-buster: these feeds are one URL that returns a new frame each time. */
-function freshen(url: string): string {
-  return url.includes('?') ? `${url}&_t=${Date.now()}` : `${url}?_t=${Date.now()}`;
+interface MediaProps {
+  cam: PreviewCamera;
+  onReady: () => void;
+  onFail: () => void;
+}
+
+const FIT = 'h-full w-full object-cover transition-opacity duration-500';
+
+/** Snapshot and MJPEG feeds: an <img>, re-requested only if its kind needs it. */
+function ImageMedia({ cam: camera, onReady, onFail }: MediaProps) {
+  const { kind, url } = camera.media;
+  const every = refreshInterval(kind);
+  const [src, setSrc] = useState(() => (every ? freshen(url) : url));
+
+  useEffect(() => {
+    if (!every) return;
+    /* Staggered, so eight tiles do not all hit their origin on the same tick. */
+    let interval: ReturnType<typeof setInterval> | undefined;
+    const first = setTimeout(() => {
+      setSrc(freshen(url));
+      interval = setInterval(() => setSrc(freshen(url)), every);
+    }, every + Math.random() * 2000);
+    return () => {
+      clearTimeout(first);
+      if (interval) clearInterval(interval);
+    };
+  }, [url, every]);
+
+  return (
+    /* eslint-disable-next-line @next/next/no-img-element -- remote camera frames, no loader */
+    <img
+      src={src}
+      alt={camera.name}
+      width={TILE_W}
+      height={IMG_H}
+      className={FIT}
+      onLoad={onReady}
+      onError={onFail}
+      draggable={false}
+    />
+  );
+}
+
+/**
+ * MP4 clips and HLS streams.
+ *
+ * Muted and inline, which is what browsers require before they will autoplay
+ * anything without a gesture. hls.js is imported only when an HLS tile is
+ * actually on screen: it is a decoder, and the overwhelming majority of tiles
+ * never need it.
+ */
+function VideoMedia({ cam: camera, onReady, onFail }: MediaProps) {
+  const { kind, url } = camera.media;
+  const ref = useRef<HTMLVideoElement>(null);
+  /* MP4 clips are a few seconds long and loop, so they go stale; re-pointing
+     the element is what refreshes them. HLS is already live and returns 0. */
+  const [cacheBust, setCacheBust] = useState(0);
+  const every = refreshInterval(kind);
+
+  useEffect(() => {
+    if (!every) return;
+    const t = setInterval(() => setCacheBust(n => n + 1), every + Math.random() * 4000);
+    return () => clearInterval(t);
+  }, [every]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    if (kind === 'mp4') {
+      el.src = cacheBust ? freshen(url) : url;
+      el.play().catch(() => { /* autoplay refused: the frame still shows */ });
+      return;
+    }
+
+    /* HLS: the decoder first, native playback only as the fallback — the same
+       order the full viewer uses. Chrome answers `canPlayType` for HLS with
+       "maybe" whether or not the build can actually decode it, so trusting it
+       first would leave a dead tile on every build that cannot. */
+    let cancelled = false;
+    let hls: { destroy: () => void } | null = null;
+    import('hls.js').then(({ default: Hls }) => {
+      if (cancelled || !ref.current) return;
+      if (!Hls.isSupported()) {
+        if (ref.current.canPlayType('application/vnd.apple.mpegurl')) {
+          ref.current.src = url;
+          ref.current.play().catch(() => {});
+        } else {
+          onFail();
+        }
+        return;
+      }
+      /* A short buffer: eight of these would otherwise each hold seconds of
+         video for a tile the size of a postage stamp. */
+      const instance = new Hls({ enableWorker: false, maxBufferLength: 6 });
+      hls = instance;
+      instance.on(Hls.Events.ERROR, (_e, data) => { if (data.fatal) onFail(); });
+      instance.loadSource(url);
+      instance.attachMedia(ref.current);
+      ref.current.play().catch(() => {});
+    }).catch(onFail);
+
+    return () => { cancelled = true; hls?.destroy(); };
+  }, [kind, url, cacheBust, onFail]);
+
+  return (
+    <video
+      ref={ref}
+      className={FIT}
+      muted
+      playsInline
+      loop
+      autoPlay
+      preload="auto"
+      onLoadedData={onReady}
+      onError={onFail}
+    />
+  );
 }
 
 function Tile({ cam: camera, onOpen }: { cam: PreviewCamera; onOpen: (cam: PreviewCamera) => void }) {
-  const [src, setSrc] = useState(() => freshen(camera.feed_url));
   const [failed, setFailed] = useState(false);
   const [loaded, setLoaded] = useState(false);
 
   /* No reset needed on the way in: each tile is keyed by camera id, so a slot
      changing hands remounts this component with fresh state. */
-  useEffect(() => {
-    /* Staggered, so eight tiles do not all hit their origin on the same tick. */
-    let interval: ReturnType<typeof setInterval> | undefined;
-    const first = setTimeout(() => {
-      setSrc(freshen(camera.feed_url));
-      interval = setInterval(() => setSrc(freshen(camera.feed_url)), REFRESH_MS);
-    }, REFRESH_MS + Math.random() * 2000);
-
-    return () => {
-      clearTimeout(first);
-      if (interval) clearInterval(interval);
-    };
-  }, [camera.feed_url]);
+  const onReady = useCallback(() => setLoaded(true), []);
+  const onFail = useCallback(() => setFailed(true), []);
 
   /* A camera that will not load is worse than no tile: it is a broken box
      sitting over the map claiming to be a feed. */
@@ -135,18 +243,11 @@ function Tile({ cam: camera, onOpen }: { cam: PreviewCamera; onOpen: (cam: Previ
           boxShadow: '0 6px 20px rgba(0,0,0,0.65)',
         }}
       >
-        {/* eslint-disable-next-line @next/next/no-img-element -- remote camera frames, no loader */}
-        <img
-          src={src}
-          alt={camera.name}
-          width={TILE_W}
-          height={IMG_H}
-          className="h-full w-full object-cover transition-opacity duration-500"
-          style={{ opacity: loaded ? 1 : 0 }}
-          onLoad={() => setLoaded(true)}
-          onError={() => setFailed(true)}
-          draggable={false}
-        />
+        <div className="h-full w-full transition-opacity duration-500" style={{ opacity: loaded ? 1 : 0 }}>
+          {VIDEO_KINDS.has(camera.media.kind)
+            ? <VideoMedia cam={camera} onReady={onReady} onFail={onFail} />
+            : <ImageMedia cam={camera} onReady={onReady} onFail={onFail} />}
+        </div>
 
         {/* Two cosmetic passes over the picture: scanlines, for the same CRT
             read the full viewer already has, and an inner vignette so a bright
@@ -277,11 +378,13 @@ function CctvPreviews({ mapRef, active, onOpen }: {
     for (const f of feats) {
       const p = (f.properties ?? {}) as Record<string, unknown>;
       const id = String(p.id ?? '');
-      const feed = String(p.feed_url ?? '');
-      /* Absent stream_type means a snapshot feed, the same default the full
-         viewer uses. Anything else needs a player, so it stays a dot. */
-      const kind = String(p.stream_type ?? 'jpg');
-      if (!id || seen.has(id) || !feed || kind !== 'jpg') continue;
+      if (!id || seen.has(id)) continue;
+
+      const str = (k: string) => (p[k] ? String(p[k]) : undefined);
+      /* What this camera can actually show in a tile. Null means it needs an
+         embed, or has no usable URL — either way it stays a dot. */
+      const media = previewMedia({ stream_type: str('stream_type'), feed_url: str('feed_url'), stream_url: str('stream_url') });
+      if (!media) continue;
 
       const coords = (f.geometry as { coordinates?: [number, number] })?.coordinates;
       if (!coords) continue;
@@ -294,13 +397,14 @@ function CctvPreviews({ mapRef, active, onOpen }: {
           name: String(p.name ?? 'CAMERA'),
           lng: coords[0],
           lat: coords[1],
-          feed_url: feed,
-          city: p.city ? String(p.city) : undefined,
-          country: p.country ? String(p.country) : undefined,
-          source: p.source ? String(p.source) : undefined,
-          stream_url: p.stream_url ? String(p.stream_url) : undefined,
-          stream_type: p.stream_type ? String(p.stream_type) : undefined,
-          external_url: p.external_url ? String(p.external_url) : undefined,
+          feed_url: String(p.feed_url ?? ''),
+          city: str('city'),
+          country: str('country'),
+          source: str('source'),
+          stream_url: str('stream_url'),
+          stream_type: str('stream_type'),
+          external_url: str('external_url'),
+          media,
         },
         box: layout(pt, canvas.clientWidth, canvas.clientHeight),
         d: (pt.x - cx) ** 2 + (pt.y - cy) ** 2,
@@ -312,10 +416,18 @@ function CctvPreviews({ mapRef, active, onOpen }: {
        unusable smear rather than as several cameras. */
     candidates.sort((a, b) => a.d - b.d);
     const picked: typeof candidates = [];
+    let videos = 0;
     for (const c of candidates) {
       if (picked.length >= MAX_TILES) break;
+      /* Decoding is the expensive part, so the moving tiles are rationed
+         separately. A video camera past the cap is skipped rather than
+         ending the search: the snapshot behind it can still have the slot. */
+      const isVideo = VIDEO_KINDS.has(c.cam.media.kind);
+      if (isVideo && videos >= MAX_VIDEO_TILES) continue;
       const clash = picked.some(p => Math.abs(p.box.x - c.box.x) < TILE_W + 8 && Math.abs(p.box.y - c.box.y) < TILE_H + GAP);
-      if (!clash) picked.push(c);
+      if (clash) continue;
+      picked.push(c);
+      if (isVideo) videos++;
     }
 
     setCams(prev => {

--- a/src/lib/camera-preview.test.ts
+++ b/src/lib/camera-preview.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { previewMedia, refreshInterval, VIDEO_KINDS, type PreviewKind } from './camera-preview';
+
+describe('previewMedia', () => {
+  it('treats a missing stream_type as a snapshot, like the full viewer', () => {
+    expect(previewMedia({ feed_url: 'https://x/cam.jpg' })).toEqual({ kind: 'jpg', url: 'https://x/cam.jpg' });
+  });
+
+  it('gives Quebec 511 cameras a tile', () => {
+    // 675 of these, and every one of them was a bare dot at every zoom.
+    const qc = { stream_type: 'mp4', stream_url: 'https://www.quebec511.info/Carte/Fenetres/camera.ashx?id=4057&format=mp4' };
+    expect(previewMedia(qc)).toEqual({ kind: 'mp4', url: qc.stream_url });
+  });
+
+  it('gives HLS webcams a tile', () => {
+    const hls = { stream_type: 'hls', stream_url: 'https://ls.example/live/x.m3u8' };
+    expect(previewMedia(hls)).toEqual({ kind: 'hls', url: hls.stream_url });
+  });
+
+  it('reads MJPEG off stream_url', () => {
+    expect(previewMedia({ stream_type: 'mjpeg', stream_url: 'https://x/stream' }))
+      .toEqual({ kind: 'mjpeg', url: 'https://x/stream' });
+  });
+
+  it('leaves embeds as dots', () => {
+    // Eight YouTube players over the map is a different feature.
+    expect(previewMedia({ stream_type: 'iframe', stream_url: 'https://youtube.com/embed/x' })).toBeNull();
+  });
+
+  it('leaves a kind it does not know as a dot', () => {
+    expect(previewMedia({ stream_type: 'rtsp', stream_url: 'rtsp://x/1' })).toBeNull();
+  });
+
+  it('refuses a camera whose URL for its own kind is missing or blank', () => {
+    expect(previewMedia({ stream_type: 'mp4' })).toBeNull();
+    expect(previewMedia({ stream_type: 'mp4', feed_url: 'https://x/cam.jpg' })).toBeNull();
+    expect(previewMedia({ stream_type: 'hls', stream_url: '   ' })).toBeNull();
+    expect(previewMedia({})).toBeNull();
+  });
+
+  it('falls back to stream_url for a snapshot that only carries one', () => {
+    expect(previewMedia({ stream_type: 'jpg', stream_url: 'https://x/snap.jpg' }))
+      .toEqual({ kind: 'jpg', url: 'https://x/snap.jpg' });
+  });
+
+  it('is not confused by the case a source writes its type in', () => {
+    expect(previewMedia({ stream_type: 'MP4', stream_url: 'https://x/c.mp4' })?.kind).toBe('mp4');
+    expect(previewMedia({ stream_type: 'HLS', stream_url: 'https://x/c.m3u8' })?.kind).toBe('hls');
+  });
+});
+
+describe('refreshInterval', () => {
+  it('re-requests snapshots often enough to look live', () => {
+    expect(refreshInterval('jpg')).toBe(15000);
+  });
+
+  it('re-points MP4 clips far less often, because that restarts playback', () => {
+    expect(refreshInterval('mp4')).toBeGreaterThan(refreshInterval('jpg'));
+  });
+
+  it('never re-points a continuous stream', () => {
+    // Re-pointing an HLS or MJPEG source tears down a stream that is already live.
+    expect(refreshInterval('hls')).toBe(0);
+    expect(refreshInterval('mjpeg')).toBe(0);
+  });
+});
+
+describe('VIDEO_KINDS', () => {
+  it('is exactly the kinds that need a video element', () => {
+    const kinds: PreviewKind[] = ['jpg', 'mjpeg', 'mp4', 'hls'];
+    expect(kinds.filter(k => VIDEO_KINDS.has(k))).toEqual(['mp4', 'hls']);
+  });
+});

--- a/src/lib/camera-preview.ts
+++ b/src/lib/camera-preview.ts
@@ -1,0 +1,77 @@
+/**
+ * OSIRIS — what a camera can show inside a map preview tile.
+ *
+ * The tiles started out as JPEG snapshots only. That left Quebec 511 — 675
+ * cameras, every one of them an MP4 clip — and the 75 HLS webcams as bare dots
+ * at every zoom, which reads as "no camera here" rather than "this one needs a
+ * player". Both play in a `<video>`, so both can have a tile.
+ *
+ * Kept out of the component so the rules are testable without a map.
+ */
+
+export type PreviewKind = 'jpg' | 'mjpeg' | 'mp4' | 'hls';
+
+/** Fields of a camera record this module reads. */
+export interface PreviewSource {
+  stream_type?: string;
+  feed_url?: string;
+  stream_url?: string;
+}
+
+/** Kinds that need a `<video>` rather than an `<img>`. */
+export const VIDEO_KINDS: ReadonlySet<PreviewKind> = new Set<PreviewKind>(['mp4', 'hls']);
+
+/**
+ * The URL a tile should render, and how.
+ *
+ * `null` means the camera stays a dot: either it is an embed (a YouTube or
+ * operator page — eight of those in iframes over the map is a different
+ * feature with a far worse frame budget) or the record has no usable URL for
+ * the kind it claims to be.
+ */
+export function previewMedia(cam: PreviewSource): { kind: PreviewKind; url: string } | null {
+  /* Absent stream_type means a snapshot feed, the same default the full viewer
+     uses. */
+  const declared = (cam.stream_type ?? 'jpg').toLowerCase();
+
+  if (declared === 'mp4' || declared === 'hls') {
+    const url = cam.stream_url?.trim();
+    return url ? { kind: declared, url } : null;
+  }
+
+  if (declared === 'mjpeg') {
+    /* A single response that never ends, so it is an <img> like a snapshot —
+       but it must not be cache-busted, or every refresh restarts the stream. */
+    const url = cam.stream_url?.trim();
+    return url ? { kind: 'mjpeg', url } : null;
+  }
+
+  if (declared === 'jpg') {
+    const url = cam.feed_url?.trim() || cam.stream_url?.trim();
+    return url ? { kind: 'jpg', url } : null;
+  }
+
+  // iframe, and anything unrecognised.
+  return null;
+}
+
+/** Cache-buster: snapshot feeds are one URL that returns a new frame each time. */
+export function freshen(url: string): string {
+  return url.includes('?') ? `${url}&_t=${Date.now()}` : `${url}?_t=${Date.now()}`;
+}
+
+/**
+ * How often a tile should re-request, in ms — or 0 for the kinds that keep
+ * themselves current.
+ *
+ * A snapshot is one still frame, so it has to be re-fetched to look live. MP4
+ * clips are short and loop, so they go stale too, but re-pointing a `<video>`
+ * restarts playback: doing that on the snapshot cadence would make every clip
+ * stutter every 15 seconds, so they refresh far less often. HLS and MJPEG are
+ * continuous streams and must never be re-pointed.
+ */
+export function refreshInterval(kind: PreviewKind): number {
+  if (kind === 'jpg') return 15000;
+  if (kind === 'mp4') return 60000;
+  return 0;
+}


### PR DESCRIPTION
Zoom in on Quebec and every camera stayed a dot.

All 675 Quebec 511 cameras are `stream_type: 'mp4'` with no `feed_url`, and the preview tiles only ever accepted JPEG snapshots:

```ts
const kind = String(p.stream_type ?? 'jpg');
if (!id || seen.has(id) || !feed || kind !== 'jpg') continue;
```

So the map said "no camera here" where it meant "this one needs a player". The 75 HLS webcams and the one MJPEG stream were in the same position.

## What now gets a tile

| kind | count | rendered as |
| --- | --- | --- |
| jpg | 18,162 | `<img>` — unchanged |
| **mp4** (Quebec 511) | **675** | `<video>`, muted and inline so it autoplays without a gesture |
| **hls** | **75** | hls.js, imported only when an HLS tile is actually on screen |
| **mjpeg** | **1** | `<img>`, which is what it already is |
| iframe | 49 | still a dot |

Embeds stay dots deliberately. Eight YouTube players floating over the map is a different feature, and not one the frame budget can pay for.

## Rationing the decoders

Decoding is the cost that matters, so the moving tiles are limited on their own: **at most four at once** out of the eight slots. A video camera past the cap is skipped rather than ending the search, so a snapshot behind it can still take the slot.

## Refresh cadence follows the feed

A snapshot is one still frame and has to be re-fetched to look live — the existing 15s. An MP4 clip is a few seconds long and loops, so it goes stale too, but re-pointing a `<video>` restarts playback: on the snapshot cadence every clip would stutter every 15 seconds, so those refresh at 60s. HLS and MJPEG are already continuous and are never re-pointed.

hls.js is tried **before** native playback, matching the full viewer. Chrome answers `canPlayType('application/vnd.apple.mpegurl')` with `"maybe"` whether or not the build can actually decode HLS, so trusting it first leaves a dead tile on every build that cannot.

## This looks like a proxy job and is not

Quebec 511 sits behind Cloudflare, which refuses the server outright. Same machine, same IP, same User-Agent, at the same moment:

```
curl  #1: 200 video/mp4
node  #1: 403 text/html
curl  #2: 200 video/mp4
```

It is the TLS fingerprint, not the headers — no server-side proxy can fetch these. The browser is a real browser and simply plays the URL, which is why these go direct rather than through `/api/cctv/proxy`. (I had whitelisted `quebec511.info` there before measuring this; reverted, since it cannot work.)

## Verified in the browser

- **Montréal** — 20 cameras in view, 4 tiles, all 4 playing (`readyState 4`, 352×240)
- **Cap** — 24 cameras in view at z13.2 → exactly 4 video tiles
- **Mixed** — Ottawa/Gatineau: 5 tiles = 3 video + 2 snapshots, coexisting
- **HLS** — Dębki, Poland: playing through hls.js (blob source), 2688×1520, clock advancing

The rules for which URL a camera plays, and how often, live in `lib/camera-preview` with 13 tests; the component keeps the DOM. 447 tests pass, lint clean, production build OK.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
