### PR TITLE
feat(map): an on-screen pan/zoom pad, and 336 Louisiana cameras

### DIFF
--- a/src/app/api/cctv/louisiana.test.ts
+++ b/src/app/api/cctv/louisiana.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { fetchLouisianaCameras, mapRecord, type LouisianaCameraRecord } from './louisiana';
+
+/** A representative row from 511la.org/List/GetData/Cameras. */
+const sample: LouisianaCameraRecord = {
+  id: 1,
+  roadway: 'I-20',
+  location: 'I-20 at I-220 Off Ramp',
+  latLng: { geography: { wellKnownText: 'POINT (-93.630833 32.538889)' } },
+  images: [{
+    id: 1,
+    description: 'Traffic closest to this camera is traveling eastbound on I-20.',
+    imageUrl: '/map/Cctv/1',
+    videoUrl: 'https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-030.streams/playlist.m3u8',
+    blocked: false,
+    disabled: false,
+  }],
+};
+
+describe('mapRecord', () => {
+  it('labels the camera by its cross-street, not the traffic-direction blurb', () => {
+    expect(mapRecord(sample)).toEqual({
+      id: 'ladotd-1',
+      lat: 32.538889,
+      lng: -93.630833,
+      name: 'I-20 at I-220 Off Ramp',
+      city: 'Louisiana',
+      country: 'US',
+      feed_url: 'https://511la.org/map/Cctv/1',
+      stream_url: 'https://ITSStreamingBR2.dotd.la.gov/public/shr-cam-030.streams/playlist.m3u8',
+      stream_type: 'hls',
+      source: 'LADOTD',
+    });
+  });
+
+  it('falls back to the roadway, then the caption, when there is no location', () => {
+    expect(mapRecord({ ...sample, location: null })?.name).toBe('I-20');
+    expect(mapRecord({ ...sample, location: 'N/A', roadway: null })?.name)
+      .toBe('Traffic closest to this camera is traveling eastbound on I-20.');
+    expect(mapRecord({ ...sample, location: null, roadway: null, images: [{ ...sample.images![0], description: null }] })?.name)
+      .toBe('LADOTD Camera 1');
+  });
+
+  /* One real row advertises `/snapshots?…&ext=.jpg` as its videoUrl, and that
+     address answers with a JPEG. Handing it to an HLS player would break a
+     camera that has a perfectly good snapshot. */
+  it('keeps the snapshot when videoUrl is not actually a playlist', () => {
+    const cam = mapRecord({
+      ...sample,
+      images: [{
+        ...sample.images![0],
+        videoUrl: 'http://ITSStreamingNO.dotd.la.gov:1935/snapshots?application=public&snap=ns-cam-059.streams&ext=.jpg',
+      }],
+    });
+    expect(cam?.stream_url).toBeUndefined();
+    expect(cam?.stream_type).toBeUndefined();
+    expect(cam?.feed_url).toBe('https://511la.org/map/Cctv/1');
+  });
+
+  it('ignores a video feed the operator has switched off', () => {
+    const cam = mapRecord({ ...sample, images: [{ ...sample.images![0], videoDisabled: true }] });
+    expect(cam?.stream_url).toBeUndefined();
+    expect(cam?.feed_url).toBe('https://511la.org/map/Cctv/1');
+  });
+
+  it('drops blocked, disabled and imageless rows', () => {
+    expect(mapRecord({ ...sample, images: [{ ...sample.images![0], blocked: true }] })).toBeNull();
+    expect(mapRecord({ ...sample, images: [{ ...sample.images![0], disabled: true }] })).toBeNull();
+    expect(mapRecord({ ...sample, images: [] })).toBeNull();
+  });
+
+  it('drops rows without usable coordinates, and any that land outside Louisiana', () => {
+    expect(mapRecord({ ...sample, latLng: null })).toBeNull();
+    expect(mapRecord({ ...sample, latLng: { geography: { wellKnownText: 'POINT (0 0)' } } })).toBeNull();
+    // Houston — over the Texas line, so not ours to draw.
+    expect(mapRecord({ ...sample, latLng: { geography: { wellKnownText: 'POINT (-95.37 29.76)' } } })).toBeNull();
+  });
+});
+
+// Live integration test — opt in with RUN_LIVE_TESTS=1 (hits the real 511LA endpoint).
+const liveIt = process.env.RUN_LIVE_TESTS === '1' ? it : it.skip;
+
+describe('fetchLouisianaCameras (live)', () => {
+  liveIt('pages the whole state and returns well-formed cameras', async () => {
+    const cams = await fetchLouisianaCameras();
+    expect(cams.length).toBeGreaterThan(300);
+    expect(new Set(cams.map(c => c.id)).size).toBe(cams.length);
+
+    for (const cam of cams) {
+      expect(cam.id).toMatch(/^ladotd-\d+$/);
+      expect(cam.country).toBe('US');
+      expect(cam.source).toBe('LADOTD');
+      expect(cam.feed_url).toMatch(/^https:\/\/511la\.org\/map\/Cctv\/\d+$/);
+      expect(cam.lat).toBeGreaterThan(28.8);
+      expect(cam.lat).toBeLessThan(33.1);
+      expect(cam.lng).toBeGreaterThan(-94.2);
+      expect(cam.lng).toBeLessThan(-88.6);
+      if (cam.stream_url) {
+        expect(cam.stream_type).toBe('hls');
+        expect(cam.stream_url).toMatch(/\.m3u8$/);
+      }
+    }
+
+    // Nearly all of them stream; the map should be showing video, not stills.
+    expect(cams.filter(c => c.stream_url).length).toBeGreaterThan(cams.length * 0.9);
+  }, 60_000);
+});

--- a/src/app/api/cctv/louisiana.ts
+++ b/src/app/api/cctv/louisiana.ts
@@ -1,0 +1,143 @@
+import { stealthFetch } from '@/lib/stealthFetch';
+import { cachedSource } from '@/lib/sourceCache';
+import { buildQuery, parseWkt } from './ibi511';
+import type { CctvCamera } from './types';
+
+/**
+ * OSIRIS — Louisiana CCTV Cameras (LADOTD / 511la.org)
+ * Source: https://511la.org — the same IBI 511 stack Utah and Nevada run on
+ * Data endpoint: /List/GetData/Cameras (DataTables, 100 rows/page)
+ * 336 statewide traffic cameras — NO API KEY NEEDED.
+ *
+ * 511LA's documented REST API wants a developer key and throttles to ten calls
+ * a minute. The list page its own browser uses does not: `/List/GetData/`
+ * takes the DataTables state as a JSON `query` parameter and hands back every
+ * field, coordinates included. That is what this reads.
+ *
+ * Every row carries both a JPEG at /map/Cctv/{id} and an HLS playlist on one
+ * of three `*.dotd.la.gov` edges, so these come up as video tiles with a
+ * snapshot behind them.
+ *
+ * This fills in I-10, I-12, I-20, I-49 and the New Orleans and Baton Rouge
+ * approaches — the stretch of the Gulf coast the map had nothing on.
+ */
+
+const BASE = 'https://511la.org';
+const PAGE_SIZE = 100; // the server caps a response at 100 rows whatever we ask for
+const MAX_PAGES = 10; // safety bound (~1000 cameras) so a bad total can't fan out forever
+
+/** Louisiana bounding box — drops any mis-geocoded rows. */
+const LA_BOUNDS = { minLat: 28.8, maxLat: 33.1, minLng: -94.2, maxLng: -88.6 };
+
+/** One row from /List/GetData/Cameras (only the fields we consume). */
+export interface LouisianaCameraRecord {
+  id: number;
+  roadway?: string | null;
+  location?: string | null;
+  latLng?: { geography?: { wellKnownText?: string | null } | null } | null;
+  images?: Array<{
+    id?: number;
+    description?: string | null;
+    imageUrl?: string | null;
+    videoUrl?: string | null;
+    blocked?: boolean;
+    disabled?: boolean;
+    videoDisabled?: boolean;
+  }> | null;
+}
+
+/** Map a raw record to a CctvCamera, or null if it should be skipped. */
+export function mapRecord(rec: LouisianaCameraRecord): CctvCamera | null {
+  if (!rec || typeof rec.id !== 'number') return null;
+
+  const img = rec.images?.[0];
+  if (!img || img.blocked || img.disabled) return null;
+
+  const coords = parseWkt(rec.latLng?.geography?.wellKnownText);
+  if (!coords) return null;
+
+  const { lat, lng } = coords;
+  if (lat < LA_BOUNDS.minLat || lat > LA_BOUNDS.maxLat) return null;
+  if (lng < LA_BOUNDS.minLng || lng > LA_BOUNDS.maxLng) return null;
+
+  /* The opposite of Nevada's problem: here `location` is a real cross-street
+     on all 336 ("I-20 at Greenwood Road (US 79)"), while `description` is
+     usually a sentence about which way the traffic runs. So the caption is the
+     fallback, not the label.
+
+     "N/A" has to drop out during the pick rather than after it — the platform
+     writes that string into whichever field it has nothing for, and it is
+     truthy enough to end the chain and lose the fields behind it. */
+  const name = [rec.location, rec.roadway, img.description]
+    .map(v => v?.trim())
+    .find(v => v && v !== 'N/A');
+
+  const snapshot = img.imageUrl ? `${BASE}${img.imageUrl}` : undefined;
+  /* One row (I-12 at LA 21) puts a `/snapshots?…&ext=.jpg` address in
+     `videoUrl` rather than a playlist, and it answers with a JPEG. Requiring
+     .m3u8 leaves that camera on its snapshot instead of handing the player
+     something it cannot read. */
+  const video = img.videoDisabled ? undefined : hlsUrl(img.videoUrl);
+  if (!snapshot && !video) return null;
+
+  return {
+    id: `ladotd-${rec.id}`,
+    lat,
+    lng,
+    name: name || `LADOTD Camera ${rec.id}`,
+    city: 'Louisiana',
+    country: 'US',
+    ...(snapshot ? { feed_url: snapshot } : {}),
+    ...(video ? { stream_url: video, stream_type: 'hls' as const } : {}),
+    source: 'LADOTD',
+  };
+}
+
+/** The video address, but only when it is actually an HLS playlist. */
+function hlsUrl(url?: string | null): string | undefined {
+  const trimmed = url?.trim();
+  return trimmed && /\.m3u8(\?|$)/i.test(trimmed) ? trimmed : undefined;
+}
+
+async function fetchPage(start: number): Promise<{ rows: LouisianaCameraRecord[]; total: number }> {
+  const url = `${BASE}/List/GetData/Cameras?query=${buildQuery(start, PAGE_SIZE)}&lang=en`;
+  const res = await stealthFetch(url, {
+    signal: AbortSignal.timeout(15000),
+    headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
+  });
+  if (!res.ok) throw new Error(`LADOTD HTTP ${res.status}`);
+  const data = await res.json();
+  return {
+    rows: Array.isArray(data?.data) ? data.data : [],
+    total: Number(data?.recordsTotal) || 0,
+  };
+}
+
+async function loadLouisianaCameras(): Promise<CctvCamera[]> {
+  // The first page also tells us how many there are in total.
+  const first = await fetchPage(0);
+  const seen = new Map<number, CctvCamera>();
+
+  const ingest = (rows: LouisianaCameraRecord[]) => {
+    for (const rec of rows) {
+      const cam = mapRecord(rec);
+      if (cam) seen.set(rec.id, cam);
+    }
+  };
+  ingest(first.rows);
+
+  const starts: number[] = [];
+  for (let s = PAGE_SIZE; s < first.total && s < PAGE_SIZE * MAX_PAGES; s += PAGE_SIZE) {
+    starts.push(s);
+  }
+  const results = await Promise.allSettled(starts.map(s => fetchPage(s)));
+  for (const r of results) {
+    if (r.status === 'fulfilled') ingest(r.value.rows);
+  }
+
+  const cams = [...seen.values()];
+  console.log(`[OSIRIS] Louisiana cameras — LADOTD: ${cams.length}`);
+  return cams;
+}
+
+export const fetchLouisianaCameras = cachedSource('louisiana', loadLouisianaCameras);

--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -32,6 +32,7 @@ import { fetchOregonCameras } from './oregon';
 import { fetchMichiganCameras } from './michigan';
 import { fetchIndianaCameras } from './indiana';
 import { fetchNevadaCameras } from './nevada';
+import { fetchLouisianaCameras } from './louisiana';
 import { fetchEastAsiaCameras, fetchSeAsiaCameras, fetchWestAsiaCameras } from './opencctv';
 import {
   fetchLatamLiveCameras,
@@ -466,6 +467,7 @@ const RAW_REGION_FETCHERS: Record<string, RegionFetcher> = {
   'michigan': fetchMichiganCameras,
   'indiana': fetchIndianaCameras,
   'nevada': fetchNevadaCameras,
+  'louisiana': fetchLouisianaCameras,
   'eastasia': fetchEastAsiaCameras,
   'seasia': fetchSeAsiaCameras,
   'westasia': fetchWestAsiaCameras,
@@ -532,6 +534,8 @@ function getRegionsForBounds(lat: number, lng: number, radius: number): string[]
   if (lat > 41.6 && lat < 48.3 && lng > -90.5 && lng < -82.1) regions.push('michigan');
   // Indiana (INDOT TrafficWise) — explicit, since us-central only covers Illinois
   if (lat > 37.7 && lat < 41.9 && lng > -88.2 && lng < -84.6) regions.push('indiana');
+  // Louisiana (LADOTD 511) — explicit, since neither us-central nor us-east reaches the Gulf coast
+  if (lat > 28.8 && lat < 33.1 && lng > -94.2 && lng < -88.6) regions.push('louisiana');
   // Canada
   if (lat > 42 && lat < 70 && lng > -141 && lng < -52) regions.push('canada');
   // Europe

--- a/src/components/MapControls.tsx
+++ b/src/components/MapControls.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { motion } from 'framer-motion';
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Minus, Plus } from 'lucide-react';
+import type { Map as MlMap } from 'maplibre-gl';
+
+/**
+ * OSIRIS — on-screen map controls
+ *
+ * On a desktop the camera could only be driven by the two mouse gestures: the
+ * wheel to zoom, a held drag to pan. Neither is available on a trackpad-less
+ * machine, a touchscreen kiosk, or to anyone driving the map from the
+ * keyboard, so the map was simply stuck for them.
+ *
+ * These mirror those gestures rather than adding new ones: the +/- pair is the
+ * wheel, the pad is a held drag. A tap moves one step; holding keeps moving
+ * for as long as the button is down, the way a wheel spun or a drag held
+ * would.
+ *
+ * Phones are deliberately left out — pinch and drag already work there, and
+ * the pad would cost a quarter of the screen to duplicate them.
+ *
+ * Continuous motion is a chain of short overlapping `easeTo` calls rather than
+ * a per-frame camera write. Both look the same, but a per-frame write fires
+ * `moveend` sixty times a second, and the page re-renders on every one.
+ */
+
+/** Zoom levels, and screen pixels, covered per second of holding. */
+const ZOOM_RATE = 1.6;
+const PAN_RATE = 640;
+/** What a single tap is worth. */
+const ZOOM_STEP = 1;
+const PAN_STEP = 220;
+/** How long the tap's own animation runs. */
+const STEP_MS = 240;
+/** Grace period before a press turns into a hold, so a tap is only ever one step. */
+const HOLD_DELAY_MS = 280;
+/**
+ * Each continuous leg is started twice as often as it is long, so the next one
+ * always interrupts the last mid-flight and the camera never pauses between
+ * them. Halving it keeps the resulting speed at exactly the rates above.
+ */
+const TICK_MS = 200;
+const LEG_MS = TICK_MS * 2;
+
+const linear = (t: number) => t;
+
+type Move =
+  /** Wheel equivalent: which way, in zoom levels. */
+  | { kind: 'zoom'; dir: 1 | -1 }
+  /** Drag equivalent: which way, as a unit vector in screen space. */
+  | { kind: 'pan'; dx: number; dy: number };
+
+interface MapControlsProps {
+  mapRef: React.RefObject<MlMap | null>;
+  /** Called when the operator drives the camera, to hand back a follow lock. */
+  onInteract?: () => void;
+}
+
+export default function MapControls({ mapRef, onInteract }: MapControlsProps) {
+  /** The pending hold timer and its repeat, cleared on release and on unmount. */
+  const holdRef = useRef<{ delay: number; repeat: number } | null>(null);
+
+  const release = useCallback(() => {
+    const hold = holdRef.current;
+    if (!hold) return;
+    holdRef.current = null;
+    window.clearTimeout(hold.delay);
+    // Only a hold has a leg in flight worth cutting, and cutting it is what
+    // stops the camera under the finger rather than a beat later. A tap must
+    // be left alone: `stop()` there would abort the step's own animation
+    // partway and leave the map short of the level it was asked for.
+    if (hold.repeat) {
+      window.clearInterval(hold.repeat);
+      mapRef.current?.stop();
+    }
+  }, [mapRef]);
+
+  useEffect(() => release, [release]);
+
+  /** One step's worth of movement — what a tap, or a keyboard press, gives. */
+  const step = useCallback((move: Move) => {
+    const map = mapRef.current;
+    if (!map) return;
+    onInteract?.();
+    if (move.kind === 'zoom') map.easeTo({ zoom: map.getZoom() + move.dir * ZOOM_STEP, duration: STEP_MS });
+    else map.panBy([move.dx * PAN_STEP, move.dy * PAN_STEP], { duration: STEP_MS });
+  }, [mapRef, onInteract]);
+
+  const press = useCallback((move: Move) => {
+    const map = mapRef.current;
+    if (!map) return;
+    release();
+    step(move);
+
+    const leg = () => {
+      const m = mapRef.current;
+      if (!m) return;
+      if (move.kind === 'zoom') {
+        m.easeTo({ zoom: m.getZoom() + move.dir * ZOOM_RATE * (LEG_MS / 1000), duration: LEG_MS, easing: linear });
+      } else {
+        const d = PAN_RATE * (LEG_MS / 1000);
+        m.panBy([move.dx * d, move.dy * d], { duration: LEG_MS, easing: linear });
+      }
+    };
+
+    const delay = window.setTimeout(() => {
+      leg();
+      const repeat = window.setInterval(leg, TICK_MS);
+      if (holdRef.current) holdRef.current.repeat = repeat;
+      else window.clearInterval(repeat);
+    }, HOLD_DELAY_MS);
+    holdRef.current = { delay, repeat: 0 };
+  }, [mapRef, release, step]);
+
+  return (
+    <motion.div
+      /* Desktop, laptop and fullscreen only. A phone already has pinch and
+         drag, and the pad would only crowd a 390px screen; `desktop-only` is
+         the app's own definition of that line, landscape phones included.
+         The entrance owns this element's opacity, so the resting dim below
+         has to live on the panel inside it. */
+      initial={{ opacity: 0, x: 10 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.5, delay: 0.4, ease: [0.16, 1, 0.3, 1] }}
+      className="desktop-only absolute right-2 bottom-12 z-[240] pointer-events-auto"
+      /* The Style Studio's off switch hides the pad through this. */
+      data-map-controls
+    >
+      {/* The pad sits back, and comes forward as the cursor approaches it or a
+          key focuses it. */}
+      <div
+        className="flex items-center gap-[3px] p-[3px] rounded-xl border border-[var(--border-secondary)] bg-black/35 backdrop-blur-md shadow-[0_8px_28px_rgba(0,0,0,0.45)] transition-[opacity,border-color] duration-300 opacity-60 hover:opacity-100 focus-within:opacity-100 hover:border-[var(--border-primary)] focus-within:border-[var(--border-primary)]"
+        role="group"
+        aria-label="Map camera controls"
+      >
+        {/* The wheel's two directions, stacked the way every zoom control is.
+            The pad is kept to three rows in all: the tool rail above reaches
+            this far down on a short window, and taller would run into it. */}
+        <div className="flex flex-col gap-[3px]">
+          <Btn label="Zoom in" move={{ kind: 'zoom', dir: 1 }} icon={Plus} press={press} release={release} step={step} />
+          <Btn label="Zoom out" move={{ kind: 'zoom', dir: -1 }} icon={Minus} press={press} release={release} step={step} />
+        </div>
+
+        <div aria-hidden="true" className="self-stretch w-px mx-1 bg-gradient-to-b from-transparent via-[var(--border-secondary)] to-transparent" />
+
+        {/* A held drag, laid out as the compass it stands for rather than a list. */}
+        <div className="grid grid-cols-3 grid-rows-3 gap-[3px]">
+          <Btn cell="col-start-2 row-start-1" label="Pan north" move={{ kind: 'pan', dx: 0, dy: -1 }} icon={ChevronUp} press={press} release={release} step={step} />
+          <Btn cell="col-start-1 row-start-2" label="Pan west" move={{ kind: 'pan', dx: -1, dy: 0 }} icon={ChevronLeft} press={press} release={release} step={step} />
+          <Btn cell="col-start-3 row-start-2" label="Pan east" move={{ kind: 'pan', dx: 1, dy: 0 }} icon={ChevronRight} press={press} release={release} step={step} />
+          <Btn cell="col-start-2 row-start-3" label="Pan south" move={{ kind: 'pan', dx: 0, dy: 1 }} icon={ChevronDown} press={press} release={release} step={step} />
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function Btn({ cell = '', label, icon: Icon, move, press, release, step }: {
+  /** Grid placement, for the compass buttons that need one. */
+  cell?: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  move: Move;
+  press: (m: Move) => void;
+  release: () => void;
+  step: (m: Move) => void;
+}) {
+  return (
+    <button
+      type="button"
+      title={`${label} — hold to keep going`}
+      aria-label={label}
+      className={`${cell} w-7 h-7 rounded-md flex items-center justify-center text-[var(--text-secondary)] transition-colors duration-200 hover:text-[var(--text-primary)] hover:bg-[rgba(var(--gold-rgb),0.06)] active:text-[var(--gold-light)] active:bg-[rgba(var(--gold-rgb),0.12)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--border-active)] touch-none select-none`}
+      onPointerDown={(e) => {
+        // Only the primary button drives the camera, and the press has to keep
+        // receiving its own pointerup even once the cursor leaves the target.
+        if (e.button !== 0) return;
+        e.preventDefault();
+        e.currentTarget.setPointerCapture(e.pointerId);
+        press(move);
+      }}
+      onPointerUp={release}
+      onPointerCancel={release}
+      // Losing the capture without a pointerup — the button unmounting under
+      // the cursor, say — would otherwise leave the camera moving on its own.
+      onLostPointerCapture={release}
+      // A keyboard press never sends pointer events, so it lands here instead —
+      // and `detail` is 0 only for those, which keeps clicks from stepping twice.
+      onClick={(e) => { if (e.detail === 0) step(move); }}
+    >
+      <Icon className="w-3 h-3" strokeWidth={1.5} />
+    </button>
+  );
+}

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -9,6 +9,7 @@ import { STYLE_EVENT } from '@/lib/style-tokens';
 import { arrivalBeacons } from '@/lib/malware-intel';
 import SatelliteCard, { type SatelliteDetail } from '@/components/SatelliteCard';
 import CctvPreviews, { type PreviewCamera } from '@/components/CctvPreviews';
+import MapControls from '@/components/MapControls';
 import LiveNewsPreviews, { type PreviewFeed } from '@/components/LiveNewsPreviews';
 
 /** The catalogue fields the satellite layer and its popup actually read. */
@@ -2974,6 +2975,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         />
       )}
       {selectedSat && <SatelliteCard sat={selectedSat} onClose={clearSat} />}
+      {mapReady && <MapControls mapRef={mapRef} onInteract={onFollowInterrupt} />}
     </>
   );
 }

--- a/src/components/StyleStudio.tsx
+++ b/src/components/StyleStudio.tsx
@@ -134,6 +134,8 @@ function Segmented({ label, options, value, onChange }: {
   );
 }
 
+const ON_OFF = [{ label: 'ON', value: 'on' }, { label: 'OFF', value: 'off' }];
+
 /** Groups rows inside a section without starting a new one. */
 function SubHead({ label, note }: { label: string; note?: string }) {
   return (
@@ -337,6 +339,17 @@ function StyleStudio({ onClose, isMobile }: { onClose: () => void; isMobile?: bo
           <Row label="Warning"><Swatch label="Warning colour" value={s.alertOrange} onChange={v => set('alertOrange', v)} /></Row>
           <Row label="Nominal"><Swatch label="Nominal colour" value={s.alertGreen} onChange={v => set('alertGreen', v)} /></Row>
           <Row label="Info"><Swatch label="Info colour" value={s.alertBlue} onChange={v => set('alertBlue', v)} /></Row>
+        </Section>
+
+        <Section title="Map controls">
+          <Row label="Pan/zoom pad">
+            <Segmented
+              label="On-screen pan and zoom pad"
+              options={ON_OFF}
+              value={s.mapControls ? 'on' : 'off'}
+              onChange={v => set('mapControls', v === 'on')}
+            />
+          </Row>
         </Section>
 
         <Section title="Map layers">

--- a/src/lib/style-tokens.ts
+++ b/src/lib/style-tokens.ts
@@ -54,6 +54,8 @@ export interface StyleSettings {
   scanlines: number;
   vignette: number;
   grain: number;
+  /** The map's on-screen pan/zoom pad. Off leaves the wheel and drag alone. */
+  mapControls: boolean;
   /** Colours the map itself draws with — see ./map-palette. */
   map: MapPalette;
 }
@@ -100,6 +102,7 @@ export const DEFAULTS: StyleSettings = {
   scanlines: 0,
   vignette: 0,
   grain: 0,
+  mapControls: true,
   map: MAP_DEFAULTS,
 };
 
@@ -202,8 +205,13 @@ export function sanitize(input: unknown, base: StyleSettings): StyleSettings {
     scanlines: normNum(o.scanlines, base.scanlines, 0, 0.2),
     vignette: normNum(o.vignette, base.vignette, 0, 1),
     grain: normNum(o.grain, base.grain, 0, 0.3),
+    mapControls: normBool(o.mapControls, base.mapControls),
     map: normMap(o.map, base.map),
   };
+}
+
+function normBool(v: unknown, fallback: boolean) {
+  return typeof v === 'boolean' ? v : fallback;
 }
 
 /** Same treatment as every other colour: these reach body.style as text. */
@@ -292,6 +300,12 @@ ${at} .rounded-full { border-radius: 9999px; }`,
 
   if (s.motion !== 1) {
     blocks.push(`${at} *, ${at} *::before, ${at} *::after { transition-duration: ${Math.round(600 * s.motion)}ms !important; }`);
+  }
+
+  if (!s.mapControls) {
+    /* Hidden by rule rather than unmounted: flipping it back on costs no
+       remount, and a held button cannot be orphaned mid-press. */
+    blocks.push(`${at} [data-map-controls] { display: none !important; }`);
   }
 
   /* Scanlines, vignette and grain share one pseudo-element: a second ::after


### PR DESCRIPTION
## Why

The map could only be driven by two mouse gestures — the wheel to zoom, a held drag to pan. Neither is available on a trackpad-less machine, a touchscreen kiosk, or to anyone driving the map from the keyboard, so for them the map was simply stuck. Separately, the Gulf coast had no cameras on it at all.

## The pad

`MapControls` mirrors those two gestures rather than inventing new ones: the `+`/`−` pair is the wheel, the compass is a held drag. **A tap moves one step; holding keeps moving until release.** Screen-space panning, so it works at any bearing.

Continuous motion is a chain of short overlapping `easeTo` legs rather than a per-frame camera write. Both look identical, but a per-frame write fires `moveend` sixty times a second and re-renders `page.tsx` on every one.

Desktop only, gated on the app's existing `.desktop-only` rule so it stays one definition of "desktop" and covers landscape phones too — a phone already has pinch and drag, and the pad would cost a quarter of a 390px screen to duplicate them.

Sits at 60% opacity and comes forward on hover or keyboard focus, so it stays out of the way until wanted.

## The toggle

New **Map controls → Pan/zoom pad** section in the Style Studio, reusing the existing `Segmented` control and riding the machinery already there (`StyleSettings` → `sanitize` → `buildCss` → localStorage), so it persists and resets like every other setting and presets don't clobber it.

It hides the pad by CSS rule on a `data-map-controls` hook rather than unmounting it — flipping it back costs no remount, and a held button can't be orphaned mid-press.

## Louisiana

511LA runs the **same IBI 511 stack as Utah and Nevada**, so `louisiana.ts` reuses `./ibi511` exactly as they do — no new abstraction, no changes to the working sources. The documented REST API wants a developer key and throttles to 10 calls/minute; the endpoint the site's own list page uses needs neither.

| | |
|---|---|
| Cameras | **336**, all with coordinates |
| Media | **335 HLS** streams on three `*.dotd.la.gov` edges, plus a JPEG each |
| Coverage | I-10, I-12, I-20, I-49, I-55, I-59, I-210/220/310/610, US 61, US 190 |

Two quirks the data forced:

- **Labels.** Unlike Nevada, `description` here is usually a sentence ("Traffic closest to this camera is traveling eastbound on I-20"), while `location` is a real cross-street on all 336 — so the caption is the fallback, not the label.
- **One bad row.** I-12 at LA 21 advertises a `/snapshots?…&ext=.jpg` address as its `videoUrl` and answers with a JPEG. Requiring `.m3u8` leaves that camera on its working snapshot instead of handing the player something it can't read.

A test also caught a bug in the first draft: `'N/A'` is truthy, so it ended the label fallback chain instead of being skipped — the platform writes that string into whichever field it has nothing for.

## Verification

- **Pad, in the browser:** tap = exactly +1.00 zoom level (6.50 → 7.50); all four pan directions correct (N 42.70→43.96, E 25.48→27.16, W 25.48→24.01, S 42.71→41.66); hold ran 25.48°→33.91° and **stopped dead** on release; keyboard activation steps once and a mouse tap doesn't double-fire.
- **Breakpoints:** hidden at 390×844, 900×1200 and 900×450; visible at 1100×800 and 1440×900. Clears the tool rail by 24px at 1440×720 and the shortcut hint by 8.5px.
- **Toggle:** OFF → `display: none` (still mounted, rule emitted, `mapControls: false` persisted); ON → `display: block`; after a reload the hide rule is re-emitted before the pad ever mounts.
- **Louisiana:** live integration test against the real endpoint (`RUN_LIVE_TESTS=1`) — 336 cameras, unique ids, all inside the state bounds, >90% streaming.
- 549 tests pass · `tsc --noEmit` clean · eslint clean on all changed files.

Note: the Louisiana cameras can't be seen on a sandboxed dev server that can't reach `511la.org` — the same restriction that times out 511in.org, nvroads.com and tripcheck.com there. The route wiring is confirmed (the region resolves and fires the fetch) and the loader is proven by the live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
