### PR TITLE
feat(cctv): 10,779 cameras across the southern tier

### DIFF
--- a/src/app/api/cctv/arizona.ts
+++ b/src/app/api/cctv/arizona.ts
@@ -1,0 +1,24 @@
+import { cachedSource } from '@/lib/sourceCache';
+import { loadIbi511Cameras, type Ibi511Source } from './ibi511';
+
+/**
+ * OSIRIS — Arizona CCTV Cameras (ADOT / az511.gov)
+ * Source: https://az511.gov — the same IBI 511 stack Louisiana and Nevada run
+ * ~640 cameras statewide — NO API KEY NEEDED.
+ *
+ * Phoenix and Tucson metro freeways, plus the I-10, I-17 and I-40 runs across
+ * the desert. ADOT publishes no video for these, only refreshing stills, so
+ * they come up as snapshot cameras rather than video tiles.
+ *
+ * The one deployment of the four that fills in `city`, which is what the
+ * caption uses in preference to the county.
+ */
+const ADOT: Ibi511Source = {
+  base: 'https://az511.gov',
+  idPrefix: 'adot',
+  source: 'ADOT',
+  state: 'Arizona',
+  bounds: { minLat: 31.3, maxLat: 37.1, minLng: -115.0, maxLng: -109.0 },
+};
+
+export const fetchArizonaCameras = cachedSource('arizona', () => loadIbi511Cameras(ADOT));

--- a/src/app/api/cctv/florida.ts
+++ b/src/app/api/cctv/florida.ts
@@ -1,0 +1,26 @@
+import { cachedSource } from '@/lib/sourceCache';
+import { loadIbi511Cameras, type Ibi511Source } from './ibi511';
+
+/**
+ * OSIRIS — Florida CCTV Cameras (FDOT / fl511.com)
+ * Source: https://fl511.com — the same IBI 511 stack Louisiana and Nevada run
+ * ~4,950 cameras statewide — NO API KEY NEEDED.
+ *
+ * The largest single camera network on the map. It covers the whole peninsula:
+ * I-95 and I-75 end to end, the Turnpike, and the Miami, Tampa, Orlando and
+ * Jacksonville metros. Almost all of them carry an HLS stream as well as a
+ * snapshot, so they come up as video tiles.
+ *
+ * Most rows name a milepost — `I-95 MP 134.0 Northbound`. The Alligator Alley
+ * stretch instead uses internal asset codes, and those fall back to the road
+ * and direction; see cameraLabel in ./ibi511.
+ */
+const FDOT: Ibi511Source = {
+  base: 'https://fl511.com',
+  idPrefix: 'fdot',
+  source: 'FDOT',
+  state: 'Florida',
+  bounds: { minLat: 24.4, maxLat: 31.1, minLng: -87.7, maxLng: -79.9 },
+};
+
+export const fetchFloridaCameras = cachedSource('florida', () => loadIbi511Cameras(FDOT));

--- a/src/app/api/cctv/georgia.ts
+++ b/src/app/api/cctv/georgia.ts
@@ -1,0 +1,24 @@
+import { cachedSource } from '@/lib/sourceCache';
+import { loadIbi511Cameras, type Ibi511Source } from './ibi511';
+
+/**
+ * OSIRIS — Georgia CCTV Cameras (GDOT NaviGAtor / 511ga.org)
+ * Source: https://511ga.org — the same IBI 511 stack Louisiana and Nevada run
+ * ~4,040 cameras statewide — NO API KEY NEEDED.
+ *
+ * Dense across metro Atlanta — the I-285 perimeter, the I-75/I-85 connector —
+ * and out along I-16, I-20 and I-95 to Savannah. Every row carries an HLS
+ * playlist off GDOT's own edge as well as a snapshot.
+ *
+ * Labels arrive behind an agency asset code (`GDOT-1130: I-20 E at SR5 MM
+ * 34.2 (Douglas)`); ./ibi511 strips the prefix and keeps the cross-street.
+ */
+const GDOT: Ibi511Source = {
+  base: 'https://511ga.org',
+  idPrefix: 'gdot',
+  source: 'GDOT',
+  state: 'Georgia',
+  bounds: { minLat: 30.3, maxLat: 35.1, minLng: -85.7, maxLng: -80.8 },
+};
+
+export const fetchGeorgiaCameras = cachedSource('georgia', () => loadIbi511Cameras(GDOT));

--- a/src/app/api/cctv/ibi511.test.ts
+++ b/src/app/api/cctv/ibi511.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import { cameraCity, cameraLabel, mapIbi511Record, parseWkt, type Ibi511Record, type Ibi511Source } from './ibi511';
+import { fetchFloridaCameras } from './florida';
+import { fetchGeorgiaCameras } from './georgia';
+import { fetchNorthCarolinaCameras } from './northcarolina';
+import { fetchArizonaCameras } from './arizona';
+
+const FDOT: Ibi511Source = {
+  base: 'https://fl511.com',
+  idPrefix: 'fdot',
+  source: 'FDOT',
+  state: 'Florida',
+  bounds: { minLat: 24.4, maxLat: 31.1, minLng: -87.7, maxLng: -79.9 },
+};
+
+/** A representative row from fl511.com/List/GetData/Cameras. */
+const sample: Ibi511Record = {
+  id: 1,
+  roadway: 'I-95',
+  direction: 'Northbound',
+  location: 'I-95 MP 134.0 Northbound',
+  county: 'Brevard',
+  latLng: { geography: { wellKnownText: 'POINT (-80.892882 26.17325)' } },
+  images: [{
+    imageUrl: '/map/Cctv/1',
+    videoUrl: 'https://dis-se18.divas.cloud:8200/chan-1_h/index.m3u8',
+    blocked: false,
+    disabled: false,
+  }],
+};
+
+describe('cameraLabel', () => {
+  it('keeps a location that reads as a place', () => {
+    expect(cameraLabel(sample)).toBe('I-95 MP 134.0 Northbound');
+    expect(cameraLabel({ ...sample, location: 'SR-95 @SR-68 Laughlin Rd' }))
+      .toBe('SR-95 @SR-68 Laughlin Rd');
+  });
+
+  it('strips the agency asset-code prefix Georgia puts in front of its labels', () => {
+    expect(cameraLabel({ ...sample, location: 'GDOT-1130: I-20 E at SR5 MM 34.2 (Douglas)' }))
+      .toBe('I-20 E at SR5 MM 34.2 (Douglas)');
+    expect(cameraLabel({ ...sample, location: 'ALPH-0050: Rucker Rd at Charlotte Dr (Alpharetta)' }))
+      .toBe('Rucker Rd at Charlotte Dr (Alpharetta)');
+  });
+
+  /* NCDOT, and the Alligator Alley run of FDOT, put a pure equipment code
+     here. There is no place name hiding in it to recover. */
+  it('falls back to road and direction when the location is only an asset code', () => {
+    expect(cameraLabel({ ...sample, roadway: 'I-485', direction: 'Outer', location: 'CCTV10-I485-30.1O_I85' }))
+      .toBe('I-485 Outer');
+    expect(cameraLabel({ ...sample, roadway: 'I-75', direction: 'Northbound', location: '0517N_75_Alligator_Alley_M052' }))
+      .toBe('I-75 Northbound');
+  });
+
+  it('does not mistake an @-style cross-street for a code prefix', () => {
+    // `SR-389 @MP3.3` starts with letters, a dash and digits, like a code — but
+    // there is no colon, so it must survive intact.
+    expect(cameraLabel({ ...sample, location: 'SR-389 @MP3.3' })).toBe('SR-389 @MP3.3');
+  });
+
+  it('uses the road alone when there is no direction, and nothing when there is no road', () => {
+    expect(cameraLabel({ ...sample, location: 'CCTV01-NC12-28S', direction: null })).toBe('I-95');
+    expect(cameraLabel({ ...sample, location: null, roadway: null })).toBeNull();
+  });
+
+  it('treats the platform’s "N/A" filler as absent', () => {
+    expect(cameraLabel({ ...sample, location: 'N/A' })).toBe('I-95 Northbound');
+    expect(cameraLabel({ ...sample, location: 'N/A', roadway: 'N/A' })).toBeNull();
+  });
+});
+
+describe('cameraCity', () => {
+  it('prefers the city, then the county, then the state', () => {
+    expect(cameraCity({ ...sample, city: 'Bullhead City' }, 'Arizona')).toBe('Bullhead City');
+    expect(cameraCity(sample, 'Florida')).toBe('Brevard County');
+    expect(cameraCity({ ...sample, county: null }, 'Florida')).toBe('Florida');
+    expect(cameraCity({ ...sample, city: 'N/A', county: 'N/A' }, 'Florida')).toBe('Florida');
+  });
+});
+
+describe('mapIbi511Record', () => {
+  it('maps a streaming camera', () => {
+    expect(mapIbi511Record(sample, FDOT)).toEqual({
+      id: 'fdot-1',
+      lat: 26.17325,
+      lng: -80.892882,
+      name: 'I-95 MP 134.0 Northbound',
+      city: 'Brevard County',
+      country: 'US',
+      feed_url: 'https://fl511.com/map/Cctv/1',
+      stream_url: 'https://dis-se18.divas.cloud:8200/chan-1_h/index.m3u8',
+      stream_type: 'hls',
+      source: 'FDOT',
+    });
+  });
+
+  /* ADOT publishes no video at all, and Louisiana proved an agency will put a
+     JPEG address in videoUrl, so a playlist is only taken when it is one. */
+  it('keeps a camera on its snapshot when there is no usable playlist', () => {
+    const noVideo = mapIbi511Record({ ...sample, images: [{ ...sample.images![0], videoUrl: null }] }, FDOT);
+    expect(noVideo?.stream_url).toBeUndefined();
+    expect(noVideo?.feed_url).toBe('https://fl511.com/map/Cctv/1');
+
+    const jpegVideo = mapIbi511Record(
+      { ...sample, images: [{ ...sample.images![0], videoUrl: 'https://fl511.com/snapshots?id=4&ext=.jpg' }] },
+      FDOT,
+    );
+    expect(jpegVideo?.stream_url).toBeUndefined();
+  });
+
+  it('skips rows that are blocked, disabled, unplaceable or out of state', () => {
+    expect(mapIbi511Record({ ...sample, images: [{ ...sample.images![0], blocked: true }] }, FDOT)).toBeNull();
+    expect(mapIbi511Record({ ...sample, images: [{ ...sample.images![0], disabled: true }] }, FDOT)).toBeNull();
+    expect(mapIbi511Record({ ...sample, images: [] }, FDOT)).toBeNull();
+    expect(mapIbi511Record({ ...sample, latLng: null }, FDOT)).toBeNull();
+    // Coordinates in Georgia must not turn up in the Florida layer.
+    expect(mapIbi511Record({ ...sample, latLng: { geography: { wellKnownText: 'POINT (-84.33 34.07)' } } }, FDOT)).toBeNull();
+  });
+
+  /* The three biggest of these feeds gate their playlists behind a session the
+     map cannot get; their edges answer 401 to everyone else. The row says so
+     itself, and taking the URL anyway would give the player a dead stream. */
+  it('leaves an auth-gated playlist alone and keeps the public snapshot', () => {
+    const gated = mapIbi511Record(
+      { ...sample, images: [{ ...sample.images![0], isVideoAuthRequired: true }] },
+      FDOT,
+    );
+    expect(gated?.stream_url).toBeUndefined();
+    expect(gated?.stream_type).toBeUndefined();
+    expect(gated?.feed_url).toBe('https://fl511.com/map/Cctv/1');
+  });
+
+  it('still takes a playlist the row marks as open', () => {
+    const open = mapIbi511Record(
+      { ...sample, images: [{ ...sample.images![0], isVideoAuthRequired: false }] },
+      FDOT,
+    );
+    expect(open?.stream_url).toBe('https://dis-se18.divas.cloud:8200/chan-1_h/index.m3u8');
+  });
+
+  it('honours videoDisabled without dropping the camera', () => {
+    const cam = mapIbi511Record({ ...sample, images: [{ ...sample.images![0], videoDisabled: true }] }, FDOT);
+    expect(cam?.stream_url).toBeUndefined();
+    expect(cam?.feed_url).toBeDefined();
+  });
+
+  it('prefixes ids per agency so two states cannot collide', () => {
+    const asGeorgia = mapIbi511Record(
+      { ...sample, latLng: { geography: { wellKnownText: 'POINT (-84.33 34.07)' } } },
+      { ...FDOT, idPrefix: 'gdot', source: 'GDOT', state: 'Georgia', bounds: { minLat: 30.3, maxLat: 35.1, minLng: -85.7, maxLng: -80.8 } },
+    );
+    expect(asGeorgia?.id).toBe('gdot-1');
+    expect(mapIbi511Record(sample, FDOT)?.id).toBe('fdot-1');
+  });
+});
+
+describe('parseWkt', () => {
+  it('reads longitude first, as the platform writes it', () => {
+    expect(parseWkt('POINT (-80.892882 26.17325)')).toEqual({ lat: 26.17325, lng: -80.892882 });
+  });
+  it('returns null for anything else', () => {
+    expect(parseWkt(null)).toBeNull();
+    expect(parseWkt('LINESTRING (0 0, 1 1)')).toBeNull();
+  });
+});
+
+// Live integration test — opt in with RUN_LIVE_TESTS=1 (hits the real endpoints).
+const liveIt = process.env.RUN_LIVE_TESTS === '1' ? it : it.skip;
+
+describe('live southern-tier feeds', () => {
+  const cases: Array<[string, () => Promise<unknown[]>, number, { minLat: number; maxLat: number; minLng: number; maxLng: number }]> = [
+    ['Florida', fetchFloridaCameras, 3000, FDOT.bounds],
+    ['Georgia', fetchGeorgiaCameras, 2500, { minLat: 30.3, maxLat: 35.1, minLng: -85.7, maxLng: -80.8 }],
+    ['North Carolina', fetchNorthCarolinaCameras, 800, { minLat: 33.8, maxLat: 36.6, minLng: -84.4, maxLng: -75.4 }],
+    ['Arizona', fetchArizonaCameras, 400, { minLat: 31.3, maxLat: 37.1, minLng: -115.0, maxLng: -109.0 }],
+  ];
+
+  for (const [name, fetcher, atLeast, bounds] of cases) {
+    liveIt(`${name} returns placed, uniquely identified cameras`, async () => {
+      const cams = (await fetcher()) as Array<{ id: string; lat: number; lng: number; name: string }>;
+      expect(cams.length).toBeGreaterThan(atLeast);
+      expect(new Set(cams.map(c => c.id)).size).toBe(cams.length);
+      for (const c of cams) {
+        expect(c.lat).toBeGreaterThanOrEqual(bounds.minLat);
+        expect(c.lat).toBeLessThanOrEqual(bounds.maxLat);
+        expect(c.lng).toBeGreaterThanOrEqual(bounds.minLng);
+        expect(c.lng).toBeLessThanOrEqual(bounds.maxLng);
+        expect(c.name.trim()).not.toBe('');
+      }
+    }, 120_000);
+  }
+});

--- a/src/app/api/cctv/ibi511.ts
+++ b/src/app/api/cctv/ibi511.ts
@@ -1,10 +1,18 @@
+import { stealthFetch } from '@/lib/stealthFetch';
+import type { CctvCamera } from './types';
+
 /**
  * OSIRIS — helpers for the IBI 511 traveler-information platform.
  *
  * Several state DOTs run the same vendor stack behind different domains, and
  * they all expose cameras the same way: a DataTables endpoint at
  * `/List/GetData/Cameras` that pages 100 rows at a time, with each row's
- * position as WKT. Utah and Nevada both read through here.
+ * position as WKT. Utah and Nevada read the query builder and WKT parser from
+ * here; Florida, Georgia, North Carolina and Arizona read the whole loader.
+ *
+ * Each of those four publishes the same record shape, so the only thing that
+ * differs between them is the domain, the bounding box, and the wording of
+ * their `location` column — which `cameraLabel` handles for all of them.
  */
 
 /** Build the URL-encoded DataTables `query` parameter for a given page. */
@@ -33,4 +41,211 @@ export function parseWkt(wkt?: string | null): { lat: number; lng: number } | nu
   const lat = parseFloat(m[2]);
   if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
   return { lat, lng };
+}
+
+/** One row from /List/GetData/Cameras — only the fields we consume. */
+export interface Ibi511Record {
+  id: number;
+  roadway?: string | null;
+  direction?: string | null;
+  location?: string | null;
+  city?: string | null;
+  county?: string | null;
+  latLng?: { geography?: { wellKnownText?: string | null } | null } | null;
+  images?: Array<{
+    description?: string | null;
+    imageUrl?: string | null;
+    videoUrl?: string | null;
+    /** True when the playlist needs a session the map cannot obtain. */
+    isVideoAuthRequired?: boolean;
+    blocked?: boolean;
+    disabled?: boolean;
+    videoDisabled?: boolean;
+  }> | null;
+}
+
+/** What separates one state's deployment from another's. */
+export interface Ibi511Source {
+  /** Origin, e.g. `https://fl511.com`. */
+  base: string;
+  /** Prefixes every camera id, so two states can't collide on a numeric id. */
+  idPrefix: string;
+  /** The agency shown on the camera card. */
+  source: string;
+  /** Caption of last resort, when a row names neither a city nor a county. */
+  state: string;
+  /** Drops mis-geocoded rows — every one of these feeds has a few. */
+  bounds: { minLat: number; maxLat: number; minLng: number; maxLng: number };
+}
+
+const PAGE_SIZE = 100; // the server caps a response at 100 rows whatever we ask for
+/** Safety bound (~6,000 cameras) so a bad `recordsTotal` can't fan out forever. */
+const MAX_PAGES = 60;
+/**
+ * Florida alone is fifty pages, so these go in batches rather than all at once.
+ *
+ * Ten is deliberate. At six, Georgia's forty-one pages took 16.5s and blew the
+ * route's 12s per-region budget, which meant its cameras only ever appeared on
+ * the *second* request — the first one having been abandoned while the fetch
+ * carried on filling the cache. Ten brings Georgia to 4.4s and Florida to
+ * 5.8s, both inside the budget, with no refusals from either agency.
+ */
+const CONCURRENCY = 10;
+
+/**
+ * An asset-code prefix on an otherwise readable label: GDOT writes
+ * `GDOT-1130: I-20 E at SR5 MM 34.2 (Douglas)`, Alpharetta writes `ALPH-0050:`.
+ */
+const CODE_PREFIX = /^[A-Z]{2,8}-?\d*\s*:\s*/;
+
+/**
+ * Whether a location string names a place rather than a piece of equipment.
+ *
+ * A space is the whole test, and it is enough: across a 1,200-row sample every
+ * NCDOT code and every FDOT asset code ran the words together with underscores
+ * or dashes (`CCTV01-NC12-28S_CANALZONE`, `0517N_75_Alligator_Alley_M052`),
+ * and every value with a space in it was a real label. Also requiring a
+ * lowercase letter looks like a stronger test but throws away good ones —
+ * `I-95 @ MM 306.9` in Florida, and one Arizona label in nine.
+ */
+function readable(s: string): boolean {
+  return / /.test(s);
+}
+
+/**
+ * The best name the row can honestly support.
+ *
+ * Most rows carry a real cross-street in `location` — `SR-95 @SR-68 Laughlin
+ * Rd`, `I-95 MP 134.0 Northbound` — sometimes behind an asset-code prefix.
+ * NCDOT and a corner of FDOT instead put a pure internal code there
+ * (`CCTV01-NC12-28S_CANALZONE`), and no amount of parsing turns that into a
+ * place name, so those fall back to the road and the direction it watches.
+ */
+export function cameraLabel(rec: Ibi511Record): string | null {
+  const loc = rec.location?.trim().replace(CODE_PREFIX, '');
+  if (loc && loc !== 'N/A' && readable(loc)) return loc;
+
+  const road = rec.roadway?.trim();
+  if (!road || road === 'N/A') return loc && loc !== 'N/A' ? loc : null;
+  const dir = rec.direction?.trim();
+  return dir && dir !== 'N/A' ? `${road} ${dir}` : road;
+}
+
+/** Where the camera is, for the caption under its name. */
+export function cameraCity(rec: Ibi511Record, state: string): string {
+  const city = rec.city?.trim();
+  if (city && city !== 'N/A') return city;
+  const county = rec.county?.trim();
+  if (county && county !== 'N/A') return `${county} County`;
+  return state;
+}
+
+/** The video address, but only when it is actually an HLS playlist. */
+function hlsUrl(url?: string | null): string | undefined {
+  const trimmed = url?.trim();
+  return trimmed && /\.m3u8(\?|$)/i.test(trimmed) ? trimmed : undefined;
+}
+
+/** Map a raw row to a camera, or null if it should be skipped. */
+export function mapIbi511Record(rec: Ibi511Record, cfg: Ibi511Source): CctvCamera | null {
+  if (!rec || typeof rec.id !== 'number') return null;
+
+  const img = rec.images?.[0];
+  if (!img || img.blocked || img.disabled) return null;
+
+  const coords = parseWkt(rec.latLng?.geography?.wellKnownText);
+  if (!coords) return null;
+
+  const { lat, lng } = coords;
+  const b = cfg.bounds;
+  if (lat < b.minLat || lat > b.maxLat || lng < b.minLng || lng > b.maxLng) return null;
+
+  const snapshot = img.imageUrl ? `${cfg.base}${img.imageUrl}` : undefined;
+  /* `isVideoAuthRequired` is the platform saying the playlist is gated behind
+     a session its own player negotiates. Georgia, Florida and NCDOT set it on
+     every row and their edges answer 401 to anyone else — user agent and
+     referer make no difference — so taking those URLs would hand the player
+     nine thousand streams that cannot open. Their snapshots are public and
+     serve fine, which is what those cameras show instead. Louisiana and
+     Arizona set it on none. */
+  const gated = img.isVideoAuthRequired === true;
+  const video = img.videoDisabled || gated ? undefined : hlsUrl(img.videoUrl);
+  if (!snapshot && !video) return null;
+
+  return {
+    id: `${cfg.idPrefix}-${rec.id}`,
+    lat,
+    lng,
+    name: cameraLabel(rec) || `${cfg.source} Camera ${rec.id}`,
+    city: cameraCity(rec, cfg.state),
+    country: 'US',
+    ...(snapshot ? { feed_url: snapshot } : {}),
+    ...(video ? { stream_url: video, stream_type: 'hls' as const } : {}),
+    source: cfg.source,
+  };
+}
+
+async function fetchPage(cfg: Ibi511Source, start: number): Promise<{ rows: Ibi511Record[]; total: number }> {
+  const url = `${cfg.base}/List/GetData/Cameras?query=${buildQuery(start, PAGE_SIZE)}&lang=en`;
+  const res = await stealthFetch(url, {
+    signal: AbortSignal.timeout(15000),
+    headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
+  });
+  if (!res.ok) throw new Error(`${cfg.source} HTTP ${res.status}`);
+  const data = await res.json();
+  return {
+    rows: Array.isArray(data?.data) ? data.data : [],
+    total: Number(data?.recordsTotal) || 0,
+  };
+}
+
+/** Every camera one of these deployments publishes, paged and de-duplicated. */
+export async function loadIbi511Cameras(cfg: Ibi511Source): Promise<CctvCamera[]> {
+  // The first page also tells us how many there are in total.
+  const first = await fetchPage(cfg, 0);
+  const seen = new Map<number, CctvCamera>();
+
+  const ingest = (rows: Ibi511Record[]) => {
+    for (const rec of rows) {
+      const cam = mapIbi511Record(rec, cfg);
+      if (cam) seen.set(rec.id, cam);
+    }
+  };
+  ingest(first.rows);
+
+  const starts: number[] = [];
+  for (let s = PAGE_SIZE; s < first.total && s < PAGE_SIZE * MAX_PAGES; s += PAGE_SIZE) {
+    starts.push(s);
+  }
+
+  const failed: number[] = [];
+  for (let i = 0; i < starts.length; i += CONCURRENCY) {
+    const batch = starts.slice(i, i + CONCURRENCY);
+    const results = await Promise.allSettled(batch.map(s => fetchPage(cfg, s)));
+    results.forEach((r, j) => r.status === 'fulfilled' ? ingest(r.value.rows) : failed.push(batch[j]));
+  }
+
+  // One more go at whatever dropped. These agencies throttle a burst rather
+  // than refuse it outright, so a page that failed in a batch of ten usually
+  // succeeds on its own a moment later.
+  if (failed.length) {
+    const retried = await Promise.allSettled(failed.map(s => fetchPage(cfg, s)));
+    for (const r of retried) if (r.status === 'fulfilled') ingest(r.value.rows);
+  }
+
+  const cams = [...seen.values()];
+
+  /* A short read is a failed refresh, not a smaller state.
+     `Promise.allSettled` made lost pages invisible: a burst that came back
+     throttled once cached 200 of Arizona's 644 and 3,143 of Georgia's 4,043,
+     and served that for the next half hour. Throwing hands the decision to
+     sourceCache, which keeps the last good index instead — none of these
+     feeds drops rows of its own accord, so anything materially short of
+     `recordsTotal` is pages we did not get. */
+  if (first.total > 0 && cams.length < first.total * 0.95) {
+    throw new Error(`${cfg.source} short read: ${cams.length} of ${first.total}`);
+  }
+
+  console.log(`[OSIRIS] ${cfg.source} cameras: ${cams.length} of ${first.total}`);
+  return cams;
 }

--- a/src/app/api/cctv/northcarolina.ts
+++ b/src/app/api/cctv/northcarolina.ts
@@ -1,0 +1,24 @@
+import { cachedSource } from '@/lib/sourceCache';
+import { loadIbi511Cameras, type Ibi511Source } from './ibi511';
+
+/**
+ * OSIRIS — North Carolina CCTV Cameras (NCDOT DriveNC / drivenc.gov)
+ * Source: https://drivenc.gov — the same IBI 511 stack Louisiana and Nevada run
+ * ~1,140 cameras statewide — NO API KEY NEEDED.
+ *
+ * Charlotte and the Triangle, plus the I-40 and I-95 corridors and the Outer
+ * Banks run of NC-12. Roughly nine in ten carry an HLS stream.
+ *
+ * NCDOT is the one deployment that puts a pure asset code in its location
+ * column (`CCTV01-NC12-28S_CANALZONE`), so these are named for the road and
+ * direction they watch, with the county as the caption.
+ */
+const NCDOT: Ibi511Source = {
+  base: 'https://drivenc.gov',
+  idPrefix: 'ncdot',
+  source: 'NCDOT',
+  state: 'North Carolina',
+  bounds: { minLat: 33.8, maxLat: 36.6, minLng: -84.4, maxLng: -75.4 },
+};
+
+export const fetchNorthCarolinaCameras = cachedSource('northcarolina', () => loadIbi511Cameras(NCDOT));

--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -33,6 +33,10 @@ import { fetchMichiganCameras } from './michigan';
 import { fetchIndianaCameras } from './indiana';
 import { fetchNevadaCameras } from './nevada';
 import { fetchLouisianaCameras } from './louisiana';
+import { fetchFloridaCameras } from './florida';
+import { fetchGeorgiaCameras } from './georgia';
+import { fetchNorthCarolinaCameras } from './northcarolina';
+import { fetchArizonaCameras } from './arizona';
 import { fetchEastAsiaCameras, fetchSeAsiaCameras, fetchWestAsiaCameras } from './opencctv';
 import {
   fetchLatamLiveCameras,
@@ -468,6 +472,10 @@ const RAW_REGION_FETCHERS: Record<string, RegionFetcher> = {
   'indiana': fetchIndianaCameras,
   'nevada': fetchNevadaCameras,
   'louisiana': fetchLouisianaCameras,
+  'florida': fetchFloridaCameras,
+  'georgia': fetchGeorgiaCameras,
+  'northcarolina': fetchNorthCarolinaCameras,
+  'arizona': fetchArizonaCameras,
   'eastasia': fetchEastAsiaCameras,
   'seasia': fetchSeAsiaCameras,
   'westasia': fetchWestAsiaCameras,
@@ -536,6 +544,13 @@ function getRegionsForBounds(lat: number, lng: number, radius: number): string[]
   if (lat > 37.7 && lat < 41.9 && lng > -88.2 && lng < -84.6) regions.push('indiana');
   // Louisiana (LADOTD 511) — explicit, since neither us-central nor us-east reaches the Gulf coast
   if (lat > 28.8 && lat < 33.1 && lng > -94.2 && lng < -88.6) regions.push('louisiana');
+  /* The rest of the southern tier, all on the same IBI 511 stack. Each is
+     listed explicitly for the same reason Louisiana is: the broad us-east and
+     us-central boxes cover the latitudes but carry none of these agencies. */
+  if (lat > 24.4 && lat < 31.1 && lng > -87.7 && lng < -79.9) regions.push('florida');
+  if (lat > 30.3 && lat < 35.1 && lng > -85.7 && lng < -80.8) regions.push('georgia');
+  if (lat > 33.8 && lat < 36.6 && lng > -84.4 && lng < -75.4) regions.push('northcarolina');
+  if (lat > 31.3 && lat < 37.1 && lng > -115.0 && lng < -109.0) regions.push('arizona');
   // Canada
   if (lat > 42 && lat < 70 && lng > -141 && lng < -52) regions.push('canada');
   // Europe


### PR DESCRIPTION
Florida, Georgia, North Carolina and Arizona all run the same IBI 511 stack as Louisiana and Nevada, and all four answer without an API key.

| agency | cameras | coverage |
|---|---|---|
| **FDOT** Â· fl511.com | 4,953 | I-95, I-75, the Turnpike, Miami / Tampa / Orlando / Jacksonville |
| **GDOT** Â· 511ga.org | 4,043 | I-285 perimeter, the connector, I-16 and I-20 to Savannah |
| **NCDOT** Â· drivenc.gov | 1,139 | Charlotte, the Triangle, I-40 and I-95, NC-12 on the Outer Banks |
| **ADOT** Â· az511.gov | 644 | Phoenix and Tucson loops, I-10 / I-17 / I-40 |

That fills the Gulf coast, the Atlantic seaboard and the desert southwest, which had almost nothing on them.

Rather than a fifth copy of Louisiana's loader, `./ibi511` grows the paging, mapping and naming, and each state becomes a config: a domain, a bounding box, an id prefix. Louisiana keeps its own â€” it works, it is tested, and its naming rule genuinely differs.

## Four things the feeds forced

**Video.** Georgia, Florida and NCDOT publish HLS playlists their edges answer **401** to for anyone but their own player â€” user agent and referer make no difference. The row declares this itself in `isVideoAuthRequired`, so that flag is honoured and those cameras show their public snapshots instead. Taking the URLs anyway would have shipped **9,537 streams that cannot open**. NCDOT's 20 genuinely-open ones are kept, as are Louisiana's 335.

**Naming.** Most rows carry a real cross-street, sometimes behind an agency asset code. NCDOT and one corner of FDOT instead put a pure equipment code there, and nothing recovers a place name from `CCTV01-NC12-28S_CANALZONE`, so those fall back to the road and the direction it watches. Telling the two apart comes down to whether the string has a space in it: across a 1,200-row sample every code ran its words together and every value with a space was real. Also requiring a lowercase letter looks like a stronger test but discards good labels â€” `I-95 @ MM 306.9` in Florida, and one Arizona label in nine.

**Short reads.** `Promise.allSettled` made a lost page invisible, and the partial index it produced was cached as a *success* — one throttled burst cached **200 of Arizona's 644** and **3,143 of Georgia's 4,043**, and served that for half an hour. Dropped pages are retried once (these agencies throttle a burst rather than refuse it), and anything still materially short of `recordsTotal` throws, so `sourceCache` keeps the last good index instead. None of these feeds drops rows of its own accord, so a shortfall is only ever pages we did not get.

**Pace.** Pages go ten at a time. At six, Georgia's forty-one pages took 16.5s and blew the route's 12s per-region budget, so its cameras only ever arrived on the *following* request. Ten brings Georgia to 4.4s and Florida to 5.8s, with no refusals from either agency.

## Verification

- **Live on localhost:** Atlanta 4,994 GDOT features Â· Miami 1,507 FDOT Â· Phoenix 855 ADOT Â· Charlotte 415 NCDOT
- **Live integration** against all four real endpoints (`RUN_LIVE_TESTS=1`): `4953 of 4953`, `4043 of 4043`, `1139 of 1139`, `644 of 644` â€” all inside their state bounds, uniquely identified, every one named
- Every non-gated stream tested: NCDOT 20/22 serve 200; snapshots serve 200 for all four
- Verified against the failure directly: three full passes over all four states now return 4,043 / 4,953 / 1,139 / 644 every time, where the same pattern previously stuck at 3,143 / 4,153 / 1,139 / 200
- **565 tests pass** (16 new) Â· `tsc` clean Â· eslint clean on every new file Â· CRLF matched to sibling sources Â· Louisiana unchanged at 336

Two caveats worth stating: one Florida row named `I10 MM 121.4 WB-DMS (test)` is flagged auth-free but still 401s â€” a mislabelled test rig, 1 of 4,953. And on a cold **dev** server Georgia can still exceed the region budget and arrive on the following poll, which is the route's designed behaviour for slow sources; it was 160ms warm.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

