### PR TITLE
feat(cctv): live Nevada and Indiana camera feeds, and a switch for the preview tiles

### DIFF
--- a/src/app/api/cctv/ibi511.ts
+++ b/src/app/api/cctv/ibi511.ts
@@ -1,0 +1,36 @@
+/**
+ * OSIRIS — helpers for the IBI 511 traveler-information platform.
+ *
+ * Several state DOTs run the same vendor stack behind different domains, and
+ * they all expose cameras the same way: a DataTables endpoint at
+ * `/List/GetData/Cameras` that pages 100 rows at a time, with each row's
+ * position as WKT. Utah and Nevada both read through here.
+ */
+
+/** Build the URL-encoded DataTables `query` parameter for a given page. */
+export function buildQuery(start: number, length: number): string {
+  const query = {
+    columns: [
+      { data: null, name: '' },
+      { name: 'sortOrder', s: true },
+      { name: 'roadway', s: true },
+      { data: 3, name: '' },
+    ],
+    order: [{ column: 1, dir: 'asc' }],
+    start,
+    length,
+    search: { value: '' },
+  };
+  return encodeURIComponent(JSON.stringify(query));
+}
+
+/** Parse a `POINT (lng lat)` WKT string into coordinates. */
+export function parseWkt(wkt?: string | null): { lat: number; lng: number } | null {
+  if (!wkt) return null;
+  const m = wkt.match(/POINT\s*\(\s*(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s*\)/i);
+  if (!m) return null;
+  const lng = parseFloat(m[1]);
+  const lat = parseFloat(m[2]);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  return { lat, lng };
+}

--- a/src/app/api/cctv/indiana.test.ts
+++ b/src/app/api/cctv/indiana.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { mapFeature, cleanTitle, streamUrl, type IndotFeature } from './indiana';
+
+/** A live camera, verbatim from 511in.org's MapFeatures response. */
+const liveCamera: IndotFeature = {
+  title: 'I-94: 1-094-035-8-1 E OF US421',
+  uri: 'camera/21504',
+  features: [{ geometry: { coordinates: [-86.86994, 41.66028] } }],
+  __typename: 'Camera',
+  active: true,
+  views: [{ url: 'https://public.carsprogram.org/cameras/IN/INDOT_528_sdRf2LeZp7VYFgcF.flv.png', category: 'VIDEO' }],
+};
+
+describe('mapFeature', () => {
+  it('maps a live camera to an HLS stream', () => {
+    expect(mapFeature(liveCamera)).toEqual({
+      id: 'indot-21504',
+      lat: 41.66028,
+      lng: -86.86994,
+      name: 'I-94: E OF US421',
+      city: 'Indiana',
+      country: 'US',
+      stream_url: 'https://skysfs4.trafficwise.org/preroll/INDOT_528_sdRf2LeZp7VYFgcF/playlist.m3u8',
+      stream_type: 'hls',
+      external_url: 'https://511in.org/@41.66028,-86.86994,14?show=camera%2F21504',
+      source: 'INDOT TrafficWise',
+    });
+  });
+
+  it('drops a camera whose feed is a placeholder icon, not a stream', () => {
+    expect(mapFeature({
+      ...liveCamera,
+      views: [{ url: '/images/icon-camera-closed-fill-solid-padded.svg', category: 'VIDEO' }],
+    })).toBeNull();
+  });
+
+  it('drops inactive cameras and non-camera features', () => {
+    expect(mapFeature({ ...liveCamera, active: false })).toBeNull();
+    expect(mapFeature({ ...liveCamera, __typename: 'Event' })).toBeNull();
+  });
+
+  it('drops coordinates outside Indiana', () => {
+    // Same record, moved to Los Angeles.
+    expect(mapFeature({
+      ...liveCamera,
+      features: [{ geometry: { coordinates: [-118.24, 34.05] } }],
+    })).toBeNull();
+  });
+
+  it('drops a record with no coordinates or no id', () => {
+    expect(mapFeature({ ...liveCamera, features: [] })).toBeNull();
+    expect(mapFeature({ ...liveCamera, uri: null })).toBeNull();
+  });
+});
+
+describe('cleanTitle', () => {
+  it('strips the internal asset number but keeps route and place', () => {
+    expect(cleanTitle('I-94: 1-094-035-8-1 E OF US421')).toBe('I-94: E OF US421');
+    expect(cleanTitle('I-65: 1-065-172-4-2 SR-38')).toBe('I-65: SR-38');
+  });
+
+  it('keeps the original when the place is glued onto the number', () => {
+    // No space to cut at, so guessing where the number ends would mangle it.
+    expect(cleanTitle('I-94: 1-094-041-0-2NORTH OF WARNKE RD')).toBe('I-94: 1-094-041-0-2NORTH OF WARNKE RD');
+  });
+
+  it('strips lowercase camera suffixes inside the asset number', () => {
+    expect(cleanTitle('I-70: 1-070-064-6-eb-ra-cam-1 REST PARK PLAINFIELD EB'))
+      .toBe('I-70: REST PARK PLAINFIELD EB');
+  });
+
+  it('leaves a title with no asset number alone', () => {
+    expect(cleanTitle('US-31 at Main St')).toBe('US-31 at Main St');
+  });
+});
+
+describe('streamUrl', () => {
+  it('builds the playlist URL from the camera token', () => {
+    expect(streamUrl('INDOT_755_39XmtxVzQBD4XQVb'))
+      .toBe('https://skysfs4.trafficwise.org/preroll/INDOT_755_39XmtxVzQBD4XQVb/playlist.m3u8');
+  });
+});

--- a/src/app/api/cctv/indiana.ts
+++ b/src/app/api/cctv/indiana.ts
@@ -1,0 +1,161 @@
+import type { CctvCamera } from './types';
+import { stealthFetch } from '@/lib/stealthFetch';
+import { cachedSource } from '@/lib/sourceCache';
+
+/**
+ * OSIRIS — Indiana CCTV Cameras (INDOT TrafficWise / 511in.org)
+ * Source: https://511in.org/api/graphql — the CARS 511 platform's map query
+ * ~730 statewide traffic cameras — NO API KEY NEEDED.
+ *
+ * Every INDOT camera is video. The API hands back a poster frame
+ * (`…/INDOT_528_sdRf2LeZp7VYFgcF.flv.png`) that does refresh, but only about
+ * once a minute. The live feed is HLS, keyed by the same `INDOT_{id}_{token}`
+ * the poster URL carries, which is what `streamUrl` rebuilds — the API never
+ * gives out the playlist address itself.
+ *
+ * The stream starts cold: the first request gets a short `PreRoll` filler loop
+ * while the encoder session spins up, and real segments follow within ~20s. A
+ * tile sits in LINKING until then.
+ */
+
+const GRAPHQL = 'https://511in.org/api/graphql';
+
+/** Indiana bounding box — drops any stray/placeholder coordinates. */
+const IN_BOUNDS = { minLat: 37.7, maxLat: 41.9, minLng: -88.2, maxLng: -84.6 };
+
+/**
+ * The streaming edge, and it has to be this one. skysfs1 and skysfs2 answer
+ * every request with HTTP 200, which reads as healthy, but what they serve is
+ * the two-segment `PreRoll` placeholder loop and never anything else — polled
+ * for two minutes straight a camera there never reaches a `media_*.ts`
+ * segment. Only skysfs4 hands over the real feed.
+ */
+const STREAM_HOST = 'https://skysfs4.trafficwise.org';
+
+/** Pulls the poster URL apart; the token half is what the stream is keyed by. */
+const POSTER = /\/cameras\/IN\/(INDOT_\d+_[A-Za-z0-9_-]+)\.flv\.png$/;
+
+/**
+ * A view's `url` lives on CameraView, not on the interface `views` returns, so
+ * it has to come through an inline fragment. Selecting it bare validates as an
+ * error and the server answers those with a 400, not a message.
+ */
+const QUERY = `query MapFeatures($input: MapFeaturesArgs!) {
+  mapFeaturesQuery(input: $input) {
+    mapFeatures {
+      title
+      uri
+      features { geometry }
+      __typename
+      ... on Camera { active views(limit: 1) { category ... on CameraView { url } } }
+    }
+    error { message }
+  }
+}`;
+
+export interface IndotFeature {
+  title?: string | null;
+  uri?: string | null;
+  features?: Array<{ geometry?: { coordinates?: [number, number] } | null }> | null;
+  __typename?: string | null;
+  active?: boolean | null;
+  views?: Array<{ url?: string | null; category?: string | null }> | null;
+}
+
+/** The HLS playlist for a camera token. Exported for tests. */
+export function streamUrl(token: string): string {
+  return `${STREAM_HOST}/preroll/${token}/playlist.m3u8`;
+}
+
+/**
+ * INDOT titles read `I-94: 1-094-035-8-1 E OF US421` — a route, then an
+ * internal asset number, then the actual place. The asset number is noise on a
+ * map label, so it goes.
+ *
+ * Only when it is cleanly delimited, though. Fifty-odd titles have the place
+ * glued straight onto the number (`1-094-041-0-2NORTH OF WARNKE RD`), and
+ * nothing says where the number ends — so those keep their original title
+ * rather than get cut down to `-2NORTH OF WARNKE RD`.
+ */
+export function cleanTitle(title: string): string {
+  return title
+    .replace(/(^|:\s*)\d+(?:-[0-9a-z_]+)*\s+/, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Map one map feature to a camera, or null if unusable. Exported for tests. */
+export function mapFeature(f: IndotFeature): CctvCamera | null {
+  if (f?.__typename !== 'Camera' || f.active === false) return null;
+
+  /* Cameras that are down come back with an icon in place of a feed. */
+  const url = f.views?.[0]?.url || '';
+  const token = url.match(POSTER)?.[1];
+  if (!token) return null;
+
+  const coords = f.features?.[0]?.geometry?.coordinates;
+  if (!coords) return null;
+  const [lng, lat] = coords;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  if (lat < IN_BOUNDS.minLat || lat > IN_BOUNDS.maxLat) return null;
+  if (lng < IN_BOUNDS.minLng || lng > IN_BOUNDS.maxLng) return null;
+
+  const id = f.uri?.match(/camera\/(\d+)/)?.[1];
+  if (!id) return null;
+
+  return {
+    id: `indot-${id}`,
+    lat,
+    lng,
+    name: cleanTitle(f.title || '') || `INDOT Camera ${id}`,
+    city: 'Indiana',
+    country: 'US',
+    stream_url: streamUrl(token),
+    stream_type: 'hls',
+    external_url: `https://511in.org/@${lat},${lng},14?show=${encodeURIComponent(f.uri || '')}`,
+    source: 'INDOT TrafficWise',
+  };
+}
+
+async function loadIndianaCameras(): Promise<CctvCamera[]> {
+  const res = await stealthFetch(GRAPHQL, {
+    method: 'POST',
+    signal: AbortSignal.timeout(20000),
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json', Referer: 'https://511in.org/' },
+    body: JSON.stringify({
+      query: QUERY,
+      /* One query for the whole state. `zoom` is what decides clustering, so it
+         has to be high enough that the server returns cameras and not clusters. */
+      variables: {
+        input: {
+          north: IN_BOUNDS.maxLat,
+          south: IN_BOUNDS.minLat,
+          east: IN_BOUNDS.maxLng,
+          west: IN_BOUNDS.minLng,
+          zoom: 16,
+          layerSlugs: ['normalCameras'],
+          nonClusterableUris: null,
+        },
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`511in HTTP ${res.status}`);
+
+  const json = await res.json();
+  const feats = json?.data?.mapFeaturesQuery?.mapFeatures;
+  if (!Array.isArray(feats)) throw new Error('511in returned no mapFeatures');
+
+  const cams: CctvCamera[] = [];
+  const seen = new Set<string>();
+  for (const f of feats) {
+    const cam = mapFeature(f);
+    if (!cam || seen.has(cam.id)) continue;
+    seen.add(cam.id);
+    cams.push(cam);
+  }
+
+  console.log(`[OSIRIS] Indiana cameras — INDOT TrafficWise: ${cams.length}`);
+  return cams;
+}
+
+export const fetchIndianaCameras = cachedSource('indiana', loadIndianaCameras);

--- a/src/app/api/cctv/nevada.test.ts
+++ b/src/app/api/cctv/nevada.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { mapRecord, type NevadaCameraRecord } from './nevada';
+
+/** A representative row from /List/GetData/Cameras. */
+const sample: NevadaCameraRecord = {
+  id: 2,
+  roadway: 'McCarran & Caughlin/cashill',
+  location: 'N/A',
+  latLng: { geography: { wellKnownText: 'POINT (-119.8 39.5)' } },
+  images: [{
+    id: 2,
+    description: 'McCarran & Caughlin/cashill',
+    imageUrl: '/map/Cctv/2',
+    videoUrl: 'https://d2wse2.its.nv.gov:443/renoxcd02/abc_public.stream/playlist.m3u8',
+    blocked: false,
+    disabled: false,
+  }],
+};
+
+describe('mapRecord', () => {
+  it('takes the HLS URL straight from the feed, and keeps the snapshot', () => {
+    expect(mapRecord(sample)).toEqual({
+      id: 'ndot-2',
+      lat: 39.5,
+      lng: -119.8,
+      name: 'McCarran & Caughlin/cashill',
+      city: 'Nevada',
+      country: 'US',
+      feed_url: 'https://www.nvroads.com/map/Cctv/2',
+      stream_url: 'https://d2wse2.its.nv.gov:443/renoxcd02/abc_public.stream/playlist.m3u8',
+      stream_type: 'hls',
+      source: 'NDOT',
+    });
+  });
+
+  it('falls back to a snapshot when the camera has no video', () => {
+    const cam = mapRecord({
+      ...sample,
+      images: [{ ...sample.images![0], videoUrl: null }],
+    });
+    expect(cam?.feed_url).toBe('https://www.nvroads.com/map/Cctv/2');
+    expect(cam?.stream_url).toBeUndefined();
+    expect(cam?.stream_type).toBeUndefined();
+  });
+
+  it('ignores a video feed the operator has switched off', () => {
+    const cam = mapRecord({
+      ...sample,
+      images: [{ ...sample.images![0], videoDisabled: true }],
+    });
+    expect(cam?.stream_url).toBeUndefined();
+    expect(cam?.feed_url).toBe('https://www.nvroads.com/map/Cctv/2');
+  });
+
+  it('drops blocked, disabled and imageless rows', () => {
+    expect(mapRecord({ ...sample, images: [{ ...sample.images![0], blocked: true }] })).toBeNull();
+    expect(mapRecord({ ...sample, images: [{ ...sample.images![0], disabled: true }] })).toBeNull();
+    expect(mapRecord({ ...sample, images: [] })).toBeNull();
+  });
+
+  it('drops coordinates outside Nevada', () => {
+    // The same camera, moved to Miami.
+    expect(mapRecord({
+      ...sample,
+      latLng: { geography: { wellKnownText: 'POINT (-80.19 25.76)' } },
+    })).toBeNull();
+    expect(mapRecord({ ...sample, latLng: null })).toBeNull();
+  });
+
+  it('names a camera by its id when the feed has nothing useful', () => {
+    expect(mapRecord({
+      ...sample,
+      roadway: null,
+      location: 'N/A',
+      images: [{ ...sample.images![0], description: null }],
+    })?.name).toBe('NDOT Camera 2');
+  });
+});

--- a/src/app/api/cctv/nevada.ts
+++ b/src/app/api/cctv/nevada.ts
@@ -1,0 +1,131 @@
+import { stealthFetch } from '@/lib/stealthFetch';
+import { cachedSource } from '@/lib/sourceCache';
+import { buildQuery, parseWkt } from './ibi511';
+import type { CctvCamera } from './types';
+
+/**
+ * OSIRIS — Nevada CCTV Cameras (NDOT / nvroads.com)
+ * Source: https://www.nvroads.com — the same IBI 511 stack Utah runs on
+ * Data endpoint: /List/GetData/Cameras (DataTables, 100 rows/page)
+ * ~600 statewide traffic cameras — NO API KEY NEEDED.
+ *
+ * Unlike Indiana, nothing here has to be reconstructed: each row carries its
+ * own `videoUrl`, already a full HLS playlist address on whichever of NDOT's
+ * eight `*.its.nv.gov` edges serves that camera. 587 of the 600 have one, and
+ * those streams answer with `Access-Control-Allow-Origin: *`, so they play in
+ * a tile as they are. The remaining handful are snapshot-only and fall back to
+ * the JPEG at /map/Cctv/{imageId}.
+ */
+
+const BASE = 'https://www.nvroads.com';
+const PAGE_SIZE = 100; // the server caps a response at 100 rows whatever we ask for
+const MAX_PAGES = 20; // safety bound (~2000 cameras) so a bad total can't fan out forever
+
+/** Nevada bounding box — drops any mis-geocoded rows. */
+const NV_BOUNDS = { minLat: 34.9, maxLat: 42.1, minLng: -120.1, maxLng: -113.9 };
+
+/** One row from /List/GetData/Cameras (only the fields we consume). */
+export interface NevadaCameraRecord {
+  id: number;
+  roadway?: string | null;
+  location?: string | null;
+  latLng?: { geography?: { wellKnownText?: string | null } | null } | null;
+  images?: Array<{
+    id?: number;
+    description?: string | null;
+    imageUrl?: string | null;
+    videoUrl?: string | null;
+    blocked?: boolean;
+    disabled?: boolean;
+    videoDisabled?: boolean;
+  }> | null;
+}
+
+/** Map a raw record to a CctvCamera, or null if it should be skipped. */
+export function mapRecord(rec: NevadaCameraRecord): CctvCamera | null {
+  if (!rec || typeof rec.id !== 'number') return null;
+
+  const img = rec.images?.[0];
+  if (!img || img.blocked || img.disabled) return null;
+
+  const coords = parseWkt(rec.latLng?.geography?.wellKnownText);
+  if (!coords) return null;
+
+  const { lat, lng } = coords;
+  if (lat < NV_BOUNDS.minLat || lat > NV_BOUNDS.maxLat) return null;
+  if (lng < NV_BOUNDS.minLng || lng > NV_BOUNDS.maxLng) return null;
+
+  /* `location` is "N/A" on a good third of these, and `roadway` repeats the
+     camera description, so the picture's own caption is the best label. */
+  const name = img.description?.trim() || rec.location?.trim() || rec.roadway?.trim();
+
+  const snapshot = img.imageUrl ? `${BASE}${img.imageUrl}` : undefined;
+  const video = img.videoDisabled ? undefined : img.videoUrl?.trim() || undefined;
+  if (!snapshot && !video) return null;
+
+  return {
+    id: `ndot-${rec.id}`,
+    lat,
+    lng,
+    name: name && name !== 'N/A' ? name : `NDOT Camera ${rec.id}`,
+    city: 'Nevada',
+    country: 'US',
+    ...(snapshot ? { feed_url: snapshot } : {}),
+    ...(video ? { stream_url: video, stream_type: 'hls' as const } : {}),
+    source: 'NDOT',
+  };
+}
+
+async function fetchPage(start: number): Promise<NevadaCameraRecord[]> {
+  const url = `${BASE}/List/GetData/Cameras?query=${buildQuery(start, PAGE_SIZE)}&lang=en-US`;
+  const res = await stealthFetch(url, {
+    signal: AbortSignal.timeout(15000),
+    headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return Array.isArray(data?.data) ? data.data : [];
+}
+
+async function loadNevadaCameras(): Promise<CctvCamera[]> {
+  // The first page also tells us how many there are in total.
+  const first = await fetchPageWithTotal(0);
+  const seen = new Map<number, CctvCamera>();
+
+  const ingest = (rows: NevadaCameraRecord[]) => {
+    for (const rec of rows) {
+      const cam = mapRecord(rec);
+      if (cam) seen.set(rec.id, cam);
+    }
+  };
+  ingest(first.rows);
+
+  const starts: number[] = [];
+  for (let s = PAGE_SIZE; s < first.total && s < PAGE_SIZE * MAX_PAGES; s += PAGE_SIZE) {
+    starts.push(s);
+  }
+  const results = await Promise.allSettled(starts.map(fetchPage));
+  for (const r of results) {
+    if (r.status === 'fulfilled') ingest(r.value);
+  }
+
+  const cams = [...seen.values()];
+  console.log(`[OSIRIS] Nevada cameras — NDOT: ${cams.length}`);
+  return cams;
+}
+
+async function fetchPageWithTotal(start: number): Promise<{ rows: NevadaCameraRecord[]; total: number }> {
+  const url = `${BASE}/List/GetData/Cameras?query=${buildQuery(start, PAGE_SIZE)}&lang=en-US`;
+  const res = await stealthFetch(url, {
+    signal: AbortSignal.timeout(15000),
+    headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
+  });
+  if (!res.ok) throw new Error(`NDOT HTTP ${res.status}`);
+  const data = await res.json();
+  return {
+    rows: Array.isArray(data?.data) ? data.data : [],
+    total: Number(data?.recordsTotal) || 0,
+  };
+}
+
+export const fetchNevadaCameras = cachedSource('nevada', loadNevadaCameras);

--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -29,6 +29,8 @@ import { fetchAsiaLiveCameras } from './asia-live';
 import { fetchNewZealandCameras } from './newzealand';
 import { fetchOregonCameras } from './oregon';
 import { fetchMichiganCameras } from './michigan';
+import { fetchIndianaCameras } from './indiana';
+import { fetchNevadaCameras } from './nevada';
 import {
   fetchLatamLiveCameras,
   fetchAfricaLiveCameras,
@@ -456,6 +458,8 @@ const REGION_FETCHERS: Record<string, () => Promise<any[]>> = {
   'newzealand': fetchNewZealandCameras,
   'oregon': fetchOregonCameras,
   'michigan': fetchMichiganCameras,
+  'indiana': fetchIndianaCameras,
+  'nevada': fetchNevadaCameras,
   'latam-live': fetchLatamLiveCameras,
   'africa-live': fetchAfricaLiveCameras,
   'europe-live': fetchEuropeLiveCameras,
@@ -474,10 +478,14 @@ function getRegionsForBounds(lat: number, lng: number, radius: number): string[]
   if (lat > 36.9 && lat < 42.1 && lng > -114.2 && lng < -108.9) regions.push('utah');
   // Oregon (ODOT) — explicit, since us-west only covers WA + CA
   if (lat > 41.9 && lat < 46.3 && lng > -124.6 && lng < -116.4) regions.push('oregon');
+  // Nevada (NDOT) — explicit, since us-west only covers WA + CA
+  if (lat > 34.9 && lat < 42.1 && lng > -120.1 && lng < -113.9) regions.push('nevada');
   // US-Central
   if (lat > 24 && lat < 49 && lng > -105 && lng < -80) regions.push('us-central');
   // Michigan (MDOT) — explicit, since us-central only covers Illinois
   if (lat > 41.6 && lat < 48.3 && lng > -90.5 && lng < -82.1) regions.push('michigan');
+  // Indiana (INDOT TrafficWise) — explicit, since us-central only covers Illinois
+  if (lat > 37.7 && lat < 41.9 && lng > -88.2 && lng < -84.6) regions.push('indiana');
   // Canada
   if (lat > 42 && lat < 70 && lng > -141 && lng < -52) regions.push('canada');
   // Europe

--- a/src/app/api/cctv/utah.ts
+++ b/src/app/api/cctv/utah.ts
@@ -1,5 +1,9 @@
 import { stealthFetch } from '@/lib/stealthFetch';
 import type { CctvCamera } from './types';
+/* Shared with Nevada — both states run the same IBI 511 platform. */
+import { buildQuery, parseWkt } from './ibi511';
+
+export { buildQuery, parseWkt };
 
 /**
  * OSIRIS — Utah CCTV Cameras (UDOT Traffic / udottraffic.utah.gov)
@@ -29,34 +33,6 @@ export interface UtahCameraRecord {
     disabled?: boolean;
     videoDisabled?: boolean;
   }> | null;
-}
-
-/** Build the URL-encoded DataTables `query` parameter for a given page. */
-export function buildQuery(start: number, length: number): string {
-  const query = {
-    columns: [
-      { data: null, name: '' },
-      { name: 'sortOrder', s: true },
-      { name: 'roadway', s: true },
-      { data: 3, name: '' },
-    ],
-    order: [{ column: 1, dir: 'asc' }],
-    start,
-    length,
-    search: { value: '' },
-  };
-  return encodeURIComponent(JSON.stringify(query));
-}
-
-/** Parse a `POINT (lng lat)` WKT string into coordinates. */
-export function parseWkt(wkt?: string | null): { lat: number; lng: number } | null {
-  if (!wkt) return null;
-  const m = wkt.match(/POINT\s*\(\s*(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s*\)/i);
-  if (!m) return null;
-  const lng = parseFloat(m[1]);
-  const lat = parseFloat(m[2]);
-  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
-  return { lat, lng };
 }
 
 /** Map a raw record to a CctvCamera, or null if it should be skipped. */

--- a/src/app/api/malware/route.ts
+++ b/src/app/api/malware/route.ts
@@ -1,143 +1,41 @@
 import { NextResponse } from 'next/server';
+import { startMalwareFeed, malwareSnapshot, MALWARE_SOURCE } from '@/lib/malware-live';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * OSIRIS — Live Malware Feed (abuse.ch Feodo Tracker + URLhaus)
- * Source: abuse.ch — completely free, no auth for public feeds
- * Fetches botnet C2 servers & malware distribution URLs with geo-mapping.
+ * OSIRIS — Live Malware Feed (abuse.ch URLhaus)
+ *
+ * A snapshot of the live store. The store polls URLhaus on its own cadence and
+ * pushes to /api/malware/stream; this route is the point-in-time read for
+ * clients that do not hold a stream open, and the initial fill for those that
+ * do.
+ *
+ * The previous version of this route did the fetching itself, so every caller
+ * paid a full dump download plus a hundred geolocations. It also advertised
+ * "Feodo Tracker + URLhaus + ThreatFox" while never calling ThreatFox — whose
+ * API now requires an auth key and answers `Unauthorized` without one.
  */
-
-const COUNTRY_CENTROIDS: Record<string, [number, number]> = {
-  AF:[65,33],AL:[20,41],DZ:[3,28],AO:[18.5,-12.5],AR:[-64,-34],AM:[45,40],AU:[134,-25],AT:[14,47.5],AZ:[50,40.5],
-  BD:[90,24],BY:[28,53],BE:[4,50.8],BR:[-51,-10],BG:[25.5,42.7],CA:[-96,62],CL:[-71,-30],
-  CN:[105,35],CO:[-72,4],HR:[16,45.2],CZ:[15.5,49.8],DK:[10,56],EG:[30,27],FI:[26,64],
-  FR:[2,46],DE:[10,51],GR:[22,39],HK:[114.2,22.3],HU:[19.5,47],IN:[79,22],ID:[120,-5],
-  IR:[53,32],IQ:[44,33],IE:[-8,53],IL:[34.8,31.5],IT:[12.5,42.8],JP:[138,36],KZ:[67,48],
-  KE:[38,1],KR:[128,36],LT:[24,55.5],MY:[112,3],MX:[-102,23.5],NL:[5.5,52.5],NZ:[174,-41],
-  NG:[8,10],NO:[8,62],PK:[70,30],PA:[-80,9],PH:[122,12.5],PL:[19.5,52],PT:[-8,39.5],
-  RO:[25,46],RU:[100,60],SA:[45,25],SG:[103.8,1.35],ZA:[24,-29],ES:[-4,40],SE:[16,62],
-  CH:[8,47],TW:[121,23.7],TH:[101,15],TR:[35,39],UA:[32,49],AE:[54,24],GB:[-2,54],
-  US:[-97,38],VN:[106,16],
-};
-
 export async function GET() {
   try {
-    // Fetch Feodo Tracker botnet C2 servers (has country field)
-    const feodoRes = await fetch('https://feodotracker.abuse.ch/downloads/ipblocklist.json', {
-      signal: AbortSignal.timeout(10000),
-      cache: 'no-store',
-      headers: { 'User-Agent': 'OSIRIS/4.2', 'Accept': 'application/json' },
-    });
+    await startMalwareFeed();
+    const snap = malwareSnapshot();
 
-    console.log('[OSIRIS] Feodo response status:', feodoRes.status);
-
-    const threats: any[] = [];
-    let id = 0;
-
-    if (feodoRes.ok) {
-      const feodoData = await feodoRes.json();
-      const entries = Array.isArray(feodoData) ? feodoData : [];
-
-      for (const entry of entries.slice(0, 200)) {
-        const cc = entry.country;
-        if (!cc || !COUNTRY_CENTROIDS[cc]) continue;
-        const [lng, lat] = COUNTRY_CENTROIDS[cc];
-        // Jitter within country
-        const jLng = ((id * 173.7) % 200 - 100) / 100 * 4;
-        const jLat = ((id * 293.1) % 200 - 100) / 100 * 4;
-        threats.push({
-          id: `feodo-${id++}`,
-          lat: lat + jLat,
-          lng: lng + jLng,
-          ip: entry.ip_address || 'unknown',
-          port: entry.dst_port || 0,
-          malware: entry.malware || 'unknown',
-          status: entry.status || 'active',
-          first_seen: entry.first_seen,
-          last_online: entry.last_online,
-          country: cc,
-          threat_type: 'botnet_c2',
-        });
-      }
-    }
-
-    // 2. Fetch URLhaus active malware (CSV is free and open)
-    try {
-      const urlhausRes = await fetch('https://urlhaus.abuse.ch/downloads/csv_online/', {
-        signal: AbortSignal.timeout(10000),
-        cache: 'no-store'
-      });
-      if (urlhausRes.ok) {
-        const text = await urlhausRes.text();
-        const lines = text.split('\n').filter(l => !l.startsWith('#') && l.trim().length > 0);
-        
-        // Extract up to 100 unique IPv4 addresses
-        const ipMap = new Map<string, any>();
-        for (const line of lines) {
-          const cols = line.split('","'); // Simple CSV split since URLhaus uses "val","val"
-          if (cols.length > 3) {
-            const dateAdded = cols[1];
-            const url = cols[2];
-            const threat = cols[5] || 'malware';
-            
-            // Extract IPv4 from URL
-            const ipMatch = url.match(/https?:\/\/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})/);
-            if (ipMatch && ipMatch[1]) {
-              const ip = ipMatch[1];
-              if (!ipMap.has(ip)) {
-                ipMap.set(ip, { url, dateAdded, threat, ip });
-                if (ipMap.size >= 100) break; // limit to 100 for ip-api batch limit
-              }
-            }
-          }
-        }
-
-        // Batch Geolocate via ip-api.com (15 req/min free tier, max 100 per batch)
-        if (ipMap.size > 0) {
-          const ipsToGeo = Array.from(ipMap.keys());
-          const geoRes = await fetch('http://ip-api.com/batch', {
-            method: 'POST',
-            body: JSON.stringify(ipsToGeo),
-            headers: { 'Content-Type': 'application/json' },
-            signal: AbortSignal.timeout(10000)
-          });
-          
-          if (geoRes.ok) {
-            const geoData = await geoRes.json();
-            for (const geo of geoData) {
-              if (geo.status === 'success' && geo.lat && geo.lon) {
-                const info = ipMap.get(geo.query);
-                if (info) {
-                  threats.push({
-                    id: `urlhaus-${id++}`,
-                    lat: geo.lat,
-                    lng: geo.lon,
-                    ip: info.ip,
-                    port: info.url.includes('https') ? 443 : 80,
-                    malware: info.threat.replace(/"/g, ''),
-                    status: 'online',
-                    first_seen: info.dateAdded.replace(/"/g, '').split(' ')[0] || new Date().toISOString().split('T')[0],
-                    last_online: new Date().toISOString().split('T')[0],
-                    country: geo.countryCode || 'Unknown',
-                    threat_type: 'malware_url',
-                  });
-                }
-              }
-            }
-          }
-        }
-      }
-    } catch (e) { console.error('URLHaus CSV Fetch Error', e); }
-
-    return NextResponse.json({
-      threats,
-      total: threats.length,
-      timestamp: new Date().toISOString(),
-      source: threats[0]?.id?.includes('sim-') ? 'OSIRIS Simulated Threat Engine' : 'abuse.ch Feodo Tracker + URLhaus + ThreatFox',
-    }, {
-      headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
-    });
+    return NextResponse.json(
+      {
+        threats: snap.detections,
+        total: snap.total,
+        cursor: snap.cursor,
+        last_poll: snap.lastPollAt ? new Date(snap.lastPollAt).toISOString() : null,
+        stream: '/api/malware/stream',
+        timestamp: new Date().toISOString(),
+        source: MALWARE_SOURCE,
+        ...(snap.error ? { warning: snap.error } : {}),
+      },
+      // The store is the cache. Letting a CDN hold a copy on top of it would
+      // only serve a staler picture than the stream already has.
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
   } catch (error) {
     console.error('[OSIRIS] Malware feed error:', error);
     return NextResponse.json({ threats: [], total: 0, error: 'Malware feed unavailable' }, { status: 500 });

--- a/src/app/api/malware/stream/route.ts
+++ b/src/app/api/malware/stream/route.ts
@@ -1,0 +1,90 @@
+import { startMalwareFeed, malwareSnapshot, subscribeMalware, type LiveEvent } from '@/lib/malware-live';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * OSIRIS — Live Malware, Server-Sent Events.
+ *
+ * GET /api/malware/stream opens a connection that receives:
+ *
+ *   snapshot    once, on connect — the current picture, so a client that has
+ *               just opened the layer is not blank until something changes
+ *   detections  whenever URLhaus reports hosts this store had not seen, which
+ *               on a cold start also carries the progressive geolocation fill
+ *   status      after every poll, including quiet ones, so a client can tell
+ *               "nothing is happening" from "the feed has stalled"
+ *
+ * The poll loop is shared: a hundred connected clients cost one request per
+ * minute upstream, not a hundred. Clients do not poll this endpoint — they hold
+ * it open and are pushed to.
+ */
+export async function GET(request: Request) {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      let open = true;
+      /** How many detections this connection has actually been sent. */
+      let delivered = 0;
+
+      const send = (event: LiveEvent | { type: 'heartbeat'; at: string }) => {
+        if (!open) return;
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+          if (event.type === 'snapshot') delivered = event.detections.length;
+          else if (event.type === 'detections') delivered += event.detections.length;
+        } catch {
+          close();
+        }
+      };
+
+      const unsubscribe = subscribeMalware(send);
+
+      // 15s matches the SDK stream, and stays under the 30-60s idle timeout
+      // that proxies in front of this typically apply.
+      const heartbeat = setInterval(() => send({ type: 'heartbeat', at: new Date().toISOString() }), 15_000);
+
+      function close() {
+        if (!open) return;
+        open = false;
+        clearInterval(heartbeat);
+        unsubscribe();
+        try { controller.close(); } catch { /* already torn down */ }
+      }
+
+      request.signal.addEventListener('abort', close);
+
+      // Send whatever is already known before waiting on the first poll, so a
+      // warm store answers instantly and a cold one still opens immediately.
+      const warm = malwareSnapshot();
+      send({ type: 'snapshot', detections: warm.detections, cursor: warm.cursor, total: warm.total });
+
+      await startMalwareFeed();
+      if (!open) return;
+
+      /*
+       * A connection that arrived before the first fill has been receiving it
+       * incrementally and needs nothing more. One that joined midway through a
+       * fill another client started has only the batches emitted since it
+       * subscribed, so it is caught up here — comparing what this connection
+       * was sent against what the store holds distinguishes the two without
+       * re-sending the whole picture to everyone.
+       */
+      const filled = malwareSnapshot();
+      if (delivered < filled.total) {
+        send({ type: 'snapshot', detections: filled.detections, cursor: filled.cursor, total: filled.total });
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      Connection: 'keep-alive',
+      // nginx buffers proxied responses by default, which would hold events
+      // back until the buffer filled. The repo ships an nginx front end.
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/src/app/docs/apiCatalog.ts
+++ b/src/app/docs/apiCatalog.ts
@@ -349,8 +349,15 @@ export const API_GROUPS: ApiGroup[] = [
       {
         path: '/api/malware',
         method: 'GET',
-        summary: 'Malware indicators from public trackers.',
-        returns: ['threats', 'total', 'source', 'timestamp'],
+        summary: 'Live malware hosts from abuse.ch URLhaus, geolocated per address.',
+        returns: ['threats', 'total', 'cursor', 'last_poll', 'stream', 'source', 'timestamp'],
+      },
+      {
+        path: '/api/malware/stream',
+        method: 'GET',
+        summary:
+          'Server-sent events for the malware layer: a snapshot on connect, then new detections as URLhaus reports them.',
+        returns: ['snapshot', 'detections', 'status', 'heartbeat'],
       },
     ],
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -654,6 +654,39 @@ html:has(.docs-root) body {
 }
 
 /* ─────────────────────────────────────────────────────────────
+   LIVE TV NEWS PREVIEWS
+   The same tile as the CCTV previews, but pinned to broadcast
+   feeds and drawn at every zoom — see components/LiveNewsPreviews.
+   ───────────────────────────────────────────────────────────── */
+.news-tile {
+  transform-origin: 50% 100%;
+  transition: filter 0.18s ease;
+}
+.news-tile:hover {
+  filter: brightness(1.1) drop-shadow(0 0 12px color-mix(in srgb, #EC407A 32%, transparent));
+}
+
+[data-flip="above"] .news-stem-up,
+[data-flip="below"] .news-stem-down,
+[data-flip="none"] .news-stem { display: none; }
+
+/* The on-air dot, blinking like the malware arrival beacon so that "live"
+   reads the same way wherever it appears on the map. */
+.news-live-dot {
+  animation: news-live-blink 1.6s ease-in-out infinite;
+}
+@keyframes news-live-blink {
+  0%, 100% { opacity: 1;   box-shadow: 0 0 6px #EC407A; }
+  50%      { opacity: 0.3; box-shadow: 0 0 2px #EC407A; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .news-tile { transition: none; }
+  .news-tile:hover { filter: none; }
+  .news-live-dot { animation: none; }
+}
+
+/* ─────────────────────────────────────────────────────────────
    4. SCANNING LINE — Vertical sweep for splash/loading screens
    ───────────────────────────────────────────────────────────── */
 @keyframes scan-line-sweep {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import DirectionsBar, { type RouteResult, type LiveLocation } from '@/components
 import NavigationView from '@/components/NavigationView';
 import FlightWatchPanel, { type WatchedFlight, type FlightTelemetry, type AircraftDetail, type Airport } from '@/components/FlightWatchPanel';
 import type { NavProgress } from '@/lib/navigation';
+import type { LiveDetection } from '@/lib/malware-intel';
 import ScaleBar from '@/components/ScaleBar';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import { applySettings, loadSavedSettings } from '@/lib/style-tokens';
@@ -683,11 +684,7 @@ export default function Dashboard() {
     }
 
 
-    // Live Malware (abuse.ch)
-    if (activeLayers.malware && !layerFetchedRef.current.has('malware')) {
-      fetchEndpoint('/api/malware', d => ({ malware_threats: d.threats }));
-      layerFetchedRef.current.add('malware');
-    }
+    // Live Malware (abuse.ch) is pushed, not fetched — see the SSE subscription below.
 
     // Live Cyber Attacks (animated arcs)
     if ((activeLayers as any).cyber_attacks && !layerFetchedRef.current.has('cyber_attacks')) {
@@ -747,6 +744,72 @@ export default function Dashboard() {
     }
     return () => intervals.forEach(clearInterval);
   }, [activeLayers, fetchEndpoint]);
+
+  /* ── LIVE MALWARE — pushed over SSE while the layer is on ──
+     Detections arrive when URLhaus reports them rather than on a timer, so
+     there is no poll interval to tune and no request that re-downloads the
+     same rows to discover nothing changed. The connection also carries the
+     progressive geolocation fill, which is why a cold server paints the map in
+     batches instead of staying empty and then snapping to full. */
+  useEffect(() => {
+    if (!activeLayers.malware) return;
+
+    const source = new EventSource('/api/malware/stream');
+    // Keyed by address: a host re-reported with a new payload updates its node
+    // rather than stacking a second dot on the same coordinates.
+    const byIp = new Map<string, LiveDetection>();
+    // The server sends `status` at the end of every poll, so the first one
+    // marks the end of the initial fill — anything after it is genuinely new
+    // and worth drawing attention to.
+    let filled = false;
+
+    const commit = () => {
+      dataRef.current = { ...dataRef.current, malware_threats: [...byIp.values()] };
+      setDataVersion(v => v + 1);
+    };
+
+    source.onmessage = ev => {
+      try {
+        const event = JSON.parse(ev.data);
+        if (event.type === 'snapshot') {
+          byIp.clear();
+          for (const d of event.detections) byIp.set(d.ip, d);
+          commit();
+        } else if (event.type === 'detections') {
+          // Only a first sighting is an arrival. An existing host that served
+          // another payload arrives with fresh:false and keeps whatever beacon
+          // state it already had, so it does not re-flag itself as new.
+          const beacon = filled && event.fresh;
+          for (const d of event.detections) {
+            byIp.set(d.ip, beacon ? { ...d, detected_at: Date.now() } : { ...d, detected_at: byIp.get(d.ip)?.detected_at });
+          }
+          commit();
+        } else if (event.type === 'status') {
+          filled = true;
+          // Hosts that have gone dark since the last poll. The store prunes
+          // these; without mirroring it here the map would only ever grow.
+          if (event.retired?.length) {
+            for (const ip of event.retired) byIp.delete(ip);
+            commit();
+          }
+        }
+        setBackendStatus('connected');
+      } catch {
+        // One malformed frame must not tear down the subscription.
+      }
+    };
+
+    /* EventSource reconnects on its own, firing `error` on each attempt, and
+       the store replays a snapshot on connect so a drop self-heals. Only a
+       readyState of CLOSED means it has given up — reporting the transient
+       ones would flag the backend as down every time a connection recycles. */
+    source.onopen = () => setBackendStatus('connected');
+    source.onerror = () => {
+      if (source.readyState === EventSource.CLOSED) setBackendStatus('error');
+    };
+
+    return () => source.close();
+  }, [activeLayers.malware]);
 
   // CCTV: loaded once on layer toggle via layerFetchedRef (no viewport polling)
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -294,6 +294,8 @@ export default function Dashboard() {
     sat_science: false,
     balloons: false,
     cctv: true,
+    /* The live preview tiles over the camera dots — see CctvPreviews. */
+    cctv_previews: true,
     live_news: true,
     earthquakes: true,
     fires: false,

--- a/src/components/CctvPreviews.tsx
+++ b/src/components/CctvPreviews.tsx
@@ -3,6 +3,7 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Maximize2 } from 'lucide-react';
 import { freshen, previewMedia, refreshInterval, VIDEO_KINDS, type PreviewKind } from '@/lib/camera-preview';
+import { layoutTile, tileHeight, tilesOverlap, type TileGeometry } from '@/lib/map-tile-layout';
 import type { Map as MlMap } from 'maplibre-gl';
 
 /**
@@ -26,52 +27,20 @@ import type { Map as MlMap } from 'maplibre-gl';
 
 const MIN_ZOOM = 13;
 const MAX_TILES = 8;
-const TILE_W = 176;
-/** 16:9, so a frame is not letterboxed inside its own container. */
-const IMG_H = 99;
-const LABEL_H = 20;
-/** Clearance between the bottom of a tile and the marker it belongs to — the
- *  connector that ties the two together is drawn across it. */
-const GAP = 26;
-const TILE_H = IMG_H + LABEL_H;
 /** Simultaneously decoding tiles. Snapshots fill whatever is left of MAX_TILES. */
 const MAX_VIDEO_TILES = 4;
-/** Keeps a tile clear of the viewport edge, and of the layer rail on the left. */
-const EDGE = 60;
-/** More at the top and bottom, where the app's own chrome is: the header at one
- *  end, the view controls and the ticker at the other. All of it draws over the
- *  previews, so a tile placed underneath is simply hidden. */
-const EDGE_TOP = 96;
-const EDGE_BOTTOM = 156;
 
-/**
- * Where the tile for a marker at `pt` ends up.
- *
- * Shared by the two passes deliberately. Which cameras get a tile is decided
- * when the map settles and the tiles are then repositioned on every frame of a
- * pan, and if those two disagreed about where a tile lands, the overlap check
- * would be run against coordinates nothing is ever drawn at — which is what let
- * a tile clamped back inside the viewport come to rest on top of its neighbour.
- */
+/** 16:9 frame, so nothing is letterboxed inside its own container. */
+const GEOM: TileGeometry = { width: 176, imageHeight: 99, labelHeight: 20, gap: 26 };
+const TILE_W = GEOM.width;
+const IMG_H = GEOM.imageHeight;
+const LABEL_H = GEOM.labelHeight;
+const GAP = GEOM.gap;
+const TILE_H = tileHeight(GEOM);
+
+/** Placement lives in lib/map-tile-layout — the live-news tiles share it. */
 function layout(pt: { x: number; y: number }, width: number, height: number) {
-  const maxX = width - TILE_W - EDGE;
-  const maxY = height - TILE_H - EDGE_BOTTOM;
-  /* Above the marker by default; below it when there is no room, so a camera
-     near the top of the screen still gets a visible tile. */
-  const above = pt.y - TILE_H - GAP;
-  const flipped = above < EDGE_TOP;
-  const wantX = pt.x - TILE_W / 2;
-  const wantY = flipped ? pt.y + GAP : above;
-  const x = Math.min(Math.max(wantX, EDGE), Math.max(EDGE, maxX));
-  const y = Math.min(Math.max(wantY, EDGE_TOP), Math.max(EDGE_TOP, maxY));
-  return {
-    x,
-    y,
-    flipped,
-    /* The connector is drawn straight down (or up) from the middle of the tile,
-       which is only where the marker is if the tile sits where it wanted to. */
-    anchored: Math.abs(x - wantX) < 1 && Math.abs(y - wantY) < 1,
-  };
+  return layoutTile(pt, { width, height }, GEOM);
 }
 
 /** Whatever the camera layer is currently drawn in — see lib/map-palette. */
@@ -424,7 +393,7 @@ function CctvPreviews({ mapRef, active, onOpen }: {
          ending the search: the snapshot behind it can still have the slot. */
       const isVideo = VIDEO_KINDS.has(c.cam.media.kind);
       if (isVideo && videos >= MAX_VIDEO_TILES) continue;
-      const clash = picked.some(p => Math.abs(p.box.x - c.box.x) < TILE_W + 8 && Math.abs(p.box.y - c.box.y) < TILE_H + GAP);
+      const clash = picked.some(p => tilesOverlap(p.box, c.box, GEOM));
       if (clash) continue;
       picked.push(c);
       if (isVideo) videos++;

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -29,6 +29,9 @@ interface LayerDef {
   catKey?: string;
   /** Capability that must be configured server-side for this layer to appear. */
   requires?: string;
+  /** Key of the layer this one modifies. Renders indented beneath it, and reads
+   *  as inert while that parent is off — it has nothing to act on. */
+  parent?: string;
 }
 
 interface LayerGroupDef {
@@ -85,6 +88,7 @@ const LAYER_GROUPS: LayerGroupDef[] = [
     icon: Camera,
     layers: [
       { key: 'cctv', label: 'CCTV Cameras', dataKey: 'cameras' },
+      { key: 'cctv_previews', label: 'Live Previews', dataKey: '', parent: 'cctv' },
       { key: 'live_news', label: 'Live News Feeds', dataKey: 'live_feeds' },
     ],
   },
@@ -173,6 +177,19 @@ function ToggleSwitch({ active }: { active: boolean }) {
   );
 }
 
+/**
+ * The elbow that ties a sub-layer row to the layer above it. Indentation alone
+ * reads as a typo at this size; the line is what says "this belongs to that".
+ */
+function SubLayerStem() {
+  return (
+    <span
+      aria-hidden
+      className="pointer-events-none absolute left-[6px] top-0 h-1/2 w-[8px] rounded-bl-[3px] border-b border-l border-white/[0.14]"
+    />
+  );
+}
+
 function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'core', setTheme, capabilities = {} }: LayerPanelProps) {
   const [hoveredGroup, setHoveredGroup] = useState<string | null>(null);
   /**
@@ -238,13 +255,15 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
               {group.layers.map((layer) => {
                 const isLayerActive = activeLayers[layer.key];
                 const count = getCount(layer.dataKey, layer.catKey);
+                const dormant = !!layer.parent && !activeLayers[layer.parent];
                 return (
                   <button
                     key={layer.key}
                     onClick={() => toggle(layer.key)}
                     aria-pressed={!!isLayerActive}
-                    className="w-full flex items-center gap-3 px-1 py-2 rounded-md text-left hover:bg-white/[0.04] transition-colors"
+                    className={`relative w-full flex items-center gap-3 py-2 rounded-md text-left hover:bg-white/[0.04] transition-colors ${layer.parent ? 'pl-[22px] pr-1' : 'px-1'} ${dormant ? 'opacity-40' : ''}`}
                   >
+                    {layer.parent && <SubLayerStem />}
                     <ToggleSwitch active={!!isLayerActive} />
                     <span className={`text-[11px] font-mono uppercase tracking-wider flex-1 transition-colors ${isLayerActive ? 'text-white/80' : 'text-white/40'}`}>
                       {layer.label}
@@ -315,11 +334,14 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
     >
       <div className="flex-1 flex flex-col items-center gap-1">
         {visibleGroups.map((group) => {
-          const groupActive = group.layers.some(l => activeLayers[l.key]);
+          /* Sub-layers modify a parent rather than draw anything of their own,
+             so they do not count towards the rail's reading. */
+          const counted = group.layers.filter(l => !l.parent);
+          const groupActive = counted.some(l => activeLayers[l.key]);
           const isHovered = hoveredGroup === group.label;
           const Icon = group.icon;
 
-          const activeCount = group.layers.filter(l => activeLayers[l.key]).length;
+          const activeCount = counted.filter(l => activeLayers[l.key]).length;
           const isPinned = pinnedGroup === group.label;
           const isOpen = isHovered || isPinned;
 
@@ -418,14 +440,17 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                       {group.layers.map((layer) => {
                         const isLayerActive = activeLayers[layer.key];
                         const count = getCount(layer.dataKey, layer.catKey);
+                        const dormant = !!layer.parent && !activeLayers[layer.parent];
 
                         return (
                           <button
                             key={layer.key}
                             onClick={() => toggle(layer.key)}
                             aria-pressed={!!isLayerActive}
-                            className="w-full flex items-center gap-3 px-1 py-1.5 rounded-md hover:bg-white/[0.05] transition-colors cursor-pointer text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-white/30"
+                            title={dormant ? 'Turn the layer above on to use this' : undefined}
+                            className={`relative w-full flex items-center gap-3 py-1.5 rounded-md hover:bg-white/[0.05] transition-colors cursor-pointer text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-white/30 ${layer.parent ? 'pl-[22px] pr-1' : 'px-1'} ${dormant ? 'opacity-40' : ''}`}
                           >
+                            {layer.parent && <SubLayerStem />}
                             <ToggleSwitch active={!!isLayerActive} />
                             <span className={`text-[11px] font-mono uppercase tracking-wider flex-1 transition-colors duration-200 ${isLayerActive ? 'text-white/70' : 'text-white/35'}`}>
                               {layer.label}

--- a/src/components/LiveNewsPreviews.test.ts
+++ b/src/components/LiveNewsPreviews.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { embedUrl } from './LiveNewsPreviews';
+
+/** Verbatim from /api/live-news. */
+const SKY = 'https://www.youtube.com/embed/live_stream?channel=UCoMdktPbSTixAyNGwb-UYkQ&autoplay=1&mute=1';
+const NBC = 'https://www.youtube.com/channel/UCeY0bbntWzzVIaj2z3QigXg/live';
+const RT = 'https://rumble.com/c/RTNewsEN';
+
+describe('embedUrl', () => {
+  it('accepts a channel live_stream embed, which is what the playable feeds use', () => {
+    const url = embedUrl(SKY, true);
+    expect(url).toBeTruthy();
+    expect(url!).toContain('/embed/live_stream');
+    expect(url!).toContain('channel=UCoMdktPbSTixAyNGwb-UYkQ');
+  });
+
+  it('forces the parameters a muted background player needs', () => {
+    // A tile that asks for sound is a tile the browser refuses to autoplay.
+    const p = new URL(embedUrl(SKY, true)!).searchParams;
+    expect(p.get('autoplay')).toBe('1');
+    expect(p.get('mute')).toBe('1');
+    expect(p.get('playsinline')).toBe('1');
+  });
+
+  it('overrides parameters already on the feed rather than trusting them', () => {
+    const loud = 'https://www.youtube.com/embed/live_stream?channel=UC123&mute=0&autoplay=0';
+    const p = new URL(embedUrl(loud, true)!).searchParams;
+    expect(p.get('mute')).toBe('1');
+    expect(p.get('autoplay')).toBe('1');
+  });
+
+  it('refuses a feed whose operator has disallowed embedding', () => {
+    // Eight of the fifteen are flagged this way; they stay dots and open in
+    // the full viewer instead.
+    expect(embedUrl(SKY, false)).toBeNull();
+  });
+
+  it('refuses a channel /live link — it names a channel, not a broadcast', () => {
+    expect(embedUrl(NBC, true)).toBeNull();
+  });
+
+  it('refuses a non-YouTube host', () => {
+    expect(embedUrl(RT, true)).toBeNull();
+    expect(embedUrl('https://evil.example/embed/live_stream?channel=UC1', true)).toBeNull();
+  });
+
+  it('is not fooled by a lookalike hostname', () => {
+    // Substring matching on "youtube.com" would accept this.
+    expect(embedUrl('https://www.youtube.com.evil.example/embed/live_stream?channel=UC1', true)).toBeNull();
+  });
+
+  it('accepts the privacy-preserving host', () => {
+    expect(embedUrl('https://www.youtube-nocookie.com/embed/live_stream?channel=UC1', true)).toBeTruthy();
+  });
+
+  it('refuses junk without throwing', () => {
+    expect(embedUrl('', true)).toBeNull();
+    expect(embedUrl('not a url', true)).toBeNull();
+    expect(embedUrl('https://www.youtube.com/watch?v=abc', true)).toBeNull();
+  });
+});

--- a/src/components/LiveNewsPreviews.tsx
+++ b/src/components/LiveNewsPreviews.tsx
@@ -1,0 +1,363 @@
+'use client';
+
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { layoutTile, tileHeight, tilesOverlap, type TileGeometry } from '@/lib/map-tile-layout';
+import type { Map as MlMap } from 'maplibre-gl';
+
+/**
+ * OSIRIS — live TV news playing on the map.
+ *
+ * The CCTV previews pin a live frame above a camera marker, but only past zoom
+ * 13: there are ~19,000 cameras, so at any wider view the tiles would be a
+ * solid wall and the request cost would be absurd.
+ *
+ * These behave the same way: a feed shows its broadcast only once the map is
+ * zoomed into the city it comes from, and is a dot at every wider view. Drawn
+ * from further out they stop being a detail of a place and become a wall of
+ * players over the whole planet, which is not what the layer is for.
+ *
+ * The tile, the connector, and the placement rules are the camera previews'
+ * exactly — same component shape, same lib/map-tile-layout — because they mean
+ * the same thing to an operator and should not read as two features.
+ *
+ * What differs is the media. A camera tile is an image or a short clip; these
+ * are YouTube players, which are an order of magnitude heavier. Hence a hard
+ * cap on how many run at once, and hence only the feeds whose operator permits
+ * embedding get a tile — the rest stay dots and open in the full viewer, which
+ * is what the click handler already did.
+ */
+
+/**
+ * Matches the camera previews exactly. Below this a feed is a dot; the layer
+ * is about what a place looks like right now, and that only means something
+ * once you are looking at the place.
+ */
+const MIN_ZOOM = 13;
+
+/**
+ * Concurrent players.
+ *
+ * Every tile is a YouTube iframe with its own decoder, and unlike a camera
+ * snapshot there is no cheap version of one. Four is what stays smooth on a
+ * mid-range laptop while the globe is also rendering; the rest of the feeds
+ * remain dots until the map moves and they win a slot.
+ */
+const MAX_TILES = 4;
+
+/** Slightly larger than a camera tile — this is broadcast video, not a snapshot. */
+const GEOM: TileGeometry = { width: 208, imageHeight: 117, labelHeight: 20, gap: 26 };
+const TILE_H = tileHeight(GEOM);
+
+/** The live-news layer's colour, matching news-dots in OsirisMap. */
+const NEWS = '#EC407A';
+const news = (pct: number) => `color-mix(in srgb, ${NEWS} ${pct}%, transparent)`;
+
+export interface PreviewFeed {
+  id: string;
+  name: string;
+  lng: number;
+  lat: number;
+  /** Directly embeddable player URL — see `embedUrl`. */
+  embed: string;
+  city?: string;
+  country?: string;
+  category?: string;
+  url: string;
+}
+
+/**
+ * The player URL for a feed, or null if it cannot be embedded.
+ *
+ * Seven of the fifteen feeds are already published in YouTube's
+ * `embed/live_stream?channel=…` form, which plays whatever that channel is
+ * broadcasting now without resolving a video id first — exactly what a 24/7
+ * news channel needs, since the id changes every time the stream restarts.
+ *
+ * The rest are `/channel/…/live` links, which name a channel rather than a
+ * broadcast and would need a server round-trip per feed to resolve, and Rumble,
+ * which is not an embed at all. Those are also the ones flagged
+ * `embed_allowed: false` upstream, so there is nothing to gain by chasing them:
+ * the operator has said no.
+ */
+export function embedUrl(url: string, embedAllowed: boolean): string | null {
+  if (!embedAllowed) return null;
+
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return null;
+  }
+
+  const host = u.hostname.toLowerCase();
+  if (host !== 'www.youtube.com' && host !== 'youtube.com' && host !== 'www.youtube-nocookie.com') return null;
+  if (!u.pathname.startsWith('/embed/')) return null;
+
+  // Force the parameters a muted background player needs, whatever the feed
+  // data happens to carry.
+  u.searchParams.set('autoplay', '1');
+  u.searchParams.set('mute', '1');
+  u.searchParams.set('playsinline', '1');
+  u.searchParams.set('rel', '0');
+  u.searchParams.set('modestbranding', '1');
+  // Required before the player will report its state back to the page.
+  u.searchParams.set('enablejsapi', '1');
+  return u.toString();
+}
+
+/**
+ * Ask a player to report its state, and read the answer.
+ *
+ * A channel can be embeddable in principle and still refuse a particular
+ * viewer — Sky News answers "This video is unavailable" while France 24, DW and
+ * Al Jazeera play — and from outside the iframe there is no way to see that:
+ * the frame is cross-origin, so it loads "successfully" and shows an error
+ * inside. A dead box claiming to be a live feed is worse than no tile, which is
+ * the same judgement the camera previews make about a broken camera.
+ *
+ * YouTube's iframe will post its state to the parent, but only after the parent
+ * says it is listening. That handshake is what this does; `onError` then means
+ * the channel will not play here and the tile is dropped.
+ */
+function useYouTubeError(name: string, onFail: () => void) {
+  const ref = useRef<HTMLIFrameElement>(null);
+
+  const handshake = useCallback(() => {
+    ref.current?.contentWindow?.postMessage(
+      JSON.stringify({ event: 'listening', id: name, channel: 'widget' }),
+      'https://www.youtube.com',
+    );
+  }, [name]);
+
+  useEffect(() => {
+    const onMessage = (e: MessageEvent) => {
+      if (e.origin !== 'https://www.youtube.com') return;
+      if (e.source !== ref.current?.contentWindow) return;
+      try {
+        const msg = JSON.parse(String(e.data));
+        if (msg?.event === 'onError') onFail();
+      } catch {
+        // The player also posts non-JSON frames; they are not errors.
+      }
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [onFail]);
+
+  return { ref, handshake };
+}
+
+function Tile({ feed, onOpen, onFail }: {
+  feed: PreviewFeed;
+  onOpen: (feed: PreviewFeed) => void;
+  onFail: (id: string) => void;
+}) {
+  const fail = useCallback(() => onFail(feed.id), [onFail, feed.id]);
+  const { ref, handshake } = useYouTubeError(feed.id, fail);
+
+  return (
+    <div className="news-tile block w-full text-left" style={{ width: GEOM.width }}>
+      <div
+        className="relative overflow-hidden bg-black"
+        style={{ height: GEOM.imageHeight, border: `1px solid ${news(45)}`, boxShadow: `0 0 14px ${news(18)}` }}
+      >
+        <iframe
+          ref={ref}
+          src={feed.embed}
+          title={feed.name}
+          className="h-full w-full"
+          style={{ border: 0 }}
+          allow="autoplay; encrypted-media; picture-in-picture"
+          referrerPolicy="strict-origin-when-cross-origin"
+          onLoad={handshake}
+          onError={fail}
+        />
+        {/* The player owns its own pointer events, so opening the full viewer
+            needs its own target rather than a wrapping button. */}
+        <button
+          onClick={() => onOpen(feed)}
+          title={`Open ${feed.name}`}
+          aria-label={`Open ${feed.name}`}
+          className="absolute right-1 top-1 z-10 px-1.5 py-0.5 font-mono text-[8px] uppercase tracking-[0.12em]"
+          style={{ background: 'rgba(0,0,0,0.75)', border: `1px solid ${news(50)}`, color: NEWS }}
+        >
+          Open
+        </button>
+      </div>
+
+      <div
+        className="flex items-center gap-1.5 truncate bg-black/90 px-1.5 font-mono text-[8px] uppercase tracking-[0.12em]"
+        style={{ height: GEOM.labelHeight, border: `1px solid ${news(40)}`, borderTop: 'none', color: NEWS }}
+      >
+        {/* The same blink the malware arrivals use, so "live" reads the same
+            way everywhere on the map. */}
+        <span className="news-live-dot h-1 w-1 shrink-0 rounded-full" style={{ background: NEWS }} />
+        <span className="truncate">{feed.name}</span>
+      </div>
+    </div>
+  );
+}
+
+/** The line tying a tile to its marker — the camera previews' connector, in pink. */
+function Connector() {
+  return (
+    <>
+      <span
+        className="news-stem news-stem-down pointer-events-none absolute left-1/2 w-px"
+        style={{ top: TILE_H, height: GEOM.gap - 5, background: `linear-gradient(to bottom, ${news(70)}, ${news(10)})` }}
+      />
+      <span
+        className="news-stem news-stem-up pointer-events-none absolute left-1/2 w-px"
+        style={{ bottom: TILE_H, height: GEOM.gap - 5, background: `linear-gradient(to top, ${news(70)}, ${news(10)})` }}
+      />
+    </>
+  );
+}
+
+function LiveNewsPreviews({ mapRef, active, feeds, onOpen }: {
+  mapRef: React.RefObject<MlMap | null>;
+  active: boolean;
+  /** The live-news records the map layer is built from — see OsirisMap. */
+  feeds: Array<Record<string, unknown>> | undefined;
+  onOpen: (feed: PreviewFeed) => void;
+}) {
+  const [picked, setPicked] = useState<PreviewFeed[]>([]);
+  const nodes = useRef(new Map<string, HTMLDivElement | null>());
+  /* Channels that answered with an error. Never cleared: re-picking one on the
+     next pan would reload a player that has already said no, and put the dead
+     box straight back on the map. */
+  const [dead, setDead] = useState<ReadonlySet<string>>(() => new Set());
+  const onFail = useCallback((id: string) => {
+    setDead(prev => (prev.has(id) ? prev : new Set(prev).add(id)));
+  }, []);
+
+  /** Pick which feeds get a tile. Runs only when the map settles. */
+  const recompute = useCallback(() => {
+    const map = mapRef.current;
+    if (!map || !active || !feeds?.length || map.getZoom() < MIN_ZOOM) {
+      setPicked(prev => (prev.length ? [] : prev));
+      return;
+    }
+
+    const canvas = map.getCanvas();
+    const viewport = { width: canvas.clientWidth, height: canvas.clientHeight };
+    const cx = viewport.width / 2;
+    const cy = viewport.height / 2;
+
+    const seen = new Set<string>();
+    const candidates: { feed: PreviewFeed; pt: { x: number; y: number }; d: number }[] = [];
+
+    for (const f of feeds) {
+      const name = String(f?.name ?? '');
+      const url = String(f?.url ?? '');
+      const lng = Number(f?.lng);
+      const lat = Number(f?.lat);
+      if (!name || !url || seen.has(name) || dead.has(name)) continue;
+      if (!Number.isFinite(lng) || !Number.isFinite(lat)) continue;
+
+      const embed = embedUrl(url, f?.embed_allowed !== false && f?.embed_allowed !== 'false');
+      if (!embed) continue;
+
+      const pt = map.project([lng, lat]);
+      if (pt.x < 0 || pt.y < 0 || pt.x > viewport.width || pt.y > viewport.height) continue;
+
+      seen.add(name);
+      candidates.push({
+        feed: {
+          id: name,
+          name,
+          lng,
+          lat,
+          embed,
+          url,
+          city: f?.city ? String(f.city) : undefined,
+          country: f?.country ? String(f.country) : undefined,
+          category: f?.category ? String(f.category) : undefined,
+        },
+        pt,
+        d: (pt.x - cx) ** 2 + (pt.y - cy) ** 2,
+      });
+    }
+
+    /* Nearest the middle of the screen first, then drop any tile that would
+       land on top of one already taken. Zoomed right out this is doing real
+       work: the four New York channels project to the same pixel, and London,
+       Paris and Berlin are within a tile's width of each other. */
+    candidates.sort((a, b) => a.d - b.d);
+    const chosen: { feed: PreviewFeed; box: ReturnType<typeof layoutTile> }[] = [];
+    for (const c of candidates) {
+      if (chosen.length >= MAX_TILES) break;
+      const box = layoutTile(c.pt, viewport, GEOM);
+      if (chosen.some(p => tilesOverlap(p.box, box, GEOM))) continue;
+      chosen.push({ feed: c.feed, box });
+    }
+
+    setPicked(prev => {
+      const same = prev.length === chosen.length && prev.every((p, i) => p.id === chosen[i].feed.id);
+      return same ? prev : chosen.map(p => p.feed);
+    });
+  }, [mapRef, active, feeds, dead]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const onSourceData = (e: { sourceId?: string; isSourceLoaded?: boolean }) => {
+      if (e.sourceId === 'live-news' && e.isSourceLoaded) recompute();
+    };
+
+    recompute();
+    map.on('moveend', recompute);
+    map.on('zoomend', recompute);
+    map.on('idle', recompute);
+    map.on('sourcedata', onSourceData);
+    return () => {
+      map.off('moveend', recompute);
+      map.off('zoomend', recompute);
+      map.off('idle', recompute);
+      map.off('sourcedata', onSourceData);
+    };
+  }, [mapRef, recompute]);
+
+  /* Keep tiles glued to their markers without re-rendering during a pan — and
+     without reloading the players, which a React re-render would do. */
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const place = () => {
+      const canvas = map.getCanvas();
+      const viewport = { width: canvas.clientWidth, height: canvas.clientHeight };
+      for (const feed of picked) {
+        const el = nodes.current.get(feed.id);
+        if (!el) continue;
+        const box = layoutTile(map.project([feed.lng, feed.lat]), viewport, GEOM);
+        el.dataset.flip = !box.anchored ? 'none' : box.flipped ? 'below' : 'above';
+        el.style.transform = `translate3d(${Math.round(box.x)}px, ${Math.round(box.y)}px, 0)`;
+      }
+    };
+    place();
+    map.on('move', place);
+    return () => { map.off('move', place); };
+  }, [mapRef, picked]);
+
+  if (!picked.length) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-[39] overflow-hidden">
+      {picked.map(feed => (
+        <div
+          key={feed.id}
+          ref={el => { nodes.current.set(feed.id, el); }}
+          data-flip="above"
+          className="pointer-events-auto absolute left-0 top-0 will-change-transform"
+          style={{ width: GEOM.width }}
+        >
+          <Tile feed={feed} onOpen={onOpen} onFail={onFail} />
+          <Connector />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default memo(LiveNewsPreviews);

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -6,8 +6,10 @@ import maplibregl from 'maplibre-gl';
 import { createSatelliteLayer, parseColor, type SatPoint } from '@/lib/satellite-layer';
 import { MAP_DEFAULTS, MAP_PALETTE_KEYS, readMapPalette, satColorFor, type MapPalette } from '@/lib/map-palette';
 import { STYLE_EVENT } from '@/lib/style-tokens';
+import { arrivalBeacons } from '@/lib/malware-intel';
 import SatelliteCard, { type SatelliteDetail } from '@/components/SatelliteCard';
 import CctvPreviews, { type PreviewCamera } from '@/components/CctvPreviews';
+import LiveNewsPreviews, { type PreviewFeed } from '@/components/LiveNewsPreviews';
 
 /** The catalogue fields the satellite layer and its popup actually read. */
 interface SatelliteRow {
@@ -303,7 +305,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       createDot(map, 'dot-fire', isGhost ? phantomPurple : '#E65100', 10);
       createDot(map, 'dot-cctv', cameraColor, 10);
 
-      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'malware-nodes', 'network-mesh', 'cyber-arcs', 'cyber-heads', 'cyber-impacts', 'gdelt-events', 'cf-outages', 'cf-attacks'];
+      const sources = ['flights','military','jets','private-fl','satellites','earthquakes','gdelt','day-night','cctv','fires','weather','infrastructure','maritime','maritime-choke','maritime-ships','live-news','conflict-zones', 'war-alerts-targets', 'war-alerts-lines', 'balloons', 'radiation', 'ip-sweep-devices', 'ip-sweep-pulse', 'ip-sweep-connections', 'scan-targets', 'sdk-entities', 'sdk-links', 'malware-nodes', 'malware-new', 'network-mesh', 'cyber-arcs', 'cyber-heads', 'cyber-impacts', 'gdelt-events', 'cf-outages', 'cf-attacks'];
       sources.forEach(s => map.addSource(s, { type: 'geojson', data: EMPTY_FC }));
 
       // ── FLIGHT ROUTE VISUALIZATION SOURCES & LAYERS ──
@@ -391,11 +393,32 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         'circle-radius': ['interpolate',['linear'],['zoom'], 1,6, 5,12, 10,20],
         'circle-color': '#D32F2F', 'circle-opacity': 0.06, 'circle-blur': 0.5,
       }});
+      /* Sized by how many live malicious URLs the host serves. A box running
+         forty payloads and one running a single sample were the same dot
+         before, and they are not the same thing. */
       map.addLayer({ id: 'malware-dots', type: 'circle', source: 'malware-nodes', paint: {
-        'circle-radius': ['interpolate',['linear'],['zoom'], 1,2, 5,4, 10,6],
+        /* A zoom expression has to be the top-level input to the interpolate,
+           so the activity scaling lives in the output stops rather than
+           multiplying two curves together. sqrt keeps a host serving 80 URLs
+           from dwarfing the map — it reads about three times the single-URL
+           dot, not eighty. */
+        'circle-radius': ['interpolate',['linear'],['zoom'],
+          1,  ['interpolate',['linear'],['sqrt',['max',['get','url_count'],1]], 1,1.6, 3,2.4, 9,4],
+          5,  ['interpolate',['linear'],['sqrt',['max',['get','url_count'],1]], 1,3.2, 3,4.8, 9,8],
+          10, ['interpolate',['linear'],['sqrt',['max',['get','url_count'],1]], 1,4.8, 3,7.2, 9,12],
+        ],
         'circle-color': '#D32F2F',
         'circle-opacity': 0.9,
         'circle-stroke-width': 1, 'circle-stroke-color': '#000000', 'circle-stroke-opacity': 0.8,
+      }});
+      /* Arrival beacon — expands and fades over the minute after a detection
+         is pushed, then the feature drops out of the source entirely. */
+      map.addLayer({ id: 'malware-new-ring', type: 'circle', source: 'malware-new', paint: {
+        'circle-radius': 8,
+        'circle-color': 'transparent',
+        'circle-stroke-color': '#FF1744',
+        'circle-stroke-width': 2,
+        'circle-stroke-opacity': ['interpolate',['linear'],['get','age'], 0,0.9, 1,0],
       }});
       map.addLayer({ id: 'malware-label', type: 'symbol', source: 'malware-nodes', minzoom: 5, layout: {
         'text-field': ['get','malware'], 'text-size': 8, 'text-font': ['JetBrains Mono Bold', 'Open Sans Bold'],
@@ -1047,21 +1070,31 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       if (!e.features?.length) return;
       const p = e.features[0].properties as any;
       const coords = (e.features[0].geometry as any).coordinates;
-      const tType = (p.threat_type || 'MALWARE').toUpperCase();
+      const tType = (p.threat_type || 'malware').replace(/_/g, ' ').toUpperCase();
       const statusColor = p.status === 'online' ? '#39FF14' : '#FF1744';
-      
-      popup(coords, `<div style="${pStyle}border:1px solid rgba(255,23,68,0.4);box-shadow:inset 0 0 12px rgba(255,23,68,0.1);">
+      const place = [p.city, p.country].filter(Boolean).join(', ') || 'UNKNOWN';
+      const host = p.as_name ? `AS${p.asn} ${p.as_name}` : '';
+      const urls = Number(p.url_count) || 1;
+      // Every field below is observed. Where the old popup linked to a generic
+      // browse page, this links to the specific URLhaus report behind the node.
+      const ref = urlSafe(p.reference);
+
+      popup(coords, `<div style="${pStyle}border:1px solid rgba(255,23,68,0.4);box-shadow:inset 0 0 12px rgba(255,23,68,0.1);min-width:250px;">
         <div style="display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid rgba(255,23,68,0.3);padding-bottom:6px;margin-bottom:8px;">
           <div style="color:#FF1744;font-size:12px;font-weight:700;letter-spacing:0.1em;text-shadow:0 0 4px rgba(255,23,68,0.5);">[ ${htmlEsc(tType)} ]</div>
-          <div style="color:#5C5A54;font-size:9px;">${htmlEsc(p.country || 'UNKNOWN')}</div>
+          <div style="color:#5C5A54;font-size:9px;">${htmlEsc(place)}</div>
         </div>
-        <div style="color:#E8E6E0;font-size:11px;font-weight:bold;margin-bottom:10px;">${htmlEsc(p.malware || 'Unidentified Threat Payload')}</div>
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;margin-bottom:12px;background:rgba(0,0,0,0.3);padding:6px;border-radius:4px;">
-          <div><span style="color:#5C5A54;">TARGET IP</span><br/><span style="color:#00E5FF;font-family:monospace;">${htmlEsc(p.ip)}</span></div>
-          <div><span style="color:#5C5A54;">STATUS</span><br/><span style="color:${statusColor};">${(p.status||'UNKNOWN').toUpperCase()}</span></div>
+        <div style="color:#E8E6E0;font-size:11px;font-weight:bold;margin-bottom:2px;">${htmlEsc(p.malware || 'Unclassified payload')}</div>
+        ${host ? `<div style="color:#5C5A54;font-size:9px;margin-bottom:10px;">${htmlEsc(host)}</div>` : '<div style="margin-bottom:10px;"></div>'}
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;margin-bottom:8px;background:rgba(0,0,0,0.3);padding:6px;border-radius:4px;">
+          <div><span style="color:#5C5A54;">HOST</span><br/><span style="color:#00E5FF;font-family:monospace;">${htmlEsc(p.ip)}:${htmlEsc(String(p.port ?? 0))}</span></div>
+          <div><span style="color:#5C5A54;">STATUS</span><br/><span style="color:${statusColor};">${htmlEsc((p.status||'unknown').toUpperCase())}</span></div>
+          <div><span style="color:#5C5A54;">LIVE URLS</span><br/><span style="color:#E8E6E0;">${urls}</span></div>
+          <div><span style="color:#5C5A54;">LAST REPORT</span><br/><span style="color:#E8E6E0;">${htmlEsc((p.last_seen || '').split(' ')[0] || '—')}</span></div>
         </div>
+        <div style="color:#5C5A54;font-size:9px;margin-bottom:10px;">First seen ${htmlEsc((p.first_seen || '').split(' ')[0] || '—')}${p.reporter ? ` · reported by ${htmlEsc(p.reporter)}` : ''}</div>
         <div style="display:flex;gap:6px;">
-          <a href="https://feodotracker.abuse.ch/browse/" target="_blank" style="${linkStyle}flex:1;text-align:center;color:#E8E6E0;border:1px solid rgba(255,255,255,0.2);background:rgba(255,255,255,0.05);">THREAT INTEL ↗</a>
+          ${ref ? `<a href="${ref}" target="_blank" style="${linkStyle}flex:1;text-align:center;color:#E8E6E0;border:1px solid rgba(255,255,255,0.2);background:rgba(255,255,255,0.05);">URLHAUS REPORT ↗</a>` : ''}
         </div>
       </div>`);
     });
@@ -1723,7 +1756,63 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   // Malware Threats
   useEffect(() => {
     if (!mapReady) return;
-    setGeo('malware-nodes', activeLayers.malware && data.malware_threats ? data.malware_threats.map((t: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [t.lng, t.lat] }, properties: { ip: t.ip, malware: t.malware, status: t.status, threat_type: t.threat_type, country: t.country } })) : []);
+    setGeo('malware-nodes', activeLayers.malware && data.malware_threats ? data.malware_threats.map((t: any) => ({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [t.lng, t.lat] },
+      properties: {
+        ip: t.ip, malware: t.malware, status: t.status, threat_type: t.threat_type,
+        country: t.country, city: t.city, port: t.port,
+        asn: t.asn, as_name: t.as_name,
+        // How many live malicious URLs this host serves — the dot is sized by
+        // it, so a box distributing forty payloads reads bigger than one.
+        url_count: t.url_count ?? 1,
+        first_seen: t.first_seen, last_seen: t.last_seen,
+        reference: t.reference, reporter: t.reporter,
+        detected_at: t.detected_at ?? 0,
+      },
+    })) : []);
+  }, [mapReady, data.malware_threats, activeLayers.malware, setGeo]);
+
+  /* Detections that landed while the operator was watching get a ring for a
+     minute. Without it a pushed feed is indistinguishable from a static one —
+     nodes simply appear, and the thing that makes it live goes unseen. */
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !activeLayers.malware) return;
+    const map = mapRef.current;
+
+    /* Arrivals are rare — a handful an hour — so the common case is that there
+       is nothing to draw. Tracking whether the last tick drew anything keeps
+       this from pushing an empty collection into the source five times a
+       second for the entire time the layer is on. */
+    let drawing = false;
+
+    const tick = () => {
+      const now = Date.now();
+      const beacons = arrivalBeacons(data.malware_threats ?? [], now);
+
+      if (beacons.length === 0) {
+        if (drawing) { setGeo('malware-new', []); drawing = false; }
+        return;
+      }
+
+      setGeo('malware-new', beacons.map(b => ({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [b.lng, b.lat] },
+        properties: { age: b.age },
+      })));
+      drawing = true;
+
+      try {
+        // One shared pulse, so the ring reads as a beacon rather than each
+        // node breathing on its own schedule.
+        map.setPaintProperty('malware-new-ring', 'circle-radius',
+          ['interpolate', ['linear'], ['get', 'age'], 0, 6 + Math.sin(now / 200) * 2, 1, 26]);
+      } catch { /* style not settled yet */ }
+    };
+
+    tick();
+    const timer = setInterval(tick, 200);
+    return () => { clearInterval(timer); setGeo('malware-new', []); };
   }, [mapReady, data.malware_threats, activeLayers.malware, setGeo]);
 
   // Network Mesh Generation (Nearest Neighbor Lattice)
@@ -1997,7 +2086,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     setVis(['cf-outage-halo','cf-outage-dots','cf-outage-label'], (activeLayers as any).cf_outages);
     setVis(['cf-attack-dots','cf-attack-label'], (activeLayers as any).cf_attacks);
 
-    setVis(['malware-glow','malware-dots','malware-label'], activeLayers.malware);
+    setVis(['malware-glow','malware-dots','malware-label','malware-new-ring'], activeLayers.malware);
     setVis(['network-mesh-atmo', 'network-mesh-glow', 'network-mesh-core'], activeLayers.internet_outages || activeLayers.malware);
     setVis(['cyber-arcs-atmo','cyber-arcs-glow','cyber-arcs-core','cyber-arcs-flow','cyber-heads','cyber-impacts','cyber-labels'], (activeLayers as any).cyber_attacks);
     setVis(['day-night-fill'], activeLayers.day_night);
@@ -2866,6 +2955,22 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
           mapRef={mapRef}
           active={!!activeLayers.cctv}
           onOpen={(cam: PreviewCamera) => onEntityClick?.({ type: 'cctv', ...cam })}
+        />
+      )}
+      {mapReady && (
+        <LiveNewsPreviews
+          mapRef={mapRef}
+          active={!!activeLayers.live_news}
+          feeds={data.live_feeds}
+          onOpen={(feed: PreviewFeed) => onEntityClick?.({
+            type: 'live_news',
+            name: feed.name,
+            city: feed.city,
+            country: feed.country,
+            url: feed.url,
+            category: feed.category,
+            embed_allowed: true,
+          })}
         />
       )}
       {selectedSat && <SatelliteCard sat={selectedSat} onClose={clearSat} />}

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -2953,7 +2953,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       {mapReady && mapRef.current && (
         <CctvPreviews
           mapRef={mapRef}
-          active={!!activeLayers.cctv}
+          active={!!activeLayers.cctv && !!activeLayers.cctv_previews}
           onOpen={(cam: PreviewCamera) => onEntityClick?.({ type: 'cctv', ...cam })}
         />
       )}

--- a/src/lib/httpJson.test.ts
+++ b/src/lib/httpJson.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { httpConditional } from './httpJson';
+
+/**
+ * Live integration test — opt in with RUN_LIVE_TESTS=1 (hits the real
+ * abuse.ch dump).
+ *
+ * The malware feed polls a 2.9 MB file every 60 seconds against an upstream
+ * that regenerates it every 5 minutes, and the only thing keeping that from
+ * costing 175 MB an hour is abuse.ch honouring `If-None-Match`. That is an
+ * assumption about someone else's server, so it is worth an explicit check
+ * rather than an inference from a header — if abuse.ch ever stops answering
+ * 304, the feed silently gets 35x more expensive and nothing else would say so.
+ */
+const liveIt = process.env.RUN_LIVE_TESTS === '1' ? it : it.skip;
+
+const RECENT_CSV = 'https://urlhaus.abuse.ch/downloads/csv_recent/';
+
+describe('httpConditional', () => {
+  liveIt('fetches the dump, then answers 304 to the same validators', async () => {
+    const first = await httpConditional(RECENT_CSV, {
+      timeoutMs: 60_000,
+      headers: { Accept: 'text/csv', 'Accept-Encoding': 'gzip' },
+    });
+
+    expect(first.changed).toBe(true);
+    expect(first.body).toBeTruthy();
+    expect(first.body!).toContain('abuse.ch URLhaus');
+    // One of the two must come back, or there is nothing to revalidate with.
+    expect(first.etag ?? first.lastModified).toBeTruthy();
+
+    const second = await httpConditional(RECENT_CSV, {
+      etag: first.etag,
+      lastModified: first.lastModified,
+      timeoutMs: 60_000,
+      headers: { Accept: 'text/csv', 'Accept-Encoding': 'gzip' },
+    });
+
+    expect(second.changed).toBe(false);
+    expect(second.body).toBeNull();
+    // Validators survive a 304 so the next poll can still revalidate.
+    expect(second.etag ?? second.lastModified).toBeTruthy();
+  }, 120_000);
+
+  liveIt('degrades to a plain GET when given no validators', async () => {
+    const res = await httpConditional(RECENT_CSV, {
+      timeoutMs: 60_000,
+      headers: { Accept: 'text/csv', 'Accept-Encoding': 'gzip' },
+    });
+    expect(res.changed).toBe(true);
+    expect(res.body).toBeTruthy();
+  }, 120_000);
+});

--- a/src/lib/httpJson.ts
+++ b/src/lib/httpJson.ts
@@ -1,5 +1,6 @@
 import https from 'https';
 import zlib from 'zlib';
+import type { IncomingHttpHeaders } from 'http';
 import type { Readable } from 'stream';
 
 /**
@@ -17,11 +18,27 @@ import type { Readable } from 'stream';
 
 export const OSIRIS_UA = 'OSIRIS-OSINT/1.0 (+https://github.com/simplifaisoul/osiris)';
 
-export function httpJson<T>(
-  url: string,
-  { timeoutMs = 20000, headers = {} }: { timeoutMs?: number; headers?: Record<string, string> } = {},
-): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
+export interface RequestOptions {
+  timeoutMs?: number;
+  headers?: Record<string, string>;
+}
+
+interface RawResponse {
+  status: number;
+  headers: IncomingHttpHeaders;
+  body: string;
+}
+
+/**
+ * One request, decoded but not interpreted.
+ *
+ * Everything public here is a thin wrapper over this, so the connection
+ * handling — identifying UA, timeout, content-encoding decode — is written
+ * once. A 304 resolves with an empty body rather than throwing: it is a
+ * successful answer to a conditional request, not an error.
+ */
+function request(url: string, { timeoutMs = 20000, headers = {} }: RequestOptions): Promise<RawResponse> {
+  return new Promise<RawResponse>((resolve, reject) => {
     const req = https.get(
       url,
       {
@@ -29,11 +46,21 @@ export function httpJson<T>(
         timeout: timeoutMs,
       },
       (res) => {
-        if (res.statusCode && res.statusCode >= 400) {
+        const status = res.statusCode ?? 0;
+
+        if (status >= 400) {
           res.resume();
-          reject(new Error(`HTTP ${res.statusCode}`));
+          reject(new Error(`HTTP ${status}`));
           return;
         }
+
+        // 304 carries no body, and no content-encoding to decode.
+        if (status === 304) {
+          res.resume();
+          resolve({ status, headers: res.headers, body: '' });
+          return;
+        }
+
         // Some hosts serve pre-compressed static JSON and set Content-Encoding
         // regardless of what we asked for — adsb.lol's trace files do exactly
         // that — so decode by the header rather than by what we requested.
@@ -47,14 +74,65 @@ export function httpJson<T>(
         stream.setEncoding('utf8');
         stream.on('data', (chunk: string) => { body += chunk; });
         stream.on('error', reject);
-        stream.on('end', () => {
-          try { resolve(JSON.parse(body) as T); } catch (e) { reject(e); }
-        });
+        stream.on('end', () => resolve({ status, headers: res.headers, body }));
       },
     );
     req.on('timeout', () => req.destroy(new Error('Upstream timed out')));
     req.on('error', reject);
   });
+}
+
+/** The transport, stopping short of the JSON parse — for CSV and plain text. */
+export async function httpText(url: string, opts: RequestOptions = {}): Promise<string> {
+  return (await request(url, opts)).body;
+}
+
+export async function httpJson<T>(url: string, opts: RequestOptions = {}): Promise<T> {
+  return JSON.parse(await httpText(url, opts)) as T;
+}
+
+/** Validators from a previous response, replayed to ask whether it has changed. */
+export interface Validators {
+  etag?: string;
+  lastModified?: string;
+}
+
+export interface ConditionalResult extends Validators {
+  /** False when the upstream answered 304 — the caller's copy is still current. */
+  changed: boolean;
+  /** Null on 304. */
+  body: string | null;
+}
+
+/**
+ * A conditional GET, for polling a large dump that changes rarely.
+ *
+ * Re-downloading a multi-megabyte file on a fast poll to discover it is
+ * byte-identical is the expensive way to learn nothing. Replaying the previous
+ * `ETag`/`Last-Modified` lets the upstream answer 304 with an empty body
+ * instead, which turns the common case into a few hundred bytes of headers.
+ *
+ * Pass the validators from the previous call; store the ones this returns.
+ * With none supplied it degrades to an ordinary GET, so the first call and any
+ * upstream that ignores validators both still work.
+ */
+export async function httpConditional(
+  url: string,
+  { etag, lastModified, ...opts }: RequestOptions & Validators = {},
+): Promise<ConditionalResult> {
+  const conditional: Record<string, string> = {};
+  if (etag) conditional['If-None-Match'] = etag;
+  if (lastModified) conditional['If-Modified-Since'] = lastModified;
+
+  const res = await request(url, { ...opts, headers: { ...opts.headers, ...conditional } });
+
+  const next: Validators = {
+    etag: typeof res.headers.etag === 'string' ? res.headers.etag : etag,
+    lastModified: typeof res.headers['last-modified'] === 'string' ? res.headers['last-modified'] : lastModified,
+  };
+
+  if (res.status === 304) return { changed: false, body: null, ...next };
+  return { changed: true, body: res.body, ...next };
 }
 
 /** Resolve a promise to null instead of throwing — for optional enrichment calls. */

--- a/src/lib/malware-intel.test.ts
+++ b/src/lib/malware-intel.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseUrlhausCsv,
+  hostOf,
+  familyOf,
+  groupByHost,
+  toDetection,
+  newSince,
+  maxId,
+  arrivalBeacons,
+  detectionChanged,
+  type UrlhausRecord,
+  type GeoResult,
+} from './malware-intel';
+
+/** Verbatim shape of the live dump, header comments and all. */
+const CSV = `################################################################
+# abuse.ch URLhaus Database Dump (CSV - recent URLs only)      #
+# Last updated: 2026-08-31 02:15:25 (UTC)                      #
+################################################################
+#
+# id,dateadded,url,url_status,last_online,threat,tags,urlhaus_link,reporter
+"3910216","2026-08-31 02:15:25","http://103.179.240.227:39430/i","online","2026-08-31 02:15:25","malware_download","32-bit,elf,mips,Mozi","https://urlhaus.abuse.ch/url/3910216/","geenensp"
+"3910215","2026-08-31 01:58:19","http://119.115.250.29:44519/i","online","2026-08-31 01:58:19","malware_download","32-bit,elf,mips,Mozi","https://urlhaus.abuse.ch/url/3910215/","geenensp"
+"3910214","2026-08-31 01:55:25","http://103.179.240.227:39430/bin.sh","online","2026-08-31 01:55:25","malware_download","32-bit,elf,mips,Mozi","https://urlhaus.abuse.ch/url/3910214/","geenensp"`;
+
+function rec(over: Partial<UrlhausRecord> = {}): UrlhausRecord {
+  return {
+    id: 1, dateadded: '2026-08-31 02:15:25', url: 'http://1.2.3.4/a', status: 'online',
+    threat: 'malware_download', tags: [], link: 'https://urlhaus.abuse.ch/url/1/', reporter: 'x',
+    ...over,
+  };
+}
+
+const GEO: GeoResult = {
+  ip: '103.179.240.227', lat: -6.2, lng: 106.8, country: 'ID',
+  city: 'Jakarta', asn: 138062, as_name: 'PT Trans Media',
+};
+
+describe('parseUrlhausCsv', () => {
+  it('reads the live dump, skipping the comment banner and header', () => {
+    const rows = parseUrlhausCsv(CSV);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toEqual({
+      id: 3910216,
+      dateadded: '2026-08-31 02:15:25',
+      url: 'http://103.179.240.227:39430/i',
+      status: 'online',
+      threat: 'malware_download',
+      tags: ['32-bit', 'elf', 'mips', 'Mozi'],
+      link: 'https://urlhaus.abuse.ch/url/3910216/',
+      reporter: 'geenensp',
+    });
+  });
+
+  it('keeps a comma-bearing tags field in one column', () => {
+    // The old split('","') parser cut "32-bit,elf,mips,Mozi" into four columns
+    // and shifted every field after it, so the reporter became a tag.
+    const rows = parseUrlhausCsv(CSV);
+    expect(rows[0].tags).toEqual(['32-bit', 'elf', 'mips', 'Mozi']);
+    expect(rows[0].reporter).toBe('geenensp');
+  });
+
+  it('survives a quote inside a URL', () => {
+    const line = `"42","2026-01-01 00:00:00","http://5.6.7.8/a""b","online","2026-01-01 00:00:00","malware_download","exe","https://urlhaus.abuse.ch/url/42/","anon"`;
+    const rows = parseUrlhausCsv(line);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].url).toBe('http://5.6.7.8/a"b');
+  });
+
+  it('skips a truncated row rather than half-reading it', () => {
+    expect(parseUrlhausCsv(`"42","2026-01-01 00:00:00","http://5.6.7.8/a"`)).toEqual([]);
+  });
+
+  it('returns nothing for an empty or comment-only body', () => {
+    expect(parseUrlhausCsv('')).toEqual([]);
+    expect(parseUrlhausCsv('# nothing here\n#\n')).toEqual([]);
+  });
+});
+
+describe('hostOf', () => {
+  it('takes the real port off the authority', () => {
+    // The old code inferred 443/80 from the scheme, so every Mozi node on a
+    // high port reported 80. The port is the interesting part of these.
+    expect(hostOf('http://103.179.240.227:39430/i')).toEqual({ ip: '103.179.240.227', port: 39430 });
+  });
+
+  it('defaults the port by scheme when the authority omits it', () => {
+    expect(hostOf('http://1.2.3.4/a')).toEqual({ ip: '1.2.3.4', port: 80 });
+    expect(hostOf('https://1.2.3.4/a')).toEqual({ ip: '1.2.3.4', port: 443 });
+  });
+
+  it('reads the host after userinfo', () => {
+    expect(hostOf('http://user:pass@1.2.3.4:8080/a')).toEqual({ ip: '1.2.3.4', port: 8080 });
+  });
+
+  it('rejects a domain host — it has no honest position without a lookup', () => {
+    expect(hostOf('http://robertrowe.com/STATUS/x')).toBeNull();
+  });
+
+  it('rejects malformed addresses and out-of-range octets', () => {
+    expect(hostOf('http://999.1.1.1/a')).toBeNull();
+    expect(hostOf('http://1.2.3/a')).toBeNull();
+    expect(hostOf('ftp://1.2.3.4/a')).toBeNull();
+    expect(hostOf('not a url')).toBeNull();
+  });
+
+  it('falls back to the scheme port when the port is nonsense', () => {
+    expect(hostOf('http://1.2.3.4:99999/a')).toEqual({ ip: '1.2.3.4', port: 80 });
+    expect(hostOf('http://1.2.3.4:abc/a')).toEqual({ ip: '1.2.3.4', port: 80 });
+  });
+});
+
+describe('familyOf', () => {
+  it('picks the family over the file format', () => {
+    // Labelling this node "32-bit" on the map tells an operator nothing.
+    expect(familyOf(['32-bit', 'elf', 'mips', 'Mozi'], 'malware_download')).toBe('Mozi');
+  });
+
+  it('keeps upstream capitalisation', () => {
+    expect(familyOf(['elf', 'mirai'], 'malware_download')).toBe('mirai');
+    expect(familyOf(['SmartLoader'], 'malware_download')).toBe('SmartLoader');
+  });
+
+  it('falls back to the threat class when every tag is a format', () => {
+    expect(familyOf(['exe', 'zip'], 'malware_download')).toBe('malware download');
+    expect(familyOf([], 'malware_download')).toBe('malware download');
+  });
+
+  it('has something to say with nothing to go on', () => {
+    expect(familyOf([], '')).toBe('malware');
+  });
+
+  it('skips the distribution host that reporters tag before the family', () => {
+    // Live shapes: the dash-written host sorts first, so "first usable tag"
+    // labelled 60-odd nodes "176-65-139-196" instead of "mirai".
+    expect(familyOf(['176-65-139-196', 'elf', 'mirai', 'ua-wget'], 'malware_download')).toBe('mirai');
+    expect(familyOf(['176-65-139-140', 'elf', 'gafgyt', 'ua-wget'], 'malware_download')).toBe('gafgyt');
+    expect(familyOf(['152-42-202-172', 'elf', 'Tsunami', 'ua-wget'], 'malware_download')).toBe('Tsunami');
+  });
+
+  it('skips a host tag that carries a port too', () => {
+    expect(familyOf(['121-127-245-197-8080', 'exe'], 'malware_download')).toBe('malware download');
+  });
+
+  it('skips payload hashes', () => {
+    expect(familyOf(['42d208560b5e968930dcedab3c2bf57b', 'exe', 'Vidar'], 'malware_download')).toBe('Vidar');
+    expect(familyOf(['9d2ca3'], 'malware_download')).toBe('malware download');
+  });
+
+  it('treats the literal tag "None" as no tag at all', () => {
+    // 119 of 473 live hosts carry exactly this.
+    expect(familyOf(['None'], 'malware_download')).toBe('malware download');
+  });
+
+  it('does not mistake a short family name for a hash', () => {
+    expect(familyOf(['Amos'], 'malware_download')).toBe('Amos');
+    expect(familyOf(['Chaos'], 'malware_download')).toBe('Chaos');
+  });
+});
+
+describe('groupByHost', () => {
+  it('collapses many URLs on one box into a single node', () => {
+    const hosts = groupByHost(parseUrlhausCsv(CSV));
+    expect(hosts.size).toBe(2);
+    expect(hosts.get('103.179.240.227')!.count).toBe(2);
+    expect(hosts.get('119.115.250.29')!.count).toBe(1);
+  });
+
+  it('tracks the newest and oldest report on the host', () => {
+    const host = groupByHost(parseUrlhausCsv(CSV)).get('103.179.240.227')!;
+    expect(host.newest.id).toBe(3910216);
+    expect(host.oldest.id).toBe(3910214);
+  });
+
+  it('takes the port from the newest report', () => {
+    const hosts = groupByHost([
+      rec({ id: 1, url: 'http://1.2.3.4:8080/old' }),
+      rec({ id: 2, url: 'http://1.2.3.4:9090/new' }),
+    ]);
+    expect(hosts.get('1.2.3.4')!.port).toBe(9090);
+  });
+
+  it('drops domain-hosted URLs', () => {
+    expect(groupByHost([rec({ url: 'http://example.com/x' })]).size).toBe(0);
+  });
+});
+
+describe('toDetection', () => {
+  it('places a host at its geolocation, not its country centroid', () => {
+    const host = groupByHost(parseUrlhausCsv(CSV)).get('103.179.240.227')!;
+    const d = toDetection(host, GEO)!;
+    expect(d).toMatchObject({
+      id: 'urlhaus-103.179.240.227',
+      lat: -6.2, lng: 106.8,
+      ip: '103.179.240.227',
+      port: 39430,
+      malware: 'Mozi',
+      country: 'ID', city: 'Jakarta', asn: 138062,
+      url_count: 2,
+      urlhaus_id: 3910216,
+      reference: 'https://urlhaus.abuse.ch/url/3910216/',
+    });
+  });
+
+  it('spans first to last report', () => {
+    const host = groupByHost(parseUrlhausCsv(CSV)).get('103.179.240.227')!;
+    const d = toDetection(host, GEO)!;
+    expect(d.first_seen).toBe('2026-08-31 01:55:25');
+    expect(d.last_seen).toBe('2026-08-31 02:15:25');
+  });
+
+  it('drops a host that could not be geolocated instead of guessing one', () => {
+    const host = groupByHost(parseUrlhausCsv(CSV)).get('103.179.240.227')!;
+    expect(toDetection(host, undefined)).toBeNull();
+    expect(toDetection(host, { ...GEO, lat: NaN })).toBeNull();
+  });
+});
+
+describe('detectionChanged', () => {
+  const base = () => toDetection(groupByHost(parseUrlhausCsv(CSV)).get('103.179.240.227')!, GEO)!;
+
+  it('sees a host that picked up another payload', () => {
+    // A connected client would otherwise never learn this host went from 2
+    // live URLs to 40 — it only hears about addresses it has not seen before.
+    expect(detectionChanged(base(), { ...base(), url_count: 40 })).toBe(true);
+  });
+
+  it('sees a newer report on the same host', () => {
+    expect(detectionChanged(base(), { ...base(), urlhaus_id: 3910999 })).toBe(true);
+  });
+
+  it('sees the first sighting move when an older row ages out', () => {
+    expect(detectionChanged(base(), { ...base(), first_seen: '2026-08-30 00:00:00' })).toBe(true);
+  });
+
+  it('stays quiet when nothing moved', () => {
+    // Every poll rebuilds all ~470 detections; without this they would all be
+    // pushed to every client once a minute.
+    expect(detectionChanged(base(), base())).toBe(false);
+  });
+
+  it('ignores geolocation jitter, which is cached and not host activity', () => {
+    expect(detectionChanged(base(), { ...base(), city: 'Elsewhere', lat: 1, lng: 2 })).toBe(false);
+  });
+});
+
+describe('arrivalBeacons', () => {
+  const now = 1_700_000_000_000;
+  const at = (detected_at?: number, lng = 10, lat = 20) =>
+    ({ ...toDetection(groupByHost(parseUrlhausCsv(CSV)).get('103.179.240.227')!, GEO)!, lng, lat, detected_at });
+
+  it('beacons a detection that just landed, at age 0', () => {
+    expect(arrivalBeacons([at(now)], now)).toEqual([{ lng: 10, lat: 20, age: 0 }]);
+  });
+
+  it('fades across the window', () => {
+    expect(arrivalBeacons([at(now - 30_000)], now)[0].age).toBeCloseTo(0.5);
+    expect(arrivalBeacons([at(now - 59_000)], now)[0].age).toBeCloseTo(0.983, 2);
+  });
+
+  it('drops a detection once the window closes', () => {
+    expect(arrivalBeacons([at(now - 60_000)], now)).toEqual([]);
+    expect(arrivalBeacons([at(now - 600_000)], now)).toEqual([]);
+  });
+
+  it('never beacons the initial fill', () => {
+    // Detections from the cold snapshot carry no timestamp; without this the
+    // whole map would pulse on first paint.
+    expect(arrivalBeacons([at(undefined)], now)).toEqual([]);
+    expect(arrivalBeacons([at(0)], now)).toEqual([]);
+  });
+
+  it('treats a future timestamp as expired rather than pinning a ring on', () => {
+    // A client clock behind the server must not leave a ring that never clears.
+    expect(arrivalBeacons([at(now + 5_000)], now)).toEqual([]);
+  });
+
+  it('honours a caller-supplied window', () => {
+    expect(arrivalBeacons([at(now - 5_000)], now, 10_000)[0].age).toBeCloseTo(0.5);
+    expect(arrivalBeacons([at(now - 5_000)], now, 4_000)).toEqual([]);
+  });
+});
+
+describe('newSince / maxId', () => {
+  const rows = [rec({ id: 7 }), rec({ id: 5 }), rec({ id: 9 })];
+
+  it('returns only rows above the cursor, in report order', () => {
+    expect(newSince(rows, 5).map(r => r.id)).toEqual([7, 9]);
+  });
+
+  it('returns nothing when the cursor is current — a quiet poll is not an update', () => {
+    expect(newSince(rows, 9)).toEqual([]);
+  });
+
+  it('treats a zero cursor as a cold start', () => {
+    expect(newSince(rows, 0)).toHaveLength(3);
+  });
+
+  it('advances the cursor to the highest id seen', () => {
+    expect(maxId(rows)).toBe(9);
+    expect(maxId([], 42)).toBe(42);
+  });
+});

--- a/src/lib/malware-intel.ts
+++ b/src/lib/malware-intel.ts
@@ -1,0 +1,380 @@
+/**
+ * OSIRIS — live malware detection, parsing and normalisation.
+ *
+ * This module is the pure half of the malware layer: text in, detections out,
+ * no network and no clock. The live half — polling, geolocation budget,
+ * subscribers — lives in `malware-live.ts`, so everything here is testable
+ * against a fixture.
+ *
+ * What the layer used to do, and why none of it survived:
+ *
+ *   Feodo Tracker was the primary source. It is no longer a feed in any
+ *   meaningful sense — `ipblocklist.json` currently returns five rows, four of
+ *   them `offline`. A world map of five dots is not a threat picture, so it is
+ *   not consulted at all; URLhaus alone carries the layer. Nothing here should
+ *   grow a Feodo path again without first checking that the feed has recovered.
+ *
+ *   Nodes were placed at a country centroid plus a deterministic jitter, so
+ *   every US host landed in the same blob over Kansas. That is a picture of the
+ *   country field, not of where the host is. Placement now comes from a real
+ *   per-IP geolocation, and a detection that cannot be geolocated is dropped
+ *   rather than guessed.
+ *
+ *   Ports were read off `entry.dst_port`, which does not exist on a Feodo
+ *   record — the field is `port` — so every node reported port 0. URLhaus URLs
+ *   carry the real port in the authority (`http://1.2.3.4:39430/i`), and that
+ *   is what a C2 on a high port is actually listening on.
+ *
+ * The real-time seam is URLhaus's `id`: a monotonically increasing integer, one
+ * per reported URL. Everything above the last id we saw is new since the last
+ * poll — no timestamp comparison, no clock skew, no re-reading the whole corpus
+ * to find what changed.
+ */
+
+/** One row of a URLhaus CSV dump, before geolocation. */
+export interface UrlhausRecord {
+  id: number;
+  dateadded: string;
+  url: string;
+  status: string;
+  threat: string;
+  tags: string[];
+  link: string;
+  reporter: string;
+}
+
+/** A geolocated host, as the map consumes it. */
+export interface Detection {
+  id: string;
+  lat: number;
+  lng: number;
+  ip: string;
+  port: number;
+  malware: string;
+  status: string;
+  first_seen: string;
+  last_seen: string;
+  country: string;
+  city: string;
+  asn: number | null;
+  as_name: string;
+  threat_type: string;
+  /** How many distinct malicious URLs are served from this host. */
+  url_count: number;
+  /** Newest URLhaus id on this host — the diff cursor, and the evidence link. */
+  urlhaus_id: number;
+  reference: string;
+  reporter: string;
+  tags: string[];
+}
+
+/**
+ * A detection as the client holds it.
+ *
+ * `detected_at` is stamped browser-side when a detection arrives over the live
+ * stream after the initial fill, and drives the arrival beacon on the map. It
+ * is deliberately not part of `Detection`: it records when *this session* saw
+ * the report, which is not a property of the threat.
+ */
+export type LiveDetection = Detection & { detected_at?: number };
+
+/** Per-IP geolocation, as returned by the batch lookup. */
+export interface GeoResult {
+  ip: string;
+  lat: number;
+  lng: number;
+  country: string;
+  city: string;
+  asn: number | null;
+  as_name: string;
+}
+
+/** A host as grouped out of the corpus, before geolocation joins it. */
+export interface HostGroup {
+  ip: string;
+  port: number;
+  newest: UrlhausRecord;
+  oldest: UrlhausRecord;
+  count: number;
+}
+
+/**
+ * Tags that describe the *file*, not the threat.
+ *
+ * URLhaus tags mix two different things: what the payload is built as (`elf`,
+ * `32-bit`, `mips`) and what it belongs to (`Mozi`, `mirai`, `SmartLoader`).
+ * Only the second is a malware family, and the map label is worthless if it
+ * reads "32-bit". Anything in this set is skipped when choosing a family name.
+ */
+const NON_FAMILY_TAGS = new Set([
+  '32-bit', '64-bit', 'arm', 'mips', 'mipsel', 'x86', 'x86-64', 'sparc', 'ppc', 'm68k', 'sh4', 'arc',
+  'elf', 'exe', 'dll', 'zip', 'rar', '7z', 'doc', 'docx', 'xls', 'xlsx', 'pdf', 'rtf', 'lnk',
+  'js', 'vbs', 'ps1', 'sh', 'bat', 'jar', 'apk', 'msi', 'iso', 'img', 'html', 'htm', 'php', 'py',
+  'opendir', 'censys', 'ua-wget', 'ua-curl', 'shodan', 'unknown', 'encrypted', 'obfuscated',
+  'malware', 'payload', 'binary', 'none', 'ascii', 'iot', 'honeypot',
+]);
+
+/**
+ * Tags that are an artefact of how the sample was catalogued, not a name.
+ *
+ * URLhaus reporters routinely tag a URL with the distribution host written as a
+ * dash-separated address — `176-65-139-196`, sometimes with the port appended —
+ * and it sorts before the family, so a naive "first usable tag" lands on it.
+ * Payload hashes show up the same way. Both make a map label that says nothing;
+ * the real name (`mirai`, `gafgyt`, `Tsunami`) is further down the same list.
+ */
+const TAG_ARTEFACT = [
+  /^\d+$/,                    // a bare count or index
+  /^\d{1,3}(-\d{1,5}){3,4}$/, // dash-written address, optionally with a port
+  /^[0-9a-f]{6,}$/i,          // md5/sha fragment
+];
+
+/**
+ * Parse a quoted CSV dump from URLhaus.
+ *
+ * The old code did `line.split('","')`. That looks like it works until a tags
+ * field arrives — tags are comma-separated *inside* a single quoted field
+ * (`"32-bit,elf,mips,Mozi"`) — and until a URL contains a quote. This is a real
+ * parser over the quoted-field grammar instead: it walks the line, tracks
+ * whether it is inside quotes, and treats a doubled quote as an escaped one.
+ *
+ * Comment lines and the header are skipped. Rows that do not have the nine
+ * columns the dump documents are skipped rather than half-read.
+ */
+export function parseUrlhausCsv(text: string): UrlhausRecord[] {
+  const out: UrlhausRecord[] = [];
+
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const cols = splitCsvLine(line);
+    if (cols.length < 9) continue;
+
+    const id = Number(cols[0]);
+    if (!Number.isFinite(id)) continue; // header row, or a truncated write
+
+    out.push({
+      id,
+      dateadded: cols[1],
+      url: cols[2],
+      status: cols[3],
+      threat: cols[5],
+      tags: cols[6] ? cols[6].split(',').map(t => t.trim()).filter(Boolean) : [],
+      link: cols[7],
+      reporter: cols[8],
+    });
+  }
+
+  return out;
+}
+
+function splitCsvLine(line: string): string[] {
+  const cols: string[] = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') { field += '"'; i++; } // escaped quote
+        else inQuotes = false;
+      } else field += ch;
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      cols.push(field);
+      field = '';
+    } else field += ch;
+  }
+  cols.push(field);
+
+  return cols;
+}
+
+const IPV4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+/**
+ * Pull the host and port out of a malware URL.
+ *
+ * Only IPv4-literal hosts are usable here. A domain would need a DNS
+ * resolution per URL to place on a map — thousands of lookups against hosts
+ * that are hostile by definition, and the answer would be a CDN edge as often
+ * as the actual server. Roughly half of URLhaus's online corpus is already an
+ * IP literal, which is plenty of density and is honestly placeable.
+ *
+ * Returns null for a domain host, a malformed URL, or an octet out of range.
+ */
+export function hostOf(url: string): { ip: string; port: number } | null {
+  const m = /^(https?):\/\/([^/?#]+)/i.exec(url);
+  if (!m) return null;
+
+  const scheme = m[1].toLowerCase();
+  const authority = m[2];
+
+  // Strip userinfo — `http://user:pass@1.2.3.4/x` puts the host after the '@'.
+  const hostPart = authority.slice(authority.lastIndexOf('@') + 1);
+
+  const colon = hostPart.lastIndexOf(':');
+  const host = colon === -1 ? hostPart : hostPart.slice(0, colon);
+  const portText = colon === -1 ? '' : hostPart.slice(colon + 1);
+
+  const octets = IPV4.exec(host);
+  if (!octets) return null;
+  for (let i = 1; i <= 4; i++) {
+    if (Number(octets[i]) > 255) return null;
+  }
+
+  const fallbackPort = scheme === 'https' ? 443 : 80;
+  const parsed = portText ? Number(portText) : fallbackPort;
+  const port = Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : fallbackPort;
+
+  return { ip: host, port };
+}
+
+/**
+ * Best available name for what is being served.
+ *
+ * Prefers a family tag, falls back to the threat class. Family tags are
+ * capitalised inconsistently upstream (`mirai`, `Mozi`, `SmartLoader`), and the
+ * first tag is not necessarily the most specific, so this takes the first tag
+ * that is not a file-format or scanner artefact.
+ */
+export function familyOf(tags: string[], threat: string): string {
+  for (const tag of tags) {
+    const t = tag.trim();
+    if (!t) continue;
+    if (NON_FAMILY_TAGS.has(t.toLowerCase())) continue;
+    if (TAG_ARTEFACT.some(re => re.test(t))) continue;
+    return t;
+  }
+  return threat ? threat.replace(/_/g, ' ') : 'malware';
+}
+
+/**
+ * Collapse URLhaus rows to one entry per host.
+ *
+ * A single compromised box commonly serves dozens of payload URLs. Drawing one
+ * dot per URL stacks them into an unreadable pile and makes a busy host look
+ * like a busy region. One dot per host, carrying the URL count, is both fewer
+ * addresses to geolocate and the more honest picture — and `url_count` is a
+ * real measure of how active the host is, so the map can size by it.
+ *
+ * The newest row wins the label, the port and the reference link.
+ */
+export function groupByHost(records: UrlhausRecord[]): Map<string, HostGroup> {
+  const hosts = new Map<string, HostGroup>();
+
+  for (const rec of records) {
+    const host = hostOf(rec.url);
+    if (!host) continue;
+
+    const existing = hosts.get(host.ip);
+    if (!existing) {
+      hosts.set(host.ip, { ip: host.ip, port: host.port, newest: rec, oldest: rec, count: 1 });
+      continue;
+    }
+
+    existing.count++;
+    if (rec.id > existing.newest.id) { existing.newest = rec; existing.port = host.port; }
+    if (rec.id < existing.oldest.id) existing.oldest = rec;
+  }
+
+  return hosts;
+}
+
+/** Join a grouped host to its geolocation. Hosts without one are dropped. */
+export function toDetection(host: HostGroup, geo: GeoResult | undefined): Detection | null {
+  if (!geo) return null;
+  if (!Number.isFinite(geo.lat) || !Number.isFinite(geo.lng)) return null;
+
+  return {
+    id: `urlhaus-${host.ip}`,
+    lat: geo.lat,
+    lng: geo.lng,
+    ip: host.ip,
+    port: host.port,
+    malware: familyOf(host.newest.tags, host.newest.threat),
+    status: host.newest.status || 'online',
+    first_seen: host.oldest.dateadded,
+    last_seen: host.newest.dateadded,
+    country: geo.country || 'XX',
+    city: geo.city || '',
+    asn: geo.asn,
+    as_name: geo.as_name || '',
+    threat_type: host.newest.threat || 'malware_download',
+    url_count: host.count,
+    urlhaus_id: host.newest.id,
+    reference: host.newest.link,
+    reporter: host.newest.reporter,
+    tags: host.newest.tags,
+  };
+}
+
+/**
+ * Whether a rebuilt detection says anything new about a host.
+ *
+ * Everything mutable on a detection derives from the host's newest report and
+ * how many reports it has, so these three fields settle it without comparing
+ * the whole object — and getting this wrong in either direction is costly: too
+ * strict and connected clients never learn a host grew from one payload to
+ * forty, too loose and every poll pushes 470 unchanged detections at everyone.
+ */
+export function detectionChanged(prev: Detection, next: Detection): boolean {
+  return prev.urlhaus_id !== next.urlhaus_id
+    || prev.url_count !== next.url_count
+    || prev.first_seen !== next.first_seen;
+}
+
+/** How long a freshly-reported detection keeps its arrival beacon. */
+export const BEACON_WINDOW_MS = 60_000;
+
+/**
+ * Detections still inside the arrival-beacon window, with their fade progress.
+ *
+ * A pushed feed is indistinguishable from a static one unless arrivals are
+ * marked — nodes would simply appear, and the thing that makes it live goes
+ * unseen. `age` runs 0 (just landed) to 1 (leaving the window) and drives both
+ * the ring's expansion and its fade.
+ *
+ * A detection with no `detected_at` was part of the initial fill, not an
+ * arrival, and never beacons. A timestamp in the future is treated as expired
+ * rather than pinned at full brightness: a client whose clock is behind the
+ * server should show nothing, not a ring that never clears.
+ */
+export function arrivalBeacons(
+  detections: LiveDetection[],
+  now: number,
+  windowMs: number = BEACON_WINDOW_MS,
+): Array<{ lng: number; lat: number; age: number }> {
+  const out: Array<{ lng: number; lat: number; age: number }> = [];
+
+  for (const d of detections) {
+    const at = d.detected_at;
+    if (!at) continue;
+    const elapsed = now - at;
+    if (elapsed < 0 || elapsed >= windowMs) continue;
+    out.push({ lng: d.lng, lat: d.lat, age: elapsed / windowMs });
+  }
+
+  return out;
+}
+
+/**
+ * Rows reported since the cursor.
+ *
+ * URLhaus ids only ever increase, so this is the entire real-time mechanism:
+ * hold the highest id seen, and anything above it on the next poll is new.
+ * Returned oldest-first so subscribers receive them in report order.
+ */
+export function newSince(records: UrlhausRecord[], cursor: number): UrlhausRecord[] {
+  return records.filter(r => r.id > cursor).sort((a, b) => a.id - b.id);
+}
+
+/** Highest id in a batch, or the fallback if the batch is empty. */
+export function maxId(records: UrlhausRecord[], fallback = 0): number {
+  let max = fallback;
+  for (const r of records) if (r.id > max) max = r.id;
+  return max;
+}

--- a/src/lib/malware-live.ts
+++ b/src/lib/malware-live.ts
@@ -1,0 +1,511 @@
+import http from 'http';
+import { httpConditional, OSIRIS_UA, type Validators } from './httpJson';
+import {
+  parseUrlhausCsv,
+  groupByHost,
+  toDetection,
+  detectionChanged,
+  newSince,
+  maxId,
+  type Detection,
+  type GeoResult,
+  type HostGroup,
+} from './malware-intel';
+
+/**
+ * OSIRIS — the live half of the malware layer.
+ *
+ * The layer used to be a request/response feed: the client asked, the route
+ * re-downloaded a dump, geolocated a hundred addresses inline and answered.
+ * Every caller paid the full upstream cost, nothing was shared between them,
+ * and "live" meant a ten-second poll that re-fetched the same rows to find
+ * nothing had changed.
+ *
+ * This is a single store instead. One poll loop feeds every connected client,
+ * and clients are pushed to rather than polling. Concretely:
+ *
+ *   Source. `csv_recent` — URLhaus's rolling 30-day window, regenerated
+ *   upstream every five minutes. Filtered to rows still `online`, that is
+ *   ~1,550 malicious URLs across ~470 distinct IPv4 hosts. The bigger
+ *   `json_online` dump exists, but it is 8.6 MB against 2.9 MB and its extra
+ *   depth is mostly URLs that have been up for years — this window is the one
+ *   that changes, and it is the one worth polling.
+ *
+ *   Cost. The dump is regenerated every five minutes but polled every one, so
+ *   four polls in five would re-download an identical 2.9 MB — 175 MB an hour
+ *   to learn nothing. abuse.ch serves `ETag`/`Last-Modified` and honours
+ *   `If-None-Match`, so an unchanged poll is a 304 with no body, and the
+ *   changed one is requested gzipped (2.9 MB becomes ~400 KB). The fast
+ *   cadence is what keeps latency low; the conditional request is what makes
+ *   it nearly free.
+ *
+ *   Cursor. URLhaus ids increase monotonically, so the highest id seen is the
+ *   whole synchronisation state. A poll that returns no id above the cursor is
+ *   a no-op that emits nothing.
+ *
+ *   Geolocation is the expensive half, and it is cached per address for a day.
+ *   An address is looked up once, ever, in practice: after the first fill the
+ *   only lookups are the handful of genuinely new hosts per poll. That is what
+ *   makes a 60-second cadence affordable against a free geolocation service.
+ *
+ * Nothing here starts on import. The loop is kicked by the first request that
+ * needs it, so a deployment where nobody opens the layer does no background
+ * work at all.
+ */
+
+/** URLhaus regenerates this dump every ~5 minutes; 60s keeps latency under it. */
+const POLL_MS = 60_000;
+
+/** An address does not move. Re-checking one daily is generous. */
+const GEO_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** A failed lookup should retry, but not on the very next poll. */
+const GEO_RETRY_MS = 10 * 60 * 1000;
+
+/**
+ * ip-api's free tier allows 15 batch requests per minute, 100 addresses each.
+ * A cold start is ~5 batches, so this paces well inside the limit and leaves
+ * headroom for the incremental lookups that follow.
+ */
+const GEO_BATCH_SIZE = 100;
+const GEO_BATCH_GAP_MS = 4_000;
+const GEO_BATCHES_PER_POLL = 8;
+
+/**
+ * Ceiling on the address cache.
+ *
+ * Hosts churn through the 30-day window continuously, so without a bound this
+ * map is the one structure here that grows forever on a long-running server.
+ * Entries backing a current detection are never evicted; the rest go
+ * oldest-first, and anything dropped is simply looked up again if it returns.
+ */
+const MAX_GEO_ENTRIES = 5_000;
+
+const RECENT_CSV = 'https://urlhaus.abuse.ch/downloads/csv_recent/';
+
+const GEO_ENDPOINT = 'http://ip-api.com/batch?fields=status,countryCode,city,lat,lon,as,query';
+
+export const MALWARE_SOURCE = 'abuse.ch URLhaus (live) + ip-api geolocation';
+
+export type LiveEvent =
+  | { type: 'snapshot'; detections: Detection[]; cursor: number; total: number }
+  /**
+   * `fresh` separates hosts observed for the first time from ones already on
+   * the map whose activity moved. Both must reach the client, but only the
+   * first is an arrival — beaconing an update would flag a host as new every
+   * time it served one more payload.
+   */
+  | { type: 'detections'; detections: Detection[]; fresh: boolean; cursor: number; total: number }
+  /**
+   * `retired` carries hosts that have dropped out of the online window since
+   * the last poll. Without it a client only ever accumulates: it keys
+   * detections by address and never removes one, while the store prunes on
+   * every poll, so a tab left open slowly overstates the picture.
+   */
+  | { type: 'status'; total: number; cursor: number; lastPollAt: number; error: string | null; retired: string[] };
+
+interface GeoEntry { geo: GeoResult | null; at: number }
+
+interface Store {
+  /** Current picture, keyed by address. */
+  detections: Map<string, Detection>;
+  /** Address → location, or null for a lookup that failed. */
+  geo: Map<string, GeoEntry>;
+  /**
+   * Last parsed corpus, so a 304 poll can still work the geolocation backlog
+   * without re-downloading and re-parsing what it already has.
+   */
+  hosts: Map<string, HostGroup>;
+  /** ETag / Last-Modified from the last 200, replayed on the next poll. */
+  validators: Validators;
+  cursor: number;
+  lastPollAt: number;
+  lastError: string | null;
+  subscribers: Set<(event: LiveEvent) => void>;
+  timer: ReturnType<typeof setInterval> | null;
+  polling: boolean;
+  /** Resolves once the first poll has finished, so a cold request can wait. */
+  primed: Promise<void> | null;
+}
+
+/**
+ * Held on globalThis so Next's dev-mode module reloading does not start a
+ * second poll loop against the same upstream — the SDK stream route pins its
+ * entity store the same way.
+ */
+const globalForMalware = globalThis as unknown as { osirisMalwareStore?: Store };
+
+function store(): Store {
+  if (!globalForMalware.osirisMalwareStore) {
+    globalForMalware.osirisMalwareStore = {
+      detections: new Map(),
+      geo: new Map(),
+      hosts: new Map(),
+      validators: {},
+      cursor: 0,
+      lastPollAt: 0,
+      lastError: null,
+      subscribers: new Set(),
+      timer: null,
+      polling: false,
+      primed: null,
+    };
+  }
+  return globalForMalware.osirisMalwareStore;
+}
+
+function emit(event: LiveEvent): void {
+  const s = store();
+  for (const fn of s.subscribers) {
+    try { fn(event); } catch { /* a broken subscriber must not stall the loop */ }
+  }
+}
+
+/**
+ * POST a JSON body over Node's http client.
+ *
+ * Not `fetch`: the bundled undici in the Next server runtime fails these
+ * intermittently with a bare `TypeError: fetch failed` — the same behaviour
+ * that `httpJson` exists to work around, and observed here dropping roughly one
+ * geolocation batch in five. `httpJson` itself is https-only, and ip-api's free
+ * tier does not serve TLS, so this is the plaintext sibling.
+ */
+function postJson(endpoint: string, body: unknown, timeoutMs = 15_000): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const payload = Buffer.from(JSON.stringify(body), 'utf8');
+    const url = new URL(endpoint);
+
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port || 80,
+        path: url.pathname + url.search,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': payload.length,
+          'User-Agent': OSIRIS_UA,
+        },
+        timeout: timeoutMs,
+      },
+      res => {
+        if (res.statusCode && res.statusCode >= 400) {
+          res.resume();
+          reject(new Error(`HTTP ${res.statusCode}`));
+          return;
+        }
+        let text = '';
+        res.setEncoding('utf8');
+        res.on('data', chunk => { text += chunk; });
+        res.on('error', reject);
+        res.on('end', () => {
+          try { resolve(JSON.parse(text)); } catch (e) { reject(e); }
+        });
+      },
+    );
+
+    req.on('timeout', () => req.destroy(new Error('Geolocation timed out')));
+    req.on('error', reject);
+    req.end(payload);
+  });
+}
+
+/**
+ * Look up a batch of addresses.
+ *
+ * ip-api's free tier is plaintext HTTP only — TLS is a paid feature. That is
+ * acceptable here and nowhere else in OSIRIS: the request body is a list of
+ * already-public malware host addresses, the response is coarse city-level
+ * geography, and no credential or user data is involved. It is called only
+ * with addresses parsed out of the URLhaus dump, never with anything a client
+ * supplied, so there is no request-forgery surface to guard.
+ */
+async function geolocate(ips: string[]): Promise<GeoResult[]> {
+  const rows = await postJson(GEO_ENDPOINT, ips);
+  if (!Array.isArray(rows)) return [];
+
+  const out: GeoResult[] = [];
+  for (const row of rows) {
+    if (!row || row.status !== 'success') continue;
+    const lat = Number(row.lat);
+    const lng = Number(row.lon);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+
+    // `as` arrives as "AS15169 Google LLC" — split the number from the name.
+    const asText = typeof row.as === 'string' ? row.as : '';
+    const asMatch = /^AS(\d+)\s*(.*)$/.exec(asText);
+
+    out.push({
+      ip: String(row.query),
+      lat,
+      lng,
+      country: String(row.countryCode ?? ''),
+      city: String(row.city ?? ''),
+      asn: asMatch ? Number(asMatch[1]) : null,
+      as_name: asMatch ? asMatch[2] : asText,
+    });
+  }
+  return out;
+}
+
+/** Drop cached addresses nothing is currently drawing, oldest first. */
+function evictGeo(): void {
+  const s = store();
+  if (s.geo.size <= MAX_GEO_ENTRIES) return;
+
+  for (const ip of s.geo.keys()) {
+    if (s.geo.size <= MAX_GEO_ENTRIES) break;
+    if (s.detections.has(ip)) continue;
+    s.geo.delete(ip);
+  }
+}
+
+/** Addresses with no usable cache entry, in the order they should be resolved. */
+function needsGeo(hosts: HostGroup[], now: number): string[] {
+  const s = store();
+  const out: string[] = [];
+
+  for (const host of hosts) {
+    const cached = s.geo.get(host.ip);
+    if (cached) {
+      const ttl = cached.geo ? GEO_TTL_MS : GEO_RETRY_MS;
+      if (now - cached.at < ttl) continue;
+    }
+    out.push(host.ip);
+  }
+  return out;
+}
+
+/**
+ * Resolve outstanding addresses and fold the results into the picture.
+ *
+ * Emits after each batch rather than at the end, so a cold start fills the map
+ * progressively instead of staying empty for half a minute and then snapping
+ * to 470 nodes at once.
+ */
+async function fillGeo(hosts: Map<string, HostGroup>, pending: string[]): Promise<void> {
+  const s = store();
+  const batches = Math.min(Math.ceil(pending.length / GEO_BATCH_SIZE), GEO_BATCHES_PER_POLL);
+
+  for (let b = 0; b < batches; b++) {
+    const slice = pending.slice(b * GEO_BATCH_SIZE, (b + 1) * GEO_BATCH_SIZE);
+    if (slice.length === 0) break;
+    if (b > 0) await new Promise(r => setTimeout(r, GEO_BATCH_GAP_MS));
+
+    const now = Date.now();
+    let results: GeoResult[] = [];
+    try {
+      results = await geolocate(slice);
+    } catch (e) {
+      // Leave these addresses uncached so the next poll retries them.
+      s.lastError = `geolocation failed: ${e instanceof Error ? e.message : String(e)}`;
+      continue;
+    }
+
+    const found = new Set<string>();
+    for (const geo of results) {
+      s.geo.set(geo.ip, { geo, at: now });
+      found.add(geo.ip);
+    }
+    // Remember the misses too, or every poll re-asks about the same dead hosts.
+    for (const ip of slice) if (!found.has(ip)) s.geo.set(ip, { geo: null, at: now });
+
+    const added: Detection[] = [];
+    for (const ip of slice) {
+      const host = hosts.get(ip);
+      const entry = s.geo.get(ip);
+      if (!host || !entry?.geo) continue;
+      const detection = toDetection(host, entry.geo);
+      if (!detection) continue;
+      s.detections.set(ip, detection);
+      added.push(detection);
+    }
+
+    if (added.length > 0) {
+      emit({ type: 'detections', detections: added, fresh: true, cursor: s.cursor, total: s.detections.size });
+    }
+  }
+
+  evictGeo();
+}
+
+/**
+ * Rebuild detections for hosts already geolocated, and return the ones that
+ * actually moved.
+ *
+ * A host that picks up nine more payloads is a materially different node — it
+ * is drawn larger and its popup count changes — but a client that connected an
+ * hour ago would never learn that, because it only ever hears about addresses
+ * it has not seen. Returning the delta lets the caller push it.
+ */
+function refreshKnown(hosts: Map<string, HostGroup>): Detection[] {
+  const s = store();
+  const changed: Detection[] = [];
+
+  for (const [ip, host] of hosts) {
+    const entry = s.geo.get(ip);
+    if (!entry?.geo) continue;
+
+    const next = toDetection(host, entry.geo);
+    if (!next) continue;
+
+    const prev = s.detections.get(ip);
+    s.detections.set(ip, next);
+    if (prev && detectionChanged(prev, next)) changed.push(next);
+  }
+
+  return changed;
+}
+
+/**
+ * One pass: pull the dump if it moved, advance the cursor, resolve what is new.
+ *
+ * A host that has dropped out of the online window is removed, so the map
+ * reflects what is serving malware now rather than accumulating forever.
+ */
+async function poll(): Promise<void> {
+  const s = store();
+  if (s.polling) return;
+  s.polling = true;
+
+  try {
+    const res = await httpConditional(RECENT_CSV, {
+      ...s.validators,
+      timeoutMs: 30_000,
+      headers: { Accept: 'text/csv', 'Accept-Encoding': 'gzip' },
+    });
+
+    s.validators = { etag: res.etag, lastModified: res.lastModified };
+    s.lastPollAt = Date.now();
+    s.lastError = null;
+
+    const cold = s.cursor === 0;
+    const retired: string[] = [];
+    const freshHosts = new Set<string>();
+
+    if (res.changed && res.body !== null) {
+      const rows = parseUrlhausCsv(res.body).filter(r => r.status === 'online');
+      const fresh = newSince(rows, s.cursor);
+
+      s.hosts = groupByHost(rows);
+      s.cursor = maxId(rows, s.cursor);
+
+      for (const host of groupByHost(fresh).values()) freshHosts.add(host.ip);
+
+      // Drop hosts no longer in the online window, and remember which, so
+      // subscribers prune the same ones rather than drifting upward.
+      for (const ip of [...s.detections.keys()]) {
+        if (s.hosts.has(ip)) continue;
+        s.detections.delete(ip);
+        retired.push(ip);
+      }
+
+      // Hosts already on the map whose activity moved. Not arrivals, so these
+      // go out without the beacon flag.
+      const updated = refreshKnown(s.hosts);
+      if (updated.length > 0) {
+        emit({ type: 'detections', detections: updated, fresh: false, cursor: s.cursor, total: s.detections.size });
+      }
+
+      // Only the polls that moved something are worth a line. The quiet ones
+      // are the overwhelming majority and logging them would bury this.
+      console.log(
+        `[OSIRIS] malware: dump changed — ${fresh.length} new URL(s), ` +
+        `${updated.length} host(s) updated, ${retired.length} retired, ${s.hosts.size} online`,
+      );
+    }
+
+    // On a cold start, resolve the busiest hosts first — if the geolocation
+    // budget runs out mid-fill, the map already shows what matters most.
+    const ordered = [...s.hosts.values()].sort((a, b) => b.count - a.count);
+    const pending = needsGeo(ordered, Date.now());
+
+    if (pending.length > 0) {
+      // A poll that brought new rows chases only the addresses those rows
+      // introduced, so one new host does not drag the whole backlog along with
+      // it. Any other poll — cold, or quiet — spends the idle budget on the
+      // backlog itself.
+      const target = !cold && freshHosts.size > 0 ? pending.filter(ip => freshHosts.has(ip)) : pending;
+      await fillGeo(s.hosts, target);
+    }
+
+    emit({
+      type: 'status',
+      total: s.detections.size,
+      cursor: s.cursor,
+      lastPollAt: s.lastPollAt,
+      error: s.lastError,
+      retired,
+    });
+  } catch (e) {
+    // Keep serving the last good picture — an upstream blip must not empty the
+    // layer, which is exactly what the old route did on any fetch failure.
+    s.lastError = e instanceof Error ? e.message : String(e);
+    console.warn('[OSIRIS] malware poll failed:', s.lastError);
+
+    // A first poll that failed left the store empty. Clearing this lets the
+    // next request retry immediately instead of serving nothing until the
+    // interval comes round again.
+    if (s.detections.size === 0) s.primed = null;
+  } finally {
+    s.polling = false;
+  }
+}
+
+/** Start the loop if it is not already running, and wait for the first pass. */
+export function startMalwareFeed(): Promise<void> {
+  const s = store();
+
+  if (!s.primed) s.primed = poll();
+  if (!s.timer) {
+    s.timer = setInterval(() => { void poll(); }, POLL_MS);
+    // Node keeps the process alive for a pending interval; this loop should
+    // never be the reason a server refuses to exit.
+    (s.timer as unknown as { unref?: () => void }).unref?.();
+  }
+
+  return s.primed;
+}
+
+/** Current picture, newest report first. */
+export function malwareSnapshot(): {
+  detections: Detection[];
+  total: number;
+  cursor: number;
+  lastPollAt: number;
+  error: string | null;
+} {
+  const s = store();
+  const detections = [...s.detections.values()].sort((a, b) => b.urlhaus_id - a.urlhaus_id);
+  return {
+    detections,
+    total: detections.length,
+    cursor: s.cursor,
+    lastPollAt: s.lastPollAt,
+    error: s.lastError,
+  };
+}
+
+/** Subscribe to live events. Returns the unsubscribe. */
+export function subscribeMalware(fn: (event: LiveEvent) => void): () => void {
+  const s = store();
+  s.subscribers.add(fn);
+  return () => { s.subscribers.delete(fn); };
+}
+
+/** Test seam — drops all state and stops the loop. */
+export function resetMalwareFeed(): void {
+  const s = store();
+  if (s.timer) clearInterval(s.timer);
+  s.detections.clear();
+  s.geo.clear();
+  s.hosts.clear();
+  s.subscribers.clear();
+  s.validators = {};
+  s.cursor = 0;
+  s.lastPollAt = 0;
+  s.lastError = null;
+  s.timer = null;
+  s.polling = false;
+  s.primed = null;
+}

--- a/src/lib/map-tile-layout.test.ts
+++ b/src/lib/map-tile-layout.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { layoutTile, tileHeight, tilesOverlap, type TileGeometry } from './map-tile-layout';
+
+/** The CCTV tile, which is what these numbers were tuned against. */
+const CCTV: TileGeometry = { width: 176, imageHeight: 99, labelHeight: 20, gap: 26 };
+const VIEW = { width: 1440, height: 900 };
+
+describe('layoutTile', () => {
+  it('centres the tile above its marker when there is room', () => {
+    const box = layoutTile({ x: 700, y: 500 }, VIEW, CCTV);
+    expect(box.x).toBe(700 - CCTV.width / 2);
+    expect(box.y).toBe(500 - tileHeight(CCTV) - CCTV.gap);
+    expect(box.flipped).toBe(false);
+    expect(box.anchored).toBe(true);
+  });
+
+  it('flips below the marker when the header would cover the tile', () => {
+    // A marker near the top of the screen: above it is app chrome, and a tile
+    // drawn under the header is simply invisible.
+    const box = layoutTile({ x: 700, y: 120 }, VIEW, CCTV);
+    expect(box.flipped).toBe(true);
+    expect(box.y).toBe(120 + CCTV.gap);
+    expect(box.anchored).toBe(true);
+  });
+
+  it('clamps a tile back inside the left edge and reports it unanchored', () => {
+    // The layer rail lives here, so the tile is pushed clear of it — and that
+    // moves it off its marker, which is what `anchored: false` is for.
+    const box = layoutTile({ x: 10, y: 500 }, VIEW, CCTV);
+    expect(box.x).toBe(60);
+    expect(box.anchored).toBe(false);
+  });
+
+  it('clamps against the right edge too', () => {
+    const box = layoutTile({ x: VIEW.width - 5, y: 500 }, VIEW, CCTV);
+    expect(box.x).toBe(VIEW.width - CCTV.width - 60);
+    expect(box.anchored).toBe(false);
+  });
+
+  it('keeps a low marker clear of the ticker at the bottom', () => {
+    const box = layoutTile({ x: 700, y: VIEW.height - 10 }, VIEW, CCTV);
+    expect(box.y).toBeLessThanOrEqual(VIEW.height - tileHeight(CCTV) - 156);
+    expect(box.anchored).toBe(false);
+  });
+
+  it('never places a tile outside a viewport too small to hold one', () => {
+    // Degenerate, but the clamps must not invert and produce a negative origin.
+    const box = layoutTile({ x: 100, y: 100 }, { width: 200, height: 200 }, CCTV);
+    expect(box.x).toBeGreaterThanOrEqual(60);
+    expect(box.y).toBeGreaterThanOrEqual(96);
+  });
+
+  it('is deterministic — the two passes must agree', () => {
+    // Selection decides overlap from this; the pan loop draws from it. If they
+    // disagreed, tiles would settle on top of each other.
+    const a = layoutTile({ x: 640, y: 480 }, VIEW, CCTV);
+    const b = layoutTile({ x: 640, y: 480 }, VIEW, CCTV);
+    expect(a).toEqual(b);
+  });
+
+  it('scales with the geometry it is given', () => {
+    const big: TileGeometry = { width: 240, imageHeight: 135, labelHeight: 20, gap: 26 };
+    const box = layoutTile({ x: 700, y: 500 }, VIEW, big);
+    expect(box.x).toBe(700 - 120);
+    expect(box.y).toBe(500 - 155 - 26);
+  });
+});
+
+describe('tilesOverlap', () => {
+  const at = (x: number, y: number) => ({ x, y, flipped: false, anchored: true });
+
+  it('sees two tiles in the same place as overlapping', () => {
+    expect(tilesOverlap(at(100, 100), at(100, 100), CCTV)).toBe(true);
+  });
+
+  it('lets tiles a full width apart coexist', () => {
+    expect(tilesOverlap(at(100, 100), at(100 + CCTV.width + 8, 100), CCTV)).toBe(false);
+  });
+
+  it('lets tiles a full height apart coexist', () => {
+    expect(tilesOverlap(at(100, 100), at(100, 100 + tileHeight(CCTV) + CCTV.gap), CCTV)).toBe(false);
+  });
+
+  it('catches a near miss on both axes', () => {
+    expect(tilesOverlap(at(100, 100), at(120, 110), CCTV)).toBe(true);
+  });
+});

--- a/src/lib/map-tile-layout.ts
+++ b/src/lib/map-tile-layout.ts
@@ -1,0 +1,87 @@
+/**
+ * OSIRIS — where a preview tile sits relative to the marker it belongs to.
+ *
+ * Two layers pin live frames to markers past zoom 13: CCTV cameras, and the
+ * live TV news feeds. They want different tile sizes but exactly the same
+ * placement behaviour, and that behaviour has one subtlety worth keeping in a
+ * single place:
+ *
+ *   The set of tiles to show is chosen when the map settles, and the tiles are
+ *   then repositioned on every frame of a pan. If those two passes disagreed
+ *   about where a tile lands, the overlap check would run against coordinates
+ *   nothing is ever drawn at — which is what once let a tile clamped back
+ *   inside the viewport come to rest on top of its neighbour.
+ *
+ * So both passes call this, and neither does placement arithmetic of its own.
+ */
+
+export interface TileGeometry {
+  width: number;
+  /** Frame height. 16:9 against `width`, so nothing is letterboxed. */
+  imageHeight: number;
+  /** Caption strip under the frame. */
+  labelHeight: number;
+  /** Clearance between the tile and its marker; the connector crosses it. */
+  gap: number;
+}
+
+export interface TilePlacement {
+  x: number;
+  y: number;
+  /** True when the tile had no room above its marker and sits below instead. */
+  flipped: boolean;
+  /**
+   * False when the tile had to be clamped back inside the viewport, which
+   * moves it off its marker. The caller drops the connector rather than draw a
+   * line pointing at empty map.
+   */
+  anchored: boolean;
+}
+
+/** Keeps a tile clear of the viewport edge, and of the layer rail on the left. */
+const EDGE = 60;
+/**
+ * More at the top and bottom, where the app's own chrome is: the header at one
+ * end, the view controls and the ticker at the other. All of it draws over the
+ * previews, so a tile placed underneath is simply hidden.
+ */
+const EDGE_TOP = 96;
+const EDGE_BOTTOM = 156;
+
+export function tileHeight(geom: TileGeometry): number {
+  return geom.imageHeight + geom.labelHeight;
+}
+
+/** Where the tile for a marker at `pt` ends up inside a `width`×`height` canvas. */
+export function layoutTile(
+  pt: { x: number; y: number },
+  viewport: { width: number; height: number },
+  geom: TileGeometry,
+): TilePlacement {
+  const h = tileHeight(geom);
+  const maxX = viewport.width - geom.width - EDGE;
+  const maxY = viewport.height - h - EDGE_BOTTOM;
+
+  /* Above the marker by default; below it when there is no room, so a marker
+     near the top of the screen still gets a visible tile. */
+  const above = pt.y - h - geom.gap;
+  const flipped = above < EDGE_TOP;
+  const wantX = pt.x - geom.width / 2;
+  const wantY = flipped ? pt.y + geom.gap : above;
+
+  const x = Math.min(Math.max(wantX, EDGE), Math.max(EDGE, maxX));
+  const y = Math.min(Math.max(wantY, EDGE_TOP), Math.max(EDGE_TOP, maxY));
+
+  return {
+    x,
+    y,
+    flipped,
+    anchored: Math.abs(x - wantX) < 1 && Math.abs(y - wantY) < 1,
+  };
+}
+
+/** Whether two placed tiles would visually collide. */
+export function tilesOverlap(a: TilePlacement, b: TilePlacement, geom: TileGeometry): boolean {
+  return Math.abs(a.x - b.x) < geom.width + 8
+    && Math.abs(a.y - b.y) < tileHeight(geom) + geom.gap;
+}


### PR DESCRIPTION
## What this adds

Two new statewide camera sources, both live video, plus a way to turn the map's preview tiles off.

### Nevada — NDOT / nvroads.com

**643 cameras, 628 of them live HLS.** Nothing is reconstructed here: every row carries its own `videoUrl`, already a complete playlist address on whichever of NDOT's eight `*.its.nv.gov` edges serves that camera. Those streams answer with `Access-Control-Allow-Origin: *`, so they play in a tile as they are. The 15 without video keep the JPEG at `/map/Cctv/{id}`.

Nevada runs the same IBI 511 platform as Utah, so `buildQuery` and `parseWkt` move out into `ibi511.ts` and both states read through it rather than carrying two copies. `utah.ts` re-exports them, so `utah.test.ts` is untouched.

### Indiana — INDOT TrafficWise / 511in.org

**738 cameras, all HLS.** The API hands back a poster frame rather than a playlist, so the stream URL is rebuilt from the `INDOT_{id}_{token}` the poster carries.

It has to point at `skysfs4`. `skysfs1` and `skysfs2` answer every request with HTTP 200 — which reads as healthy — but they only ever serve a two-segment `PreRoll` placeholder loop; polled for two minutes straight, a camera there never reaches a real `media_*.ts` segment. Only `skysfs4` hands over the feed.

### A switch for the preview tiles

`cctv_previews` sits under **CCTV Cameras** in the SURVEILLANCE group as a sub-layer — indented, tied to its parent by an elbow, and inert while that parent is off. Sub-layers modify a parent rather than draw anything of their own, so they don't count towards the rail's active badge. On by default, so existing behaviour is unchanged.

## Verification

Checked on a local dev server, not just in tests:

- **Las Vegas Strip** — 19 NDOT dots, 4 tiles decoding at 360×240 (`readyState: 4`), each advancing 6.0s over 6s of wall clock.
- **Indianapolis** — I-70 at the I-65 North Split and I-65 at St. Clair St, same result.
- Toggling **Live Previews** off drops the tiles and leaves the camera dots.

`tsc --noEmit` clean · **526 tests pass** · no new lint findings.

## Note

This branch also carries `beae4d7`, the live-malware-detection commit, which is no longer on `master`. Merging this restores it alongside the camera work — say the word if you'd rather I split it out.

## Known wart

A few of Nevada's 15 snapshot-only cameras serve NDOT's own *"No live camera feed at this time"* placeholder as a normal 200 JPEG. Nothing in the feed metadata flags them, so there's no honest way to filter those without also dropping working snapshot cameras. Easy to drop all 15 if you'd prefer only the 628 with video.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
