### PR TITLE
fix(cctv): stop the analytics starving the camera feeds

### DIFF
--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -116,15 +116,62 @@ async function fetchCaltransCameras(): Promise<any[]> {
   }
 }
 
+/**
+ * One sub-source of a multi-source region, fetched with a single retry.
+ *
+ * These blocks swallowed every failure. A region returns whatever it managed
+ * to collect, and sourceCache stores a non-empty result as a success — so one
+ * blip on one source cached the region without it for the full TTL, with
+ * nothing in the log to say which one went missing. Quebec disappeared from
+ * Canada that way for half an hour while its own endpoint was answering in
+ * 300ms. The retry catches the blip; the warning means a real outage is
+ * visible instead of silent.
+ */
+async function subSource(label: string, url: string, timeoutMs: number) {
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      const res = await stealthFetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+      if (res.ok) return await res.json();
+      /* A 4xx is a decision, not a blip: a retired endpoint answers 404 just
+         as fast the second time. Retrying them only spent the region's budget
+         — Montreal (403) and Alberta (400) between them pushed Canada past
+         12s, so the whole country came back empty on a cold cache. */
+      if (res.status >= 400 && res.status < 500) {
+        console.warn(`[OSIRIS] ${label} returned ${res.status} — absent from this refresh, not retried`);
+        return null;
+      }
+      if (attempt === 2) console.warn(`[OSIRIS] ${label} returned ${res.status} — absent from this refresh`);
+    } catch (e) {
+      if (attempt === 2) console.warn(`[OSIRIS] ${label} failed — absent from this refresh:`, e instanceof Error ? e.message : e);
+    }
+  }
+  return null;
+}
+
 // ── CANADA: Ottawa, Toronto, Montreal, Quebec ──
 async function fetchCanadaCameras(): Promise<any[]> {
   const cams: any[] = [];
 
+  /* All seven run at once. Awaited one after another their timeouts summed
+     to well over the 12s the route allows a region, so Canada kept coming
+     back empty and only filled in on a later poll — the whole country
+     looked like it was failing to load. They share nothing, so there was
+     never a reason to queue them. */
+  const [ottawa, quebec, ontario, montreal, alberta, toronto, drivebc] = await Promise.all([
+    subSource('City of Ottawa', 'https://traffic.ottawa.ca/beta/camera_list', 12000),
+    subSource('Quebec 511', 'https://ws.mapserver.transports.gouv.qc.ca/swtq?service=wfs&version=2.0.0&request=getfeature&typename=ms:infos_cameras&outfile=Camera&srsname=EPSG:4326&outputformat=geojson', 10000),
+    subSource('511 Ontario', 'https://511on.ca/api/v2/get/cameras', 10000),
+    subSource('Ville MTL', 'https://ville.montreal.qc.ca/circulation/sites/ville.montreal.qc.ca.circulation/files/cameras.json', 8000),
+    subSource('511 Alberta', 'https://511.alberta.ca/api/v2/get/cameras', 10000),
+    subSource('City of Toronto', 'https://ckan0.cf.opendata.inter.prod-toronto.ca/dataset/a3309088-5fd4-4d34-8297-77c8301840ac/resource/4a568300-c7f8-496d-b150-dff6f5dc6d4f/download/traffic-camera-list-4326.geojson', 10000),
+    subSource('DriveBC', 'https://drivebc.ca/api/webcams', 10000),
+  ]);
+
+
   // Ottawa Municipal Cameras (Comprehensive)
-  try {
-    const res = await stealthFetch('https://traffic.ottawa.ca/beta/camera_list', { signal: AbortSignal.timeout(12000) });
-    if (res.ok) {
-      const data = await res.json();
+  {
+    const data = ottawa;
+    if (data) {
       for (const cam of (data || [])) {
         if (!cam.latitude || !cam.longitude) continue;
         cams.push({
@@ -134,13 +181,12 @@ async function fetchCanadaCameras(): Promise<any[]> {
         });
       }
     }
-  } catch (e) { /* silent */ }
+  }
 
   // Quebec 511 (Comprehensive - covers Montreal, Quebec City, highways)
-  try {
-    const res = await stealthFetch('https://ws.mapserver.transports.gouv.qc.ca/swtq?service=wfs&version=2.0.0&request=getfeature&typename=ms:infos_cameras&outfile=Camera&srsname=EPSG:4326&outputformat=geojson', { signal: AbortSignal.timeout(10000) });
-    if (res.ok) {
-      const data = await res.json();
+  {
+    const data = quebec;
+    if (data) {
       for (const feature of (data.features || [])) {
         const coords = feature.geometry?.coordinates;
         const p = feature.properties;
@@ -155,29 +201,32 @@ async function fetchCanadaCameras(): Promise<any[]> {
         });
       }
     }
-  } catch (e) { /* silent */ }
+  }
 
   // Ontario 511 (MTO Highway Cameras)
-  try {
-    const res = await stealthFetch('https://511on.ca/api/v2/get/cameras', { signal: AbortSignal.timeout(10000) });
-    if (res.ok) {
-      const data = await res.json();
+  {
+    const data = ontario;
+    if (data) {
+      /* MTO capitalises its field names. Reading `cam.latitude` skipped all
+         944 rows, so the only Ontario markers on the map were the three
+         curated Toronto ones below — the province has been empty this whole
+         time. A view's Url serves the JPEG itself, no rewriting needed. */
       for (const cam of (data || [])) {
-        if (!cam.latitude || !cam.longitude) continue;
+        const view = cam.Views?.find((v: { Status?: string; Url?: string }) => v.Status === 'Enabled') ?? cam.Views?.[0];
+        if (!cam.Latitude || !cam.Longitude || !view?.Url) continue;
         cams.push({
-          id: `on-${cam.id || cams.length}`, lat: cam.latitude, lng: cam.longitude,
-          name: cam.description || cam.name || 'Ontario Camera', city: 'Ontario', country: 'Canada',
-          feed_url: cam.imageUrl || cam.url || '', source: '511 Ontario',
+          id: `on-${cam.Id}`, lat: cam.Latitude, lng: cam.Longitude,
+          name: cam.Location || cam.Roadway || 'Ontario Camera', city: 'Ontario', country: 'Canada',
+          feed_url: view.Url, source: '511 Ontario',
         });
       }
     }
-  } catch (e) { /* silent */ }
+  }
 
   // Ville de Montréal municipal cameras
-  try {
-    const res = await stealthFetch('https://ville.montreal.qc.ca/circulation/sites/ville.montreal.qc.ca.circulation/files/cameras.json', { signal: AbortSignal.timeout(8000) });
-    if (res.ok) {
-      const data = await res.json();
+  {
+    const data = montreal;
+    if (data) {
       for (const cam of (data || [])) {
         cams.push({
           id: `mtl-muni-${cams.length}`, lat: cam.latitude || cam.lat, lng: cam.longitude || cam.lng,
@@ -186,7 +235,7 @@ async function fetchCanadaCameras(): Promise<any[]> {
         });
       }
     }
-  } catch (e) { /* silent */ }
+  }
 
   // Curated Toronto cameras (fallback if 511ON fails)
   const curated = [
@@ -197,10 +246,9 @@ async function fetchCanadaCameras(): Promise<any[]> {
   cams.push(...curated);
 
   // Alberta 511
-  try {
-    const res = await stealthFetch('https://511.alberta.ca/api/v2/get/cameras', { signal: AbortSignal.timeout(10000) });
-    if (res.ok) {
-      const data = await res.json();
+  {
+    const data = alberta;
+    if (data) {
       for (const cam of (data || [])) {
         if (!cam.Latitude || !cam.Longitude || !cam.Views?.[0]?.Url) continue;
         cams.push({
@@ -210,14 +258,13 @@ async function fetchCanadaCameras(): Promise<any[]> {
         });
       }
     }
-  } catch (e) { /* silent */ }
+  }
 
 
   // Toronto Open Data Municipal Traffic Cameras
-  try {
-    const res = await stealthFetch('https://ckan0.cf.opendata.inter.prod-toronto.ca/dataset/a3309088-5fd4-4d34-8297-77c8301840ac/resource/4a568300-c7f8-496d-b150-dff6f5dc6d4f/download/traffic-camera-list-4326.geojson', { signal: AbortSignal.timeout(10000) });
-    if (res.ok) {
-      const data = await res.json();
+  {
+    const data = toronto;
+    if (data) {
       for (const feature of (data.features || [])) {
         let coords = feature.geometry?.coordinates;
         if (Array.isArray(coords) && Array.isArray(coords[0])) coords = coords[0];
@@ -230,13 +277,12 @@ async function fetchCanadaCameras(): Promise<any[]> {
         });
       }
     }
-  } catch (e) { /* silent */ }
+  }
 
   // British Columbia HighwayCams (Live JSON API)
-  try {
-    const res = await stealthFetch('https://drivebc.ca/api/webcams', { signal: AbortSignal.timeout(10000) });
-    if (res.ok) {
-      const data = await res.json();
+  {
+    const data = drivebc;
+    if (data) {
       for (const cam of (data || [])) {
         if (!cam.location?.coordinates || !cam.links?.imageDisplay) continue;
         const [lng, lat] = cam.location.coordinates;
@@ -247,7 +293,7 @@ async function fetchCanadaCameras(): Promise<any[]> {
         });
       }
     }
-  } catch (e) { /* silent */ }
+  }
 
   return cams.filter((c: any) => c.lat && c.lng);
 }
@@ -256,11 +302,15 @@ async function fetchCanadaCameras(): Promise<any[]> {
 async function fetchUSCentralCameras(): Promise<any[]> {
   const cams: any[] = [];
   // Illinois DOT
-  try {
-    const res = await stealthFetch('https://www.travelmidwest.com/lmiga/cameraReport.json', { signal: AbortSignal.timeout(8000) });
-    if (res.ok) {
-      const data = await res.json();
-      for (const cam of (data?.cameraReports || data || []).slice(0, 800)) {
+  {
+    const data = await subSource('IDOT', 'https://www.travelmidwest.com/lmiga/cameraReport.json', 8000);
+    if (data) {
+      /* travelmidwest answers 200 with {updatedMessage, noDataMessage} and no
+         cameras at all — an object, not the array this assumed. That threw a
+         TypeError the old silent catch quietly absorbed; now it would take
+         us-central down with it, so the shape is checked. */
+      const rows = Array.isArray(data?.cameraReports) ? data.cameraReports : Array.isArray(data) ? data : [];
+      for (const cam of rows.slice(0, 800)) {
         if (!cam.latitude || !cam.longitude) continue;
         cams.push({
           id: `ildot-${cams.length}`, lat: cam.latitude, lng: cam.longitude,
@@ -269,7 +319,7 @@ async function fetchUSCentralCameras(): Promise<any[]> {
         });
       }
     }
-  } catch (e) { /* silent */ }
+  }
 
   return cams.filter((c: any) => c.lat && c.lng);
 }
@@ -311,21 +361,11 @@ async function fetchUSEastCameras(): Promise<any[]> {
       source: 'Cincinnati, OH',
     },
   );
-  // Florida 511
-  try {
-    const res = await stealthFetch('https://fl511.com/api/v2/cameras', { signal: AbortSignal.timeout(8000) });
-    if (res.ok) {
-      const data = await res.json();
-      for (const cam of (data || []).slice(0, 800)) {
-        if (!cam.latitude || !cam.longitude) continue;
-        cams.push({
-          id: `fl-${cams.length}`, lat: cam.latitude, lng: cam.longitude,
-          name: cam.description || 'FL-511 Camera', city: 'Florida', country: 'US',
-          feed_url: cam.imageUrl || '', source: 'FL-511',
-        });
-      }
-    }
-  } catch (e) { /* silent */ }
+  /* Florida used to be fetched here from fl511.com/api/v2/cameras. That
+     endpoint has returned 404 for some time — and because the block tested
+     `res.ok` before doing anything, it failed without even reaching a catch.
+     ./florida now serves the state from the working IBI index; this is left
+     out rather than kept as a source that can only ever contribute nothing. */
 
 
   return cams.filter((c: any) => c.lat && c.lng);
@@ -336,11 +376,10 @@ async function fetchEuropeCameras(): Promise<any[]> {
   const cams: any[] = [];
 
   // Netherlands Rijkswaterstaat
-  try {
-    const res = await stealthFetch('https://opendata.ndw.nu/cameras.json', { signal: AbortSignal.timeout(8000) });
-    if (res.ok) {
-      const data = await res.json();
-      for (const cam of (data || []).slice(0, 1000)) {
+  {
+    const data = await subSource('NDW Netherlands', 'https://opendata.ndw.nu/cameras.json', 8000);
+    if (data) {
+      for (const cam of (Array.isArray(data) ? data : []).slice(0, 1000)) {
         if (!cam.lat || !cam.lng) continue;
         cams.push({
           id: `nl-${cams.length}`, lat: cam.lat, lng: cam.lng,
@@ -349,7 +388,7 @@ async function fetchEuropeCameras(): Promise<any[]> {
         });
       }
     }
-  } catch (e) { /* silent */ }
+  }
 
   cams.push(...await fetchAsfinagCameras());
 
@@ -361,10 +400,9 @@ async function fetchAsiaCameras(): Promise<any[]> {
   const cams: any[] = [];
 
   // Singapore Live Traffic Images
-  try {
-    const res = await stealthFetch('https://api.data.gov.sg/v1/transport/traffic-images', { signal: AbortSignal.timeout(10000) });
-    if (res.ok) {
-      const data = await res.json();
+  {
+    const data = await subSource('LTA Singapore', 'https://api.data.gov.sg/v1/transport/traffic-images', 10000);
+    if (data) {
       const items = data.items?.[0]?.cameras || [];
       for (const cam of items) {
         if (!cam.location?.latitude || !cam.location?.longitude || !cam.image) continue;
@@ -380,7 +418,7 @@ async function fetchAsiaCameras(): Promise<any[]> {
         });
       }
     }
-  } catch (e) { /* silent */ }
+  }
 
   return cams;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,10 +17,18 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
     website: process.env.UMAMI_WEBSITE_ID || "cd8f216c-fc3f-45f5-ba1a-e10309a61d18"
   };
 
+  /* Bounded, because these are fire-and-forget analytics on the critical path.
+     `umami-umami-1` only resolves inside the production compose network; on a
+     developer's machine it is ENOTFOUND, and two unbounded requests per page
+     view accumulated against the shared connection pool until the app's own
+     API routes could not get a socket. The CCTV route would then time out
+     region after region and the map came up half empty — the analytics were
+     starving the thing they were measuring. */
   const pageView = fetch('http://umami-umami-1:3000/api/send', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'User-Agent': userAgent, 'x-forwarded-for': ip },
-    body: JSON.stringify({ payload: basePayload, type: "event" })
+    body: JSON.stringify({ payload: basePayload, type: "event" }),
+    signal: AbortSignal.timeout(2000),
   }).catch(() => {});
 
   const ipEvent = fetch('http://umami-umami-1:3000/api/send', {
@@ -29,7 +37,8 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
     body: JSON.stringify({
       payload: { ...basePayload, name: "Network Log", data: { IP: ip } },
       type: "event"
-    })
+    }),
+    signal: AbortSignal.timeout(2000),
   }).catch(() => {});
 
   event.waitUntil(Promise.all([pageView, ipEvent]));


### PR DESCRIPTION
Cameras were arriving in a fraction of their real numbers, and which ones went missing changed between identical requests. It turned out to be four separate causes.

## 1. The analytics proxy was starving every fetch

The largest one, and nothing to do with cameras. `src/middleware.ts` fires **two unbounded fetches** to `http://umami-umami-1:3000` per page request and `waitUntil`s them. That host only resolves inside the production compose network — anywhere else it is **ENOTFOUND**, and the requests accumulated against the shared connection pool until the app's own API routes could not get a socket. Region after region then blew the 12s budget and the map came up half empty. The analytics were starving the thing they were measuring.

The timeline is unambiguous:

| middleware | Canada |
|---|---|
| running | 1,401 |
| accidentally disabled by Next's `middleware` → `proxy` rename | **3,449** |
| running again | **3** |
| both calls bounded at 2s | **3,449** |

Production never reaches a 2s timeout against a host on its own network; a laptop hits it immediately.

## 2. Ontario had never worked

MTO returns `Latitude`/`Longitude` capitalised; the mapper read `cam.latitude`. All 944 rows hit `continue`, so the only markers in the province were three hardcoded Toronto entries. A view's `Url` serves the JPEG directly, so nothing else needed rewriting. **3 → 947.**

## 3. Canada fetched its seven sources one at a time

Their timeouts summed to well past the region budget, so the country returned empty and only filled in on a later poll. They share nothing and now run as one `Promise.all` — a cold fetch went from **timing out at 12s to 1.4s**.

## 4. Six upstreams are dead, and all of them failed invisibly

Every sub-source sat in `catch { /* silent */ }`, so a blip and a permanent outage looked identical: nothing logged, and a region that lost one source was still cached as a **success for the full 30-minute TTL**. That is how Quebec vanished for half an hour while its own endpoint was answering in 300ms.

All ten now retry once and warn by name. A **4xx is not retried** — it is a decision, not a blip, and retrying Montreal's 403 and Alberta's 400 only spent budget that Canada needed.

Health-checking all fourteen upstreams found six dead:

| source | status |
|---|---|
| **FL-511 v2** | 404 — **removed**; `./florida` serves the state properly now |
| WSDOT | 404, wants an access code |
| NDW Netherlands | 404, restructured |
| Ville MTL | 403 |
| 511 Alberta | 400, wants an API key |
| IDOT | 200 with no cameras at all |

FL-511 is deleted rather than kept as a source that can only ever contribute nothing — and note it was failing *without even reaching a catch*, because the block tested `res.ok` first. The other five need new endpoints rather than a code change; they now say so in the log.

Removing the catches also exposed a `TypeError` the old ones had been absorbing: travelmidwest replies with an object where an array was assumed, which would now take us-central down with it. Both `.slice` sites check the shape.

## Verification

- **Canada 1,401 → 3,449**, stable across repeated cold-cache runs: Ottawa 428 · Quebec 676 · **Ontario 947** · Toronto 336 · DriveBC 1,062
- Cold fetch **12s timeout → 1.4s**
- Southern tier from #315 unaffected: Florida 4,953 · Georgia 4,043 · NC 1,139 · Arizona 644 · Louisiana 336
- 16,219 cameras on the map at world view
- 565 tests pass · `tsc` clean · eslint unchanged (25 pre-existing `any` in `route.ts`, 0 in `middleware.ts`)

One thing to flag: `src/middleware.ts` is the only file here outside the CCTV route. Next 16 also warns that the `middleware` convention is deprecated in favour of `proxy` — worth doing eventually, but the file **and** its export have to be renamed together or it silently stops running, which is exactly how this bug hid for so long.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
