### PR TITLE
perf(maritime): serve one cached snapshot instead of rebuilding per request

### DIFF
--- a/src/app/api/maritime/route.test.ts
+++ b/src/app/api/maritime/route.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET, clearMaritimeSnapshot } from './route';
+
+/* The route aggregates over the websocket-fed ship map on globalThis, so the
+   tests drive it directly rather than standing up an AIS stream. */
+interface Ship {
+  id: number; mmsi: number; lat: number; lng: number;
+  speed: number; type: string; name: string; timestamp: number;
+}
+
+const ships = () => (globalThis as unknown as { shipsCache: Map<number, Ship> }).shipsCache;
+
+function addShip(mmsi: number, lat: number, lng: number) {
+  ships().set(mmsi, {
+    id: mmsi, mmsi, lat, lng, speed: 0, type: 'cargo',
+    name: `SHIP-${mmsi}`, timestamp: Date.now(),
+  });
+}
+
+describe('GET /api/maritime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    ships().clear();
+    clearMaritimeSnapshot();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('still counts the ships sitting off a port', async () => {
+    addShip(1, 1.26, 103.84); // on top of Singapore
+    const body = await (await GET()).json();
+
+    const singapore = body.ports.find((p: { name: string }) => p.name === 'Singapore');
+    expect(singapore.volume).toContain('LIVE: 1');
+    expect(singapore.volume).toContain('WAITING: 1');
+    expect(body.total_ships).toBe(1);
+  });
+
+  it('serves one snapshot to every caller inside the TTL', async () => {
+    addShip(1, 1.26, 103.84);
+    const first = await (await GET()).json();
+
+    vi.advanceTimersByTime(4_000);
+    addShip(2, 1.27, 103.85);
+    const second = await (await GET()).json();
+
+    // The aggregation did not run again — the second caller got the first
+    // caller's bytes, which is the whole point under load.
+    expect(second).toEqual(first);
+    expect(second.total_ships).toBe(1);
+  });
+
+  it('rebuilds once the TTL has passed', async () => {
+    addShip(1, 1.26, 103.84);
+    expect((await (await GET()).json()).total_ships).toBe(1);
+
+    vi.advanceTimersByTime(5_000);
+    addShip(2, 1.27, 103.85);
+    expect((await (await GET()).json()).total_ships).toBe(2);
+  });
+
+  it('lets the browser and any CDN reuse the response', async () => {
+    const res = await GET();
+    const cc = res.headers.get('cache-control') ?? '';
+
+    expect(cc).toContain('s-maxage=5');
+    expect(cc).toContain('max-age=5');
+    expect(cc).not.toContain('no-store');
+    expect(res.headers.get('content-type')).toContain('application/json');
+  });
+});

--- a/src/app/api/maritime/route.ts
+++ b/src/app/api/maritime/route.ts
@@ -215,12 +215,27 @@ async function fetchVesselApiFallback() {
   // Mock data removed per user request. We only rely on real live stream data.
 }
 
-export async function GET() {
-  // Trigger Hybrid Fallback
-  await fetchVesselApiFallback();
+/* ── Response snapshot cache ──────────────────────────────────────────────
+   The AIS websocket writes into shipsCache continuously, so a GET is pure
+   aggregation over whatever that map happens to hold. Rebuilding it per
+   request is what pins the CPU once the maritime layer gets popular: 58 ports
+   and 10 chokepoints scanned against up to 20,000 ships is ~1.4M distance
+   calculations, and the reply then serialises every one of those ships — a
+   multi-megabyte JSON.stringify. At ~30 req/s that whole job runs thirty
+   times a second to produce a byte-identical answer.
 
+   Building it once per SNAPSHOT_TTL_MS and handing every caller the same
+   pre-serialised string makes the cost independent of how many people are
+   watching. The window sits well under the 10s the client polls at, so
+   nothing reaches the map staler than it already was. */
+const SNAPSHOT_TTL_MS = 5_000;
+
+const globalForSnapshot = globalThis as unknown as {
+  maritimeSnapshot?: { body: string; builtAt: number };
+};
+
+function buildSnapshot(now: number): string {
   // Clean up stale ships (older than 10 minutes)
-  const now = Date.now();
   for (const [mmsi, ship] of shipsCache.entries()) {
     if (now - ship.timestamp > 10 * 60 * 1000) {
       shipsCache.delete(mmsi);
@@ -290,18 +305,43 @@ export async function GET() {
     };
   });
 
-  return NextResponse.json({
+  return JSON.stringify({
     ports: dynamicPorts,
     chokepoints: dynamicChokepoints,
     ships: ships,
     total_ports: dynamicPorts.length,
     total_chokepoints: dynamicChokepoints.length,
     total_ships: ships.length,
-    timestamp: new Date().toISOString(),
-  }, {
-    headers: { 
-      'Cache-Control': 'no-store, no-cache, must-revalidate',
-      'Pragma': 'no-cache'
+    timestamp: new Date(now).toISOString(),
+  });
+}
+
+/** Test seam — forces the next GET to rebuild. */
+export function clearMaritimeSnapshot(): void {
+  delete globalForSnapshot.maritimeSnapshot;
+}
+
+export async function GET() {
+  // Trigger Hybrid Fallback
+  await fetchVesselApiFallback();
+
+  const now = Date.now();
+  const cached = globalForSnapshot.maritimeSnapshot;
+
+  const snapshot = cached && now - cached.builtAt < SNAPSHOT_TTL_MS
+    ? cached
+    : { body: buildSnapshot(now), builtAt: now };
+  globalForSnapshot.maritimeSnapshot = snapshot;
+
+  const maxAgeSeconds = Math.floor(SNAPSHOT_TTL_MS / 1000);
+
+  return new NextResponse(snapshot.body, {
+    headers: {
+      'Content-Type': 'application/json',
+      // The server would not have produced anything newer inside this window
+      // either, so let the browser and any CDN in front of it skip the round
+      // trip entirely rather than re-asking every 10s per open tab.
+      'Cache-Control': `public, max-age=${maxAgeSeconds}, s-maxage=${maxAgeSeconds}, stale-while-revalidate=15`,
     },
   });
 }


### PR DESCRIPTION
## The problem

`/api/maritime` took **108,410 requests in the last hour** (~30 req/s) and the container is sitting at ~145% CPU. The endpoint was doing its full aggregation on *every* GET:

- 58 ports × the whole AIS ship map, plus 10 chokepoints × the same — ~1.4M distance calculations with a warm 20k-ship cache
- then a `JSON.stringify` of every ship in it — a ~4 MB payload
- and `Cache-Control: no-store`, so no browser or CDN could reuse any of it

The client polls this every 10s per open tab (`src/app/page.tsx:738`), and `/api/markets` self-fetches the route as well, so the same job ran ~30 times a second to produce a byte-identical answer.

Measured on a 20,000-ship cache:

| | before | after |
|---|---|---|
| GET | 68.2 ms | 1.5 ms |
| CPU at 30 req/s | ~204% of one core | ~1.4% |

## The fix

Build the payload at most once every 5s and hand every caller the same pre-serialised string. The cost stops scaling with the number of viewers.

The 5s window sits under the 10s client poll, so nothing reaches the map staler than it already was — and the ship data itself arrives on a websocket that was already writing into a shared cache, so no upstream behaviour changes.

`no-store` is replaced with `public, max-age=5, s-maxage=5, stale-while-revalidate=15`, which lets an edge coalesce a thousand pollers into one origin hit.

## Verification

- 4 new tests in `src/app/api/maritime/route.test.ts` cover the aggregation still counting ships correctly, callers inside the TTL sharing one snapshot, the rebuild after the TTL, and the cache headers
- full suite: 683 passed, `tsc --noEmit` clean, `next build` clean
- no new lint findings (the 5 in this file are pre-existing and untouched)

## Not in scope

The 4 MB payload itself is untouched — serialisation now happens once per 5s, but the bytes still go out on every request. Trimming it (rounding coordinates, or viewport-bounding the ship list) is the obvious follow-up if bandwidth becomes the next ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
