### PR TITLE
fix(intel): follow GDELT's redirect, revive the Dutch feeds, rebuild the nuclear layer

### DIFF
--- a/src/app/api/cctv/netherlands.test.ts
+++ b/src/app/api/cctv/netherlands.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { parseRwsCameras, fetchNetherlandsCameras } from './netherlands';
+
+/** One record in the shape Rijkswaterstaat actually serves. */
+const AMERSFOORT = {
+  id: 4,
+  latitude: '52.185241',
+  longitude: '5.41449',
+  road: 'A1',
+  near: 'Amersfoort',
+  location_description: 'Langs de A1, net ten westen van knooppunt Hoevelaken.',
+  stream_url: 'https://stream.inmoves.nl/62/embed',
+  static_url: 'https://stream.inmoves.nl/62',
+};
+
+describe('parseRwsCameras', () => {
+  it('maps a record, proxying the hotlink-protected frame', () => {
+    expect(parseRwsCameras([AMERSFOORT])).toEqual([{
+      id: 'nl-rws-4',
+      lat: 52.185241,
+      lng: 5.41449,
+      name: 'A1 — Amersfoort',
+      city: 'Amersfoort',
+      country: 'Netherlands',
+      feed_url: '/api/cctv/proxy?url=https%3A%2F%2Fstream.inmoves.nl%2F62',
+      external_url: 'https://stream.inmoves.nl/62/embed',
+      source: 'Rijkswaterstaat',
+    }]);
+  });
+
+  it('parses the string coordinates into numbers', () => {
+    const [cam] = parseRwsCameras([AMERSFOORT]);
+    expect(typeof cam.lat).toBe('number');
+    expect(typeof cam.lng).toBe('number');
+  });
+
+  it('drops records that cannot be placed or shown', () => {
+    expect(parseRwsCameras([
+      { ...AMERSFOORT, id: 1, latitude: 'n/a' },              // unparseable
+      { ...AMERSFOORT, id: 2, latitude: '48.85', longitude: '2.35' }, // Paris — outside NL
+      { ...AMERSFOORT, id: 3, static_url: undefined, stream_url: undefined }, // nothing to show
+      { ...AMERSFOORT, id: undefined },                        // no id to key on
+    ])).toEqual([]);
+  });
+
+  it('keeps the first of a repeated id', () => {
+    expect(parseRwsCameras([AMERSFOORT, { ...AMERSFOORT, near: 'Elsewhere' }])).toHaveLength(1);
+  });
+
+  it('falls back through name sources rather than emitting a blank label', () => {
+    const [noRoad] = parseRwsCameras([{ ...AMERSFOORT, road: undefined }]);
+    expect(noRoad.name).toBe('Amersfoort');
+
+    const [bare] = parseRwsCameras([{ ...AMERSFOORT, road: undefined, near: undefined }]);
+    expect(bare.name).toBe('Langs de A1, net ten westen van knooppunt Hoevelaken.');
+    expect(bare.city).toBe('Netherlands');
+  });
+
+  it('returns nothing for a payload that is not an array', () => {
+    expect(parseRwsCameras(null)).toEqual([]);
+    expect(parseRwsCameras({ error: 'nope' })).toEqual([]);
+  });
+});
+
+// Live integration test — opt in with RUN_LIVE_TESTS=1 (hits the real RWS feed).
+const liveIt = process.env.RUN_LIVE_TESTS === '1' ? it : it.skip;
+
+describe('fetchNetherlandsCameras', () => {
+  liveIt('returns the live Rijkswaterstaat cameras, all inside the Netherlands', async () => {
+    const cams = await fetchNetherlandsCameras();
+
+    // The feed carried 26 when this replaced NDW; it is curated, so it moves slowly.
+    expect(cams.length).toBeGreaterThanOrEqual(20);
+    expect(new Set(cams.map(c => c.id)).size).toBe(cams.length);
+
+    for (const c of cams) {
+      expect(c.lat).toBeGreaterThan(50.7);
+      expect(c.lat).toBeLessThan(53.7);
+      expect(c.lng).toBeGreaterThan(3.3);
+      expect(c.lng).toBeLessThan(7.3);
+      expect(c.country).toBe('Netherlands');
+      expect(c.source).toBe('Rijkswaterstaat');
+      expect(c.feed_url).toMatch(/^\/api\/cctv\/proxy\?url=/);
+    }
+  }, 60_000);
+});

--- a/src/app/api/cctv/netherlands.ts
+++ b/src/app/api/cctv/netherlands.ts
@@ -1,0 +1,92 @@
+import type { CctvCamera } from './types';
+import { stealthFetch } from '@/lib/stealthFetch';
+
+/**
+ * OSIRIS — Netherlands CCTV Cameras (Rijkswaterstaat)
+ * Source: https://api.rwsverkeersinfo.nl/api/cameras
+ * 26 operator-controlled HD motorway cameras — NO API KEY NEEDED.
+ *
+ * Replaces opendata.ndw.nu/cameras.json. NDW retired that dataset and it has
+ * been answering 404 into a silent catch ever since, so the layer carried no
+ * Dutch cameras at all rather than reporting a dead source.
+ */
+
+const CAMERAS_JSON = 'https://api.rwsverkeersinfo.nl/api/cameras';
+
+/** Netherlands bounding box — RWS publishes mainland motorways only. */
+const NL_BOUNDS = { minLat: 50.7, maxLat: 53.7, minLng: 3.3, maxLng: 7.3 };
+
+/**
+ * The frames are hotlink-protected: asked without a Referer, stream.inmoves.nl
+ * answers 401 with a zero-length PNG, so the browser cannot load `static_url`
+ * itself. The proxy sends `Referer: https://<host>/`, which the origin accepts,
+ * and returns the real JPEG.
+ */
+function proxied(url: string): string {
+  return `/api/cctv/proxy?url=${encodeURIComponent(url)}`;
+}
+
+/** One record of the RWS feed. Coordinates arrive as strings. */
+interface RwsCamera {
+  id?: number | string;
+  latitude?: string;
+  longitude?: string;
+  road?: string;
+  near?: string;
+  location_description?: string;
+  /** Embeddable player page — a document, not a frame. */
+  stream_url?: string;
+  /** Single JPEG frame, behind the Referer check. */
+  static_url?: string;
+}
+
+/** Parse the RWS camera feed. Exported for tests. */
+export function parseRwsCameras(payload: unknown): CctvCamera[] {
+  if (!Array.isArray(payload)) return [];
+
+  const cams: CctvCamera[] = [];
+  const seen = new Set<string>();
+
+  for (const cam of payload as RwsCamera[]) {
+    const id = String(cam?.id ?? '');
+    const lat = parseFloat(cam?.latitude ?? '');
+    const lng = parseFloat(cam?.longitude ?? '');
+
+    if (!id || seen.has(id)) continue;
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+    if (lat < NL_BOUNDS.minLat || lat > NL_BOUNDS.maxLat) continue;
+    if (lng < NL_BOUNDS.minLng || lng > NL_BOUNDS.maxLng) continue;
+    // Without a frame or a page to open, a pin has nothing to show.
+    if (!cam.static_url && !cam.stream_url) continue;
+    seen.add(id);
+
+    const near = cam.near?.trim() || '';
+    const road = cam.road?.trim() || '';
+
+    cams.push({
+      id: `nl-rws-${id}`,
+      lat,
+      lng,
+      name: [road, near].filter(Boolean).join(' — ') || cam.location_description?.trim() || `RWS Camera ${id}`,
+      city: near || 'Netherlands',
+      country: 'Netherlands',
+      ...(cam.static_url ? { feed_url: proxied(cam.static_url) } : {}),
+      ...(cam.stream_url ? { external_url: cam.stream_url } : {}),
+      source: 'Rijkswaterstaat',
+    });
+  }
+
+  return cams;
+}
+
+export async function fetchNetherlandsCameras(): Promise<CctvCamera[]> {
+  const res = await stealthFetch(CAMERAS_JSON, {
+    signal: AbortSignal.timeout(10000),
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) throw new Error(`RWS HTTP ${res.status}`);
+
+  const cams = parseRwsCameras(await res.json());
+  console.log(`[OSIRIS] Netherlands cameras — Rijkswaterstaat: ${cams.length}`);
+  return cams;
+}

--- a/src/app/api/cctv/proxy/route.ts
+++ b/src/app/api/cctv/proxy/route.ts
@@ -14,6 +14,8 @@ const ALLOWED_HOSTS = [
   'cdn2.skylinewebcams.com',
   's3-eu-west-1.amazonaws.com',
   'voyage.aprr.fr',
+  // Rijkswaterstaat motorway frames — 401 without a Referer.
+  'stream.inmoves.nl',
   'thb.gov.tw',
   'etraffic.dgt.es',
 ];

--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -4,6 +4,7 @@ import { cachedSource } from '@/lib/sourceCache';
 
 export const maxDuration = 60;
 import { fetchAsfinagCameras } from './asfinag';
+import { fetchNetherlandsCameras } from './netherlands';
 import { fetchBulgariaCameras } from './bulgaria';
 import { fetchGreeceCameras } from './greece';
 import { fetchSerbiaCameras } from './serbia';
@@ -375,19 +376,13 @@ async function fetchUSEastCameras(): Promise<any[]> {
 async function fetchEuropeCameras(): Promise<any[]> {
   const cams: any[] = [];
 
-  // Netherlands Rijkswaterstaat
-  {
-    const data = await subSource('NDW Netherlands', 'https://opendata.ndw.nu/cameras.json', 8000);
-    if (data) {
-      for (const cam of (Array.isArray(data) ? data : []).slice(0, 1000)) {
-        if (!cam.lat || !cam.lng) continue;
-        cams.push({
-          id: `nl-${cams.length}`, lat: cam.lat, lng: cam.lng,
-          name: cam.name || 'NL Camera', city: 'Netherlands', country: 'NL',
-          feed_url: cam.imageUrl || '', source: 'RWS',
-        });
-      }
-    }
+  /* The Netherlands used to be fetched here from opendata.ndw.nu/cameras.json.
+     NDW retired that dataset and it 404s; ./netherlands now serves the country
+     from the Rijkswaterstaat feed, which is still published. */
+  try {
+    cams.push(...await fetchNetherlandsCameras());
+  } catch (e) {
+    console.warn('[OSIRIS] Netherlands cameras failed — absent from this refresh:', e instanceof Error ? e.message : e);
   }
 
   cams.push(...await fetchAsfinagCameras());
@@ -480,6 +475,7 @@ const RAW_REGION_FETCHERS: Record<string, RegionFetcher> = {
   'us-central': fetchUSCentralCameras,
   'canada': fetchCanadaCameras,
   'europe': fetchEuropeCameras,
+  'netherlands': fetchNetherlandsCameras,
   'asia': fetchAsiaCameras,
   'bulgaria': fetchBulgariaCameras,
   'greece': fetchGreeceCameras,

--- a/src/app/api/infrastructure/route.ts
+++ b/src/app/api/infrastructure/route.ts
@@ -9,88 +9,101 @@ import { NextResponse } from 'next/server';
 const NUCLEAR_FACILITIES = [
   // ═══ EUROPE ═══
   // Ukraine
-  { id: 'nuc-ua-zaporizhzhia', name: 'Zaporizhzhia NPP', city: 'Enerhodar', country: 'Ukraine', lat: 47.5113, lng: 34.5861, status: 'Active Conflict Zone', reactors: 6, capacityMW: 5700, owner: 'Energoatom (Russian controlled)' },
-  { id: 'nuc-ua-rivne', name: 'Rivne NPP', city: 'Varash', country: 'Ukraine', lat: 51.3278, lng: 25.8917, status: 'Operational', reactors: 4, capacityMW: 2835, owner: 'Energoatom' },
-  { id: 'nuc-ua-south', name: 'South Ukraine NPP', city: 'Yuzhnoukrainsk', country: 'Ukraine', lat: 47.8147, lng: 31.2186, status: 'Operational', reactors: 3, capacityMW: 2850, owner: 'Energoatom' },
-  { id: 'nuc-ua-khmelnytskyi', name: 'Khmelnytskyi NPP', city: 'Netishyn', country: 'Ukraine', lat: 50.3017, lng: 26.6489, status: 'Operational', reactors: 2, capacityMW: 2000, owner: 'Energoatom' },
-  { id: 'nuc-ua-chernobyl', name: 'Chernobyl (Decommissioned)', city: 'Pripyat', country: 'Ukraine', lat: 51.3891, lng: 30.0992, status: 'Decommissioned / Exclusion Zone', reactors: 4, capacityMW: 0, owner: 'State Agency' },
+  { id: 'nuc-ua-zaporizhzhia', name: 'Zaporizhzhia NPP', city: 'Enerhodar', country: 'Ukraine', lat: 47.5113, lng: 34.5861, status: 'Active Conflict Zone', reactors: 6, capacityMW: 5700, owner: 'Energoatom (Russian controlled)', sourceUrl: 'https://en.wikipedia.org/wiki/Zaporizhzhia_Nuclear_Power_Plant' },
+  { id: 'nuc-ua-rivne', name: 'Rivne NPP', city: 'Varash', country: 'Ukraine', lat: 51.3278, lng: 25.8917, status: 'Operational', reactors: 4, capacityMW: 2835, owner: 'Energoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Rivne_Nuclear_Power_Plant' },
+  { id: 'nuc-ua-south', name: 'South Ukraine NPP', city: 'Yuzhnoukrainsk', country: 'Ukraine', lat: 47.8147, lng: 31.2186, status: 'Operational', reactors: 3, capacityMW: 2850, owner: 'Energoatom', sourceUrl: 'https://en.wikipedia.org/wiki/South_Ukraine_Nuclear_Power_Plant' },
+  { id: 'nuc-ua-khmelnytskyi', name: 'Khmelnytskyi NPP', city: 'Netishyn', country: 'Ukraine', lat: 50.3017, lng: 26.6489, status: 'Operational', reactors: 2, capacityMW: 2000, owner: 'Energoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Khmelnytskyi_Nuclear_Power_Plant' },
+  { id: 'nuc-ua-chernobyl', name: 'Chernobyl (Decommissioned)', city: 'Pripyat', country: 'Ukraine', lat: 51.3891, lng: 30.0992, status: 'Decommissioned / Exclusion Zone', reactors: 4, capacityMW: 0, owner: 'State Agency', sourceUrl: 'https://en.wikipedia.org/wiki/Chernobyl_Nuclear_Power_Plant' },
 
   // France
-  { id: 'nuc-fr-gravelines', name: 'Gravelines NPP', city: 'Gravelines', country: 'France', lat: 51.0125, lng: 2.1363, status: 'Operational', reactors: 6, capacityMW: 5460, owner: 'EDF' },
-  { id: 'nuc-fr-cattenom', name: 'Cattenom NPP', city: 'Cattenom', country: 'France', lat: 49.4158, lng: 6.2181, status: 'Operational', reactors: 4, capacityMW: 5200, owner: 'EDF' },
-  { id: 'nuc-fr-flamanville', name: 'Flamanville NPP', city: 'Flamanville', country: 'France', lat: 49.5386, lng: -1.8811, status: 'Operational', reactors: 3, capacityMW: 3960, owner: 'EDF' },
-  { id: 'nuc-fr-tricastin', name: 'Tricastin NPP', city: 'Saint-Paul-Trois-Châteaux', country: 'France', lat: 44.3322, lng: 4.7306, status: 'Operational', reactors: 4, capacityMW: 3660, owner: 'EDF' },
+  { id: 'nuc-fr-gravelines', name: 'Gravelines NPP', city: 'Gravelines', country: 'France', lat: 51.0125, lng: 2.1363, status: 'Operational', reactors: 6, capacityMW: 5460, owner: 'EDF', sourceUrl: 'https://en.wikipedia.org/wiki/Gravelines_Nuclear_Power_Station' },
+  { id: 'nuc-fr-cattenom', name: 'Cattenom NPP', city: 'Cattenom', country: 'France', lat: 49.4158, lng: 6.2181, status: 'Operational', reactors: 4, capacityMW: 5200, owner: 'EDF', sourceUrl: 'https://en.wikipedia.org/wiki/Cattenom_Nuclear_Power_Plant' },
+  { id: 'nuc-fr-flamanville', name: 'Flamanville NPP', city: 'Flamanville', country: 'France', lat: 49.5386, lng: -1.8811, status: 'Operational', reactors: 3, capacityMW: 3960, owner: 'EDF', sourceUrl: 'https://en.wikipedia.org/wiki/Flamanville_Nuclear_Power_Plant' },
+  { id: 'nuc-fr-tricastin', name: 'Tricastin NPP', city: 'Saint-Paul-Trois-Châteaux', country: 'France', lat: 44.3322, lng: 4.7306, status: 'Operational', reactors: 4, capacityMW: 3660, owner: 'EDF', sourceUrl: 'https://en.wikipedia.org/wiki/Tricastin_Nuclear_Power_Plant' },
 
   // UK
-  { id: 'nuc-uk-sizewell', name: 'Sizewell B NPP', city: 'Leiston', country: 'UK', lat: 52.2131, lng: 1.6186, status: 'Operational', reactors: 1, capacityMW: 1198, owner: 'EDF Energy' },
-  { id: 'nuc-uk-hinkley', name: 'Hinkley Point C', city: 'Somerset', country: 'UK', lat: 51.2081, lng: -3.1319, status: 'Under Construction', reactors: 2, capacityMW: 3200, owner: 'EDF Energy' },
+  { id: 'nuc-uk-sizewell', name: 'Sizewell B NPP', city: 'Leiston', country: 'UK', lat: 52.2131, lng: 1.6186, status: 'Operational', reactors: 1, capacityMW: 1198, owner: 'EDF Energy', sourceUrl: 'https://en.wikipedia.org/wiki/Sizewell_nuclear_power_stations' },
+  { id: 'nuc-uk-hinkley', name: 'Hinkley Point C', city: 'Somerset', country: 'UK', lat: 51.2081, lng: -3.1319, status: 'Under Construction', reactors: 2, capacityMW: 3200, owner: 'EDF Energy', sourceUrl: 'https://en.wikipedia.org/wiki/Hinkley_Point_C_nuclear_power_station' },
+
+  // Netherlands — the seven installations licensed by the ANVS.
+  // COVRA and Urenco hold no reactor, so `reactors`/`capacityMW` stay 0 and the
+  // popup renders them as "—". Research reactors are rated in thermal MW, which
+  // is not the electrical figure this column carries, so they are left at 0 too
+  // rather than sitting next to Borssele's 485 MWe as if they compared.
+  { id: 'nuc-nl-borssele', name: 'Borssele NPP', city: 'Borssele', country: 'Netherlands', lat: 51.4308, lng: 3.7183, status: 'Operational', reactors: 1, capacityMW: 485, owner: 'EPZ', sourceUrl: 'https://en.wikipedia.org/wiki/Borssele_Nuclear_Power_Station' },
+  { id: 'nuc-nl-covra', name: 'COVRA (Waste Storage)', city: 'Nieuwdorp', country: 'Netherlands', lat: 51.4450, lng: 3.7160, status: 'Operational', reactors: 0, capacityMW: 0, owner: 'COVRA N.V.', sourceUrl: 'https://en.wikipedia.org/wiki/COVRA' },
+  { id: 'nuc-nl-hfr', name: 'High Flux Reactor (HFR)', city: 'Petten', country: 'Netherlands', lat: 52.7860, lng: 4.6810, status: 'Operational', reactors: 1, capacityMW: 0, owner: 'NRG', sourceUrl: 'https://en.wikipedia.org/wiki/Petten_nuclear_reactor' },
+  { id: 'nuc-nl-pallas', name: 'PALLAS (HFR Successor)', city: 'Petten', country: 'Netherlands', lat: 52.7860, lng: 4.6830, status: 'Under Construction', reactors: 1, capacityMW: 0, owner: 'PALLAS Foundation', sourceUrl: 'https://en.wikipedia.org/wiki/Petten_nuclear_reactor' },
+  { id: 'nuc-nl-urenco', name: 'Urenco Nederland (Enrichment)', city: 'Almelo', country: 'Netherlands', lat: 52.3300, lng: 6.6500, status: 'Operational', reactors: 0, capacityMW: 0, owner: 'Urenco', sourceUrl: 'https://en.wikipedia.org/wiki/Urenco_Group' },
+  { id: 'nuc-nl-hor-delft', name: 'HOR (Reactor Institute Delft)', city: 'Delft', country: 'Netherlands', lat: 51.9900, lng: 4.3770, status: 'Operational', reactors: 1, capacityMW: 0, owner: 'TU Delft', sourceUrl: 'https://en.wikipedia.org/wiki/Reactor_Institute_Delft' },
+  { id: 'nuc-nl-dodewaard', name: 'Dodewaard NPP (Decommissioned)', city: 'Dodewaard', country: 'Netherlands', lat: 51.9010, lng: 5.6410, status: 'Decommissioned / Safe Enclosure', reactors: 1, capacityMW: 0, owner: 'GKN', sourceUrl: 'https://en.wikipedia.org/wiki/Dodewaard_nuclear_power_plant' },
 
   // Other Europe
-  { id: 'nuc-se-ringhals', name: 'Ringhals NPP', city: 'Varberg', country: 'Sweden', lat: 57.2639, lng: 12.1128, status: 'Operational', reactors: 3, capacityMW: 3156, owner: 'Vattenfall' },
-  { id: 'nuc-fi-olkiluoto', name: 'Olkiluoto NPP', city: 'Eurajoki', country: 'Finland', lat: 61.2353, lng: 21.4469, status: 'Operational', reactors: 3, capacityMW: 4360, owner: 'TVO' },
-  { id: 'nuc-be-doel', name: 'Doel NPP', city: 'Doel', country: 'Belgium', lat: 51.3256, lng: 4.2589, status: 'Partial Shutdown', reactors: 4, capacityMW: 2911, owner: 'Engie' },
-  { id: 'nuc-ch-beznau', name: 'Beznau NPP', city: 'Döttingen', country: 'Switzerland', lat: 47.5581, lng: 8.2286, status: 'Operational', reactors: 2, capacityMW: 730, owner: 'Axpo' },
-  { id: 'nuc-es-cofrentes', name: 'Cofrentes NPP', city: 'Cofrentes', country: 'Spain', lat: 39.2142, lng: -1.0486, status: 'Operational', reactors: 1, capacityMW: 1064, owner: 'Iberdrola' },
-  { id: 'nuc-cz-temelin', name: 'Temelín NPP', city: 'Temelín', country: 'Czech Republic', lat: 49.1814, lng: 14.3758, status: 'Operational', reactors: 2, capacityMW: 2116, owner: 'ČEZ' },
-  { id: 'nuc-hu-paks', name: 'Paks NPP', city: 'Paks', country: 'Hungary', lat: 46.5722, lng: 18.8533, status: 'Operational', reactors: 4, capacityMW: 2000, owner: 'MVM' },
-  { id: 'nuc-by-ostrovets', name: 'Belarusian NPP', city: 'Ostrovets', country: 'Belarus', lat: 54.7556, lng: 26.0889, status: 'Operational', reactors: 2, capacityMW: 2400, owner: 'Rosatom-built' },
+  { id: 'nuc-se-ringhals', name: 'Ringhals NPP', city: 'Varberg', country: 'Sweden', lat: 57.2639, lng: 12.1128, status: 'Operational', reactors: 3, capacityMW: 3156, owner: 'Vattenfall', sourceUrl: 'https://en.wikipedia.org/wiki/Ringhals_Nuclear_Power_Plant' },
+  { id: 'nuc-fi-olkiluoto', name: 'Olkiluoto NPP', city: 'Eurajoki', country: 'Finland', lat: 61.2353, lng: 21.4469, status: 'Operational', reactors: 3, capacityMW: 4360, owner: 'TVO', sourceUrl: 'https://en.wikipedia.org/wiki/Olkiluoto_Nuclear_Power_Plant' },
+  { id: 'nuc-be-doel', name: 'Doel NPP', city: 'Doel', country: 'Belgium', lat: 51.3256, lng: 4.2589, status: 'Partial Shutdown', reactors: 4, capacityMW: 2911, owner: 'Engie', sourceUrl: 'https://en.wikipedia.org/wiki/Doel_Nuclear_Power_Station' },
+  { id: 'nuc-ch-beznau', name: 'Beznau NPP', city: 'Döttingen', country: 'Switzerland', lat: 47.5581, lng: 8.2286, status: 'Operational', reactors: 2, capacityMW: 730, owner: 'Axpo', sourceUrl: 'https://en.wikipedia.org/wiki/Beznau_Nuclear_Power_Plant' },
+  { id: 'nuc-es-cofrentes', name: 'Cofrentes NPP', city: 'Cofrentes', country: 'Spain', lat: 39.2142, lng: -1.0486, status: 'Operational', reactors: 1, capacityMW: 1064, owner: 'Iberdrola', sourceUrl: 'https://en.wikipedia.org/wiki/Cofrentes_Nuclear_Power_Plant' },
+  { id: 'nuc-cz-temelin', name: 'Temelín NPP', city: 'Temelín', country: 'Czech Republic', lat: 49.1814, lng: 14.3758, status: 'Operational', reactors: 2, capacityMW: 2116, owner: 'ČEZ', sourceUrl: 'https://en.wikipedia.org/wiki/Temel%C3%ADn_Nuclear_Power_Station' },
+  { id: 'nuc-hu-paks', name: 'Paks NPP', city: 'Paks', country: 'Hungary', lat: 46.5722, lng: 18.8533, status: 'Operational', reactors: 4, capacityMW: 2000, owner: 'MVM', sourceUrl: 'https://en.wikipedia.org/wiki/Paks_Nuclear_Power_Plant' },
+  { id: 'nuc-by-ostrovets', name: 'Belarusian NPP', city: 'Ostrovets', country: 'Belarus', lat: 54.7556, lng: 26.0889, status: 'Operational', reactors: 2, capacityMW: 2400, owner: 'Rosatom-built', sourceUrl: 'https://en.wikipedia.org/wiki/Astravets_Nuclear_Power_Plant' },
 
   // ═══ RUSSIA (comprehensive) ═══
-  { id: 'nuc-ru-kursk', name: 'Kursk NPP', city: 'Kurchatov', country: 'Russia', lat: 51.6742, lng: 35.6033, status: 'Operational', reactors: 4, capacityMW: 4000, owner: 'Rosenergoatom' },
-  { id: 'nuc-ru-leningrad', name: 'Leningrad NPP', city: 'Sosnovy Bor', country: 'Russia', lat: 59.8406, lng: 29.0433, status: 'Operational', reactors: 4, capacityMW: 4000, owner: 'Rosenergoatom' },
-  { id: 'nuc-ru-novovoronezh', name: 'Novovoronezh NPP', city: 'Novovoronezh', country: 'Russia', lat: 51.2756, lng: 39.2144, status: 'Operational', reactors: 5, capacityMW: 3600, owner: 'Rosenergoatom' },
-  { id: 'nuc-ru-kalinin', name: 'Kalinin NPP', city: 'Udomlya', country: 'Russia', lat: 57.8708, lng: 34.9786, status: 'Operational', reactors: 4, capacityMW: 4000, owner: 'Rosenergoatom' },
-  { id: 'nuc-ru-balakovo', name: 'Balakovo NPP', city: 'Balakovo', country: 'Russia', lat: 52.0911, lng: 47.9564, status: 'Operational', reactors: 4, capacityMW: 4000, owner: 'Rosenergoatom' },
-  { id: 'nuc-ru-rostov', name: 'Rostov NPP', city: 'Volgodonsk', country: 'Russia', lat: 47.5286, lng: 42.1014, status: 'Operational', reactors: 4, capacityMW: 4014, owner: 'Rosenergoatom' },
-  { id: 'nuc-ru-smolensk', name: 'Smolensk NPP', city: 'Desnogorsk', country: 'Russia', lat: 54.1528, lng: 33.2331, status: 'Operational', reactors: 3, capacityMW: 3000, owner: 'Rosenergoatom' },
-  { id: 'nuc-ru-kola', name: 'Kola NPP', city: 'Polyarnyye Zori', country: 'Russia', lat: 67.4642, lng: 32.4750, status: 'Operational', reactors: 4, capacityMW: 1760, owner: 'Rosenergoatom' },
-  { id: 'nuc-ru-bilibino', name: 'Bilibino NPP', city: 'Bilibino', country: 'Russia', lat: 68.0544, lng: 166.5444, status: 'Operational', reactors: 4, capacityMW: 48, owner: 'Rosenergoatom' },
-  { id: 'nuc-ru-beloyarsk', name: 'Beloyarsk NPP (BN-800)', city: 'Zarechny', country: 'Russia', lat: 56.8419, lng: 60.7250, status: 'Operational', reactors: 2, capacityMW: 1400, owner: 'Rosenergoatom' },
-  { id: 'nuc-ru-akademik', name: 'Akademik Lomonosov (Floating)', city: 'Pevek', country: 'Russia', lat: 69.7008, lng: 170.3131, status: 'Operational', reactors: 2, capacityMW: 70, owner: 'Rosenergoatom' },
+  { id: 'nuc-ru-kursk', name: 'Kursk NPP', city: 'Kurchatov', country: 'Russia', lat: 51.6742, lng: 35.6033, status: 'Operational', reactors: 4, capacityMW: 4000, owner: 'Rosenergoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Kursk_Nuclear_Power_Plant' },
+  { id: 'nuc-ru-leningrad', name: 'Leningrad NPP', city: 'Sosnovy Bor', country: 'Russia', lat: 59.8406, lng: 29.0433, status: 'Operational', reactors: 4, capacityMW: 4000, owner: 'Rosenergoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Leningrad_Nuclear_Power_Plant' },
+  { id: 'nuc-ru-novovoronezh', name: 'Novovoronezh NPP', city: 'Novovoronezh', country: 'Russia', lat: 51.2756, lng: 39.2144, status: 'Operational', reactors: 5, capacityMW: 3600, owner: 'Rosenergoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Novovoronezh_Nuclear_Power_Plant' },
+  { id: 'nuc-ru-kalinin', name: 'Kalinin NPP', city: 'Udomlya', country: 'Russia', lat: 57.8708, lng: 34.9786, status: 'Operational', reactors: 4, capacityMW: 4000, owner: 'Rosenergoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Kalinin_Nuclear_Power_Plant' },
+  { id: 'nuc-ru-balakovo', name: 'Balakovo NPP', city: 'Balakovo', country: 'Russia', lat: 52.0911, lng: 47.9564, status: 'Operational', reactors: 4, capacityMW: 4000, owner: 'Rosenergoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Balakovo_Nuclear_Power_Plant' },
+  { id: 'nuc-ru-rostov', name: 'Rostov NPP', city: 'Volgodonsk', country: 'Russia', lat: 47.5286, lng: 42.1014, status: 'Operational', reactors: 4, capacityMW: 4014, owner: 'Rosenergoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Rostov_Nuclear_Power_Plant' },
+  { id: 'nuc-ru-smolensk', name: 'Smolensk NPP', city: 'Desnogorsk', country: 'Russia', lat: 54.1528, lng: 33.2331, status: 'Operational', reactors: 3, capacityMW: 3000, owner: 'Rosenergoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Smolensk_Nuclear_Power_Plant' },
+  { id: 'nuc-ru-kola', name: 'Kola NPP', city: 'Polyarnyye Zori', country: 'Russia', lat: 67.4642, lng: 32.4750, status: 'Operational', reactors: 4, capacityMW: 1760, owner: 'Rosenergoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Kola_Nuclear_Power_Plant' },
+  { id: 'nuc-ru-bilibino', name: 'Bilibino NPP', city: 'Bilibino', country: 'Russia', lat: 68.0544, lng: 166.5444, status: 'Operational', reactors: 4, capacityMW: 48, owner: 'Rosenergoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Bilibino_Nuclear_Power_Plant' },
+  { id: 'nuc-ru-beloyarsk', name: 'Beloyarsk NPP (BN-800)', city: 'Zarechny', country: 'Russia', lat: 56.8419, lng: 60.7250, status: 'Operational', reactors: 2, capacityMW: 1400, owner: 'Rosenergoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Beloyarsk_Nuclear_Power_Station' },
+  { id: 'nuc-ru-akademik', name: 'Akademik Lomonosov (Floating)', city: 'Pevek', country: 'Russia', lat: 69.7008, lng: 170.3131, status: 'Operational', reactors: 2, capacityMW: 70, owner: 'Rosenergoatom', sourceUrl: 'https://en.wikipedia.org/wiki/Akademik_Lomonosov' },
 
   // ═══ NORTH AMERICA ═══
-  { id: 'nuc-us-palo-verde', name: 'Palo Verde', city: 'Tonopah', country: 'US', lat: 33.3886, lng: -112.8617, status: 'Operational', reactors: 3, capacityMW: 3937, owner: 'APS' },
-  { id: 'nuc-us-browns-ferry', name: 'Browns Ferry', city: 'Athens', country: 'US', lat: 34.7042, lng: -87.1186, status: 'Operational', reactors: 3, capacityMW: 3400, owner: 'TVA' },
-  { id: 'nuc-us-south-texas', name: 'South Texas Project', city: 'Bay City', country: 'US', lat: 28.7950, lng: -96.0481, status: 'Operational', reactors: 2, capacityMW: 2560, owner: 'STP Nuclear' },
-  { id: 'nuc-us-vogtle', name: 'Vogtle (AP1000)', city: 'Waynesboro', country: 'US', lat: 33.1417, lng: -81.7631, status: 'Operational', reactors: 4, capacityMW: 4500, owner: 'Georgia Power' },
-  { id: 'nuc-ca-bruce', name: 'Bruce Nuclear', city: 'Tiverton', country: 'Canada', lat: 44.3253, lng: -81.5997, status: 'Operational', reactors: 8, capacityMW: 6503, owner: 'Bruce Power' },
-  { id: 'nuc-ca-darlington', name: 'Darlington Nuclear', city: 'Bowmanville', country: 'Canada', lat: 43.8719, lng: -78.7183, status: 'Operational', reactors: 4, capacityMW: 3512, owner: 'OPG' },
-  { id: 'nuc-ca-pickering', name: 'Pickering Nuclear', city: 'Pickering', country: 'Canada', lat: 43.8103, lng: -79.0661, status: 'Operational (Extended)', reactors: 6, capacityMW: 3094, owner: 'OPG' },
+  { id: 'nuc-us-palo-verde', name: 'Palo Verde', city: 'Tonopah', country: 'US', lat: 33.3886, lng: -112.8617, status: 'Operational', reactors: 3, capacityMW: 3937, owner: 'APS', sourceUrl: 'https://en.wikipedia.org/wiki/Palo_Verde_Nuclear_Generating_Station' },
+  { id: 'nuc-us-browns-ferry', name: 'Browns Ferry', city: 'Athens', country: 'US', lat: 34.7042, lng: -87.1186, status: 'Operational', reactors: 3, capacityMW: 3400, owner: 'TVA', sourceUrl: 'https://en.wikipedia.org/wiki/Browns_Ferry_Nuclear_Plant' },
+  { id: 'nuc-us-south-texas', name: 'South Texas Project', city: 'Bay City', country: 'US', lat: 28.7950, lng: -96.0481, status: 'Operational', reactors: 2, capacityMW: 2560, owner: 'STP Nuclear', sourceUrl: 'https://en.wikipedia.org/wiki/South_Texas_Nuclear_Generating_Station' },
+  { id: 'nuc-us-vogtle', name: 'Vogtle (AP1000)', city: 'Waynesboro', country: 'US', lat: 33.1417, lng: -81.7631, status: 'Operational', reactors: 4, capacityMW: 4500, owner: 'Georgia Power', sourceUrl: 'https://en.wikipedia.org/wiki/Vogtle_Electric_Generating_Plant' },
+  { id: 'nuc-ca-bruce', name: 'Bruce Nuclear', city: 'Tiverton', country: 'Canada', lat: 44.3253, lng: -81.5997, status: 'Operational', reactors: 8, capacityMW: 6503, owner: 'Bruce Power', sourceUrl: 'https://en.wikipedia.org/wiki/Bruce_Nuclear_Generating_Station' },
+  { id: 'nuc-ca-darlington', name: 'Darlington Nuclear', city: 'Bowmanville', country: 'Canada', lat: 43.8719, lng: -78.7183, status: 'Operational', reactors: 4, capacityMW: 3512, owner: 'OPG', sourceUrl: 'https://en.wikipedia.org/wiki/Darlington_Nuclear_Generating_Station' },
+  { id: 'nuc-ca-pickering', name: 'Pickering Nuclear', city: 'Pickering', country: 'Canada', lat: 43.8103, lng: -79.0661, status: 'Operational (Extended)', reactors: 6, capacityMW: 3094, owner: 'OPG', sourceUrl: 'https://en.wikipedia.org/wiki/Pickering_Nuclear_Generating_Station' },
 
   // ═══ ASIA ═══
   // China
-  { id: 'nuc-cn-hongyanhe', name: 'Hongyanhe NPP', city: 'Dalian', country: 'China', lat: 39.7944, lng: 121.4800, status: 'Operational', reactors: 6, capacityMW: 6366, owner: 'CGN' },
-  { id: 'nuc-cn-yangjiang', name: 'Yangjiang NPP', city: 'Yangjiang', country: 'China', lat: 21.7061, lng: 112.2597, status: 'Operational', reactors: 6, capacityMW: 6000, owner: 'CGN' },
-  { id: 'nuc-cn-tianwan', name: 'Tianwan NPP', city: 'Lianyungang', country: 'China', lat: 34.6869, lng: 119.4597, status: 'Operational', reactors: 6, capacityMW: 6050, owner: 'CNNC' },
-  { id: 'nuc-cn-fuqing', name: 'Fuqing NPP (Hualong One)', city: 'Fuqing', country: 'China', lat: 25.4375, lng: 119.4444, status: 'Operational', reactors: 6, capacityMW: 6000, owner: 'CNNC' },
-  { id: 'nuc-cn-taishan', name: 'Taishan NPP (EPR)', city: 'Taishan', country: 'China', lat: 21.9167, lng: 112.9833, status: 'Operational', reactors: 2, capacityMW: 3320, owner: 'CGN/EDF' },
-  { id: 'nuc-cn-daya-bay', name: 'Daya Bay NPP', city: 'Shenzhen', country: 'China', lat: 22.5975, lng: 114.5436, status: 'Operational', reactors: 6, capacityMW: 6086, owner: 'CGN' },
+  { id: 'nuc-cn-hongyanhe', name: 'Hongyanhe NPP', city: 'Dalian', country: 'China', lat: 39.7944, lng: 121.4800, status: 'Operational', reactors: 6, capacityMW: 6366, owner: 'CGN', sourceUrl: 'https://en.wikipedia.org/wiki/Hongyanhe_Nuclear_Power_Plant' },
+  { id: 'nuc-cn-yangjiang', name: 'Yangjiang NPP', city: 'Yangjiang', country: 'China', lat: 21.7061, lng: 112.2597, status: 'Operational', reactors: 6, capacityMW: 6000, owner: 'CGN', sourceUrl: 'https://en.wikipedia.org/wiki/Yangjiang_Nuclear_Power_Station' },
+  { id: 'nuc-cn-tianwan', name: 'Tianwan NPP', city: 'Lianyungang', country: 'China', lat: 34.6869, lng: 119.4597, status: 'Operational', reactors: 6, capacityMW: 6050, owner: 'CNNC', sourceUrl: 'https://en.wikipedia.org/wiki/Tianwan_Nuclear_Power_Plant' },
+  { id: 'nuc-cn-fuqing', name: 'Fuqing NPP (Hualong One)', city: 'Fuqing', country: 'China', lat: 25.4375, lng: 119.4444, status: 'Operational', reactors: 6, capacityMW: 6000, owner: 'CNNC', sourceUrl: 'https://en.wikipedia.org/wiki/Fuqing_Nuclear_Power_Plant' },
+  { id: 'nuc-cn-taishan', name: 'Taishan NPP (EPR)', city: 'Taishan', country: 'China', lat: 21.9167, lng: 112.9833, status: 'Operational', reactors: 2, capacityMW: 3320, owner: 'CGN/EDF', sourceUrl: 'https://en.wikipedia.org/wiki/Taishan_Nuclear_Power_Plant' },
+  { id: 'nuc-cn-daya-bay', name: 'Daya Bay NPP', city: 'Shenzhen', country: 'China', lat: 22.5975, lng: 114.5436, status: 'Operational', reactors: 6, capacityMW: 6086, owner: 'CGN', sourceUrl: 'https://en.wikipedia.org/wiki/Daya_Bay_Nuclear_Power_Plant' },
 
   // Japan
-  { id: 'nuc-jp-kashiwazaki', name: 'Kashiwazaki-Kariwa', city: 'Kashiwazaki', country: 'Japan', lat: 37.4286, lng: 138.5958, status: 'Suspended', reactors: 7, capacityMW: 7965, owner: 'TEPCO' },
-  { id: 'nuc-jp-fukushima', name: 'Fukushima Daiichi', city: 'Okuma', country: 'Japan', lat: 37.4211, lng: 141.0328, status: 'Destroyed / Decommissioning', reactors: 6, capacityMW: 0, owner: 'TEPCO' },
-  { id: 'nuc-jp-takahama', name: 'Takahama NPP', city: 'Takahama', country: 'Japan', lat: 35.5217, lng: 135.4950, status: 'Partially Operational', reactors: 4, capacityMW: 3392, owner: 'KEPCO' },
-  { id: 'nuc-jp-ohi', name: 'Ōi NPP', city: 'Ōi', country: 'Japan', lat: 35.5439, lng: 135.6581, status: 'Operational', reactors: 4, capacityMW: 4710, owner: 'KEPCO' },
+  { id: 'nuc-jp-kashiwazaki', name: 'Kashiwazaki-Kariwa', city: 'Kashiwazaki', country: 'Japan', lat: 37.4286, lng: 138.5958, status: 'Suspended', reactors: 7, capacityMW: 7965, owner: 'TEPCO', sourceUrl: 'https://en.wikipedia.org/wiki/Kashiwazaki-Kariwa_Nuclear_Power_Plant' },
+  { id: 'nuc-jp-fukushima', name: 'Fukushima Daiichi', city: 'Okuma', country: 'Japan', lat: 37.4211, lng: 141.0328, status: 'Destroyed / Decommissioning', reactors: 6, capacityMW: 0, owner: 'TEPCO', sourceUrl: 'https://en.wikipedia.org/wiki/Fukushima_Daiichi_Nuclear_Power_Plant' },
+  { id: 'nuc-jp-takahama', name: 'Takahama NPP', city: 'Takahama', country: 'Japan', lat: 35.5217, lng: 135.4950, status: 'Partially Operational', reactors: 4, capacityMW: 3392, owner: 'KEPCO', sourceUrl: 'https://en.wikipedia.org/wiki/Takahama_Nuclear_Power_Plant' },
+  { id: 'nuc-jp-ohi', name: 'Ōi NPP', city: 'Ōi', country: 'Japan', lat: 35.5439, lng: 135.6581, status: 'Operational', reactors: 4, capacityMW: 4710, owner: 'KEPCO', sourceUrl: 'https://en.wikipedia.org/wiki/%C5%8Ci_Nuclear_Power_Plant' },
 
   // South Korea
-  { id: 'nuc-kr-kori', name: 'Kori/Shin-Kori NPP', city: 'Busan', country: 'South Korea', lat: 35.3197, lng: 129.2894, status: 'Operational', reactors: 7, capacityMW: 7489, owner: 'KHNP' },
-  { id: 'nuc-kr-hanul', name: 'Hanul NPP', city: 'Uljin', country: 'South Korea', lat: 37.0933, lng: 129.3831, status: 'Operational', reactors: 6, capacityMW: 5928, owner: 'KHNP' },
-  { id: 'nuc-kr-wolsong', name: 'Wolsong NPP', city: 'Gyeongju', country: 'South Korea', lat: 35.7131, lng: 129.4739, status: 'Operational', reactors: 4, capacityMW: 2779, owner: 'KHNP' },
+  { id: 'nuc-kr-kori', name: 'Kori/Shin-Kori NPP', city: 'Busan', country: 'South Korea', lat: 35.3197, lng: 129.2894, status: 'Operational', reactors: 7, capacityMW: 7489, owner: 'KHNP', sourceUrl: 'https://en.wikipedia.org/wiki/Kori_Nuclear_Power_Plant' },
+  { id: 'nuc-kr-hanul', name: 'Hanul NPP', city: 'Uljin', country: 'South Korea', lat: 37.0933, lng: 129.3831, status: 'Operational', reactors: 6, capacityMW: 5928, owner: 'KHNP', sourceUrl: 'https://en.wikipedia.org/wiki/Hanul_Nuclear_Power_Plant' },
+  { id: 'nuc-kr-wolsong', name: 'Wolsong NPP', city: 'Gyeongju', country: 'South Korea', lat: 35.7131, lng: 129.4739, status: 'Operational', reactors: 4, capacityMW: 2779, owner: 'KHNP', sourceUrl: 'https://en.wikipedia.org/wiki/Wolseong_Nuclear_Power_Plant' },
 
   // India
-  { id: 'nuc-in-kudankulam', name: 'Kudankulam NPP', city: 'Kudankulam', country: 'India', lat: 8.1706, lng: 77.7114, status: 'Operational', reactors: 2, capacityMW: 2000, owner: 'NPCIL' },
-  { id: 'nuc-in-tarapur', name: 'Tarapur NPP', city: 'Tarapur', country: 'India', lat: 19.8306, lng: 72.6550, status: 'Operational', reactors: 4, capacityMW: 1400, owner: 'NPCIL' },
+  { id: 'nuc-in-kudankulam', name: 'Kudankulam NPP', city: 'Kudankulam', country: 'India', lat: 8.1706, lng: 77.7114, status: 'Operational', reactors: 2, capacityMW: 2000, owner: 'NPCIL', sourceUrl: 'https://en.wikipedia.org/wiki/Kudankulam_Nuclear_Power_Plant' },
+  { id: 'nuc-in-tarapur', name: 'Tarapur NPP', city: 'Tarapur', country: 'India', lat: 19.8306, lng: 72.6550, status: 'Operational', reactors: 4, capacityMW: 1400, owner: 'NPCIL', sourceUrl: 'https://en.wikipedia.org/wiki/Tarapur_Atomic_Power_Station' },
 
   // ═══ MIDDLE EAST ═══
-  { id: 'nuc-ir-bushehr', name: 'Bushehr NPP', city: 'Bushehr', country: 'Iran', lat: 28.8292, lng: 50.8864, status: 'Operational', reactors: 1, capacityMW: 915, owner: 'AEOI' },
-  { id: 'nuc-ae-barakah', name: 'Barakah NPP', city: 'Al Dhafra', country: 'UAE', lat: 23.9686, lng: 52.2356, status: 'Operational', reactors: 4, capacityMW: 5380, owner: 'ENEC' },
+  { id: 'nuc-ir-bushehr', name: 'Bushehr NPP', city: 'Bushehr', country: 'Iran', lat: 28.8292, lng: 50.8864, status: 'Operational', reactors: 1, capacityMW: 915, owner: 'AEOI', sourceUrl: 'https://en.wikipedia.org/wiki/Bushehr_Nuclear_Power_Plant' },
+  { id: 'nuc-ae-barakah', name: 'Barakah NPP', city: 'Al Dhafra', country: 'UAE', lat: 23.9686, lng: 52.2356, status: 'Operational', reactors: 4, capacityMW: 5380, owner: 'ENEC', sourceUrl: 'https://en.wikipedia.org/wiki/Barakah_nuclear_power_plant' },
 
   // ═══ AFRICA ═══
-  { id: 'nuc-za-koeberg', name: 'Koeberg NPP', city: 'Cape Town', country: 'South Africa', lat: -33.6769, lng: 18.4344, status: 'Operational', reactors: 2, capacityMW: 1860, owner: 'Eskom' },
+  { id: 'nuc-za-koeberg', name: 'Koeberg NPP', city: 'Cape Town', country: 'South Africa', lat: -33.6769, lng: 18.4344, status: 'Operational', reactors: 2, capacityMW: 1860, owner: 'Eskom', sourceUrl: 'https://en.wikipedia.org/wiki/Koeberg_Nuclear_Power_Station' },
 
   // ═══ SOUTH AMERICA ═══
-  { id: 'nuc-ar-atucha', name: 'Atucha NPP', city: 'Lima', country: 'Argentina', lat: -34.0167, lng: -59.2083, status: 'Operational', reactors: 2, capacityMW: 745, owner: 'NA-SA' },
-  { id: 'nuc-br-angra', name: 'Angra NPP', city: 'Angra dos Reis', country: 'Brazil', lat: -23.0083, lng: -44.4583, status: 'Operational', reactors: 2, capacityMW: 1884, owner: 'Eletronuclear' },
+  { id: 'nuc-ar-atucha', name: 'Atucha NPP', city: 'Lima', country: 'Argentina', lat: -34.0167, lng: -59.2083, status: 'Operational', reactors: 2, capacityMW: 745, owner: 'NA-SA', sourceUrl: 'https://en.wikipedia.org/wiki/Atucha_Nuclear_Power_Plant' },
+  { id: 'nuc-br-angra', name: 'Angra NPP', city: 'Angra dos Reis', country: 'Brazil', lat: -23.0083, lng: -44.4583, status: 'Operational', reactors: 2, capacityMW: 1884, owner: 'Eletronuclear', sourceUrl: 'https://en.wikipedia.org/wiki/Angra_Nuclear_Power_Plant' },
 ];
 
 export async function GET() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,7 @@ import WorldRemote from '@/components/WorldRemote';
 import ArcGISPanel from '@/components/ArcGISPanel';
 const OsirisMap = dynamic(() => import('@/components/OsirisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
+const NuclearPanel = dynamic(() => import('@/components/NuclearPanel'), { ssr: false });
 const SpaceCam = dynamic(() => import('@/components/SpaceCam'), { ssr: false });
 const CameraViewer = dynamic(() => import('@/components/CameraViewer'));
 const OsintPanel = dynamic(() => import('@/components/OsintPanel'));
@@ -1215,6 +1216,24 @@ export default function Dashboard() {
           />
         </motion.div>
       )}
+
+      {/* ── NUCLEAR WATCH ── rides the infrastructure layer being switched on ── */}
+      <AnimatePresence>
+        {activeLayers.infrastructure && (
+          <motion.div
+            key="nuclear-watch"
+            initial={{ opacity: 0, x: 16 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 16 }}
+            /* Clear of the status bar, which runs the full width up top. */
+            className="absolute z-[380] w-[min(92vw,320px)] pointer-events-auto"
+            style={{ right: isMobile ? '12px' : '64px', top: isMobile ? '56px' : '80px' }}
+          >
+            <NuclearPanel
+              facilities={data.infrastructure || []}
+              onLocate={(lat, lng) => setFlyToLocation({ lat, lng, zoom: 9, ts: Date.now() })}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* ── MAP VIEW CONTROLS ── */}
       <motion.div

--- a/src/components/NuclearPanel.tsx
+++ b/src/components/NuclearPanel.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Radiation, ChevronDown, ChevronUp, Maximize2, Minimize2,
+  Search, MapPin, Zap, Atom, TriangleAlert, ExternalLink, Globe2,
+} from 'lucide-react';
+import {
+  selectFacilities, summarise, nuclearStyle, seismicMagnitude,
+  formatCapacity, NUCLEAR_STATES,
+  type NuclearFacility, type NuclearFilter,
+} from '@/lib/nuclear';
+
+interface NuclearPanelProps {
+  facilities: NuclearFacility[];
+  onLocate: (lat: number, lng: number) => void;
+}
+
+const FILTERS: { key: NuclearFilter; label: string }[] = [
+  { key: 'all', label: 'ALL' },
+  { key: 'alerts', label: 'ALERTS' },
+  { key: 'online', label: 'ONLINE' },
+  { key: 'construction', label: 'BUILDING' },
+  { key: 'offline', label: 'OFFLINE' },
+];
+
+/** One number in the fleet strip. */
+function Stat({ label, value, color }: { label: string; value: string; color?: string }) {
+  return (
+    <div className="flex-1 min-w-0">
+      <div className="text-[9px] font-mono uppercase tracking-wider text-[var(--text-muted)] truncate">{label}</div>
+      <div className="text-[13px] font-mono font-bold truncate" style={{ color: color || 'var(--text-primary)' }}>{value}</div>
+    </div>
+  );
+}
+
+export default function NuclearPanel({ facilities, onLocate }: NuclearPanelProps) {
+  /* Collapsed on open. Switching the layer on is a map action, not a request
+     for a full-height list, so this stays a slim bar until it is asked for. */
+  const [expanded, setExpanded] = useState(false);
+  const [maximized, setMaximized] = useState(false);
+  const [filter, setFilter] = useState<NuclearFilter>('all');
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const summary = useMemo(() => summarise(facilities), [facilities]);
+  const shown = useMemo(() => selectFacilities(facilities, filter, query), [facilities, filter, query]);
+
+  const content = (
+    <motion.div
+      initial={{ opacity: 0, x: -20 }}
+      animate={{ opacity: 1, x: 0 }}
+      className={`glass-panel flex flex-col overflow-hidden pointer-events-auto transition-all duration-300 ${
+        maximized ? 'fixed left-4 right-4 top-4 bottom-12 z-[9999]' : expanded ? 'shrink-0 h-[460px] max-h-[70vh]' : 'shrink-0'
+      }`}
+      /* .glass-panel sets its own translucent background and beats a utility
+         class on equal specificity, so full-screen opacity goes inline. */
+      style={maximized ? { background: '#0A0A09' } : undefined}
+    >
+      {/* Header */}
+      <div
+        onClick={() => setExpanded(!expanded)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setExpanded(!expanded); } }}
+        className="flex-shrink-0 flex items-center justify-between px-3 py-2 hover:bg-[var(--hover-accent)] transition-colors cursor-pointer outline-none border-b border-[rgba(255,255,255,0.05)] bg-[rgba(0,0,0,0.3)]"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <Radiation className="w-3.5 h-3.5 flex-shrink-0 text-[var(--accent-nuclear)]" />
+          <span className="hud-text text-[11px] text-[var(--text-primary)]">NUCLEAR WATCH</span>
+          <span className="gotham-tag gotham-tag--low" style={{ fontSize: '9px', padding: '1px 5px' }}>{summary.total}</span>
+          {summary.alerts > 0 && (
+            <span className="gotham-tag gotham-tag--critical" style={{ fontSize: '9px', padding: '1px 5px' }}>
+              {summary.alerts} ALERT{summary.alerts > 1 ? 'S' : ''}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <div
+            className="w-1.5 h-1.5 rounded-full animate-osiris-pulse"
+            style={{ backgroundColor: summary.alerts > 0 ? '#FF1744' : 'var(--accent-nuclear)' }}
+          />
+          <button
+            onClick={e => { e.stopPropagation(); setMaximized(!maximized); if (!expanded) setExpanded(true); }}
+            className="p-1.5 -m-0.5 rounded hover:text-white hover:bg-white/10 transition-colors"
+            title={maximized ? 'Restore' : 'Maximize'}
+          >
+            {maximized
+              ? <Minimize2 className="w-3 h-3 text-[var(--text-muted)]" />
+              : <Maximize2 className="w-3 h-3 text-[var(--text-muted)]" />}
+          </button>
+          {expanded
+            ? <ChevronUp className="w-3.5 h-3.5 text-[var(--text-muted)]" />
+            : <ChevronDown className="w-3.5 h-3.5 text-[var(--text-muted)]" />}
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className={`flex flex-col flex-1 min-h-0 ${maximized ? 'bg-[#0a0a09]' : 'bg-transparent'}`}
+          >
+            {/* Fleet at a glance */}
+            <div className="flex-shrink-0 flex gap-2 px-3 py-2 border-b border-[rgba(255,255,255,0.05)] bg-[rgba(0,0,0,0.15)]">
+              <Stat label="Reactors" value={String(summary.reactors)} color="var(--accent-nuclear)" />
+              <Stat label="Capacity" value={formatCapacity(summary.capacityMW)} />
+              <Stat label="Countries" value={String(summary.countries)} />
+              <Stat
+                label="Alerts"
+                value={String(summary.alerts)}
+                color={summary.alerts > 0 ? '#FF1744' : 'var(--text-muted)'}
+              />
+            </div>
+
+            {/* Filters */}
+            <div className="flex-shrink-0 flex flex-wrap gap-1 px-3 py-2 border-b border-[rgba(255,255,255,0.05)]">
+              {FILTERS.map(f => {
+                const count = f.key === 'all' ? summary.total
+                  : f.key === 'alerts' ? summary.alerts
+                  : summary.byState[f.key];
+                return (
+                  <button
+                    key={f.key}
+                    onClick={() => setFilter(f.key)}
+                    disabled={count === 0 && f.key !== 'all'}
+                    className={`px-2 py-1 rounded text-[10px] font-mono tracking-wider transition-all disabled:opacity-30 disabled:cursor-not-allowed ${
+                      filter === f.key
+                        ? 'bg-[var(--accent-nuclear)]/20 text-[var(--accent-nuclear)] border border-[var(--accent-nuclear)]/50'
+                        : 'text-[#8A8880] border border-transparent hover:text-[#E8E6E0] hover:bg-[#2A2A28]'
+                    }`}
+                  >
+                    {f.label} <span className="opacity-60">{count}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Search */}
+            <div className="flex-shrink-0 px-3 py-2 border-b border-[rgba(255,255,255,0.05)]">
+              <div className="flex items-center gap-2 px-2 py-1.5 rounded bg-[#111111]/60 border border-[#2A2A28] focus-within:border-[var(--accent-nuclear)]/50 transition-colors">
+                <Search className="w-3 h-3 text-[var(--text-muted)] flex-shrink-0" />
+                <input
+                  value={query}
+                  onChange={e => setQuery(e.target.value)}
+                  placeholder="Filter by site, city, country or operator"
+                  aria-label="Filter nuclear facilities"
+                  className="flex-1 min-w-0 bg-transparent outline-none text-[11px] font-mono text-[#E8E6E0] placeholder:text-[#5C5A54]"
+                />
+                {query && (
+                  <button
+                    onClick={() => setQuery('')}
+                    className="text-[10px] font-mono text-[var(--text-muted)] hover:text-[#E8E6E0]"
+                    aria-label="Clear filter"
+                  >
+                    CLEAR
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Facility list */}
+            <div className={`flex-1 overflow-y-auto styled-scrollbar ${maximized ? 'p-4' : 'p-2'}`}>
+              <div className={maximized ? 'grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-2 items-start' : 'space-y-1.5'}>
+                {shown.map(f => {
+                  const style = nuclearStyle(f.status);
+                  const mag = seismicMagnitude(f.status);
+                  const isOpen = selected === f.id;
+
+                  return (
+                    <div
+                      key={f.id}
+                      onClick={() => { setSelected(isOpen ? null : f.id); onLocate(f.lat, f.lng); }}
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          setSelected(isOpen ? null : f.id);
+                          onLocate(f.lat, f.lng);
+                        }
+                      }}
+                      className={`w-full text-left p-2.5 rounded-lg bg-[#111111]/60 border transition-all cursor-pointer ${
+                        isOpen
+                          ? 'border-[var(--accent-nuclear)]/50 bg-[#1A1A1A]'
+                          : 'border-[#2A2A28] hover:bg-[#1A1A1A] hover:border-[#3A3A38]'
+                      }`}
+                    >
+                      <div className="flex items-start gap-2.5">
+                        {/* State indicator — urgent sites pulse */}
+                        <div className="flex-shrink-0 mt-1">
+                          <div
+                            className={`w-2 h-2 rounded-full ${style.urgent ? 'animate-osiris-pulse' : ''}`}
+                            style={{ backgroundColor: style.color, boxShadow: `0 0 6px ${style.color}80` }}
+                          />
+                        </div>
+
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-[11px] font-mono text-[#E8E6E0] truncate">{f.name}</span>
+                            <span
+                              className="text-[9px] font-mono px-1.5 py-[1px] rounded flex-shrink-0 border"
+                              style={{
+                                color: style.color,
+                                borderColor: `${style.color}4D`,
+                                backgroundColor: `${style.color}1A`,
+                              }}
+                            >
+                              {style.label}{mag !== null ? ` M${mag}` : ''}
+                            </span>
+                          </div>
+
+                          <div className="mt-1.5 text-[10px] font-mono text-[#8A8880] truncate">
+                            {f.city}, {f.country}
+                          </div>
+
+                          <div className="flex items-center gap-3 mt-1.5 pt-1.5 border-t border-[#2A2A28]/50 text-[10px] font-mono">
+                            <span className="flex items-center gap-1 text-[#8A8880] whitespace-nowrap" title="Reactors">
+                              <Atom className="w-2.5 h-2.5" />
+                              {f.reactors || '—'}
+                            </span>
+                            <span className="flex items-center gap-1 text-[#8A8880] whitespace-nowrap" title="Net electrical capacity">
+                              <Zap className="w-2.5 h-2.5" />
+                              {formatCapacity(f.capacityMW)}
+                            </span>
+                            <span className="truncate text-[#5C5A54] ml-auto">{f.owner}</span>
+                          </div>
+
+                          {/* Detail, kept out of the row until asked for */}
+                          <AnimatePresence>
+                            {isOpen && (
+                              <motion.div
+                                initial={{ height: 0, opacity: 0 }}
+                                animate={{ height: 'auto', opacity: 1 }}
+                                exit={{ height: 0, opacity: 0 }}
+                                transition={{ duration: 0.15 }}
+                                className="overflow-hidden"
+                              >
+                                <div className="mt-2 pt-2 border-t border-[#2A2A28] space-y-1">
+                                  <div className="flex justify-between gap-2 text-[10px] font-mono">
+                                    <span className="text-[var(--text-muted)] flex-shrink-0">STATUS</span>
+                                    <span className="truncate text-right" style={{ color: style.color }}>{f.status}</span>
+                                  </div>
+                                  <div className="flex justify-between gap-2 text-[10px] font-mono">
+                                    <span className="text-[var(--text-muted)] flex-shrink-0">COORDS</span>
+                                    <span className="text-[#E8E6E0]">{f.lat.toFixed(4)}°, {f.lng.toFixed(4)}°</span>
+                                  </div>
+                                  <div className="flex gap-1.5 pt-1">
+                                    <button
+                                      onClick={e => { e.stopPropagation(); onLocate(f.lat, f.lng); }}
+                                      className="flex-1 flex items-center justify-center gap-1 py-1.5 rounded text-[9px] font-mono text-[var(--accent-nuclear)] border border-[var(--accent-nuclear)]/40 bg-[var(--accent-nuclear)]/10 hover:bg-[var(--accent-nuclear)]/20 transition-colors"
+                                    >
+                                      <MapPin className="w-2.5 h-2.5" /> LOCATE
+                                    </button>
+                                    {f.sourceUrl && (
+                                      <a
+                                        href={f.sourceUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        onClick={e => e.stopPropagation()}
+                                        title={`Reference page for ${f.name}`}
+                                        className="flex-1 flex items-center justify-center gap-1 py-1.5 rounded text-[9px] font-mono text-[var(--cyan-primary)] border border-[var(--cyan-primary)]/40 bg-[var(--cyan-primary)]/10 hover:bg-[var(--cyan-primary)]/20 transition-colors"
+                                      >
+                                        <ExternalLink className="w-2.5 h-2.5" /> SOURCE
+                                      </a>
+                                    )}
+                                  </div>
+                                </div>
+                              </motion.div>
+                            )}
+                          </AnimatePresence>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {shown.length === 0 && (
+                <div className="flex flex-col items-center gap-2 py-8 text-[11px] font-mono text-[var(--text-muted)]">
+                  <Globe2 className="w-5 h-5 opacity-40" />
+                  {facilities.length === 0 ? 'Loading facilities…' : 'No facilities match this filter'}
+                </div>
+              )}
+            </div>
+
+            {/* Legend */}
+            <div className="flex-shrink-0 flex flex-wrap items-center gap-x-3 gap-y-1 px-3 py-1.5 border-t border-[rgba(255,255,255,0.05)] bg-[rgba(0,0,0,0.2)]">
+              {(Object.keys(NUCLEAR_STATES) as (keyof typeof NUCLEAR_STATES)[]).map(k => (
+                <span key={k} className="flex items-center gap-1 text-[9px] font-mono text-[var(--text-muted)]">
+                  <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: NUCLEAR_STATES[k].color }} />
+                  {NUCLEAR_STATES[k].label}
+                </span>
+              ))}
+              {summary.byState.seismic > 0 && (
+                <span className="flex items-center gap-1 text-[9px] font-mono text-[#FF9500] ml-auto">
+                  <TriangleAlert className="w-2.5 h-2.5" /> USGS M4.5+ within 150 km
+                </span>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+
+  // Only a click sets this, so by now we are certainly on the client.
+  if (maximized && typeof document !== 'undefined') {
+    return createPortal(content, document.body);
+  }
+  return content;
+}

--- a/src/components/OsintPanel.tsx
+++ b/src/components/OsintPanel.tsx
@@ -9,7 +9,7 @@ import {
   ChevronDown, ChevronUp, Loader2, AlertTriangle, Server,
   Wifi, Lock, MapPin, Bug, Code, Layers, Network, Fingerprint,
   CheckCircle, XCircle, Clock, ExternalLink, Crosshair,
-  Maximize2, Minimize2, Gavel, Bitcoin, Phone, Terminal, ShieldAlert, User, Skull, Monitor, KeyRound
+  Maximize2, Minimize2, Gavel, Bitcoin, Phone, Terminal, ShieldAlert, User
 } from 'lucide-react';
 import { ipToNumber, numberToIp, calculateSubnetStart, classifyDevice, assessRisk, batchFetch, ShodanInternetDBResponse, SweepDevice } from '@/lib/osint-utils';
 import ChainBrief from '@/components/ChainBrief';
@@ -62,7 +62,6 @@ const TABS: ToolDef[] = [
 
   { id: 'threats', label: 'THREATS', icon: AlertTriangle, placeholder: 'IP, domain, or hash', color: '#FF9500', group: 'threat', blurb: 'Reputation across feeds' },
   { id: 'leaks', label: 'DATA LEAKS', icon: ShieldAlert, placeholder: 'Email address', color: '#E040FB', group: 'threat', blurb: 'Breach exposure for an address' },
-  { id: 'infostealer', label: 'INFOSTEALER', icon: Skull, placeholder: 'Email, domain, username or phone', color: '#FF1744', group: 'threat', blurb: 'Hudson Rock malware-compromised assets' },
 
   { id: 'crypto', label: 'CHAIN INTEL', icon: Bitcoin, placeholder: 'BTC, ETH or SOL wallet address', color: '#F7931A', group: 'chain', blurb: 'Wallet forensics and daily brief' },
 ];
@@ -259,7 +258,6 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
         case 'mac': url = `/api/osint/mac?mac=${encodeURIComponent(query)}`; break;
         case 'phone': url = `/api/osint/phone?number=${encodeURIComponent(query)}`; break;
         case 'leaks': url = `https://api.xposedornot.com/v1/breach-analytics?email=${encodeURIComponent(query)}`; break;
-        case 'infostealer': url = `/api/osint/hudsonrock?query=${encodeURIComponent(query)}`; break;
         case 'crypto': url = `/api/osint/crypto?address=${encodeURIComponent(query)}`; break;
         case 'username': url = `/api/osint/username?username=${encodeURIComponent(query)}`; break;
         case 'github': url = `/api/osint/github?user=${encodeURIComponent(query)}`; break;
@@ -315,7 +313,7 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
           if (data.lat && data.lng && onScanGeolocate) {
              onScanGeolocate(query, { lat: data.lat, lng: data.lng, type: 'phone', region: data.region });
           }
-        } else if (activeTab !== 'sweep' && activeTab !== 'vuln' && activeTab !== 'crypto' && activeTab !== 'username' && activeTab !== 'mac' && activeTab !== 'bgp' && activeTab !== 'github' && activeTab !== 'leaks' && activeTab !== 'phone' && activeTab !== 'infostealer') {
+        } else if (activeTab !== 'sweep' && activeTab !== 'vuln' && activeTab !== 'crypto' && activeTab !== 'username' && activeTab !== 'mac' && activeTab !== 'bgp' && activeTab !== 'github' && activeTab !== 'leaks' && activeTab !== 'phone') {
           fetch(`/api/osint/ip?ip=${encodeURIComponent(query)}`)
             .then(r => r.json())
             .then(locData => {
@@ -377,21 +375,6 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
       </div>
     );
   };
-
-  // Cavalier's data is complimentary; the terms ask that it be credited.
-  const HudsonRockCredit = () => (
-    <a
-      href="https://www.hudsonrock.com/free-tools"
-      target="_blank"
-      rel="noreferrer"
-      className="mt-2 flex items-center justify-between px-2 py-1.5 rounded bg-[#1A1A18] border border-[var(--border-secondary)]/30 hover:border-[#FF1744]/40 transition-colors"
-    >
-      <span className="text-[9px] font-mono text-[var(--text-muted)]">
-        Data by Hudson Rock Cavalier · free infostealer intelligence
-      </span>
-      <ExternalLink className="w-2.5 h-2.5 text-[var(--text-muted)]" />
-    </a>
-  );
 
   const SectionHeader = ({ title, icon: Icon, color }: { title: string; icon: any; color: string }) => (
     <div className="flex items-center gap-2 mt-3 mb-1.5 first:mt-0">
@@ -980,158 +963,6 @@ function OsintPanelInner({ isMobile, onSweepVisualize, onScanGeolocate }: OsintP
               </div>
             </div>
           )}
-        </div>
-      );
-    }
-
-    // ── INFOSTEALER (Hudson Rock) ──
-    if (activeTab === 'infostealer') {
-      const hit = r.compromised;
-      const accent = hit ? '#FF1744' : '#00E676';
-      const TYPE_LABEL: Record<string, string> = {
-        email: 'EMAIL ADDRESS', domain: 'DOMAIN', username: 'USERNAME', phone: 'PHONE NUMBER',
-      };
-
-      // Domain lookups answer a different question — how much of an
-      // organisation is exposed — so they get their own view rather than an
-      // empty version of the per-machine one.
-      if (r.type === 'domain') {
-        const families = Object.entries(r.stealerFamilies || {})
-          .filter(([k, v]) => k !== 'total' && Number(v) > 0)
-          .sort((a, b) => Number(b[1]) - Number(a[1]));
-        const pw = r.employeePasswords || {};
-        const weakPct = (Number(pw.too_weak?.perc) || 0) + (Number(pw.weak?.perc) || 0);
-
-        return (
-          <div>
-            <SectionHeader title="INFOSTEALER EXPOSURE" icon={Skull} color={accent} />
-            <ResultRow label="Domain" value={r.query} color={accent} />
-            <ResultRow label="Status" value={hit ? 'COMPROMISED MACHINES FOUND' : 'NO RECORDS'} color={accent} />
-            {hit && (
-              <>
-                <div className="grid grid-cols-2 gap-1.5 mt-2">
-                  {[
-                    ['Employees', r.employees, '#FF1744'],
-                    ['Users', r.users, '#FF9500'],
-                    ['Third parties', r.third_parties, '#FFD500'],
-                    ['Total machines', r.totalStealers, '#E040FB'],
-                  ].map(([label, value, color]: any) => (
-                    <div key={label} className="p-2 rounded border border-[var(--border-secondary)]/30 bg-[var(--bg-tertiary)]/30">
-                      <div className="text-[10px] font-mono text-[var(--text-muted)] uppercase tracking-wider">{label}</div>
-                      <div className="text-[15px] font-mono font-bold" style={{ color }}>{Number(value || 0).toLocaleString()}</div>
-                    </div>
-                  ))}
-                </div>
-
-                <ResultRow label="Last employee" value={r.last_employee_compromised?.slice(0, 10)} />
-                <ResultRow label="Last user" value={r.last_user_compromised?.slice(0, 10)} />
-                <ResultRow label="Exposed URLs" value={Number(r.totalUrls || 0).toLocaleString()} />
-
-                {pw.has_stats && (
-                  <div className="mt-2 p-2 border border-[#FF9500]/30 bg-[#FF9500]/10 rounded">
-                    <span className="text-[11px] font-mono text-[#FF9500] font-bold mb-1 block">
-                      EMPLOYEE PASSWORD STRENGTH ({Number(pw.totalPass || 0).toLocaleString()})
-                    </span>
-                    <div className="flex h-2 rounded overflow-hidden mb-1">
-                      {[['too_weak', '#FF1744'], ['weak', '#FF9500'], ['medium', '#FFD500'], ['strong', '#00E676']].map(([k, c]) => (
-                        <div key={k} style={{ width: `${Number(pw[k]?.perc) || 0}%`, background: c }} />
-                      ))}
-                    </div>
-                    <div className="text-[10px] font-mono text-[var(--text-muted)]">
-                      {weakPct.toFixed(0)}% weak or worse · {(Number(pw.strong?.perc) || 0).toFixed(0)}% strong
-                    </div>
-                  </div>
-                )}
-
-                {families.length > 0 && (
-                  <div className="mt-2 p-2 border border-[#FF1744]/30 bg-[#FF1744]/10 rounded">
-                    <span className="text-[11px] font-mono text-[#FF1744] font-bold mb-1 block">STEALER FAMILIES</span>
-                    <div className="flex flex-wrap gap-1">
-                      {families.slice(0, 14).map(([name, count]) => (
-                        <span key={name} className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#E8E6E0] border border-[#FF1744]/20">
-                          {name} <span className="text-[#FF1744]">{String(count)}</span>
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {Array.isArray(r.thirdPartyDomains) && r.thirdPartyDomains.length > 0 && (
-                  <div className="mt-2 p-2 border border-[var(--border-secondary)]/30 rounded">
-                    <span className="text-[11px] font-mono text-[var(--text-secondary)] font-bold mb-1 block">
-                      TOP THIRD-PARTY DOMAINS ({r.thirdPartyDomains.length})
-                    </span>
-                    {r.thirdPartyDomains.slice(0, 8).map((d: any) => (
-                      <div key={d.domain} className="flex items-center justify-between py-0.5">
-                        <span className="text-[10px] font-mono text-[var(--text-primary)] break-all">{d.domain}</span>
-                        <span className="text-[10px] font-mono text-[var(--text-muted)] flex-shrink-0 ml-2">{d.occurrence}</span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </>
-            )}
-            <HudsonRockCredit />
-          </div>
-        );
-      }
-
-      // email / username / phone — one card per compromised machine.
-      const stealers: any[] = Array.isArray(r.stealers) ? r.stealers : [];
-      return (
-        <div>
-          <SectionHeader title="INFOSTEALER EXPOSURE" icon={Skull} color={accent} />
-          <ResultRow label={TYPE_LABEL[r.type] || 'TARGET'} value={r.query} color={accent} />
-          <ResultRow label="Status" value={hit ? 'COMPROMISED' : 'NOT FOUND IN CORPUS'} color={accent} />
-          {hit && (
-            <>
-              <ResultRow label="Machines" value={stealers.length} color="#FF1744" />
-              <ResultRow label="Corporate svcs" value={r.total_corporate_services} />
-              <ResultRow label="User svcs" value={r.total_user_services} />
-
-              {stealers.map((s: any, i: number) => (
-                <div key={i} className="mt-2 p-2 rounded border border-[#FF1744]/30 bg-[#FF1744]/5">
-                  <div className="flex items-center gap-2 mb-1.5">
-                    <Monitor className="w-3 h-3 text-[#FF1744]" />
-                    <span className="text-[11px] font-mono font-bold text-[#FF1744] break-all">
-                      {s.computer_name || 'UNKNOWN MACHINE'}
-                    </span>
-                  </div>
-                  <ResultRow label="Compromised" value={s.date_compromised?.slice(0, 10)} color="#FF9500" />
-                  <ResultRow label="Stealer" value={s.stealer_family} color="#FF9500" />
-                  <ResultRow label="OS" value={s.operating_system} />
-                  <ResultRow label="IP" value={s.ip} />
-                  <ResultRow label="Antivirus" value={(s.antiviruses || []).join(', ')} />
-                  <ResultRow label="Malware path" value={s.malware_path} />
-
-                  {(s.top_logins?.length > 0 || s.top_passwords?.length > 0) && (
-                    <div className="mt-1.5 pt-1.5 border-t border-[#FF1744]/20">
-                      <div className="flex items-center gap-1.5 mb-1">
-                        <KeyRound className="w-2.5 h-2.5 text-[var(--text-muted)]" />
-                        <span className="text-[10px] font-mono text-[var(--text-muted)] uppercase tracking-wider">
-                          Credentials (redacted by Hudson Rock)
-                        </span>
-                      </div>
-                      <div className="flex flex-wrap gap-1">
-                        {(s.top_logins || []).map((l: string, j: number) => (
-                          <span key={`l${j}`} className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#87CEEB] border border-[#87CEEB]/20 break-all">{l}</span>
-                        ))}
-                        {(s.top_passwords || []).map((p: string, j: number) => (
-                          <span key={`p${j}`} className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[#1A1A18] text-[#E040FB] border border-[#E040FB]/20 break-all">{p}</span>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ))}
-            </>
-          )}
-          {!hit && r.message && (
-            <div className="mt-2 text-[10px] font-mono text-[var(--text-muted)] leading-relaxed">
-              {String(r.message).split('Visit')[0].trim()}
-            </div>
-          )}
-          <HudsonRockCredit />
         </div>
       );
     }

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -7,6 +7,7 @@ import { createSatelliteLayer, parseColor, type SatPoint } from '@/lib/satellite
 import { MAP_DEFAULTS, MAP_PALETTE_KEYS, readMapPalette, satColorFor, type MapPalette } from '@/lib/map-palette';
 import { STYLE_EVENT } from '@/lib/style-tokens';
 import { arrivalBeacons } from '@/lib/malware-intel';
+import { nuclearStyle, seismicMagnitude, formatCapacity } from '@/lib/nuclear';
 import SatelliteCard, { type SatelliteDetail } from '@/components/SatelliteCard';
 import CctvPreviews, { type PreviewCamera } from '@/components/CctvPreviews';
 import MapControls from '@/components/MapControls';
@@ -542,27 +543,50 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
         'text-offset': [0, 2], 'text-max-width': 14, 'text-allow-overlap': false,
       }, paint: { 'text-color': '#7E57C2', 'text-halo-color': '#000', 'text-halo-width': 1, 'text-opacity': 0.8 }});
 
-      // Nuclear Infrastructure — teal / amber risk
+      /* Nuclear Infrastructure — one colour per operational state.
+         This mirrors nuclearState() in @/lib/nuclear; the panel legend, the
+         popup and these dots have to agree or the colours mean nothing.
+         Expression matching is case-sensitive, so these track the exact
+         status strings /api/infrastructure emits. */
+      const INFRA_COLOR: any = ['case',
+        ['in', 'SEISMIC', ['get', 'status']], '#FF9500',
+        ['in', 'Conflict', ['get', 'status']], '#FF1744',
+        ['in', 'Construction', ['get', 'status']], '#00E5FF',
+        ['any',
+          ['in', 'Decommission', ['get', 'status']],
+          ['in', 'Destroyed', ['get', 'status']],
+          ['in', 'Shutdown', ['get', 'status']],
+          ['in', 'Suspended', ['get', 'status']],
+        ], '#8A8880',
+        '#76FF03',
+      ];
+      /* Conflict and seismic sites are the reason to look at this layer, so
+         they carry a wider halo and a heavier ring than a healthy plant. */
+      const INFRA_URGENT: any = ['any',
+        ['in', 'SEISMIC', ['get', 'status']],
+        ['in', 'Conflict', ['get', 'status']],
+      ];
+
       map.addLayer({ id: 'infra-glow', type: 'circle', source: 'infrastructure', paint: {
-        'circle-radius': ['interpolate',['linear'],['zoom'], 1,8, 5,14, 10,22],
-        'circle-color': ['case', ['in', 'SEISMIC RISK', ['get', 'status']], '#E65100', '#26A69A'],
-        'circle-opacity': 0.08, 'circle-blur': 1,
+        'circle-radius': ['interpolate',['linear'],['zoom'],
+          1, ['case', INFRA_URGENT, 14, 8],
+          5, ['case', INFRA_URGENT, 22, 14],
+          10, ['case', INFRA_URGENT, 34, 22]],
+        'circle-color': INFRA_COLOR,
+        'circle-opacity': ['case', INFRA_URGENT, 0.18, 0.08], 'circle-blur': 1,
       }});
       map.addLayer({ id: 'infra-dots', type: 'circle', source: 'infrastructure', paint: {
         'circle-radius': ['interpolate',['linear'],['zoom'], 1,4, 5,6, 10,10],
-        'circle-color': ['case', 
-          ['in', 'SEISMIC RISK', ['get', 'status']], '#E65100',
-          ['==', ['get','status'], 'Active Conflict Zone'], '#D32F2F', 
-          ['==', ['get','status'], 'Destroyed / Decommissioning'], '#546E7A', 
-          '#26A69A'
-        ],
-        'circle-opacity': 0.75,
-        'circle-stroke-width': 1.5, 'circle-stroke-color': ['case', ['in', 'SEISMIC RISK', ['get', 'status']], '#E65100', '#26A69A'], 'circle-stroke-opacity': 0.35,
+        'circle-color': INFRA_COLOR,
+        'circle-opacity': 0.85,
+        'circle-stroke-width': ['case', INFRA_URGENT, 2.5, 1.5],
+        'circle-stroke-color': INFRA_COLOR,
+        'circle-stroke-opacity': ['case', INFRA_URGENT, 0.6, 0.35],
       }});
       map.addLayer({ id: 'infra-label', type: 'symbol', source: 'infrastructure', minzoom: 5, layout: {
         'text-field': ['get','name'], 'text-size': 9, 'text-font': ['Open Sans Regular'],
         'text-offset': [0, 2], 'text-max-width': 14, 'text-allow-overlap': false,
-      }, paint: { 'text-color': ['case', ['in', 'SEISMIC RISK', ['get', 'status']], '#E65100', '#26A69A'], 'text-halo-color': '#000', 'text-halo-width': 1, 'text-opacity': 0.7 }});
+      }, paint: { 'text-color': INFRA_COLOR, 'text-halo-color': '#000', 'text-halo-width': 1, 'text-opacity': 0.8 }});
 
       // Satellites.
       // Every satellite is drawn once, by the custom 3D layer below, at its
@@ -1442,18 +1466,44 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       if (!e.features?.length) return;
       const p = e.features[0].properties as any;
       const coords = (e.features[0].geometry as any).coordinates;
-      const statusColor = p.status.includes('SEISMIC RISK') ? '#FF9500' : p.status === 'Active Conflict Zone' ? '#FF1744' : p.status === 'Operational' ? '#76FF03' : '#757575';
-      popup(coords, `<div style="${pStyle}border:1px solid rgba(118,255,3,0.3);">
-        <div style="color:#76FF03;font-size:14px;font-weight:700;margin-bottom:4px;">☢️ ${p.name || 'Nuclear Facility'}</div>
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:9px;margin-bottom:8px;">
-          <div><span style="color:#5C5A54;">STATUS</span><br/><span style="color:${statusColor};">${p.status || '—'}</span></div>
-          <div><span style="color:#5C5A54;">CITY</span><br/><span style="color:#E8E6E0;">${p.city || '—'}, ${p.country || ''}</span></div>
-          <div><span style="color:#5C5A54;">REACTORS</span><br/><span style="color:#76FF03;">${p.reactors || '—'}</span></div>
-          <div><span style="color:#5C5A54;">CAPACITY</span><br/><span style="color:#E8E6E0;">${p.capacityMW ? p.capacityMW.toLocaleString() + ' MW' : '—'}</span></div>
-          <div><span style="color:#5C5A54;">OWNER</span><br/><span style="color:#E8E6E0;">${p.owner || '—'}</span></div>
-          <div><span style="color:#5C5A54;">COORDS</span><br/><span style="color:#E8E6E0;">${coords[1].toFixed(3)}°, ${coords[0].toFixed(3)}°</span></div>
+
+      // Same classification the panel and the dot colours use.
+      const style = nuclearStyle(p.status || '');
+      const mag = seismicMagnitude(p.status || '');
+      const c = style.color;
+
+      /* A research reactor or a waste store has no electrical output, and an
+         enrichment plant has no reactor at all — those cells read "—" rather
+         than a zero that would look like a fault. */
+      const cell = (label: string, value: string, color = '#E8E6E0') => `
+        <div style="min-width:0;">
+          <div style="color:#5C5A54;font-size:8px;letter-spacing:0.14em;margin-bottom:3px;">${label}</div>
+          <div style="color:${color};font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${value}</div>
+        </div>`;
+
+      popup(coords, `<div style="${pStyle}padding:0;overflow:hidden;border:1px solid ${c}59;min-width:250px;">
+
+        <div style="display:flex;align-items:center;gap:8px;padding:10px 12px;background:linear-gradient(90deg,${c}26,transparent);border-bottom:1px solid ${c}33;">
+          <span style="width:8px;height:8px;border-radius:50%;background:${c};box-shadow:0 0 8px ${c};flex-shrink:0;"></span>
+          <div style="min-width:0;flex:1;">
+            <div style="color:#E8E6E0;font-size:12px;font-weight:700;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${p.name || 'Nuclear Facility'}</div>
+            <div style="color:#8A8880;font-size:9px;margin-top:2px;">${p.city || '—'}${p.country ? ', ' + p.country : ''}</div>
+          </div>
+          <span style="flex-shrink:0;font-size:8px;letter-spacing:0.1em;padding:2px 6px;border-radius:4px;color:${c};border:1px solid ${c}4D;background:${c}1A;">${style.label}${mag !== null ? ' M' + mag : ''}</span>
         </div>
-        <a href="https://www.google.com/maps/@${coords[1]},${coords[0]},14z/data=!3m1!1e3" target="_blank" style="${linkStyle}color:#76FF03;border:1px solid rgba(118,255,3,0.4);background:rgba(118,255,3,0.1);">SATELLITE VIEW</a>
+
+        <div style="padding:10px 12px;">
+          <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;margin-bottom:10px;">
+            ${cell('REACTORS', p.reactors ? String(p.reactors) : '—', c)}
+            ${cell('CAPACITY', formatCapacity(Number(p.capacityMW) || 0))}
+            ${cell('COORDS', `${coords[1].toFixed(2)}°, ${coords[0].toFixed(2)}°`)}
+          </div>
+          <div style="display:grid;grid-template-columns:1fr;gap:10px;padding-top:8px;border-top:1px solid rgba(255,255,255,0.06);">
+            ${cell('STATUS', p.status || '—', c)}
+            ${cell('OPERATOR', p.owner || '—')}
+          </div>
+          ${p.sourceUrl ? `<a href="${p.sourceUrl}" target="_blank" rel="noopener noreferrer" style="${linkStyle}display:block;text-align:center;margin-top:10px;color:${c};border:1px solid ${c}66;background:${c}1A;">SOURCE</a>` : ''}
+        </div>
       </div>`);
     });
 
@@ -1941,7 +1991,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
 
   useEffect(() => {
     if (!mapReady) return;
-    setGeo('infrastructure', activeLayers.infrastructure && data.infrastructure ? data.infrastructure.map((i: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [i.lng, i.lat] }, properties: { name: i.name, city: i.city, country: i.country, status: i.status, reactors: i.reactors, capacityMW: i.capacityMW, owner: i.owner } })) : []);
+    setGeo('infrastructure', activeLayers.infrastructure && data.infrastructure ? data.infrastructure.map((i: any) => ({ type: 'Feature', geometry: { type: 'Point', coordinates: [i.lng, i.lat] }, properties: { name: i.name, city: i.city, country: i.country, status: i.status, reactors: i.reactors, capacityMW: i.capacityMW, owner: i.owner, sourceUrl: i.sourceUrl } })) : []);
   }, [mapReady, data.infrastructure, activeLayers.infrastructure, setGeo]);
 
   useEffect(() => {

--- a/src/lib/gdeltEvents.test.ts
+++ b/src/lib/gdeltEvents.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server } from 'http';
+import { AddressInfo } from 'net';
+import { httpGetBufferIPv4, fetchGdeltEvents } from './gdeltEvents';
+
+/**
+ * The events feed died with `ERR_INVALID_PROTOCOL: Protocol "https:" not
+ * supported` (#318): data.gdeltproject.org started answering plain HTTP with a
+ * 301 to HTTPS, and the redirect was followed with Node's *http* client.
+ *
+ * These cover the fetcher rather than the parser, so they need a socket — but a
+ * loopback one, so they still run offline.
+ */
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(s => new Promise<void>(r => s.close(() => r()))));
+});
+
+/** Starts a loopback HTTP server and returns its `http://127.0.0.1:port` origin. */
+function serve(handler: (url: string) => { status: number; headers?: Record<string, string>; body?: string }): Promise<string> {
+  const server = createServer((req, res) => {
+    const { status, headers = {}, body = '' } = handler(req.url ?? '/');
+    res.writeHead(status, headers);
+    res.end(body);
+  });
+  servers.push(server);
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => resolve(`http://127.0.0.1:${(server.address() as AddressInfo).port}`));
+  });
+}
+
+describe('httpGetBufferIPv4', () => {
+  it('reads a plain 200 body', async () => {
+    const origin = await serve(() => ({ status: 200, body: 'hello gdelt' }));
+    expect((await httpGetBufferIPv4(origin, 5000)).toString('utf8')).toBe('hello gdelt');
+  });
+
+  it('follows a same-protocol redirect', async () => {
+    const origin = await serve(url =>
+      url === '/here' ? { status: 200, body: 'arrived' } : { status: 301, headers: { location: '/here' } }
+    );
+    expect((await httpGetBufferIPv4(origin, 5000)).toString('utf8')).toBe('arrived');
+  });
+
+  /* The regression itself. Port 1 is reserved and never listening, so a correct
+     client gets as far as a refused TLS connection; the old one never opened a
+     socket at all because http.get rejected the `https:` URL outright. */
+  it('switches to the https client when a redirect crosses protocol', async () => {
+    const origin = await serve(() => ({ status: 302, headers: { location: 'https://127.0.0.1:1/export.zip' } }));
+
+    const err = await httpGetBufferIPv4(origin, 5000).then(() => null, (e: NodeJS.ErrnoException) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.code).not.toBe('ERR_INVALID_PROTOCOL');
+    expect(err!.code).toBe('ECONNREFUSED');
+  });
+
+  it('gives up on a redirect loop instead of recursing forever', async () => {
+    const origin = await serve(() => ({ status: 301, headers: { location: '/loop' } }));
+    await expect(httpGetBufferIPv4(origin, 5000)).rejects.toThrow(/exceeded 5 redirects/);
+  });
+
+  it('reports a non-200 with its status', async () => {
+    const origin = await serve(() => ({ status: 404 }));
+    await expect(httpGetBufferIPv4(origin, 5000)).rejects.toThrow(/responded 404$/);
+  });
+});
+
+// Live integration test — opt in with RUN_LIVE_TESTS=1 (hits the real GDELT host).
+const liveIt = process.env.RUN_LIVE_TESTS === '1' ? it : it.skip;
+
+describe('fetchGdeltEvents', () => {
+  liveIt('pulls a real 15-minute export end to end', async () => {
+    const { events, window, scanned } = await fetchGdeltEvents({ limit: 25 });
+
+    expect(window).toMatch(/^\d{14}\.export\.CSV\.zip$/);
+    expect(scanned).toBeGreaterThan(0);
+    expect(events.length).toBeGreaterThan(0);
+
+    for (const e of events) {
+      expect(Number.isFinite(e.lat)).toBe(true);
+      expect(Number.isFinite(e.lng)).toBe(true);
+      expect(Math.abs(e.lat)).toBeLessThanOrEqual(90);
+      expect(Math.abs(e.lng)).toBeLessThanOrEqual(180);
+      expect(e.date).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    }
+  }, 120_000);
+});

--- a/src/lib/gdeltEvents.ts
+++ b/src/lib/gdeltEvents.ts
@@ -1,5 +1,6 @@
 import { inflateRawSync } from 'zlib';
 import { get as httpGet } from 'http';
+import { get as httpsGet } from 'https';
 
 /**
  * ═══════════════════════════════════════════════════════════════
@@ -17,24 +18,38 @@ import { get as httpGet } from 'http';
 
 const LASTUPDATE_URL = 'http://data.gdeltproject.org/gdeltv2/lastupdate.txt';
 
+/** A redirect chain longer than this is a loop, not a route to the archive. */
+const MAX_REDIRECTS = 5;
+
 /**
- * GDELT's file host is plain HTTP only — its HTTPS certificate belongs to
- * Google Cloud Storage and does not cover the domain, so TLS is not an option.
+ * GDELT's file host answers plain HTTP with a 301 to HTTPS, so a request that
+ * starts on `http:` finishes on `https:`. The client has to be picked from the
+ * URL in hand rather than the one we started with — handing an `https:` location
+ * to Node's http client is what raised ERR_INVALID_PROTOCOL and took the whole
+ * events feed down. lastupdate.txt still advertises `http://` archive URLs, so
+ * the redirect is on the path whatever we point the first request at.
  *
- * It also advertises AAAA records ahead of A records. Hosts without working
+ * The host also lists AAAA records ahead of A records. Hosts without working
  * IPv6 egress see the platform fetch() pick the first address and stall until
- * its connect timeout, so we go through Node's http client with family: 4 to
- * pin the request to IPv4 instead of depending on Happy Eyeballs behaviour we
- * do not control.
+ * its connect timeout, so we go through Node's own client with family: 4 to pin
+ * the request to IPv4 rather than depend on Happy Eyeballs behaviour we do not
+ * control.
+ *
+ * Exported for tests.
  */
-function httpGetBufferIPv4(url: string, timeoutMs: number): Promise<Buffer> {
+export function httpGetBufferIPv4(url: string, timeoutMs: number, redirectsLeft = MAX_REDIRECTS): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    const req = httpGet(url, { family: 4, timeout: timeoutMs }, res => {
+    const get = new URL(url).protocol === 'https:' ? httpsGet : httpGet;
+    const req = get(url, { family: 4, timeout: timeoutMs }, res => {
       const status = res.statusCode ?? 0;
 
       if (status >= 300 && status < 400 && res.headers.location) {
         res.resume();
-        resolve(httpGetBufferIPv4(new URL(res.headers.location, url).toString(), timeoutMs));
+        if (redirectsLeft <= 0) {
+          reject(new Error(`${url} exceeded ${MAX_REDIRECTS} redirects`));
+          return;
+        }
+        resolve(httpGetBufferIPv4(new URL(res.headers.location, url).toString(), timeoutMs, redirectsLeft - 1));
         return;
       }
       if (status !== 200) {

--- a/src/lib/nuclear.test.ts
+++ b/src/lib/nuclear.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import {
+  nuclearState, nuclearStyle, seismicMagnitude, summarise,
+  selectFacilities, formatCapacity, type NuclearFacility,
+} from './nuclear';
+
+const fac = (over: Partial<NuclearFacility>): NuclearFacility => ({
+  id: 'x', name: 'Site', city: 'City', country: 'Country',
+  lat: 0, lng: 0, status: 'Operational', reactors: 1, capacityMW: 1000, owner: 'Owner',
+  ...over,
+});
+
+describe('nuclearState', () => {
+  it('reads the statuses the API actually emits', () => {
+    expect(nuclearState('Operational')).toBe('online');
+    expect(nuclearState('Under Construction')).toBe('construction');
+    expect(nuclearState('Active Conflict Zone')).toBe('conflict');
+    expect(nuclearState('SEISMIC RISK (M5.2)')).toBe('seismic');
+    expect(nuclearState('Decommissioned / Exclusion Zone')).toBe('offline');
+    expect(nuclearState('Decommissioned / Safe Enclosure')).toBe('offline');
+    expect(nuclearState('Destroyed / Decommissioning')).toBe('offline');
+    expect(nuclearState('Suspended')).toBe('offline');
+  });
+
+  it('treats an unrecognised or missing status as running', () => {
+    expect(nuclearState('Operational (Extended)')).toBe('online');
+    expect(nuclearState('Partially Operational')).toBe('online');
+    expect(nuclearState('')).toBe('online');
+  });
+
+  it('marks only conflict and seismic as urgent', () => {
+    expect(nuclearStyle('Active Conflict Zone').urgent).toBe(true);
+    expect(nuclearStyle('SEISMIC RISK (M4.8)').urgent).toBe(true);
+    expect(nuclearStyle('Operational').urgent).toBe(false);
+    expect(nuclearStyle('Under Construction').urgent).toBe(false);
+  });
+});
+
+describe('seismicMagnitude', () => {
+  it('pulls the magnitude the route embedded', () => {
+    expect(seismicMagnitude('SEISMIC RISK (M5.2)')).toBe(5.2);
+    expect(seismicMagnitude('SEISMIC RISK (M6.0)')).toBe(6);
+  });
+
+  it('returns null when there is no magnitude to read', () => {
+    expect(seismicMagnitude('Operational')).toBeNull();
+    expect(seismicMagnitude('')).toBeNull();
+  });
+});
+
+describe('summarise', () => {
+  it('counts states, countries and alerts', () => {
+    const s = summarise([
+      fac({ country: 'Ukraine', status: 'Active Conflict Zone' }),
+      fac({ country: 'Japan', status: 'SEISMIC RISK (M5.1)' }),
+      fac({ country: 'Japan', status: 'Operational' }),
+      fac({ country: 'UK', status: 'Under Construction' }),
+      fac({ country: 'UK', status: 'Decommissioned / Safe Enclosure' }),
+    ]);
+
+    expect(s.total).toBe(5);
+    expect(s.countries).toBe(3);
+    expect(s.alerts).toBe(2);
+    expect(s.byState).toEqual({ conflict: 1, seismic: 1, construction: 1, offline: 1, online: 1 });
+  });
+
+  /* A decommissioned reactor generates nothing — counting Chernobyl's four
+     units as capacity would overstate the running fleet. */
+  it('excludes offline sites from the reactor and capacity totals', () => {
+    const s = summarise([
+      fac({ status: 'Operational', reactors: 4, capacityMW: 4000 }),
+      fac({ status: 'Decommissioned / Exclusion Zone', reactors: 4, capacityMW: 0 }),
+      fac({ status: 'Destroyed / Decommissioning', reactors: 6, capacityMW: 0 }),
+    ]);
+
+    expect(s.reactors).toBe(4);
+    expect(s.capacityMW).toBe(4000);
+  });
+
+  it('tolerates missing reactor and capacity figures', () => {
+    const s = summarise([fac({ reactors: 0, capacityMW: 0 })]);
+    expect(s.reactors).toBe(0);
+    expect(s.capacityMW).toBe(0);
+  });
+
+  it('handles an empty list', () => {
+    const s = summarise([]);
+    expect(s.total).toBe(0);
+    expect(s.countries).toBe(0);
+    expect(s.alerts).toBe(0);
+  });
+});
+
+describe('selectFacilities', () => {
+  const list = [
+    fac({ id: 'small', name: 'Small NPP', status: 'Operational', capacityMW: 500 }),
+    fac({ id: 'big', name: 'Big NPP', status: 'Operational', capacityMW: 5000 }),
+    fac({ id: 'war', name: 'Zaporizhzhia NPP', status: 'Active Conflict Zone', capacityMW: 5700 }),
+    fac({ id: 'quake', name: 'Ohi NPP', status: 'SEISMIC RISK (M5.0)', capacityMW: 4710 }),
+    fac({ id: 'dead', name: 'Dodewaard NPP', status: 'Decommissioned / Safe Enclosure', capacityMW: 0 }),
+    fac({ id: 'new', name: 'Hinkley Point C', status: 'Under Construction', capacityMW: 3200 }),
+  ];
+
+  it('puts what needs attention first, then the biggest sites', () => {
+    expect(selectFacilities(list, 'all', '').map(f => f.id))
+      .toEqual(['war', 'quake', 'new', 'big', 'small', 'dead']);
+  });
+
+  it('narrows to the urgent sites', () => {
+    expect(selectFacilities(list, 'alerts', '').map(f => f.id)).toEqual(['war', 'quake']);
+  });
+
+  it('narrows to a single state', () => {
+    expect(selectFacilities(list, 'online', '').map(f => f.id)).toEqual(['big', 'small']);
+    expect(selectFacilities(list, 'offline', '').map(f => f.id)).toEqual(['dead']);
+  });
+
+  it('searches name, city, country and owner, case-insensitively', () => {
+    expect(selectFacilities(list, 'all', 'zapor').map(f => f.id)).toEqual(['war']);
+    expect(selectFacilities(list, 'all', 'HINKLEY').map(f => f.id)).toEqual(['new']);
+    expect(selectFacilities([fac({ id: 'o', owner: 'Energoatom' })], 'all', 'energo')).toHaveLength(1);
+    expect(selectFacilities(list, 'all', 'nothing here')).toEqual([]);
+  });
+
+  it('combines a state filter with a query', () => {
+    expect(selectFacilities(list, 'online', 'big').map(f => f.id)).toEqual(['big']);
+    expect(selectFacilities(list, 'offline', 'big')).toEqual([]);
+  });
+
+  it('ignores surrounding whitespace in the query', () => {
+    expect(selectFacilities(list, 'all', '  big  ').map(f => f.id)).toEqual(['big']);
+  });
+
+  it('does not mutate the list it was given', () => {
+    const order = list.map(f => f.id);
+    selectFacilities(list, 'all', '');
+    expect(list.map(f => f.id)).toEqual(order);
+  });
+});
+
+describe('sourceUrl on the facility record', () => {
+  /* The reference link is data, not something derived from the name — a search
+     built from "PALLAS (HFR Successor)" lands on a Prussian naturalist, and
+     "HOR (Reactor Institute Delft)" on an Egyptian pharaoh. Filtering and
+     sorting must not drop the field on the way to the panel. */
+  it('survives selection', () => {
+    const withUrl = fac({ id: 'u', sourceUrl: 'https://en.wikipedia.org/wiki/COVRA' });
+    expect(selectFacilities([withUrl], 'all', '')[0].sourceUrl)
+      .toBe('https://en.wikipedia.org/wiki/COVRA');
+  });
+
+  it('is optional — a facility without one is still valid', () => {
+    expect(selectFacilities([fac({ id: 'n' })], 'all', '')[0].sourceUrl).toBeUndefined();
+  });
+});
+
+describe('formatCapacity', () => {
+  it('switches to GW once MW stops being readable', () => {
+    expect(formatCapacity(485)).toBe('485 MW');
+    expect(formatCapacity(5700)).toBe('5,700 MW');
+    expect(formatCapacity(10_000)).toBe('10.0 GW');
+    expect(formatCapacity(12_400)).toBe('12.4 GW');
+  });
+
+  it('shows a dash where there is no generating capacity', () => {
+    expect(formatCapacity(0)).toBe('—');
+  });
+});

--- a/src/lib/nuclear.ts
+++ b/src/lib/nuclear.ts
@@ -1,0 +1,151 @@
+/**
+ * ═══════════════════════════════════════════════════════════════
+ *  OSIRIS — Nuclear facility classification
+ *
+ *  /api/infrastructure returns a flat list whose `status` is free text, and
+ *  which the route rewrites in place when a quake lands near a site
+ *  ("SEISMIC RISK (M5.2)"). Everything that needs to colour, group, sort or
+ *  count a facility goes through here so the map dots, the popup and the panel
+ *  cannot drift apart.
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+export interface NuclearFacility {
+  id: string;
+  name: string;
+  city: string;
+  country: string;
+  lat: number;
+  lng: number;
+  status: string;
+  reactors: number;
+  capacityMW: number;
+  owner: string;
+  /** Reference page for this specific site. Absent if none is known. */
+  sourceUrl?: string;
+}
+
+/** Operational condition, worst-first — this order is the panel's sort order. */
+export type NuclearState = 'conflict' | 'seismic' | 'construction' | 'offline' | 'online';
+
+export interface StateStyle {
+  /** Short label for tags and the popup. */
+  label: string;
+  color: string;
+  /** Draws attention on the map and pulses in the panel. */
+  urgent: boolean;
+}
+
+export const NUCLEAR_STATES: Record<NuclearState, StateStyle> = {
+  conflict: { label: 'CONFLICT', color: '#FF1744', urgent: true },
+  seismic: { label: 'SEISMIC', color: '#FF9500', urgent: true },
+  construction: { label: 'BUILDING', color: '#00E5FF', urgent: false },
+  offline: { label: 'OFFLINE', color: '#8A8880', urgent: false },
+  online: { label: 'ONLINE', color: '#76FF03', urgent: false },
+};
+
+/** Rank used for sorting; lower sorts first. */
+const STATE_ORDER: NuclearState[] = ['conflict', 'seismic', 'construction', 'online', 'offline'];
+
+/**
+ * Reads the free-text status into a state.
+ *
+ * Order matters: the route overwrites `status` wholesale with the seismic
+ * string, so a site that is both in a conflict zone and near a quake arrives
+ * carrying only the seismic text. Conflict is still checked first for the case
+ * where it survives.
+ */
+export function nuclearState(status: string): NuclearState {
+  const s = (status || '').toLowerCase();
+  if (s.includes('conflict')) return 'conflict';
+  if (s.includes('seismic')) return 'seismic';
+  if (s.includes('construction')) return 'construction';
+  if (/decommission|destroyed|shutdown|suspended|exclusion|safe enclosure/.test(s)) return 'offline';
+  return 'online';
+}
+
+export function nuclearStyle(status: string): StateStyle {
+  return NUCLEAR_STATES[nuclearState(status)];
+}
+
+/** The magnitude the route embedded in a seismic status, if there is one. */
+export function seismicMagnitude(status: string): number | null {
+  const m = (status || '').match(/M(\d+(?:\.\d+)?)/);
+  return m ? Number(m[1]) : null;
+}
+
+export interface NuclearSummary {
+  total: number;
+  /** Reactors at sites that are actually running. */
+  reactors: number;
+  /** Installed electrical capacity in MW, across running sites. */
+  capacityMW: number;
+  byState: Record<NuclearState, number>;
+  countries: number;
+  /** Sites needing attention — conflict or seismic. */
+  alerts: number;
+}
+
+export function summarise(facilities: NuclearFacility[]): NuclearSummary {
+  const byState: Record<NuclearState, number> = {
+    conflict: 0, seismic: 0, construction: 0, offline: 0, online: 0,
+  };
+  let reactors = 0;
+  let capacityMW = 0;
+  const countries = new Set<string>();
+
+  for (const f of facilities) {
+    const state = nuclearState(f.status);
+    byState[state]++;
+    countries.add(f.country);
+    // A decommissioned site's reactors are not generating anything.
+    if (state !== 'offline') {
+      reactors += f.reactors || 0;
+      capacityMW += f.capacityMW || 0;
+    }
+  }
+
+  return {
+    total: facilities.length,
+    reactors,
+    capacityMW,
+    byState,
+    countries: countries.size,
+    alerts: byState.conflict + byState.seismic,
+  };
+}
+
+export type NuclearFilter = 'all' | 'alerts' | NuclearState;
+
+/**
+ * Filter by state and free-text query, then order worst-first so anything that
+ * needs attention is at the top without the operator sorting for it.
+ */
+export function selectFacilities(
+  facilities: NuclearFacility[],
+  filter: NuclearFilter,
+  query: string,
+): NuclearFacility[] {
+  const q = query.trim().toLowerCase();
+
+  return facilities
+    .filter(f => {
+      const state = nuclearState(f.status);
+      if (filter === 'alerts' && !NUCLEAR_STATES[state].urgent) return false;
+      if (filter !== 'all' && filter !== 'alerts' && state !== filter) return false;
+      if (!q) return true;
+      return `${f.name} ${f.city} ${f.country} ${f.owner}`.toLowerCase().includes(q);
+    })
+    .sort((a, b) => {
+      const rank = STATE_ORDER.indexOf(nuclearState(a.status)) - STATE_ORDER.indexOf(nuclearState(b.status));
+      if (rank !== 0) return rank;
+      // Within a state, the biggest sites first — they matter most.
+      return (b.capacityMW || 0) - (a.capacityMW || 0);
+    });
+}
+
+/** "5,700 MW" / "12.4 GW" — capacity spans three orders of magnitude. */
+export function formatCapacity(mw: number): string {
+  if (!mw) return '—';
+  return mw >= 10_000 ? `${(mw / 1000).toFixed(1)} GW` : `${mw.toLocaleString()} MW`;
+}


### PR DESCRIPTION
Closes #318
Closes #307
Closes #306

---

### #318 — GDELT `ERR_INVALID_PROTOCOL`

`data.gdeltproject.org` now answers plain HTTP with a **301 to HTTPS**. The events reader followed redirects recursively but always through Node's `http` client, so the `https:` `Location` raised `ERR_INVALID_PROTOCOL` and the feed died on the first request. The client is now chosen from the URL in hand, and the chain is capped at five hops.

`lastupdate.txt` still advertises `http://` archive URLs, so the redirect is on the path whatever the first request targets — changing the constant would not have fixed this.

The comment claiming GDELT's certificate belongs to Google Cloud Storage and can't be used is **stale** — HTTPS answers 200 with a valid cert — so it's rewritten rather than left to invite the fix being undone.

A hermetic regression test reproduces the exact error: a loopback server 301s to an `https:` URL, and the old code fails it with `ERR_INVALID_PROTOCOL`.

### #306 — dead Dutch CCTV source

`opendata.ndw.nu` retired its dataset (#317 already noted it 404ing) and the 404 landed in a catch that dropped it, so the layer carried **no Dutch cameras** rather than reporting a dead source. `./netherlands` reads Rijkswaterstaat instead — 26 operator-controlled motorway cameras — registered as its own region like every other European source.

**One deliberate divergence from the issue.** It suggested `external_url` because "there is no still image URL". There is: `static_url` serves a JPEG, it's just hotlink-protected and answers 401 without a `Referer`. Through the existing camera proxy it returns real ~9 KB frames, so Dutch cameras render as live tiles like the rest of the layer instead of click-out links. Cost: one host on the proxy allowlist.

### #307 — Dutch nuclear infrastructure

All seven ANVS-licensed installations added (57 → 64 facilities).

No `type` field: the file's own convention is a parenthetical qualifier (`Chernobyl (Decommissioned)`, `Beloyarsk NPP (BN-800)`), and the popup already renders `—` for zero reactors, so COVRA and Urenco display correctly with no schema change. The two research reactors are rated in **thermal** MW, which isn't the electrical figure that column carries, so they stay 0 rather than sitting next to Borssele's 485 MWe as if comparable.

---

### Nuclear layer UI

The layer was a raw HTML grid in a map popup and a teal dot whose colour said nothing. `nuclearState()` now classifies a facility once, and the dot colour, the popup and a new **NUCLEAR WATCH** panel all read from it, so the legend means something.

The panel opens with the layer, collapsed to a slim bar, and carries fleet totals, state filters, search, worst-first ordering and a full-screen mode.

Every facility gained a verified **SOURCE** link, replacing the generic satellite view. These are *data*, not a search built from the name — searching `PALLAS (HFR Successor)` returns an 18th-century naturalist and `HOR (Reactor Institute Delft)` an Egyptian pharaoh. Titles were resolved against Wikipedia and reviewed by hand, catching five that pointed at the town rather than the plant (Chernobyl, Kola, Bilibino, Taishan, Bushehr) and two at an operator or sub-site (Bruce, Novovoronezh). **All 64 resolve to a real article.**

Also removes the Infostealer tool from the Recon panel, with the icons and Hudson Rock attribution block it orphaned. `/api/osint/hudsonrock` is untouched.

### Data audit

- All 64 facilities reverse-geocoded — every pin lands in the country it claims
- Dutch 7 checked at city level — 6 exact; PALLAS resolves to a neighbouring hamlet but sits 140 m from the HFR on the same Petten site
- No duplicate IDs, no coincident coordinates, nothing out of range, no site with capacity but no reactors

**Not verified:** capacity and reactor counts against IAEA PRIS. Two pre-existing entries look wrong and are left alone rather than rewritten from memory — **Flamanville** (3960 MW listed; 2×1330 + the 1650 MW EPR is nearer 4310) and **Ringhals** (3 reactors listed, but units 1 and 2 are shut down). Worth a follow-up.

### Verification

- 638 tests pass (38 new), `tsc --noEmit` clean, new files lint clean
- Live: GDELT 538 events, 26 Dutch cameras with a real Rijkswaterstaat frame, 7 Dutch facilities on the map
- All three fixes exercised in the browser against the running dev server

🤖 Generated with [SIMPLIFAI](https://Simplifai-1.com)

