### PR TITLE
fix(cctv): cache every camera source, and bound the slow ones

### DIFF
--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { stealthFetch } from '@/lib/stealthFetch';
+import { cachedSource } from '@/lib/sourceCache';
 
 export const maxDuration = 60;
 import { fetchAsfinagCameras } from './asfinag';
@@ -423,7 +424,11 @@ async function fetchMiddleEastCameras(): Promise<any[]> {
 }
 
 // ═══ REGION MAPPING ═══
-const REGION_FETCHERS: Record<string, () => Promise<any[]>> = {
+/** Camera records are shaped per source; only `source` is read back here. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RegionFetcher = () => Promise<any[]>;
+
+const RAW_REGION_FETCHERS: Record<string, RegionFetcher> = {
   'middle-east': fetchMiddleEastCameras,
   'uk': fetchTfLCameras,
   'us-west': async () => { const [w, c] = await Promise.all([fetchWSDOTCameras(), fetchCaltransCameras()]); return [...w, ...c]; },
@@ -464,6 +469,43 @@ const REGION_FETCHERS: Record<string, () => Promise<any[]>> = {
   'africa-live': fetchAfricaLiveCameras,
   'europe-live': fetchEuropeLiveCameras,
 };
+
+/**
+ * Every region is served from the shared source cache.
+ *
+ * Six of these modules cached themselves and thirty-three did not, which meant
+ * a request with no `region` refetched thirty-three upstreams live — several of
+ * them megabytes, two of them long dead. Under real traffic that is one
+ * outbound fetch storm per visitor. Caching here rather than in each module
+ * means a source added later cannot forget to do it.
+ */
+const REGION_FETCHERS: Record<string, RegionFetcher> = Object.fromEntries(
+  Object.entries(RAW_REGION_FETCHERS).map(([region, fetcher]) => [
+    region,
+    cachedSource(`cctv:${region}`, fetcher),
+  ]),
+);
+
+/**
+ * A region that will not answer must not hold the other thirty-eight hostage.
+ * The abandoned fetch keeps running inside the cache, so the frame it was
+ * fetching lands in time for the next request rather than being thrown away —
+ * this drops a slow region from the current response, not from the map.
+ */
+const REGION_BUDGET_MS = 12_000;
+
+function withBudget(region: string, fetcher: RegionFetcher): ReturnType<RegionFetcher> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    fetcher().finally(() => clearTimeout(timer)),
+    new Promise<Awaited<ReturnType<RegionFetcher>>>(resolve => {
+      timer = setTimeout(() => {
+        console.warn(`[OSIRIS] cctv:${region} over ${REGION_BUDGET_MS}ms — returning without it`);
+        resolve([]);
+      }, REGION_BUDGET_MS);
+    }),
+  ]);
+}
 
 // Determine which regions to fetch based on viewport bounds
 function getRegionsForBounds(lat: number, lng: number, radius: number): string[] {
@@ -585,7 +627,7 @@ export async function GET(request: Request) {
     }
 
     const results = await Promise.allSettled(
-      regionsToFetch.map(r => REGION_FETCHERS[r]())
+      regionsToFetch.map(r => withBudget(r, REGION_FETCHERS[r]))
     );
 
     const allCameras: any[] = [];


### PR DESCRIPTION
The camera layer stopped loading in production under load. This is the origin-side half of the fix.

## What was happening

`/api/cctv` with no `region` fans out to **39 regions** and waits for all of them under a 60s ceiling. Only **six** of those source modules cached themselves — hongkong, indiana, michigan, nevada, newzealand, oregon. The other thirty-three refetched their upstreams live on **every request**, several megabytes apiece (Caltrans alone is 1.47 MB), and two of them are long-dead URLs that 404 (`data.wsdot.wa.gov`, `opendata.ndw.nu`).

One outbound fetch storm per visitor, several hundred visitors at once, and the route stopped answering inside `maxDuration = 60`.

The failure sustained itself: because the response never completed, no cache ever populated and the `s-maxage` header never reached a real response — so every retry repeated the whole cold aggregation. Six consecutive probes against production returned three 60s timeouts, two 90s timeouts and one 502.

Diagnosis was by elimination: every region tested individually returned in 0.2–6.5s except `us-west`, `canada` and `europe`, which hung past 45s. The six fast ones were exactly the six that cache.

## The change

**Caching is applied to the region map**, not inside each module, so a source added later cannot forget to do it.

**Each region gets a 12s budget.** Caching alone would not have been enough — on a cold cache the first request still hangs, which is exactly the state the box comes back in after a restart, so nothing would ever populate and the stampede would continue. A region that will not answer is now dropped from the current response while its fetch keeps running inside the cache, so the frame it was fetching lands in time for the next request instead of being thrown away.

## Measured on localhost

| | Before | After |
|---|---|---|
| Cold (empty cache) | hangs indefinitely | **9.9s**, bounded |
| Warm | — | **0.22–0.56s** |
| Cameras returned | 0 | **20,305** (5.1 MB) |
| Sources reporting | 0 | 36 |

Verified end-to-end in the app, not just at the endpoint: the layer panel reads the full camera count and dots render across the map. Server logs show the mechanism working — on the cold request ten regions exceeded the budget and were dropped; by the next request every one of them served from cache instantly.

`tsc` clean, build compiles, **526 tests pass**. Lint goes from 41 problems to 40 — this adds none and removes one.

## What this does not fix

The multiplier. Cloudflare reports `cf-cache-status: DYNAMIC` for every API route, so each visitor hits the origin directly on every poll and still pulls the full 5 MB. A cache rule on `/api/*` would let the `s-maxage` this route already sends do its job. That is a dashboard change, not a deploy.

## Known, pre-existing, untouched

- `canada` returns almost nothing (651 B) — its Ottawa and Quebec upstreams answer but yield no usable cameras.
- `europe`'s Dutch NDW URL and `us-west`'s WSDOT URL both 404 and have presumably moved.

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)
