### PR TITLE
fix(cctv): stop the Dutch cameras landing on the map twice

### DIFF
--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -377,13 +377,11 @@ async function fetchEuropeCameras(): Promise<any[]> {
   const cams: any[] = [];
 
   /* The Netherlands used to be fetched here from opendata.ndw.nu/cameras.json.
-     NDW retired that dataset and it 404s; ./netherlands now serves the country
-     from the Rijkswaterstaat feed, which is still published. */
-  try {
-    cams.push(...await fetchNetherlandsCameras());
-  } catch (e) {
-    console.warn('[OSIRIS] Netherlands cameras failed — absent from this refresh:', e instanceof Error ? e.message : e);
-  }
+     NDW retired that dataset, ./netherlands took the country over from the
+     Rijkswaterstaat feed, and it is registered under its own region key — so
+     fetching it here as well handed every Dutch camera to the response twice.
+     It is reached through 'netherlands', in RAW_REGION_FETCHERS below and in
+     getRegionsForBounds. */
 
   cams.push(...await fetchAsfinagCameras());
 
@@ -603,6 +601,11 @@ function getRegionsForBounds(lat: number, lng: number, radius: number): string[]
   const inPoland = lat > 49.0 && lat < 55.0 && lng > 14.1 && lng < 24.1;
   const inFinland = lat > 59.5 && lat < 70.1 && lng > 20 && lng < 31.6;
   const inIceland = lat > 63.0 && lat < 67.0 && lng > -25.0 && lng < -13.0;
+  /* Rijkswaterstaat. Explicit, like Utah and Oregon are: the broad europe box
+     covers these latitudes but no longer carries the Dutch feed, so without
+     this a viewport over the Netherlands would answer with no Dutch cameras
+     at all. Same box netherlands.ts filters the feed on. */
+  const inNetherlands = lat > 50.7 && lat < 53.7 && lng > 3.3 && lng < 7.3;
   const inBalkans = inBulgaria || inGreece || inSerbia || inMacedonia || inRomania || inTurkey;
   const inWesternEurope = inItaly || inCzechia || inSlovakia || inGermany || inFrance || inSpain || inPoland || inFinland || inIceland;
 
@@ -624,6 +627,7 @@ function getRegionsForBounds(lat: number, lng: number, radius: number): string[]
   if (inPoland) regions.push('poland');
   if (inFinland) regions.push('finland');
   if (inIceland) regions.push('iceland');
+  if (inNetherlands) regions.push('netherlands');
 
   // Middle East
   const inMiddleEast = lat > 29 && lat < 34.5 && lng > 34 && lng < 36.5;
@@ -695,9 +699,19 @@ export async function GET(request: Request) {
     const allCameras: any[] = [];
     const sources: Record<string, number> = {};
 
+    /* Regions overlap by design — a bounding box can name both 'europe' and a
+       country inside it — so the same camera can arrive from two fetchers. It
+       is one camera either way, and shipping it twice draws two pins on one
+       spot and inflates every count in `sources`. */
+    const seen = new Set<string>();
+
     for (const result of results) {
       if (result.status === 'fulfilled') {
         for (const cam of result.value) {
+          if (cam.id) {
+            if (seen.has(cam.id)) continue;
+            seen.add(cam.id);
+          }
           allCameras.push(cam);
           sources[cam.source] = (sources[cam.source] || 0) + 1;
         }


### PR DESCRIPTION
`netherlands.ts` is reached two ways: as its own key in `RAW_REGION_FETCHERS`, and through `fetchEuropeCameras`, which calls `fetchNetherlandsCameras()` directly. `GET` concatenates whatever the regions return without deduplicating, so every Rijkswaterstaat camera is pushed twice — two pins on one spot, and `sources` reporting 52 cameras where there are 26.

## Measured

| | before | after |
|---|---|---|
| `?region=netherlands,europe` → `Rijkswaterstaat` | 52 | **26** |
| ...ids appearing twice | 26 | **0** |
| `?region=all` → cameras / unique ids | — | **35,004 / 35,004** |
| viewport at Harlingen → `Rijkswaterstaat` | 26 | **26** |
| viewport at Vienna → `Rijkswaterstaat` | none | **none** |

## Three parts, and the second is the one that is easy to miss

**The call comes out of `fetchEuropeCameras`.** The country has its own region key; fetching it inside Europe as well was the duplication.

**`netherlands` gains a branch in `getRegionsForBounds`,** explicit the way Utah and Oregon already are. It was never in there — the broad `europe` box was carrying the Dutch feed for viewport queries. Removing the call alone would have left a viewport over the Netherlands answering with *no* Dutch cameras at all, trading a visible bug for a silent one. The box is the one `netherlands.ts` already filters the feed on.

**`GET` deduplicates on `id`.** Regions overlap by design — a bounding box can name both `europe` and a country inside it — so this is a property of the merge rather than of any one source, and it keeps the next source that gets registered twice from doing the same thing. Cameras without an `id` are passed through untouched; several of the inline fetchers are typed `any[]`.

## Verifying

```
npm test        # 548 passed
npx tsc --noEmit
curl 'localhost:3000/api/cctv?region=netherlands,europe' | jq '.sources.Rijkswaterstaat'
curl 'localhost:3000/api/cctv?region=all' | jq '[.total, ([.cameras[].id] | unique | length)]'
```

`npm run lint` runs out of heap on this repo on `master` too, so it is not usable as a gate here. `eslint src/app/api/cctv/route.ts` reports the same 29 pre-existing findings before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
