### PR TITLE
feat(map): lightweight 3D terrain and smoother camera controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Next.js
 /.next/
 /out/
+/public/vendor/maplibre/
 
 # Production
 /build

--- a/docs/terrain-local-review.md
+++ b/docs/terrain-local-review.md
@@ -1,0 +1,75 @@
+# Lightweight terrain: local review
+
+Terrain is in **Display**, beside **3D Buildings**, on both desktop and mobile.
+Enable **3D Terrain**, then use **Zoom to terrain** to inspect the current area.
+Enabling/disabling terrain itself preserves the selected zoom, center, and tilt;
+the separate zoom button is optional and is never replayed after a map remount.
+The existing bottom view strip still selects globe/flat and map/satellite imagery.
+
+## Runtime limits
+
+- One MapLibre renderer and one canvas; no additional 3D engine.
+- No elevation downloads at startup or overview zooms. Activation starts at zoom 10 after 500 ms without camera movement; zooming below 9.5 releases terrain resources.
+- The globe transitions to a local projection between zoom 7 and 9, before elevation can activate. Mountains still use actual elevation. This avoids compiling both globe-terrain and local-terrain shader variants. See the [supported projection expression](https://maplibre.org/maplibre-style-spec/projection/).
+- Elevation: 256 px Terrarium tiles, maximum source zoom 10, bounded render-tile LOD, real-height exaggeration of 1.
+- Two simultaneous elevation requests, 12-second request deadline, shared in-flight work, cancellable requests, and an 8 MiB encoded-tile LRU. Browser HTTP caching is also used. GPU resources are not persisted across page reloads.
+- Camera pitch is limited to 60 degrees in every view, so enabling terrain never has to flatten an existing camera. Terrain caps pixel ratio at 1.5 and restores the previous pixel ratio when disabled.
+- Buildings reuse the existing CARTO building source and appear from zoom 14.5. Enabling them alone does not download elevation.
+- Satellite GPU programs are cached per projection variant; inactive satellite layers compile no programs. Picking and orbit programs are created only when needed.
+
+## Regression checks
+
+```powershell
+npm test
+npm run build
+
+# Run against an already-running production preview, not the dev server.
+$env:PREVIEW_URL='http://127.0.0.1:3001'
+$env:SMOKE_SCENARIO='terrain'
+node tools/preview-smoke.mjs
+```
+
+Other scenarios: `startup`, `zoom`, `terrain-camera`, `mobile`, `recovery`, `imagery`, `buildings`, `satellites`.
+`CHROME_PATH` selects a Chromium browser; the default is the installed Windows Chrome.
+`PROFILE_TERRAIN=1` captures a CPU profile in the test's temporary output folder.
+Each test uses an isolated headless profile, never the user's browser profile.
+Imagery/building/camera tests substitute only localhost geolocation responses; the satellite
+test substitutes a 200-object localhost feed. Map tiles and elevation remain real.
+
+The automated checks cover rapid zoom taps, source/canvas reuse, terrain gating,
+same-area cache reuse, mobile overflow, view switching, and failure/retry behavior.
+Screenshots and JSON reports are saved in the temporary profile directory printed by the test.
+
+## Review limits
+
+Latest local validation (2026-09-08): Next.js 16.3.4 production build and TypeScript
+checks pass after rebasing onto current master; 603 tests pass, with 14
+opt-in/live-network tests skipped. Camera
+regressions confirm unchanged zoom, pitch, bearing, and center when terrain is
+enabled at zoom 8 and 13, disabled, or enabled from flat mode. Same-area terrain
+re-enable reused all elevation data (22 requests before and after), reaching ready
+in 930 ms in the final isolated run. This is a one-machine observation, not a
+latency guarantee. The initial zoom/scale readout now reflects the loaded camera;
+three rapid taps correctly advance 6.5 to 9.5. Theme remounts do not replay an
+earlier explicit terrain-zoom request. Mobile layout, real Alpine imagery, and
+Edge startup failure/retry checks also pass.
+
+Production dependency hardening updates Next.js / eslint-config-next to 16.3.4
+and sharp to 0.35.4, with patched PostCSS, nanoid, and baseline-browser-mapping
+in the lockfile.
+`npm audit --omit=dev` reports zero known vulnerabilities. The full audit still
+reports 8 development-tool findings (3 moderate, 4 high, 1 critical), including
+the old Vitest/Vite toolchain. Do not expose its test UI/dev server; upgrading
+that toolchain and clearing the repository's lint debt remain separate work.
+
+This is a local release candidate, not a whole-site production certification.
+Physical iOS/Safari and low-end Android devices still need hands-on testing.
+WebGL2 is required by MapLibre 6. Cold graphics initialization can still produce
+a short hitch; headless timing is diagnostic, not a promised frame rate.
+
+The repository has pre-existing lint debt. External data feeds are independently
+fallible: CCTV catalog retries preserve successful regions, but cannot make an
+offline provider or camera available. Existing provider configuration/rate limits,
+and intermittent market-feed CORS failures, are separate from terrain rendering.
+
+The local preview does not deploy or merge changes; release through a reviewed PR.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  turbopack: {
+    rules: {
+      'maplibre-gl.mjs': {
+        loaders: [`${__dirname}/tools/maplibre-url-loader.cjs`],
+        as: '*.js',
+      },
+    },
+  },
   output: 'standalone',
   serverExternalPackages: ['ws'],
   transpilePackages: ['react-map-gl', 'mapbox-gl', 'maplibre-gl'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,15 @@
         "hls.js": "^1.6.16",
         "lightweight-charts": "^5.2.0",
         "lucide-react": "^1.14.0",
-        "maplibre-gl": "^5.24.0",
-        "next": "16.2.6",
+        "maplibre-gl": "6.7.0",
+        "next": "16.3.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-force-graph-2d": "^1.29.1",
         "react-map-gl": "^8.1.1",
         "rss-parser": "^3.13.0",
         "satellite.js": "^7.0.0",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.4",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -35,7 +35,7 @@
         "@types/web-bluetooth": "^0.0.21",
         "@types/ws": "^8.18.1",
         "eslint": "^9",
-        "eslint-config-next": "16.2.6",
+        "eslint-config-next": "16.3.4",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^2.1.9"
@@ -308,9 +308,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -948,9 +948,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -960,19 +960,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -982,19 +982,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -1008,9 +1027,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -1024,9 +1043,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -1040,9 +1059,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -1056,9 +1075,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -1072,9 +1091,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1088,9 +1107,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -1104,9 +1123,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -1120,9 +1139,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -1136,9 +1155,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -1152,9 +1171,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -1164,19 +1183,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -1186,19 +1205,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1208,19 +1227,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -1230,19 +1249,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -1252,19 +1271,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -1274,19 +1293,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -1296,19 +1315,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -1318,38 +1337,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -1359,16 +1394,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -1378,16 +1413,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -1397,7 +1432,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1454,11 +1489,12 @@
       }
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 22"
       }
     },
     "node_modules/@mapbox/point-geometry": {
@@ -1480,42 +1516,33 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
-      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
         "@types/geojson": "^7946.0.16",
-        "pbf": "^4.0.1"
-      }
-    },
-    "node_modules/@mapbox/whoots-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
-      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=6.0.0"
+        "pbf": "^5.0.0"
       }
     },
     "node_modules/@maplibre/geojson-vt": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
-      "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
       "license": "ISC",
       "dependencies": {
-        "kdbush": "^4.0.2"
+        "kdbush": "^4.1.0"
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "24.8.5",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.5.tgz",
-      "integrity": "sha512-EzEJmMt6thioRH7GI9LWS7ahXTcAhAPGWCe6oTP2Ps4YnsXOOAfeqx854lZaiDnwURfHmcCKV1mr6oo0i23x6w==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.1.tgz",
+      "integrity": "sha512-I/qcIKVFHFSg1Meu/eqHrkSTjIez0gCsSaK56TNPutM3TkE61aSq6F1cZ4Kg4KiNs3cpViLtubDjfyRcQCdEJQ==",
       "license": "ISC",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
         "quickselect": "^3.0.0",
@@ -1527,35 +1554,31 @@
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
     },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@maplibre/mlt": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.9.tgz",
-      "integrity": "sha512-g/tD8EYJB97udq33ipuJ9a4Q7fcbZnTEnUrgnEc/tLMmEL+zaCbR+X5fkDBO2dgpaAMsLH179qE3UXg2N0Nc/g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.2.1.tgz",
+      "integrity": "sha512-5n5dgolE2EYxwCKgx8vlwURCB8A+kyfJJyThlYimjlGgOcOe2Bhw9VxxnnHC91OC9PgHg+nVdgVPTYPkIo62vg==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0"
       }
     },
     "node_modules/@maplibre/vt-pbf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
-      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
       "license": "MIT",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@maplibre/geojson-vt": "^5.0.4",
         "@types/geojson": "^7946.0.16",
-        "@types/supercluster": "^7.1.3",
-        "pbf": "^4.0.1",
-        "supercluster": "^8.0.1"
+        "pbf": "^5.1.0"
       }
-    },
-    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
-      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
-      "license": "ISC"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -1571,25 +1594,26 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
-      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.4.tgz",
+      "integrity": "sha512-cjWZnUUa6jZq2kFaNe/ZyJdZonOZ/QoN0Zka2nz/FLOrfx14pQuM9c5RaSVkWMqgdt4ksgPAMWPyHSs/CyV48Q==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.6.tgz",
-      "integrity": "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.3.4.tgz",
+      "integrity": "sha512-szW9y2Aumu4z88YXfTzcFsgUAg2k64uzbtcO5L9f1AKS4w/GUKJcbFllRflROVyNPgJtGOnvNxiyp3v6b+prIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@eslint-community/eslint-utils": "4.9.1",
         "fast-glob": "3.3.1"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
-      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.4.tgz",
+      "integrity": "sha512-iBr3I5LZNk5/bgl5//iTgD2tcym14MX0Xo7fD//u9dYAEgGzza1y9oywluPtf74YnOswVdH1908aK9xVz7zQTw==",
       "cpu": [
         "arm64"
       ],
@@ -1603,9 +1627,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
-      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.4.tgz",
+      "integrity": "sha512-2dpiSyl2Jw/NrBPaU2MAKGSa+2MR82pJIn4Sm5Rjr+gxAeuh0z158Su3Z2O8zn7UNNq+ej4bToed6RcRN/Lydg==",
       "cpu": [
         "x64"
       ],
@@ -1619,9 +1643,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
-      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.4.tgz",
+      "integrity": "sha512-+t+U8HZT+fApePCS5h89CSH3datz29MkzyfCn+6fpsZBG/oiEOhINcb9rtkv6sdpToLGFn2e6146NzaKCXkqrA==",
       "cpu": [
         "arm64"
       ],
@@ -1635,9 +1659,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
-      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.4.tgz",
+      "integrity": "sha512-mx03GNs1ocQA5JQ4FxDMmIsNkdrZh8cuezKCrId28e5/gIPU/l7Kcy2+vmCCzdjnnmXJy+iOAu+7K0QppO6Urg==",
       "cpu": [
         "arm64"
       ],
@@ -1651,9 +1675,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
-      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.4.tgz",
+      "integrity": "sha512-YIhGY6fSMfha52bnVxnzc9zaVBzJg+cqQTOD8tXIBSx4fuv0pVMxQTE0PaS59YhnMOiYiG09IMwxJAf/CFm/Dw==",
       "cpu": [
         "x64"
       ],
@@ -1667,9 +1691,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
-      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.4.tgz",
+      "integrity": "sha512-+eaaX6axpDb0yF1GCpiERe6njplvdC+nks/fKfcHu3XPGRrald8P3/X7yv7QLdjA51knnxwl9pxdIJsg+w1L+Q==",
       "cpu": [
         "x64"
       ],
@@ -1683,9 +1707,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
-      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.4.tgz",
+      "integrity": "sha512-0jcXW7Xs/uzICrmgV3MhDYDeRy++1CqnpDIerlPIqYO4bhzB4WNbX/aRnQclustsAyTkFKB0z6rbcjmNg5tR8A==",
       "cpu": [
         "arm64"
       ],
@@ -1699,9 +1723,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
-      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.4.tgz",
+      "integrity": "sha512-vvBzwu1pYQCp92maZCFCIw/XgOTMR5tur9GjakwIo2cmwRTMKajRZZDS9+e4KsUZWKu1E007WUeAFXRRjZeuzw==",
       "cpu": [
         "x64"
       ],
@@ -2120,9 +2144,9 @@
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -2479,15 +2503,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/supercluster": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
-      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
       }
     },
     "node_modules/@types/web-bluetooth": {
@@ -3619,9 +3634,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4313,9 +4328,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
       "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
@@ -4663,13 +4678,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.6.tgz",
-      "integrity": "sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.3.4.tgz",
+      "integrity": "sha512-35/8RM10huEL9vlr8hUZMERMENHBrnyHN3ZZkF9efSgzGaqK34jIqry44A956//zriUhUAUW0XSkcolhrryqAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.6",
+        "@next/eslint-plugin-next": "16.3.4",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -5099,9 +5114,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6282,9 +6297,9 @@
       }
     },
     "node_modules/kdbush": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
       "license": "ISC"
     },
     "node_modules/keyv": {
@@ -6679,28 +6694,25 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
-      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.7.0.tgz",
+      "integrity": "sha512-Y1Q1+UP9WXou0DUrnaFdDsoMqiMCWy6aS968IBUaQ2eZi6H1/kPCfpfZOWXFJZbeKMkX9Wo6OFzY/k48qqPf3Q==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.1.0",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/geojson-vt": "^6.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
-        "@maplibre/mlt": "^1.1.8",
-        "@maplibre/vt-pbf": "^4.3.0",
+        "@mapbox/tiny-sdf": "^2.2.0",
+        "@mapbox/unitbezier": "^1.0.0",
+        "@mapbox/vector-tile": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^26.4.1",
+        "@maplibre/mlt": "^1.2.0",
+        "@maplibre/vt-pbf": "^4.3.2",
         "@types/geojson": "^7946.0.16",
-        "earcut": "^3.0.2",
+        "earcut": "^3.2.3",
         "gl-matrix": "^3.4.4",
-        "kdbush": "^4.0.2",
+        "kdbush": "^4.1.0",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^4.0.1",
+        "pbf": "^5.1.2",
         "potpack": "^2.1.0",
         "quickselect": "^3.0.0",
         "tinyqueue": "^3.0.0"
@@ -6712,6 +6724,12 @@
       "funding": {
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
+    },
+    "node_modules/maplibre-gl/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -6798,9 +6816,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -6839,17 +6857,17 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
-      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.4.tgz",
+      "integrity": "sha512-/Ztf6CeRH+ejEXUrYtqI4gkS66eFIHuSwqi60RgcpWKodxFZx2/dqVCMKBwILfAHXQ+F1b1vAudgj3mnxqtoIA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@next/env": "16.2.6",
-        "@swc/helpers": "0.5.15",
+        "@next/env": "16.3.4",
+        "@swc/helpers": "0.5.23",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.23",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -6859,15 +6877,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.6",
-        "@next/swc-darwin-x64": "16.2.6",
-        "@next/swc-linux-arm64-gnu": "16.2.6",
-        "@next/swc-linux-arm64-musl": "16.2.6",
-        "@next/swc-linux-x64-gnu": "16.2.6",
-        "@next/swc-linux-x64-musl": "16.2.6",
-        "@next/swc-win32-arm64-msvc": "16.2.6",
-        "@next/swc-win32-x64-msvc": "16.2.6",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "16.3.4",
+        "@next/swc-darwin-x64": "16.3.4",
+        "@next/swc-linux-arm64-gnu": "16.3.4",
+        "@next/swc-linux-arm64-musl": "16.3.4",
+        "@next/swc-linux-x64-gnu": "16.3.4",
+        "@next/swc-linux-x64-musl": "16.3.4",
+        "@next/swc-win32-arm64-msvc": "16.3.4",
+        "@next/swc-win32-x64-msvc": "16.3.4",
+        "sharp": "^0.35.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -6890,34 +6908,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-exports-info": {
@@ -7197,9 +7187,9 @@
       }
     },
     "node_modules/pbf": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
-      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"
@@ -7238,10 +7228,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "dev": true,
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7258,7 +7247,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7775,53 +7764,58 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8209,15 +8203,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/supercluster": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
-      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^4.0.2"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "node tools/prepare-map-worker.mjs",
     "dev": "next dev",
+    "prebuild": "node tools/prepare-map-worker.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
@@ -19,15 +21,15 @@
     "hls.js": "^1.6.16",
     "lightweight-charts": "^5.2.0",
     "lucide-react": "^1.14.0",
-    "maplibre-gl": "^5.24.0",
-    "next": "16.2.6",
+    "maplibre-gl": "6.7.0",
+    "next": "16.3.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-force-graph-2d": "^1.29.1",
     "react-map-gl": "^8.1.1",
     "rss-parser": "^3.13.0",
     "satellite.js": "^7.0.0",
-    "sharp": "^0.34.5",
+    "sharp": "^0.35.4",
     "ws": "^8.21.0"
   },
   "devDependencies": {
@@ -39,7 +41,7 @@
     "@types/web-bluetooth": "^0.0.21",
     "@types/ws": "^8.18.1",
     "eslint": "^9",
-    "eslint-config-next": "16.2.6",
+    "eslint-config-next": "16.3.4",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^2.1.9"

--- a/public/dark-matter-style.json
+++ b/public/dark-matter-style.json
@@ -1,15 +1,24 @@
 {
   "version": 8,
   "name": "Dark Matter",
+  "projection": { "type": ["interpolate", ["linear"], ["zoom"], 7, "vertical-perspective", 9, "mercator"] },
   "metadata": { "maputnik:renderer": "mbgljs" },
   "sources": {
     "carto": {
       "type": "vector",
-      "url": "/cartocdn-tiles/vector/carto.streets/v1/tiles.json"
+      "tiles": [
+        "https://tiles-a.basemaps.cartocdn.com/vectortiles/carto.streets/v1/{z}/{x}/{y}.mvt",
+        "https://tiles-b.basemaps.cartocdn.com/vectortiles/carto.streets/v1/{z}/{x}/{y}.mvt",
+        "https://tiles-c.basemaps.cartocdn.com/vectortiles/carto.streets/v1/{z}/{x}/{y}.mvt",
+        "https://tiles-d.basemaps.cartocdn.com/vectortiles/carto.streets/v1/{z}/{x}/{y}.mvt"
+      ],
+      "minzoom": 0,
+      "maxzoom": 14,
+      "attribution": "© CARTO, © OpenStreetMap contributors"
     }
   },
-  "sprite": "/cartocdn-tiles/gl/dark-matter-gl-style/sprite",
-  "glyphs": "/cartocdn-tiles/fonts/{fontstack}/{range}.pbf",
+  "sprite": "https://tiles.basemaps.cartocdn.com/gl/dark-matter-gl-style/sprite",
+  "glyphs": "https://tiles.basemaps.cartocdn.com/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",

--- a/src/app/api/cctv/route.test.ts
+++ b/src/app/api/cctv/route.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from './route';
+import { stealthFetch } from '@/lib/stealthFetch';
+import { clearSourceCache } from '@/lib/sourceCache';
+
+vi.mock('@/lib/stealthFetch', () => ({ stealthFetch: vi.fn(), stealthHeaders: vi.fn(() => ({})) }));
+beforeEach(() => { vi.useFakeTimers(); vi.resetAllMocks(); clearSourceCache(); });
+afterEach(() => vi.useRealTimers());
+
+describe('CCTV partial responses', () => {
+  it('returns a completed region without scheduling unnecessary retries', async () => {
+    vi.mocked(stealthFetch).mockResolvedValue(Response.json([
+      { id: 'JamCams_1', lat: 51.5, lon: -0.1, commonName: 'London' },
+    ]));
+    const response = await GET(new Request('http://localhost/api/cctv?region=uk'));
+    const body = await response.json();
+    expect(body.total).toBe(1);
+    expect(body.pendingRegions).toEqual([]);
+  });
+
+  it('marks slow regions as pending instead of silently treating them as complete', async () => {
+    vi.mocked(stealthFetch).mockReturnValue(new Promise(() => {}));
+    const pending = GET(new Request('http://localhost/api/cctv?region=uk'));
+    await vi.advanceTimersByTimeAsync(12_000);
+    const response = await pending;
+    expect((await response.json()).pendingRegions).toEqual(['uk']);
+    expect(response.headers.get('Cache-Control')).toContain('no-store');
+  });
+
+  it('allows a bounded retry for an empty/failed provider response', async () => {
+    vi.mocked(stealthFetch).mockResolvedValue(new Response('', { status: 503 }));
+    const response = await GET(new Request('http://localhost/api/cctv?region=uk'));
+    expect((await response.json()).pendingRegions).toEqual(['uk']);
+  });
+});

--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -542,14 +542,14 @@ const REGION_FETCHERS: Record<string, RegionFetcher> = Object.fromEntries(
  */
 const REGION_BUDGET_MS = 12_000;
 
-function withBudget(region: string, fetcher: RegionFetcher): ReturnType<RegionFetcher> {
+function withBudget(region: string, fetcher: RegionFetcher): Promise<{ cameras: Awaited<ReturnType<RegionFetcher>>; pending: boolean }> {
   let timer: ReturnType<typeof setTimeout>;
   return Promise.race([
-    fetcher().finally(() => clearTimeout(timer)),
-    new Promise<Awaited<ReturnType<RegionFetcher>>>(resolve => {
+    fetcher().then(cameras => ({ cameras, pending: cameras.length === 0 })).finally(() => clearTimeout(timer)),
+    new Promise<{ cameras: Awaited<ReturnType<RegionFetcher>>; pending: boolean }>(resolve => {
       timer = setTimeout(() => {
         console.warn(`[OSIRIS] cctv:${region} over ${REGION_BUDGET_MS}ms — returning without it`);
-        resolve([]);
+        resolve({ cameras: [], pending: true });
       }, REGION_BUDGET_MS);
     }),
   ]);
@@ -694,17 +694,19 @@ export async function GET(request: Request) {
 
     const allCameras: any[] = [];
     const sources: Record<string, number> = {};
+    const pendingRegions: string[] = [];
 
-    for (const result of results) {
+    for (const [index, result] of results.entries()) {
+      if (result.status === 'rejected' || result.value.pending) pendingRegions.push(regionsToFetch[index]);
       if (result.status === 'fulfilled') {
-        for (const cam of result.value) {
+        for (const cam of result.value.cameras) {
           allCameras.push(cam);
           sources[cam.source] = (sources[cam.source] || 0) + 1;
         }
       }
     }
 
-    const cacheControl = allCameras.length < 50 
+    const cacheControl = pendingRegions.length > 0 || allCameras.length < 50
       ? 'no-store, max-age=0' 
       : 'public, s-maxage=300, stale-while-revalidate=600';
 
@@ -713,6 +715,7 @@ export async function GET(request: Request) {
       total: allCameras.length,
       sources,
       regions: regionsToFetch,
+      pendingRegions,
       timestamp: new Date().toISOString(),
     }, {
       headers: { 'Cache-Control': cacheControl },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Layers, BarChart3, Newspaper, Search, X, Globe, MapPinned, Route, Radar, Satellite, Moon, ExternalLink, AlertTriangle, Activity, Database, Wifi, Play, Network, Crosshair, Bluetooth, Pentagon, Radio , PenLine } from 'lucide-react';
+import { type TerrainStatus } from '@/lib/map-terrain';
+import { loadCameraCatalog, mergeCameraCatalog } from '@/lib/camera-catalog';
 import IntelFeed from '@/components/IntelFeed';
 import MarketsPanel from '@/components/MarketsPanel';
 import ScmPanel from '@/components/ScmPanel';
@@ -109,8 +111,10 @@ function ViewSegment({ active, onClick, title, icon: Icon, label, layoutId }: {
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       title={title}
+      aria-label={title}
       aria-pressed={active}
       className={`relative flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[10px] font-mono font-medium tracking-[0.18em] transition-colors duration-200 ${
         active ? 'text-[var(--gold-light)]' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
@@ -144,6 +148,8 @@ export default function Dashboard() {
   const [regionDossier, setRegionDossier] = useState<any>(null);
   const [dossierLoading, setDossierLoading] = useState(false);
   const [showSplash, setShowSplash] = useState(true);
+  const autoLocateCancelled = useRef(false);
+  const [mapRetry, setMapRetry] = useState(0);
   const [activeCamera, setActiveCamera] = useState<any>(null);
   const [spaceWeather, setSpaceWeather] = useState<any>(null);
   const [showLayers, setShowLayers] = useState(true);
@@ -255,6 +261,9 @@ export default function Dashboard() {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [mobilePanel, setMobilePanel] = useState<'layers'|'markets'|'intel'|'search'|'recon'|'remote'|null>(null);
   const [mapProjection, setMapProjection] = useState<'globe'|'mercator'>('globe');
+  const [terrainFocus, setTerrainFocus] = useState(0);
+  const [terrainStatus, setTerrainStatus] = useState<TerrainStatus>('idle');
+  const [terrainRetry, setTerrainRetry] = useState(0);
   const [mapStyle, setMapStyle] = useState<'dark'|'satellite'>('dark');
   const [sweepData, setSweepData] = useState<any>(null);
   const [scanTargets, setScanTargets] = useState<any[]>([]);
@@ -310,6 +319,7 @@ export default function Dashboard() {
     sdk_air: true,
     sdk_naval: true,
     terrain_3d: false,
+    terrain_elevation: false,
     malware: false,
     cyber_attacks: false,
     gdelt_events: false,
@@ -317,6 +327,16 @@ export default function Dashboard() {
     cf_attacks: false,
   });
   // Server-side capability flags — gate layers that need credentials.
+  const selectFlatMap = () => {
+    setActiveLayers(prev => ({ ...prev, terrain_elevation: false, terrain_3d: false }));
+    setMapProjection('mercator');
+  };
+  const terrainPanelProps = {
+    terrainStatus,
+    on3DModeSelected: () => setMapProjection('globe'),
+    onTerrainRetry: () => setTerrainRetry(value => value + 1),
+    onTerrainFocus: () => setTerrainFocus(value => value + 1),
+  };
   const [capabilities, setCapabilities] = useState<Record<string, boolean>>({});
   const [liveFeedUrl, setLiveFeedUrl] = useState<string | null>(null);
   const [liveFeedName, setLiveFeedName] = useState('');
@@ -351,20 +371,30 @@ export default function Dashboard() {
       .then(p => { if (p) setCapabilities(c => ({ ...c, cloudflare: !!p.configured })); })
       .catch(() => { /* leave the layer hidden */ });
 
-    // Delay geolocation until map is ready (after splash screen clears)
+    // Once the user interacts, a late IP-location response must not steal the
+    // camera back. The request is also cancelled when this page unmounts.
+    const geoController = new AbortController();
+    const cancelAutoLocate = () => { autoLocateCancelled.current = true; };
+    window.addEventListener('pointerdown', cancelAutoLocate, { once: true });
+    window.addEventListener('keydown', cancelAutoLocate, { once: true });
     const geoTimer = setTimeout(() => {
-      fetch('/api/geo')
+      if (autoLocateCancelled.current) return;
+      fetch('/api/geo', { signal: geoController.signal })
         .then(r => r.json())
         .then(geo => {
-          if (geo.status === 'success' && geo.lat && geo.lon) {
-            setFlyToLocation({ lat: geo.lat, lng: geo.lon, ts: Date.now() });
-            setMapView(v => ({ ...v, zoom: 12 }));
+          if (!autoLocateCancelled.current && !geoController.signal.aborted && geo.status === 'success' &&
+              Number.isFinite(geo.lat) && Number.isFinite(geo.lon) && Math.abs(geo.lat) <= 90 && Math.abs(geo.lon) <= 180) {
+            setFlyToLocation({ lat: geo.lat, lng: geo.lon, zoom: 8, ts: Date.now() });
           }
         })
         .catch(() => { /* silent — keep default global view */ });
     }, 3000);
 
-    return () => clearTimeout(geoTimer);
+    return () => {
+      clearTimeout(geoTimer); geoController.abort();
+      window.removeEventListener('pointerdown', cancelAutoLocate);
+      window.removeEventListener('keydown', cancelAutoLocate);
+    };
   }, []);
 
   // URL state: persist active layers only (lat/lon comes from IP geolocation on each load)
@@ -402,8 +432,11 @@ export default function Dashboard() {
       if (e.key === 'c') setShowScmPanel(p => !p);
       if (e.key === 'i') setShowIntel(p => !p);
       if (e.key === 's') { setShowDesktopSearch(p => !p); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); }
-      if (e.key === 'r') setFlyToLocation({ lat: 20, lng: 0, ts: Date.now() });
-      if (e.key === 'g') setMapProjection(p => p === 'globe' ? 'mercator' : 'globe');
+      if (e.key === 'r' && !e.ctrlKey && !e.metaKey) setFlyToLocation({ lat: 20, lng: 0, zoom: 2.5, ts: Date.now() });
+      if (e.key === 'g') {
+        setActiveLayers(prev => ({ ...prev, terrain_elevation: false, terrain_3d: false }));
+        setMapProjection(p => p === 'globe' ? 'mercator' : 'globe');
+      }
       if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
         e.preventDefault();
         setShowDesktopSearch(true); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false);
@@ -605,6 +638,18 @@ export default function Dashboard() {
   // ── LAYER-AWARE DATA LOADING — only fetch when layer is toggled ON ──
   const layerFetchedRef = useRef<Set<string>>(new Set());
   useEffect(() => {
+    if (!activeLayers.cctv) return;
+    return loadCameraCatalog(cameras => {
+      dataRef.current = {
+        ...dataRef.current,
+        cameras: mergeCameraCatalog(dataRef.current.cameras ?? [], cameras),
+      };
+      setDataVersion(value => value + 1);
+      setBackendStatus('connected');
+    }, () => console.warn('[OSIRIS] Camera catalogue load failed; bounded retry scheduled'));
+  }, [activeLayers.cctv]);
+
+  useEffect(() => {
 
     // Flights
     if (activeLayers.flights || activeLayers.military || activeLayers.jets || activeLayers.private) {
@@ -627,11 +672,6 @@ export default function Dashboard() {
     if (activeLayers.fires && !layerFetchedRef.current.has('fires')) {
       fetchEndpoint('/api/fires');
       layerFetchedRef.current.add('fires');
-    }
-    // CCTV
-    if (activeLayers.cctv && !layerFetchedRef.current.has('cctv')) {
-      fetchEndpoint(`/api/cctv?region=all&_t=${Date.now()}`);
-      layerFetchedRef.current.add('cctv');
     }
     // Maritime
     if (activeLayers.maritime && !layerFetchedRef.current.has('maritime')) {
@@ -1101,10 +1141,15 @@ export default function Dashboard() {
       {/* ── MAP ── */}
       <ErrorBoundary name="Map">
         <OsirisMap 
-          key={osirisTheme}
+          key={`${osirisTheme}-${mapRetry}`}
+          onRetryMap={() => setMapRetry(retry => retry + 1)}
           data={data} 
           activeLayers={activeLayers} 
-          projection={mapProjection} 
+          projection={mapProjection === 'mercator' ? 'mercator' : 'globe'}
+          terrainEnabled={activeLayers.terrain_elevation && mapProjection === 'globe'}
+          terrainFocus={terrainFocus}
+          terrainRetry={terrainRetry}
+          onTerrainStatusChange={setTerrainStatus}
           mapStyle={mapStyle === 'satellite' ? 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}' : 'dark'} 
           onEntityClick={handleEntityClick} 
           onMouseCoords={handleMouseCoords} 
@@ -1225,11 +1270,12 @@ export default function Dashboard() {
         {/* Unified Control Strip */}
         <div className="flex items-center gap-[3px] p-[3px] pointer-events-auto rounded-xl border border-[var(--border-primary)] bg-[var(--bg-panel)] backdrop-blur-2xl shadow-[0_8px_32px_rgba(0,0,0,0.55)]">
           <ViewSegment layoutId="view-projection" active={mapProjection === 'globe'} onClick={() => setMapProjection('globe')} title="3D Globe" icon={Globe} label="3D" />
-          <ViewSegment layoutId="view-projection" active={mapProjection === 'mercator'} onClick={() => setMapProjection('mercator')} title="2D Map" icon={MapPinned} label="2D" />
+          <ViewSegment layoutId="view-projection" active={mapProjection === 'mercator'} onClick={selectFlatMap} title="2D Map" icon={MapPinned} label="2D" />
           <div className="w-px h-5 mx-1 bg-[var(--border-secondary)]" />
           <ViewSegment layoutId="view-style" active={mapStyle === 'dark'} onClick={() => setMapStyle('dark')} title="Night Mode" icon={Moon} label="MAP" />
           <ViewSegment layoutId="view-style" active={mapStyle === 'satellite'} onClick={() => setMapStyle('satellite')} title="Satellite View" icon={Satellite} label="SAT" />
         </div>
+
 
         {/* Scale Bar */}
         {!isMobile && (
@@ -1307,7 +1353,7 @@ export default function Dashboard() {
 
 
       {/* ── NEW SIDEBAR (Root Level) ── */}
-      {showLayers && !isMobile && <LayerPanel data={data} activeLayers={activeLayers} setActiveLayers={setActiveLayers} theme={osirisTheme} setTheme={setOsirisTheme} capabilities={capabilities} />}
+      {showLayers && !isMobile && <LayerPanel {...terrainPanelProps} data={data} activeLayers={activeLayers} setActiveLayers={setActiveLayers} theme={osirisTheme} setTheme={setOsirisTheme} capabilities={capabilities} />}
 
 
 
@@ -1685,9 +1731,9 @@ export default function Dashboard() {
                           <div><div className="hud-label" style={{fontSize:'9px'}}>NUC</div><div className="hud-value text-[10px]" style={{color:'var(--accent-nuclear)'}}>{(data.infrastructure?.length||0)}</div></div>
                         </div>
                       </div>
-                      <LayerPanel data={data} activeLayers={activeLayers} setActiveLayers={setActiveLayers} isMobile={true} theme={osirisTheme} setTheme={setOsirisTheme} capabilities={capabilities} />
+                      <LayerPanel {...terrainPanelProps} data={data} activeLayers={activeLayers} setActiveLayers={setActiveLayers} isMobile={true} theme={osirisTheme} setTheme={setOsirisTheme} capabilities={capabilities} />
                       <div className="mt-8">
-                        <ViewPresets onNavigate={(lat, lng, zoom) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMapView(v => ({ ...v, zoom })); setMobilePanel(null); }} />
+                        <ViewPresets onNavigate={(lat, lng, zoom) => { setFlyToLocation({ lat, lng, zoom, ts: Date.now() }); setMobilePanel(null); }} />
                       </div>
                     </>
                   )}

--- a/src/components/LayerPanel.tsx
+++ b/src/components/LayerPanel.tsx
@@ -8,6 +8,7 @@ import {
   Flame, Tv, Radio, Mountain, Anchor, Megaphone, SlidersHorizontal
 } from 'lucide-react';
 import StyleStudio from './StyleStudio';
+import { TERRAIN_MIN_ZOOM, type TerrainStatus } from '@/lib/map-terrain';
 
 interface LayerPanelProps {
   data: any;
@@ -19,12 +20,17 @@ interface LayerPanelProps {
   /** Server-side capabilities, e.g. { cloudflare: true }. Layers declaring a
    *  `requires` key stay hidden until the matching capability is present. */
   capabilities?: Record<string, boolean>;
+  terrainStatus?: TerrainStatus;
+  onTerrainRetry?: () => void;
+  onTerrainFocus?: () => void;
+  on3DModeSelected?: () => void;
 }
 
 interface LayerDef {
   key: string;
   label: string;
   dataKey: string;
+  description?: string;
   /** Reads a bucket out of data.category_counts instead of a top-level array. */
   catKey?: string;
   /** Capability that must be configured server-side for this layer to appear. */
@@ -136,7 +142,8 @@ const LAYER_GROUPS: LayerGroupDef[] = [
     icon: Sun,
     layers: [
       { key: 'day_night', label: 'Day / Night Cycle', dataKey: '' },
-      { key: 'terrain_3d', label: '3D Terrain & Buildings', dataKey: '' },
+      { key: 'terrain_3d', label: '3D Buildings', description: 'City detail · zoom 14.5+', dataKey: '' },
+      { key: 'terrain_elevation', label: '3D Terrain', description: 'Mountains · zoom 10+', dataKey: '' },
     ],
   },
 ];
@@ -190,7 +197,7 @@ function SubLayerStem() {
   );
 }
 
-function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'core', setTheme, capabilities = {} }: LayerPanelProps) {
+function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'core', setTheme, capabilities = {}, terrainStatus = 'idle', onTerrainRetry, onTerrainFocus, on3DModeSelected }: LayerPanelProps) {
   const [hoveredGroup, setHoveredGroup] = useState<string | null>(null);
   /**
    * A pinned group stays open when the pointer leaves. Hover-only flyouts are
@@ -207,11 +214,24 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
     return () => window.removeEventListener('keydown', onKey);
   }, [pinnedGroup]);
 
-  const toggle = (key: string) => setActiveLayers((prev: any) => ({ ...prev, [key]: !prev[key] }));
+  const toggle = (key: string) => {
+    if ((key === 'terrain_elevation' || key === 'terrain_3d') && !activeLayers[key]) on3DModeSelected?.();
+    setActiveLayers((prev: any) => ({ ...prev, [key]: !prev[key] }));
+  };
+  const terrainDetails = activeLayers.terrain_elevation ? (
+    <div className="mt-2 rounded-lg border border-white/10 bg-white/[0.03] p-2.5 text-[10px] text-white/60">
+      <p role="status">{terrainStatus === 'idle' ? `Terrain at zoom ${TERRAIN_MIN_ZOOM}+ · zoom in` : terrainStatus === 'waiting' ? 'Terrain starts when you stop moving' : terrainStatus === 'loading' ? 'Loading nearby terrain…' : terrainStatus === 'error' ? 'Terrain unavailable; the map is still usable.' : 'Terrain on'}</p>
+      {terrainStatus === 'idle' && <button type="button" onClick={onTerrainFocus} className="mt-2 min-h-8 rounded border border-white/15 px-2 text-[var(--gold-primary)] hover:bg-white/10">Zoom to terrain</button>}
+      {terrainStatus === 'error' && <button type="button" onClick={onTerrainRetry} className="mt-2 min-h-8 rounded border border-white/15 px-2 text-[var(--gold-primary)] hover:bg-white/10">Retry terrain</button>}
+      <p className="mt-2 text-white/35">Nearby detail only · cached tiles</p>
+      <a className="mt-1 inline-block underline underline-offset-2" href="https://github.com/tilezen/joerd/blob/master/docs/attribution.md" target="_blank" rel="noopener noreferrer">Terrain credits</a>
+    </div>
+  ) : null;
 
   /** Switch a whole group at once — off if any are on, otherwise all on. */
   const toggleGroup = (layers: LayerDef[]) => {
     const anyOn = layers.some(l => activeLayers[l.key]);
+    if (!anyOn && layers.some(l => l.key === 'terrain_elevation' || l.key === 'terrain_3d')) on3DModeSelected?.();
     setActiveLayers((prev: any) => {
       const next = { ...prev };
       for (const l of layers) next[l.key] = !anyOn;
@@ -261,12 +281,14 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                     key={layer.key}
                     onClick={() => toggle(layer.key)}
                     aria-pressed={!!isLayerActive}
+                    aria-label={layer.label}
                     className={`relative w-full flex items-center gap-3 py-2 rounded-md text-left hover:bg-white/[0.04] transition-colors ${layer.parent ? 'pl-[22px] pr-1' : 'px-1'} ${dormant ? 'opacity-40' : ''}`}
                   >
                     {layer.parent && <SubLayerStem />}
                     <ToggleSwitch active={!!isLayerActive} />
                     <span className={`text-[11px] font-mono uppercase tracking-wider flex-1 transition-colors ${isLayerActive ? 'text-white/80' : 'text-white/40'}`}>
                       {layer.label}
+                      {layer.description && <span className="block mt-0.5 text-[9px] normal-case tracking-normal text-white/35">{layer.description}</span>}
                     </span>
                     {count !== null && (
                       <span className="text-[10px] font-mono tabular-nums text-white/25">
@@ -276,6 +298,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                   </button>
                 );
               })}
+              {group.label === 'DISPLAY' && terrainDetails}
             </div>
           </div>
         ))}
@@ -447,6 +470,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                             key={layer.key}
                             onClick={() => toggle(layer.key)}
                             aria-pressed={!!isLayerActive}
+                            aria-label={layer.label}
                             title={dormant ? 'Turn the layer above on to use this' : undefined}
                             className={`relative w-full flex items-center gap-3 py-1.5 rounded-md hover:bg-white/[0.05] transition-colors cursor-pointer text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-white/30 ${layer.parent ? 'pl-[22px] pr-1' : 'px-1'} ${dormant ? 'opacity-40' : ''}`}
                           >
@@ -454,6 +478,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                             <ToggleSwitch active={!!isLayerActive} />
                             <span className={`text-[11px] font-mono uppercase tracking-wider flex-1 transition-colors duration-200 ${isLayerActive ? 'text-white/70' : 'text-white/35'}`}>
                               {layer.label}
+                              {layer.description && <span className="block mt-0.5 text-[9px] normal-case tracking-normal text-white/35">{layer.description}</span>}
                             </span>
                             {count !== null && (
                               <span className={`text-[10px] font-mono tabular-nums transition-colors ${isLayerActive ? 'text-white/45' : 'text-white/20'}`}>
@@ -463,6 +488,7 @@ function LayerPanel({ data, activeLayers, setActiveLayers, isMobile, theme = 'co
                           </button>
                         );
                       })}
+                      {group.label === 'DISPLAY' && terrainDetails}
                     </div>
                   </motion.div>
                 )}

--- a/src/components/MapControls.tsx
+++ b/src/components/MapControls.tsx
@@ -1,196 +1,88 @@
 'use client';
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Minus, Plus } from 'lucide-react';
 import type { Map as MlMap } from 'maplibre-gl';
-
-/**
- * OSIRIS — on-screen map controls
- *
- * On a desktop the camera could only be driven by the two mouse gestures: the
- * wheel to zoom, a held drag to pan. Neither is available on a trackpad-less
- * machine, a touchscreen kiosk, or to anyone driving the map from the
- * keyboard, so the map was simply stuck for them.
- *
- * These mirror those gestures rather than adding new ones: the +/- pair is the
- * wheel, the pad is a held drag. A tap moves one step; holding keeps moving
- * for as long as the button is down, the way a wheel spun or a drag held
- * would.
- *
- * Phones are deliberately left out — pinch and drag already work there, and
- * the pad would cost a quarter of the screen to duplicate them.
- *
- * Continuous motion is a chain of short overlapping `easeTo` calls rather than
- * a per-frame camera write. Both look the same, but a per-frame write fires
- * `moveend` sixty times a second, and the page re-renders on every one.
- */
-
-/** Zoom levels, and screen pixels, covered per second of holding. */
-const ZOOM_RATE = 1.6;
-const PAN_RATE = 640;
-/** What a single tap is worth. */
-const ZOOM_STEP = 1;
-const PAN_STEP = 220;
-/** How long the tap's own animation runs. */
-const STEP_MS = 240;
-/** Grace period before a press turns into a hold, so a tap is only ever one step. */
-const HOLD_DELAY_MS = 280;
-/**
- * Each continuous leg is started twice as often as it is long, so the next one
- * always interrupts the last mid-flight and the camera never pauses between
- * them. Halving it keeps the resulting speed at exactly the rates above.
- */
-const TICK_MS = 200;
-const LEG_MS = TICK_MS * 2;
-
-const linear = (t: number) => t;
-
-type Move =
-  /** Wheel equivalent: which way, in zoom levels. */
-  | { kind: 'zoom'; dir: 1 | -1 }
-  /** Drag equivalent: which way, as a unit vector in screen space. */
-  | { kind: 'pan'; dx: number; dy: number };
+import { createMapCameraControls, type CameraMove } from '@/lib/map-camera-controls';
 
 interface MapControlsProps {
   mapRef: React.RefObject<MlMap | null>;
-  /** Called when the operator drives the camera, to hand back a follow lock. */
   onInteract?: () => void;
 }
 
+/** Compact zoom on phones; desktop also gets the held-pan pad. */
 export default function MapControls({ mapRef, onInteract }: MapControlsProps) {
-  /** The pending hold timer and its repeat, cleared on release and on unmount. */
-  const holdRef = useRef<{ delay: number; repeat: number } | null>(null);
+  const controller = useRef<ReturnType<typeof createMapCameraControls> | null>(null);
+  const interact = useRef(onInteract);
+  const [limits, setLimits] = useState({ min: false, max: false });
+  useEffect(() => { interact.current = onInteract; }, [onInteract]);
 
-  const release = useCallback(() => {
-    const hold = holdRef.current;
-    if (!hold) return;
-    holdRef.current = null;
-    window.clearTimeout(hold.delay);
-    // Only a hold has a leg in flight worth cutting, and cutting it is what
-    // stops the camera under the finger rather than a beat later. A tap must
-    // be left alone: `stop()` there would abort the step's own animation
-    // partway and leave the map short of the level it was asked for.
-    if (hold.repeat) {
-      window.clearInterval(hold.repeat);
-      mapRef.current?.stop();
-    }
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const controls = createMapCameraControls(map, () => interact.current?.(),
+      () => window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+    controller.current = controls;
+    const updateLimits = () => setLimits({ min: map.getZoom() <= map.getMinZoom() + 0.001, max: map.getZoom() >= map.getMaxZoom() - 0.001 });
+    const onHidden = () => { if (document.hidden) controls.release(); };
+    updateLimits();
+    map.on('zoomend', updateLimits);
+    window.addEventListener('blur', controls.release);
+    document.addEventListener('visibilitychange', onHidden);
+    return () => {
+      controls.dispose();
+      controller.current = null;
+      map.off('zoomend', updateLimits);
+      window.removeEventListener('blur', controls.release);
+      document.removeEventListener('visibilitychange', onHidden);
+    };
   }, [mapRef]);
 
-  useEffect(() => release, [release]);
-
-  /** One step's worth of movement — what a tap, or a keyboard press, gives. */
-  const step = useCallback((move: Move) => {
-    const map = mapRef.current;
-    if (!map) return;
-    onInteract?.();
-    if (move.kind === 'zoom') map.easeTo({ zoom: map.getZoom() + move.dir * ZOOM_STEP, duration: STEP_MS });
-    else map.panBy([move.dx * PAN_STEP, move.dy * PAN_STEP], { duration: STEP_MS });
-  }, [mapRef, onInteract]);
-
-  const press = useCallback((move: Move) => {
-    const map = mapRef.current;
-    if (!map) return;
-    release();
-    step(move);
-
-    const leg = () => {
-      const m = mapRef.current;
-      if (!m) return;
-      if (move.kind === 'zoom') {
-        m.easeTo({ zoom: m.getZoom() + move.dir * ZOOM_RATE * (LEG_MS / 1000), duration: LEG_MS, easing: linear });
-      } else {
-        const d = PAN_RATE * (LEG_MS / 1000);
-        m.panBy([move.dx * d, move.dy * d], { duration: LEG_MS, easing: linear });
-      }
-    };
-
-    const delay = window.setTimeout(() => {
-      leg();
-      const repeat = window.setInterval(leg, TICK_MS);
-      if (holdRef.current) holdRef.current.repeat = repeat;
-      else window.clearInterval(repeat);
-    }, HOLD_DELAY_MS);
-    holdRef.current = { delay, repeat: 0 };
-  }, [mapRef, release, step]);
-
+  const step = useCallback((move: CameraMove) => controller.current?.step(move), []);
+  const press = useCallback((move: CameraMove) => controller.current?.press(move), []);
+  const release = useCallback(() => controller.current?.release(), []);
   return (
-    <motion.div
-      /* Desktop, laptop and fullscreen only. A phone already has pinch and
-         drag, and the pad would only crowd a 390px screen; `desktop-only` is
-         the app's own definition of that line, landscape phones included.
-         The entrance owns this element's opacity, so the resting dim below
-         has to live on the panel inside it. */
-      initial={{ opacity: 0, x: 10 }}
-      animate={{ opacity: 1, x: 0 }}
-      transition={{ duration: 0.5, delay: 0.4, ease: [0.16, 1, 0.3, 1] }}
-      className="desktop-only absolute right-2 bottom-12 z-[240] pointer-events-auto"
-      /* The Style Studio's off switch hides the pad through this. */
-      data-map-controls
-    >
-      {/* The pad sits back, and comes forward as the cursor approaches it or a
-          key focuses it. */}
-      <div
-        className="flex items-center gap-[3px] p-[3px] rounded-xl border border-[var(--border-secondary)] bg-black/35 backdrop-blur-md shadow-[0_8px_28px_rgba(0,0,0,0.45)] transition-[opacity,border-color] duration-300 opacity-60 hover:opacity-100 focus-within:opacity-100 hover:border-[var(--border-primary)] focus-within:border-[var(--border-primary)]"
-        role="group"
-        aria-label="Map camera controls"
-      >
-        {/* The wheel's two directions, stacked the way every zoom control is.
-            The pad is kept to three rows in all: the tool rail above reaches
-            this far down on a short window, and taller would run into it. */}
+    <motion.div initial={{ opacity: 0, x: 10 }} animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.3, delay: 0.4 }}
+      className="absolute right-2 bottom-[112px] md:bottom-12 z-[240] pointer-events-auto" data-map-controls>
+      <div role="group" aria-label="Map camera controls"
+        className="flex items-center gap-[3px] p-[3px] rounded-xl border border-[var(--border-secondary)] bg-black/60 backdrop-blur-md shadow-lg transition-opacity opacity-85 hover:opacity-100 focus-within:opacity-100">
         <div className="flex flex-col gap-[3px]">
-          <Btn label="Zoom in" move={{ kind: 'zoom', dir: 1 }} icon={Plus} press={press} release={release} step={step} />
-          <Btn label="Zoom out" move={{ kind: 'zoom', dir: -1 }} icon={Minus} press={press} release={release} step={step} />
+          <Btn label="Zoom in" move={{ kind: 'zoom', dir: 1 }} icon={Plus} disabled={limits.max} press={press} release={release} step={step} />
+          <Btn label="Zoom out" move={{ kind: 'zoom', dir: -1 }} icon={Minus} disabled={limits.min} press={press} release={release} step={step} />
         </div>
-
-        <div aria-hidden="true" className="self-stretch w-px mx-1 bg-gradient-to-b from-transparent via-[var(--border-secondary)] to-transparent" />
-
-        {/* A held drag, laid out as the compass it stands for rather than a list. */}
-        <div className="grid grid-cols-3 grid-rows-3 gap-[3px]">
-          <Btn cell="col-start-2 row-start-1" label="Pan north" move={{ kind: 'pan', dx: 0, dy: -1 }} icon={ChevronUp} press={press} release={release} step={step} />
-          <Btn cell="col-start-1 row-start-2" label="Pan west" move={{ kind: 'pan', dx: -1, dy: 0 }} icon={ChevronLeft} press={press} release={release} step={step} />
-          <Btn cell="col-start-3 row-start-2" label="Pan east" move={{ kind: 'pan', dx: 1, dy: 0 }} icon={ChevronRight} press={press} release={release} step={step} />
-          <Btn cell="col-start-2 row-start-3" label="Pan south" move={{ kind: 'pan', dx: 0, dy: 1 }} icon={ChevronDown} press={press} release={release} step={step} />
+        <div className="desktop-only flex items-center gap-1">
+          <div aria-hidden="true" className="h-12 w-px mx-1 bg-[var(--border-secondary)]" />
+          <div className="grid grid-cols-3 grid-rows-3 gap-[3px]">
+            <Btn cell="col-start-2 row-start-1" label="Pan north" move={{ kind: 'pan', dx: 0, dy: -1 }} icon={ChevronUp} press={press} release={release} step={step} />
+            <Btn cell="col-start-1 row-start-2" label="Pan west" move={{ kind: 'pan', dx: -1, dy: 0 }} icon={ChevronLeft} press={press} release={release} step={step} />
+            <Btn cell="col-start-3 row-start-2" label="Pan east" move={{ kind: 'pan', dx: 1, dy: 0 }} icon={ChevronRight} press={press} release={release} step={step} />
+            <Btn cell="col-start-2 row-start-3" label="Pan south" move={{ kind: 'pan', dx: 0, dy: 1 }} icon={ChevronDown} press={press} release={release} step={step} />
+          </div>
         </div>
       </div>
     </motion.div>
   );
 }
 
-function Btn({ cell = '', label, icon: Icon, move, press, release, step }: {
-  /** Grid placement, for the compass buttons that need one. */
-  cell?: string;
-  label: string;
-  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
-  move: Move;
-  press: (m: Move) => void;
-  release: () => void;
-  step: (m: Move) => void;
+function Btn({ cell = '', label, icon: Icon, move, disabled = false, press, release, step }: {
+  cell?: string; label: string; icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  move: CameraMove; disabled?: boolean;
+  press: (m: CameraMove) => void; release: () => void; step: (m: CameraMove) => void;
 }) {
   return (
-    <button
-      type="button"
-      title={`${label} — hold to keep going`}
-      aria-label={label}
-      className={`${cell} w-7 h-7 rounded-md flex items-center justify-center text-[var(--text-secondary)] transition-colors duration-200 hover:text-[var(--text-primary)] hover:bg-[rgba(var(--gold-rgb),0.06)] active:text-[var(--gold-light)] active:bg-[rgba(var(--gold-rgb),0.12)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--border-active)] touch-none select-none`}
-      onPointerDown={(e) => {
-        // Only the primary button drives the camera, and the press has to keep
-        // receiving its own pointerup even once the cursor leaves the target.
+    <button type="button" title={`${label} — hold to keep going`} aria-label={label} disabled={disabled}
+      className={`${cell} w-10 h-10 md:w-8 md:h-8 rounded-md flex items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--hover-accent)] active:text-[var(--gold-light)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--gold-primary)] disabled:opacity-25 touch-none select-none`}
+      onPointerDown={e => {
         if (e.button !== 0) return;
         e.preventDefault();
         e.currentTarget.setPointerCapture(e.pointerId);
         press(move);
       }}
-      onPointerUp={release}
-      onPointerCancel={release}
-      // Losing the capture without a pointerup — the button unmounting under
-      // the cursor, say — would otherwise leave the camera moving on its own.
-      onLostPointerCapture={release}
-      // A keyboard press never sends pointer events, so it lands here instead —
-      // and `detail` is 0 only for those, which keeps clicks from stepping twice.
-      onClick={(e) => { if (e.detail === 0) step(move); }}
-    >
-      <Icon className="w-3 h-3" strokeWidth={1.5} />
+      onPointerUp={release} onPointerCancel={release} onLostPointerCapture={release}
+      onClick={e => { if (e.detail === 0) step(move); }}>
+      <Icon className="w-3.5 h-3.5" strokeWidth={1.5} />
     </button>
   );
 }

--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -1,8 +1,9 @@
-import { buildGeometry, closeRing, drawReducer, initialDrawState, measure, type DrawAction, type DrawMode, type DrawProgress, type DrawResult, type DrawState } from '@/lib/draw';
 'use client';
 
+import { buildGeometry, closeRing, drawReducer, initialDrawState, measure, type DrawAction, type DrawMode, type DrawProgress, type DrawResult, type DrawState } from '@/lib/draw';
 import { useEffect, useRef, useState, useCallback, memo } from 'react';
-import maplibregl from 'maplibre-gl';
+import * as maplibregl from 'maplibre-gl';
+import { installTerrainTileProtocol } from '@/lib/terrain-tiles';
 import { createSatelliteLayer, parseColor, type SatPoint } from '@/lib/satellite-layer';
 import { MAP_DEFAULTS, MAP_PALETTE_KEYS, readMapPalette, satColorFor, type MapPalette } from '@/lib/map-palette';
 import { STYLE_EVENT } from '@/lib/style-tokens';
@@ -11,6 +12,9 @@ import SatelliteCard, { type SatelliteDetail } from '@/components/SatelliteCard'
 import CctvPreviews, { type PreviewCamera } from '@/components/CctvPreviews';
 import MapControls from '@/components/MapControls';
 import LiveNewsPreviews, { type PreviewFeed } from '@/components/LiveNewsPreviews';
+import { attachTerrain, type TerrainStatus } from '@/lib/map-terrain';
+import { watchMapStartup, type MapStartupStatus } from '@/lib/map-startup';
+import { applyMapProjection } from '@/lib/map-projection';
 
 /** The catalogue fields the satellite layer and its popup actually read. */
 interface SatelliteRow {
@@ -34,6 +38,11 @@ interface OsirisMapProps {
   onViewStateChange?: (vs: { zoom: number; latitude: number }) => void;
   flyToLocation?: { lat: number; lng: number; zoom?: number; ts: number } | null;
   projection?: 'mercator' | 'globe';
+  terrainEnabled?: boolean;
+  terrainRetry?: number;
+  terrainFocus?: number;
+  onTerrainStatusChange?: (status: TerrainStatus) => void;
+  onRetryMap?: () => void;
   mapStyle?: string;
   sweepData?: any;
   scanTargets?: any[];
@@ -96,11 +105,15 @@ function computeSolarTerminator(): [number, number][] {
 
 const EMPTY_FC = { type: 'FeatureCollection' as const, features: [] };
 
-function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawMode = null, onDrawComplete, onDrawProgress, onDrawCancel, drawCommand = null, onMapCenter, route = null, userLocation = null, followUser = false, onFollowInterrupt, navigating = false, aircraftAirports = {} }: OsirisMapProps) {
+function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightClick, onViewStateChange, flyToLocation, projection = 'globe', terrainEnabled = false, terrainRetry = 0, terrainFocus = 0, onTerrainStatusChange, onRetryMap, mapStyle = 'dark', sweepData, scanTargets = [], demoMode = false, theme = 'core', drawnPolygons = [], arcgisLayers = [], drawMode = null, onDrawComplete, onDrawProgress, onDrawCancel, drawCommand = null, onMapCenter, route = null, userLocation = null, followUser = false, onFollowInterrupt, navigating = false, aircraftAirports = {} }: OsirisMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
   const [mapReady, setMapReady] = useState(false);
+  const [startupStatus, setStartupStatus] = useState<MapStartupStatus>('loading');
+  // Do not replay an earlier explicit zoom request after theme/retry remounts.
+  const lastTerrainFocus = useRef(terrainFocus);
+  const wasNavigating = useRef(false);
   /**
    * What the map's own layers draw with, mirrored out of the `--map-*` custom
    * properties. Held in state rather than read at each use so a change re-runs
@@ -110,7 +123,6 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   const [palette, setPalette] = useState<MapPalette>(MAP_DEFAULTS);
   const paletteRef = useRef(palette);
   useEffect(() => { paletteRef.current = palette; }, [palette]);
-  const prevStyleRef = useRef(mapStyle);
   const prevDrawnPolygonsRef = useRef<string[]>([]);
   const prevArcgisLayersRef = useRef<string[]>([]);
   const satLayerRef = useRef<ReturnType<typeof createSatelliteLayer> | null>(null);
@@ -229,36 +241,33 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     if (!containerRef.current || mapRef.current) return;
     
     // Select basemap style
-    const styleUrl = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
+    // Local style/TileJSON metadata, with tiles delivered directly by the CDN.
+    // This avoids a blocking upstream style fetch and a server hop per tile.
+    const styleUrl = '/dark-matter-style.json';
 
     const container = containerRef.current;
+    maplibregl.setWorkerUrl(`/vendor/maplibre/${maplibregl.getVersion()}/maplibre-gl-worker.mjs`);
     const baseOptions = {
       container,
       style: styleUrl,
       center: [25.48, 42.70] as [number, number], zoom: 6.5, minZoom: 1.5, maxZoom: 18,
       attributionControl: false as const,
-      maxPitch: 85,
-      transformRequest: (url: string) => {
-        // Route all CARTO CDN requests through the internal Next.js proxy API
-        if (url.includes('cartocdn.com')) {
-          const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
-          return { url: `${baseUrl}/api/proxy-tiles?url=${encodeURIComponent(url)}` };
-        }
-        return { url };
-      },
+      // Keep the supported pitch range from the start; terrain must not flatten
+      // an already-positioned camera when its performance limits are attached.
+      maxPitch: 60,
+      pitch: 20,
     };
 
     // MapLibre asks for a high-performance WebGL2 context and throws outright if it
     // cannot get one. Some machines refuse that exact request while still granting a
-    // plainer context — a blocklisted discrete GPU, a driver Chrome only trusts for
-    // WebGL1 — so walk down to weaker requests before giving up.
+    // plainer WebGL2 context — try the low-power GPU before giving up.
     const attributeFallbacks: maplibregl.MapOptions['canvasContextAttributes'][] = [
       undefined,
       { powerPreference: 'low-power', failIfMajorPerformanceCaveat: false },
-      { contextType: 'webgl', powerPreference: 'low-power', failIfMajorPerformanceCaveat: false },
     ];
 
     let map: maplibregl.Map | undefined;
+    let initializationCancelled = false;
     for (const canvasContextAttributes of attributeFallbacks) {
       try {
         map = new maplibregl.Map(
@@ -268,11 +277,16 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       } catch (e) {
         // A failed constructor leaves its canvas behind; the next attempt needs a clean container.
         container.innerHTML = '';
-        if (canvasContextAttributes === attributeFallbacks[attributeFallbacks.length - 1]) throw e;
+        if (canvasContextAttributes === attributeFallbacks[attributeFallbacks.length - 1]) {
+          console.warn('[OSIRIS] Map initialization failed:', e);
+          queueMicrotask(() => { if (!initializationCancelled) setStartupStatus('error'); });
+          return () => { initializationCancelled = true; };
+        }
         console.warn('[OSIRIS] WebGL context rejected, retrying with weaker attributes:', e instanceof Error ? e.message : e);
       }
     }
     if (!map) return;
+    const stopWatchingStartup = watchMapStartup(map, setStartupStatus);
 
     map.on('load', () => {
       mapRef.current = map;
@@ -796,7 +810,18 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       }
     });
     map.on('contextmenu', e => { e.preventDefault(); onRightClick?.({ lat: e.lngLat.lat, lng: e.lngLat.lng }); });
-    map.on('moveend', () => { const c = map.getCenter(); onViewStateChange?.({ zoom: map.getZoom(), latitude: c.lat }); });
+    const reportViewState = () => { const c = map.getCenter(); onViewStateChange?.({ zoom: map.getZoom(), latitude: c.lat }); };
+    map.on('load', reportViewState);
+    map.on('moveend', reportViewState);
+    // Lightweight settled-view diagnostics for camera/terrain regressions.
+    const reportCamera = () => {
+      const center = map.getCenter();
+      container.dataset.mapCamera = JSON.stringify({ zoom: map.getZoom(), pitch: map.getPitch(), bearing: map.getBearing(), lat: center.lat, lng: center.lng });
+    };
+    map.on('load', reportCamera);
+    map.on('moveend', reportCamera);
+    map.on('idle', reportCamera);
+    reportCamera();
 
     // ── POPUP HELPER ──
     const popup = (coords: any, html: string) => {
@@ -1033,19 +1058,21 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     });
 
     // The cursor should say a satellite is clickable, like every other layer.
-    // Throttled to one test per frame: mousemove fires far faster than the
-    // screen updates, and each pick is a full offscreen re-render of the
-    // whole catalogue — measured at 1-2 ms with ~19,000 satellites.
-    let hoverQueued = false;
+    // Picking re-renders the entire catalogue and reads back from the GPU.
+    // Keep that work out of camera gestures and limit hover checks to 10/sec.
+    // Click selection above remains immediate and full precision.
+    let hoverFrame = 0;
+    let lastHoverPick = -Infinity;
     map.on('mousemove', e => {
       const layer = satLayerRef.current;
-      if (!layer || hoverQueued) return;
-      hoverQueued = true;
-      requestAnimationFrame(() => {
-        hoverQueued = false;
+      if (!layer || hoverFrame || map.isMoving() || performance.now() - lastHoverPick < 100) return;
+      hoverFrame = requestAnimationFrame(() => {
+        hoverFrame = 0;
+        if (map.isMoving()) return;
         const canvas = map.getCanvas();
         // Never fight another layer that has already claimed the cursor.
         if (canvas.style.cursor && canvas.style.cursor !== 'pointer') return;
+        lastHoverPick = performance.now();
         const over = layer.pick(e.point.x, e.point.y) != null;
         if (over) canvas.style.cursor = 'pointer';
         else if (canvas.style.cursor === 'pointer') canvas.style.cursor = '';
@@ -1537,7 +1564,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       });
     });
 
-    return () => { map.remove(); mapRef.current = null; };
+    return () => { stopWatchingStartup(); cancelAnimationFrame(hoverFrame); map.remove(); mapRef.current = null; };
   }, []);
 
   // Day/Night
@@ -2158,7 +2185,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
 
     // Switch to globe and fly to the sweep location
     try {
-      (map as any).setProjection({ type: 'globe' });
+      applyMapProjection(map, 'globe');
       map.setSky({ 'sky-color': '#0A0A0F', 'sky-horizon-blend': 0.02, 'horizon-color': '#0A0A0F', 'horizon-fog-blend': 0.02 });
     } catch { /* projection may not be supported */ }
 
@@ -2226,22 +2253,18 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     if (src) src.setData({ type: 'FeatureCollection', features });
   }, [scanTargets, mapReady]);
 
-  // Fly-to
-  useEffect(() => {
-    if (!mapReady || !mapRef.current || !flyToLocation) return;
-    mapRef.current.flyTo({ center: [flyToLocation.lng, flyToLocation.lat], zoom: flyToLocation.zoom || 8, duration: 2000 });
-  }, [mapReady, flyToLocation]);
-
-  // Dynamic projection switching (lightweight — no terrain DEM)
+  // Projection changes are independent of terrain. Toggling elevation must not
+  // zoom, tilt, or reposition the camera the user has already chosen.
   useEffect(() => {
     if (!mapReady || !mapRef.current) return;
     const map = mapRef.current;
     try {
-      (map as any).setProjection({ type: projection });
+      const projectionChanged = applyMapProjection(map, projection);
+      const configureSky = projectionChanged || !containerRef.current?.dataset.mapProjection;
+      if (containerRef.current) containerRef.current.dataset.mapProjection = projection;
       if (projection === 'globe') {
-        map.easeTo({ pitch: 20, duration: 1200 });
         try {
-          (map as any).setSky({
+          if (configureSky) map.setSky({
             'sky-color': '#04040A',
             'sky-horizon-blend': 0.5,
             'horizon-color': '#0a0a1a',
@@ -2251,14 +2274,40 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
           });
         } catch (e) { console.warn('[OSIRIS] Suppressed error:', e instanceof Error ? e.message : e); }
       } else {
-        map.easeTo({ pitch: 0, duration: 800 });
+        if (map.getPitch() > 0.5) map.easeTo({ pitch: 0, duration: 350 });
       }
     } catch (e) {
       console.warn('Projection switch failed:', e);
     }
   }, [mapReady, projection]);
 
-  // 3D Terrain & Buildings layer
+  // Terrain loads only at regional zooms; globe overview stays inexpensive.
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !terrainEnabled) return;
+    const map = mapRef.current;
+    installTerrainTileProtocol(maplibregl.addProtocol);
+    const dispose = attachTerrain(map, status => onTerrainStatusChange?.(status));
+    return () => {
+      // The map constructor effect removes the entire map first on unmount.
+      if (mapRef.current === map) dispose();
+    };
+  }, [mapReady, terrainEnabled, terrainRetry, onTerrainStatusChange]);
+
+  // A user-requested close-up keeps the current location and avoids a fly-out arc.
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !terrainFocus || !terrainEnabled || lastTerrainFocus.current === terrainFocus) return;
+    lastTerrainFocus.current = terrainFocus;
+    const map = mapRef.current;
+    map.easeTo({ zoom: Math.max(10.5, map.getZoom()), pitch: 45, duration: 650 });
+  }, [mapReady, terrainFocus, terrainEnabled]);
+
+  // Fly-to
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !flyToLocation) return;
+    mapRef.current.flyTo({ center: [flyToLocation.lng, flyToLocation.lat], zoom: flyToLocation.zoom ?? 8, duration: 2000 });
+  }, [mapReady, flyToLocation]);
+
+  // 3D buildings are independent of the elevation renderer.
   useEffect(() => {
     if (!mapReady || !mapRef.current) return;
     const map = mapRef.current;
@@ -2266,19 +2315,14 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
 
     try {
       if (enabled) {
-        // ── 3D BUILDINGS SOURCE (OpenFreeMap CDN — no API key, globally cached) ──
-        if (!map.getSource('osiris-buildings')) {
-          map.addSource('osiris-buildings', {
-            type: 'vector',
-            url: 'https://tiles.openfreemap.org/planet',
-          });
-        }
+        // CARTO's already-loaded vector tiles include the building footprints
+        // and render heights. No second worldwide vector source is needed.
 
         // ── 3D BUILDING EXTRUSION LAYER ──
         if (!map.getLayer('osiris-3d-buildings')) {
           map.addLayer({
             id: 'osiris-3d-buildings',
-            source: 'osiris-buildings',
+            source: 'carto',
             'source-layer': 'building',
             type: 'fill-extrusion',
             minzoom: 14.5,
@@ -2327,8 +2371,6 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   // Satellite / Dark style switching
   useEffect(() => {
     if (!mapReady || !mapRef.current) return;
-    if (mapStyle === prevStyleRef.current) return;
-    prevStyleRef.current = mapStyle;
     const map = mapRef.current;
 
     try {
@@ -2341,6 +2383,8 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
             tileSize: 256,
             maxzoom: 18,
           });
+        }
+        if (!map.getLayer('satellite-layer')) {
           map.addLayer({ id: 'satellite-layer', type: 'raster', source: 'satellite-tiles', paint: { 'raster-opacity': 0.85 } }, 'day-night-fill');
         } else {
           map.setLayoutProperty('satellite-layer', 'visibility', 'visible');
@@ -2658,11 +2702,15 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
     });
   }, [mapReady, followUser, userLocation, navigating]);
 
-  // Restore a plain north-up view when guidance ends.
+  // Restore the selected view only when guidance ends, not on first map load.
   useEffect(() => {
-    if (!mapReady || !mapRef.current || navigating) return;
-    mapRef.current.easeTo({ pitch: 0, bearing: 0, duration: 600 });
-  }, [mapReady, navigating]);
+    const ended = wasNavigating.current && !navigating;
+    wasNavigating.current = navigating;
+    if (!mapReady || !mapRef.current || !ended) return;
+    const map = mapRef.current;
+    const pitch = projection === 'mercator' ? 0 : activeLayers.terrain_3d ? 50 : terrainEnabled && map.getZoom() >= 10 ? 45 : 20;
+    map.easeTo({ pitch, bearing: 0, duration: 600 });
+  }, [mapReady, navigating, projection, terrainEnabled, activeLayers.terrain_3d]);
 
   // ── AIRPORTS FOR WATCHED AIRCRAFT ──
   // The endpoints that survived corroboration against the aircraft's reported
@@ -2976,7 +3024,18 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
 
   return (
     <>
-      <div ref={containerRef} className="absolute inset-0 w-full h-full" />
+      <div ref={containerRef} data-map-status={startupStatus} className="absolute inset-0 w-full h-full" />
+      {startupStatus !== 'ready' && (
+        <div className="absolute inset-0 z-[10] flex items-center justify-center pointer-events-none">
+          <div role="status" className="pointer-events-auto max-w-[min(360px,85vw)] rounded-xl border border-[var(--border-primary)] bg-[var(--bg-secondary)]/95 p-5 text-center shadow-lg">
+            <p className="text-sm text-[var(--text-primary)]">{startupStatus === 'loading' ? 'Loading map…' : 'The map couldn’t finish loading'}</p>
+            {startupStatus === 'error' && <>
+              <p className="mt-2 text-xs text-[var(--text-secondary)]">A map request or graphics connection failed. Your dashboard is still available.</p>
+              <button type="button" onClick={onRetryMap} className="mt-4 rounded-md border border-[var(--border-primary)] px-4 py-2 text-xs text-[var(--gold-primary)] hover:bg-[var(--hover-accent)]">Retry map</button>
+            </>}
+          </div>
+        </div>
+      )}
       {mapReady && mapRef.current && (
         <CctvPreviews
           mapRef={mapRef}

--- a/src/components/ScaleBar.test.ts
+++ b/src/components/ScaleBar.test.ts
@@ -5,27 +5,27 @@ const OTTAWA_LAT = 45.5268;
 
 describe('scaleFor', () => {
   it('picks a round step that fits inside the 100px budget', () => {
-    expect(scaleFor(3, OTTAWA_LAT)).toEqual({ barWidth: 73, label: '1000 km' });
-    expect(scaleFor(10, OTTAWA_LAT)).toEqual({ barWidth: 93, label: '10 km' });
-    expect(scaleFor(14, OTTAWA_LAT)).toEqual({ barWidth: 75, label: '500 m' });
+    expect(scaleFor(3, OTTAWA_LAT)).toEqual({ barWidth: 73, label: '500 km' });
+    expect(scaleFor(10, OTTAWA_LAT)).toEqual({ barWidth: 93, label: '5 km' });
+    expect(scaleFor(14, OTTAWA_LAT)).toEqual({ barWidth: 60, label: '200 m' });
   });
 
   it('stays narrow past zoom 16, where the step table used to run out', () => {
-    expect(scaleFor(17.8, OTTAWA_LAT)).toEqual({ barWidth: 42, label: '20 m' });
-    expect(scaleFor(22, OTTAWA_LAT)).toEqual({ barWidth: 76, label: '2 m' });
+    expect(scaleFor(17.8, OTTAWA_LAT)).toEqual({ barWidth: 83, label: '20 m' });
+    expect(scaleFor(22, OTTAWA_LAT)).toEqual({ barWidth: 76, label: '1 m' });
   });
 
   it('never stretches the bar beyond the bottom panel', () => {
     for (let zoom = 0; zoom <= 24; zoom += 0.2) {
-      for (const latitude of [0, OTTAWA_LAT, 70]) {
-        expect(scaleFor(zoom, latitude).barWidth).toBeLessThan(400);
+      for (const latitude of [0, OTTAWA_LAT, 70, 90, -90, NaN]) {
+        expect(scaleFor(zoom, latitude).barWidth).toBeLessThanOrEqual(100);
       }
     }
   });
 
   it('labels sub-kilometre steps in whole metres', () => {
     for (let zoom = 13; zoom <= 24; zoom += 0.2) {
-      expect(scaleFor(zoom, OTTAWA_LAT).label).toMatch(/^\d+ (m|km)$/);
+      expect(scaleFor(zoom, OTTAWA_LAT).label).toMatch(/^\d+ (cm|m|km)$/);
     }
   });
 });

--- a/src/components/ScaleBar.tsx
+++ b/src/components/ScaleBar.tsx
@@ -12,11 +12,14 @@ interface ScaleBarProps {
   latitude: number;
 }
 
-const SCALE_STEPS = [5000, 2000, 1000, 500, 200, 100, 50, 20, 10, 5, 2, 1, 0.5, 0.2, 0.1, 0.05, 0.02, 0.01, 0.005, 0.002, 0.001];
+const SCALE_STEPS = [5000, 2000, 1000, 500, 200, 100, 50, 20, 10, 5, 2, 1, 0.5, 0.2, 0.1, 0.05, 0.02, 0.01, 0.005, 0.002, 0.001, 0.0005, 0.0002, 0.0001, 0.00005, 0.00002, 0.00001];
 
 export function scaleFor(zoom: number, latitude: number): { barWidth: number; label: string } {
-  // Meters per pixel at given zoom and latitude
-  const metersPerPx = 156543.03392 * Math.cos(latitude * Math.PI / 180) / Math.pow(2, zoom);
+  // MapLibre uses a 512px world at zoom zero, not the 256px raster convention.
+  // This is an approximate centre scale for pitched/globe views.
+  const safeZoom = Number.isFinite(zoom) ? Math.max(0, Math.min(24, zoom)) : 0;
+  const safeLatitude = Number.isFinite(latitude) ? Math.max(-85.051129, Math.min(85.051129, latitude)) : 0;
+  const metersPerPx = (40075016.686 / 512) * Math.cos(safeLatitude * Math.PI / 180) / 2 ** safeZoom;
   const maxWidth = 100; // Max bar width in pixels
   const maxMeters = metersPerPx * maxWidth;
   const maxKm = maxMeters / 1000;
@@ -28,8 +31,8 @@ export function scaleFor(zoom: number, latitude: number): { barWidth: number; la
     if (step <= maxKm) { bestStep = step; break; }
   }
 
-  const barWidth = Math.max(24, Math.round((bestStep * 1000) / metersPerPx));
-  const label = bestStep >= 1 ? `${bestStep} km` : `${Math.round(bestStep * 1000)} m`;
+  const barWidth = Math.round((bestStep * 1000) / metersPerPx);
+  const label = bestStep >= 1 ? `${bestStep} km` : bestStep >= 0.001 ? `${Math.round(bestStep * 1000)} m` : `${Math.round(bestStep * 100000)} cm`;
 
   return { barWidth, label };
 }
@@ -38,7 +41,7 @@ export default function ScaleBar({ zoom, latitude }: ScaleBarProps) {
   const scaleInfo = useMemo(() => scaleFor(zoom, latitude), [zoom, latitude]);
 
   return (
-    <div className="flex items-center gap-1.5 pointer-events-none select-none">
+    <div className="flex items-center gap-1.5 pointer-events-none select-none" aria-label={`Approximate scale at map center: ${scaleInfo.label}`}>
       <div className="flex flex-col items-start">
         {/* Scale line with ticks */}
         <div className="relative" style={{ width: scaleInfo.barWidth }}>

--- a/src/lib/camera-catalog.test.ts
+++ b/src/lib/camera-catalog.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadCameraCatalog, mergeCameraCatalog } from './camera-catalog';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); });
+const json = (cameras: { id: string }[], pendingRegions: string[] = []) => Response.json({ cameras, pendingRegions });
+
+describe('progressive camera catalogue', () => {
+  it('retries only missing regions, preserving cameras already loaded', async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(json([{ id: 'london' }], ['canada']))
+      .mockResolvedValueOnce(json([{ id: 'ottawa' }]));
+    vi.stubGlobal('fetch', fetcher);
+    let cameras: { id: string | number }[] = [];
+    const stop = loadCameraCatalog(batch => { cameras = mergeCameraCatalog(cameras, batch); }, vi.fn());
+    await vi.advanceTimersByTimeAsync(0);
+    expect(cameras).toEqual([{ id: 'london' }]);
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(fetcher.mock.calls[1][0]).toBe('/api/cctv?region=canada');
+    expect(cameras).toEqual([{ id: 'london' }, { id: 'ottawa' }]);
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    stop();
+  });
+
+  it('bounds retries of unavailable sources and retries failed initial requests', async () => {
+    const fetcher = vi.fn().mockRejectedValueOnce(new Error('network down'))
+      .mockImplementation(async () => json([], ['canada']));
+    vi.stubGlobal('fetch', fetcher);
+    const onError = vi.fn();
+    const stop = loadCameraCatalog(vi.fn(), onError);
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(onError).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it('cancels queued retries when cameras are switched off', async () => {
+    const fetcher = vi.fn(async () => json([], ['canada']));
+    vi.stubGlobal('fetch', fetcher);
+    const stop = loadCameraCatalog(vi.fn(), vi.fn());
+    await vi.advanceTimersByTimeAsync(0);
+    stop();
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates duplicate camera IDs without duplicating dots', () => {
+    expect(mergeCameraCatalog([{ id: 'a', name: 'old' }], [{ id: 'a', name: 'new' }, { id: 'b', name: 'second' }]))
+      .toEqual([{ id: 'a', name: 'new' }, { id: 'b', name: 'second' }]);
+  });
+});

--- a/src/lib/camera-catalog.ts
+++ b/src/lib/camera-catalog.ts
@@ -1,0 +1,40 @@
+export type CatalogCamera = { id: string | number; [key: string]: unknown };
+
+/** Partial retries must add cameras, not erase previously loaded regions. */
+export function mergeCameraCatalog<T extends { id: string | number }>(previous: T[], incoming: T[]): T[] {
+  const merged = new Map(previous.map(camera => [String(camera.id), camera]));
+  for (const camera of incoming) merged.set(String(camera.id), camera);
+  return [...merged.values()];
+}
+
+/** Recover slow regions without downloading the entire worldwide list again. */
+export function loadCameraCatalog(onBatch: (cameras: CatalogCamera[]) => void, onError: () => void) {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let attempts = 0;
+  const load = async (regions: string[]) => {
+    attempts++;
+    let remaining = regions;
+    try {
+      const query = new URLSearchParams({ region: regions.join(',') });
+      const response = await fetch(`/api/cctv?${query}`, { signal: controller.signal, cache: 'no-store' });
+      if (!response.ok) throw new Error(`Camera catalogue HTTP ${response.status}`);
+      const data = await response.json();
+      if (!Array.isArray(data.cameras)) throw new Error('Invalid camera catalogue');
+      if (controller.signal.aborted) return;
+      if (data.cameras.length) onBatch(data.cameras);
+      remaining = Array.isArray(data.pendingRegions)
+        ? data.pendingRegions.filter((region: unknown): region is string => typeof region === 'string' && /^[a-z-]+$/.test(region))
+        : data.cameras.length ? [] : regions;
+    } catch {
+      if (controller.signal.aborted) return;
+      onError();
+    }
+    // Three attempts total, with backoff. No endless retries against dead feeds.
+    if (remaining.length && attempts < 3 && !controller.signal.aborted) {
+      timer = setTimeout(() => void load(remaining), attempts * 15_000);
+    }
+  };
+  void load(['all']);
+  return () => { controller.abort(); clearTimeout(timer); };
+}

--- a/src/lib/map-camera-controls.test.ts
+++ b/src/lib/map-camera-controls.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Map as MapLibreMap } from 'maplibre-gl';
+import { createMapCameraControls } from './map-camera-controls';
+
+function fixture(reducedMotion = false) {
+  const listeners = new Map<string, Set<(event: Record<string, unknown>) => void>>();
+  let zoom = 6.5;
+  let moving = false;
+  const emit = (type: string, event = {}) => listeners.get(type)?.forEach(fn => fn(event));
+  const map = {
+    getZoom: () => zoom, getMinZoom: () => 1.5, getMaxZoom: () => 18, isMoving: () => moving,
+    on: (type: string, fn: (event: Record<string, unknown>) => void) => {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(fn);
+    },
+    off: (type: string, fn: (event: Record<string, unknown>) => void) => listeners.get(type)?.delete(fn),
+    easeTo: vi.fn((options, data) => {
+      if (moving) emit('moveend');
+      moving = options.duration !== 0;
+      if (!moving) zoom = options.zoom;
+      emit('movestart', data);
+    }),
+    panBy: vi.fn(),
+    stop: vi.fn(() => { moving = false; emit('moveend'); }),
+  };
+  const interact = vi.fn();
+  const controller = createMapCameraControls(map as unknown as MapLibreMap, interact, () => reducedMotion);
+  const settle = (value: number) => { zoom = value; moving = false; emit('moveend'); };
+  return { controller, map, interact, emit, settle, setZoom: (value: number) => { zoom = value; }, listeners };
+}
+const zoomIn = { kind: 'zoom', dir: 1 } as const;
+const zoomOut = { kind: 'zoom', dir: -1 } as const;
+
+describe('map camera input', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('preserves three rapid taps through synchronous animation interruption', () => {
+    const f = fixture();
+    f.controller.step(zoomIn); f.setZoom(6.9);
+    f.controller.step(zoomIn); f.setZoom(7.2);
+    f.controller.step(zoomIn);
+    expect(f.map.easeTo.mock.calls.map(([options]) => options.zoom)).toEqual([7.5, 8.5, 9.5]);
+    f.controller.dispose();
+  });
+
+  it('reverses pending zoom intent and resets to actual zoom when settled', () => {
+    const f = fixture();
+    f.controller.step(zoomIn); f.controller.step(zoomIn); f.controller.step(zoomOut);
+    expect(f.map.easeTo).toHaveBeenLastCalledWith(expect.objectContaining({ zoom: 7.5 }), expect.anything());
+    f.settle(7.5); f.controller.step(zoomOut);
+    expect(f.map.easeTo).toHaveBeenLastCalledWith(expect.objectContaining({ zoom: 6.5 }), expect.anything());
+    f.controller.dispose();
+  });
+
+  it('clamps at both zoom limits without repeatedly restarting a clamped animation', () => {
+    const f = fixture(); f.setZoom(17.6);
+    f.controller.step(zoomIn); f.controller.step(zoomIn);
+    expect(f.map.easeTo).toHaveBeenCalledTimes(1);
+    expect(f.map.easeTo.mock.calls[0][0].zoom).toBe(18);
+    f.settle(1.7); f.controller.step(zoomOut);
+    expect(f.map.easeTo.mock.calls[1][0].zoom).toBe(1.5);
+    f.controller.dispose();
+  });
+
+  it('lets taps finish, but stops a held camera immediately on release', () => {
+    const f = fixture();
+    f.controller.press(zoomIn); f.controller.release();
+    expect(f.map.stop).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(f.map.easeTo).toHaveBeenCalledTimes(1);
+    f.settle(7.5); f.controller.press(zoomIn);
+    vi.advanceTimersByTime(300);
+    f.controller.release();
+    expect(f.map.stop).toHaveBeenCalledTimes(1);
+    const calls = f.map.easeTo.mock.calls.length;
+    vi.advanceTimersByTime(2000);
+    expect(f.map.easeTo).toHaveBeenCalledTimes(calls);
+    f.controller.dispose();
+  });
+
+  it('cancels held input when wheel, pinch, search or a view change takes over', () => {
+    const f = fixture(); f.controller.press(zoomIn);
+    vi.advanceTimersByTime(300);
+    f.emit('movestart', { originalEvent: {} });
+    const calls = f.map.easeTo.mock.calls.length;
+    vi.advanceTimersByTime(2000);
+    expect(f.map.easeTo).toHaveBeenCalledTimes(calls);
+    expect(f.map.stop).not.toHaveBeenCalled();
+    f.setZoom(4); f.controller.step(zoomIn);
+    expect(f.map.easeTo).toHaveBeenLastCalledWith(expect.objectContaining({ zoom: 5 }), expect.anything());
+    f.controller.dispose();
+  });
+
+  it('respects reduced motion without losing multiple zoom steps', () => {
+    const f = fixture(true); f.controller.step(zoomIn); f.controller.step(zoomIn);
+    expect(f.map.easeTo).toHaveBeenLastCalledWith(expect.objectContaining({ zoom: 8.5, duration: 0 }), expect.anything());
+    f.controller.dispose();
+  });
+
+  it('does not animate a removed map and cleans up listeners and timers', () => {
+    const f = fixture(); f.controller.press(zoomIn); f.emit('remove');
+    vi.advanceTimersByTime(2000); f.controller.step(zoomIn); f.controller.dispose();
+    expect(f.map.easeTo).toHaveBeenCalledTimes(1);
+    expect(f.map.stop).not.toHaveBeenCalled();
+    expect([...f.listeners.values()].every(set => !set.size)).toBe(true);
+  });
+});

--- a/src/lib/map-camera-controls.ts
+++ b/src/lib/map-camera-controls.ts
@@ -1,0 +1,110 @@
+import type { Map as MapLibreMap, MapMovementEvent } from 'maplibre-gl';
+
+export type CameraMove = { kind: 'zoom'; dir: 1 | -1 } | { kind: 'pan'; dx: number; dy: number };
+const CONTROL_EVENT = { osirisCameraControl: true };
+const STEP_MS = 240;
+const HOLD_DELAY_MS = 280;
+const LEG_MS = 400;
+const TICK_MS = 200;
+
+/** One controller owns button intent; interrupted animations do not lose taps. */
+export function createMapCameraControls(
+  map: MapLibreMap,
+  onInteract: () => void = () => {},
+  reducedMotion: () => boolean = () => false,
+) {
+  let targetZoom: number | null = null;
+  let issuing = false;
+  let ownsAnimation = false;
+  let disposed = false;
+  let delay: ReturnType<typeof setTimeout> | undefined;
+  let repeat: ReturnType<typeof setInterval> | undefined;
+  const clampZoom = (zoom: number) => Math.max(map.getMinZoom(), Math.min(map.getMaxZoom(), zoom));
+
+  const run = (action: () => void) => {
+    issuing = true;
+    ownsAnimation = true;
+    try { action(); }
+    finally { issuing = false; }
+    if (!map.isMoving()) { targetZoom = null; ownsAnimation = false; }
+  };
+
+  const release = (stop = true) => {
+    clearTimeout(delay);
+    delay = undefined;
+    const wasHolding = repeat !== undefined;
+    clearInterval(repeat);
+    repeat = undefined;
+    if (wasHolding && stop && ownsAnimation && !disposed) map.stop();
+    if (wasHolding) targetZoom = null;
+  };
+
+  const step = (move: CameraMove) => {
+    if (disposed) return;
+    onInteract();
+    const duration = reducedMotion() ? 0 : STEP_MS;
+    if (move.kind === 'zoom') {
+      const next = clampZoom((targetZoom ?? map.getZoom()) + move.dir);
+      if (next === targetZoom || (targetZoom === null && next === map.getZoom())) return;
+      targetZoom = next;
+      run(() => map.easeTo({ zoom: next, duration }, CONTROL_EVENT));
+    } else {
+      targetZoom = null;
+      run(() => map.panBy([move.dx * 220, move.dy * 220], { duration }, CONTROL_EVENT));
+    }
+  };
+
+  const press = (move: CameraMove) => {
+    if (disposed) return;
+    release();
+    step(move);
+    const leg = () => {
+      if (disposed) return;
+      targetZoom = null;
+      const duration = reducedMotion() ? 0 : LEG_MS;
+      // With reduced motion, step only the distance for this tick (no overlap).
+      const seconds = (duration ? LEG_MS : TICK_MS) / 1000;
+      if (move.kind === 'zoom') {
+        const zoom = clampZoom(map.getZoom() + move.dir * 1.6 * seconds);
+        if (zoom === map.getZoom()) { release(); return; }
+        run(() => map.easeTo({ zoom, duration, easing: t => t }, CONTROL_EVENT));
+      } else {
+        run(() => map.panBy([move.dx * 640 * seconds, move.dy * 640 * seconds], { duration, easing: t => t }, CONTROL_EVENT));
+      }
+    };
+    delay = setTimeout(() => {
+      delay = undefined;
+      repeat = setInterval(leg, TICK_MS);
+      leg();
+    }, HOLD_DELAY_MS);
+  };
+
+  const onStart = (event: MapMovementEvent & { osirisCameraControl?: boolean }) => {
+    if (event.osirisCameraControl || issuing) return;
+    // A wheel/pinch/search/view change takes ownership. Do not stop its motion.
+    release(false);
+    targetZoom = null;
+    ownsAnimation = false;
+  };
+  const onEnd = () => {
+    // easeTo synchronously ends the animation it replaces before starting anew.
+    if (!issuing) { targetZoom = null; ownsAnimation = false; }
+  };
+  const dispose = () => {
+    if (disposed) return;
+    release();
+    disposed = true;
+    map.off('movestart', onStart);
+    map.off('moveend', onEnd);
+    map.off('remove', onRemove);
+  };
+  const onRemove = () => {
+    // Map removal precedes React child cleanup; do not call stop on a dead map.
+    ownsAnimation = false;
+    dispose();
+  };
+  map.on('movestart', onStart);
+  map.on('moveend', onEnd);
+  map.on('remove', onRemove);
+  return { step, press, release: () => release(), dispose };
+}

--- a/src/lib/map-projection.test.ts
+++ b/src/lib/map-projection.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Map, ProjectionSpecification } from 'maplibre-gl';
+import style from '../../public/dark-matter-style.json';
+import { applyMapProjection, GLOBE_PROJECTION } from './map-projection';
+import { TERRAIN_MIN_ZOOM } from './map-terrain';
+
+function fixture(initial?: ProjectionSpecification) {
+  let current = initial;
+  const map = { getProjection: () => current, setProjection: vi.fn((next: ProjectionSpecification) => { current = next; }) };
+  return { map: map as unknown as Pick<Map, 'getProjection' | 'setProjection'>, set: map.setProjection };
+}
+
+describe('adaptive terrain globe', () => {
+  it('starts the local style in the same globe configuration', () => {
+    expect(style.projection).toEqual(GLOBE_PROJECTION);
+    expect(GLOBE_PROJECTION.type).toEqual(['interpolate', ['linear'], ['zoom'], 7, 'vertical-perspective', 9, 'mercator']);
+    expect(9).toBeLessThan(TERRAIN_MIN_ZOOM - 0.5);
+  });
+  it('handles styles with an omitted projection without crashing', () => {
+    const { map, set } = fixture();
+    expect(applyMapProjection(map, 'mercator')).toBe(false);
+    expect(applyMapProjection(map, 'globe')).toBe(true);
+    expect(set).toHaveBeenCalledWith(GLOBE_PROJECTION);
+  });
+  it('does not reapply the projection when only terrain changes', () => {
+    const { map, set } = fixture(structuredClone(GLOBE_PROJECTION));
+    expect(applyMapProjection(map, 'globe')).toBe(false);
+    expect(set).not.toHaveBeenCalled();
+  });
+  it('switches flat and globe views without a new map', () => {
+    const { map, set } = fixture(GLOBE_PROJECTION);
+    expect(applyMapProjection(map, 'mercator')).toBe(true);
+    expect(applyMapProjection(map, 'mercator')).toBe(false);
+    expect(applyMapProjection(map, 'globe')).toBe(true);
+    expect(set).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/map-projection.ts
+++ b/src/lib/map-projection.ts
@@ -1,0 +1,16 @@
+import type { Map, ProjectionSpecification } from 'maplibre-gl';
+
+// Keep the globe at overview zooms, but finish its local-plane transition
+// before terrain can turn on (10) or remain on during zoom-out (9.5).
+// This avoids compiling both globe+terrain and mercator+terrain GPU programs.
+export const GLOBE_PROJECTION: ProjectionSpecification = {
+  type: ['interpolate', ['linear'], ['zoom'], 7, 'vertical-perspective', 9, 'mercator'],
+};
+
+export function applyMapProjection(map: Pick<Map, 'getProjection' | 'setProjection'>, mode: 'globe' | 'mercator') {
+  const next: ProjectionSpecification = mode === 'globe' ? GLOBE_PROJECTION : { type: 'mercator' };
+  // An omitted style projection is mercator, despite the library's return type.
+  if (JSON.stringify(map.getProjection()?.type ?? 'mercator') === JSON.stringify(next.type)) return false;
+  map.setProjection(next);
+  return true;
+}

--- a/src/lib/map-startup.test.ts
+++ b/src/lib/map-startup.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Map as MapLibreMap } from 'maplibre-gl';
+import { MAP_STARTUP_TIMEOUT_MS, watchMapStartup } from './map-startup';
+import style from '../../public/dark-matter-style.json';
+
+function fixture() {
+  const listeners = new Map<string, Set<(event: unknown) => void>>();
+  const map = {
+    on(name: string, callback: (event: unknown) => void) {
+      if (!listeners.has(name)) listeners.set(name, new Set());
+      listeners.get(name)!.add(callback);
+    },
+    off(name: string, callback: (event: unknown) => void) { listeners.get(name)?.delete(callback); },
+  };
+  const status = vi.fn();
+  const stop = watchMapStartup(map as unknown as MapLibreMap, status);
+  const emit = (name: string, event: unknown = {}) => listeners.get(name)?.forEach(callback => callback(event));
+  const tile = () => emit('sourcedata', { sourceId: 'carto', tile: { state: 'loaded' } });
+  return { status, stop, emit, tile, listeners };
+}
+
+describe('map startup recovery', () => {
+  beforeEach(() => { vi.useFakeTimers(); vi.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); });
+
+  it('only reports ready after the map and a real basemap tile have loaded', () => {
+    const f = fixture();
+    f.emit('load');
+    f.emit('sourcedata', { sourceId: 'carto', tile: { state: 'errored' } });
+    f.emit('sourcedata', { sourceId: 'flights', tile: { state: 'loaded' } });
+    expect(f.status).not.toHaveBeenCalled();
+    f.tile();
+    expect(f.status).toHaveBeenLastCalledWith('ready');
+    vi.advanceTimersByTime(MAP_STARTUP_TIMEOUT_MS);
+    expect(f.status).toHaveBeenCalledTimes(1);
+    f.stop();
+  });
+
+  it('handles tile completion before the load event', () => {
+    const f = fixture();
+    f.tile();
+    expect(f.status).not.toHaveBeenCalled();
+    f.emit('load');
+    expect(f.status).toHaveBeenLastCalledWith('ready');
+    f.stop();
+  });
+
+  it('shows an actionable error for a failed style and permits a late recovery', () => {
+    const f = fixture();
+    f.emit('error', { error: new Error('Style request failed') });
+    expect(f.status).toHaveBeenLastCalledWith('error');
+    f.tile();
+    f.emit('load');
+    expect(f.status).toHaveBeenLastCalledWith('ready');
+    f.stop();
+  });
+
+  it('does not mistake a load event with no successful tiles for a usable map', () => {
+    const f = fixture();
+    f.emit('load');
+    vi.advanceTimersByTime(MAP_STARTUP_TIMEOUT_MS);
+    expect(f.status).toHaveBeenLastCalledWith('error');
+    f.tile();
+    expect(f.status).toHaveBeenLastCalledWith('ready');
+    f.stop();
+  });
+
+  it('keeps a loaded map available when an entity or terrain request fails', () => {
+    const f = fixture();
+    f.tile(); f.emit('load');
+    f.emit('error', { sourceId: 'osiris-terrain-dem', error: new Error('Tile failed') });
+    expect(f.status).toHaveBeenCalledTimes(1);
+    f.stop();
+  });
+
+  it('exposes graphics context loss and clears the message on restoration', () => {
+    const f = fixture();
+    f.tile(); f.emit('load');
+    f.emit('webglcontextlost');
+    expect(f.status).toHaveBeenLastCalledWith('error');
+    f.tile();
+    expect(f.status).toHaveBeenLastCalledWith('error');
+    f.emit('webglcontextrestored');
+    expect(f.status).toHaveBeenLastCalledWith('ready');
+    f.stop();
+  });
+
+  it('removes every listener and cancels the timeout on unmount', () => {
+    const f = fixture();
+    f.emit('remove');
+    f.stop();
+    vi.advanceTimersByTime(MAP_STARTUP_TIMEOUT_MS);
+    expect(f.status).not.toHaveBeenCalled();
+    expect([...f.listeners.values()].every(set => set.size === 0)).toBe(true);
+  });
+
+  it('ships local style metadata without the missing proxy rewrite or remote TileJSON dependency', () => {
+    expect(style.version).toBe(8);
+    expect(style.sources.carto).not.toHaveProperty('url');
+    expect(style.sources.carto.tiles).toHaveLength(4);
+    expect(style.sources.carto.maxzoom).toBe(14);
+    expect(JSON.stringify(style)).not.toContain('/cartocdn-tiles/');
+    expect(style.glyphs).toMatch(/^https:\/\/tiles\.basemaps\.cartocdn\.com\//);
+  });
+});

--- a/src/lib/map-startup.ts
+++ b/src/lib/map-startup.ts
@@ -1,0 +1,57 @@
+import type { ErrorEvent, Map, MapSourceDataEvent } from 'maplibre-gl';
+
+export type MapStartupStatus = 'loading' | 'ready' | 'error';
+export const MAP_STARTUP_TIMEOUT_MS = 15_000;
+
+/** MapLibre's load event can fire even when all basemap tiles failed. */
+export function watchMapStartup(map: Map, onStatus: (status: MapStartupStatus) => void) {
+  let disposed = false;
+  let mapLoaded = false;
+  let basemapLoaded = false;
+  let contextLost = false;
+  let status: MapStartupStatus = 'loading';
+  const report = (next: MapStartupStatus) => {
+    if (disposed || status === next) return;
+    status = next;
+    onStatus(next);
+  };
+  const timer = setTimeout(() => report('error'), MAP_STARTUP_TIMEOUT_MS);
+  const checkReady = () => {
+    if (mapLoaded && basemapLoaded && !contextLost) {
+      clearTimeout(timer);
+      report('ready');
+    }
+  };
+  const onLoad = () => { mapLoaded = true; checkReady(); };
+  const onData = (event: MapSourceDataEvent) => {
+    if (event.sourceId === 'carto' && event.tile?.state === 'loaded') {
+      basemapLoaded = true;
+      checkReady();
+    }
+  };
+  const onError = (event: ErrorEvent & { sourceId?: string }) => {
+    // Isolated entity/terrain failures must not replace a working map.
+    if (status !== 'ready' && (!event.sourceId || event.sourceId === 'carto')) report('error');
+    console.warn('[OSIRIS] Map resource unavailable:', event.error);
+  };
+  const onContextLost = () => { contextLost = true; report('error'); };
+  const onContextRestored = () => { contextLost = false; checkReady(); };
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    clearTimeout(timer);
+    map.off('load', onLoad);
+    map.off('sourcedata', onData);
+    map.off('error', onError);
+    map.off('webglcontextlost', onContextLost);
+    map.off('webglcontextrestored', onContextRestored);
+    map.off('remove', dispose);
+  };
+  map.on('load', onLoad);
+  map.on('sourcedata', onData);
+  map.on('error', onError);
+  map.on('webglcontextlost', onContextLost);
+  map.on('webglcontextrestored', onContextRestored);
+  map.on('remove', dispose);
+  return dispose;
+}

--- a/src/lib/map-terrain.test.ts
+++ b/src/lib/map-terrain.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Map as MapLibreMap } from 'maplibre-gl';
+import { attachTerrain, TERRAIN_SOURCE, TERRAIN_MIN_ZOOM, TERRAIN_SETTLE_MS } from './map-terrain';
+
+function createMap(initialZoom = 11) {
+  const listeners = new Map<string, Set<(event: Record<string, unknown>) => void>>();
+  const sources = new Set(['flights', 'satellite-tiles']);
+  const operations: string[] = [];
+  let terrain: { source: string; exaggeration: number } | null = null;
+  let zoom = initialZoom;
+  let moving = false;
+  let pixelRatio = 3;
+  let maxPitch = 85;
+  const map = {
+    getZoom: () => zoom,
+    getLayersOrder: () => [],
+    setSourceTileLodParams: vi.fn(),
+    isMoving: () => moving,
+    getPixelRatio: () => pixelRatio,
+    setPixelRatio: (value: number) => { pixelRatio = value; },
+    getMaxPitch: () => maxPitch,
+    setMaxPitch: (value: number) => { maxPitch = value; },
+    on: vi.fn((name: string, callback: (event: Record<string, unknown>) => void) => {
+      if (!listeners.has(name)) listeners.set(name, new Set());
+      listeners.get(name)!.add(callback);
+    }),
+    off: vi.fn((name: string, callback: (event: Record<string, unknown>) => void) => listeners.get(name)?.delete(callback)),
+    addSource: vi.fn((id: string) => sources.add(id)),
+    getSource: vi.fn((id: string) => sources.has(id)),
+    removeSource: vi.fn((id: string) => {
+      if (terrain?.source === id) throw new Error('Source still in use');
+      operations.push('remove source');
+      sources.delete(id);
+    }),
+    getTerrain: vi.fn(() => terrain),
+    setTerrain: vi.fn((value: typeof terrain) => {
+      terrain = value;
+      operations.push(value ? 'enable terrain' : 'disable terrain');
+    }),
+  };
+  return {
+    map: map as unknown as MapLibreMap,
+    methods: map, sources, operations, listeners,
+    moveTo: (value: number, inMotion = false) => { zoom = value; moving = inMotion; },
+    emit: (name: string, event: Record<string, unknown> = {}) => listeners.get(name)?.forEach(callback => callback(event)),
+  };
+}
+
+describe('lightweight terrain', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); });
+  it('makes no elevation requests at globe zoom and waits until the camera settles', () => {
+    const fixture = createMap(2);
+    const status = vi.fn();
+    const dispose = attachTerrain(fixture.map, status);
+    expect(fixture.methods.addSource).not.toHaveBeenCalled();
+    expect(fixture.methods.setTerrain).not.toHaveBeenCalled();
+    fixture.moveTo(11, true);
+    fixture.emit('zoom');
+    fixture.emit('moveend');
+    expect(fixture.methods.addSource).not.toHaveBeenCalled();
+    fixture.moveTo(11);
+    fixture.emit('moveend');
+    expect(fixture.methods.addSource).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(TERRAIN_SETTLE_MS);
+    expect(fixture.methods.addSource).toHaveBeenCalledTimes(1);
+    expect(status).toHaveBeenLastCalledWith('loading');
+    dispose();
+  });
+
+  it('caps elevation detail and Retina rendering without adding satellite imagery', () => {
+    const fixture = createMap();
+    const dispose = attachTerrain(fixture.map, vi.fn());
+    vi.advanceTimersByTime(TERRAIN_SETTLE_MS);
+    expect(fixture.methods.addSource).toHaveBeenCalledWith(TERRAIN_SOURCE, expect.objectContaining({
+      type: 'raster-dem', tileSize: 256, maxzoom: 10, encoding: 'terrarium',
+    }));
+    expect(fixture.map.getPixelRatio()).toBe(1.5);
+    expect(fixture.map.getMaxPitch()).toBe(60);
+    expect(fixture.methods.setSourceTileLodParams).toHaveBeenCalledWith(10, 1.25, TERRAIN_SOURCE);
+    fixture.emit('moveend');
+    fixture.emit('moveend');
+    expect(fixture.methods.addSource).toHaveBeenCalledTimes(1);
+    dispose();
+    expect(fixture.map.getPixelRatio()).toBe(3);
+    expect(fixture.map.getMaxPitch()).toBe(85);
+  });
+
+  it('unloads during zoom-out and avoids source churn near the zoom threshold', () => {
+    const fixture = createMap();
+    const status = vi.fn();
+    const dispose = attachTerrain(fixture.map, status);
+    vi.advanceTimersByTime(TERRAIN_SETTLE_MS);
+    fixture.moveTo(9.8);
+    fixture.emit('zoom');
+    fixture.emit('moveend');
+    expect(fixture.sources.has(TERRAIN_SOURCE)).toBe(true);
+    fixture.moveTo(9);
+    fixture.emit('zoom');
+    expect(fixture.sources.has(TERRAIN_SOURCE)).toBe(false);
+    expect(fixture.operations).toEqual(['enable terrain', 'disable terrain', 'remove source']);
+    expect(status).toHaveBeenLastCalledWith('idle');
+    fixture.moveTo(9.8);
+    fixture.emit('moveend');
+    expect(fixture.sources.has(TERRAIN_SOURCE)).toBe(false);
+    fixture.moveTo(TERRAIN_MIN_ZOOM);
+    fixture.emit('moveend');
+    vi.advanceTimersByTime(TERRAIN_SETTLE_MS);
+    expect(fixture.methods.addSource).toHaveBeenCalledTimes(2);
+    dispose();
+  });
+
+  it('only reports elevation ready after terrain data loads', () => {
+    const fixture = createMap();
+    const status = vi.fn();
+    const dispose = attachTerrain(fixture.map, status);
+    vi.advanceTimersByTime(TERRAIN_SETTLE_MS);
+    fixture.emit('sourcedata', { sourceId: 'flights', sourceDataType: 'content', isSourceLoaded: true });
+    fixture.emit('sourcedata', { sourceId: TERRAIN_SOURCE, sourceDataType: 'metadata', isSourceLoaded: true });
+    expect(status).toHaveBeenLastCalledWith('loading');
+    fixture.emit('sourcedata', { sourceId: TERRAIN_SOURCE, tile: {}, isSourceLoaded: true });
+    expect(status).toHaveBeenLastCalledWith('ready');
+    dispose();
+  });
+
+  it('falls back to the normal map after a tile error, without automatic retry loops', async () => {
+    const fixture = createMap();
+    const status = vi.fn();
+    const dispose = attachTerrain(fixture.map, status);
+    vi.advanceTimersByTime(TERRAIN_SETTLE_MS);
+    fixture.emit('error', { sourceId: 'flights' });
+    expect(status).toHaveBeenLastCalledWith('loading');
+    fixture.emit('error', { sourceId: TERRAIN_SOURCE });
+    await Promise.resolve();
+    fixture.emit('moveend');
+    fixture.emit('sourcedata', { sourceId: TERRAIN_SOURCE, sourceDataType: 'content', isSourceLoaded: true });
+    expect(status).toHaveBeenLastCalledWith('error');
+    expect(fixture.map.getTerrain()).toBeNull();
+    expect(fixture.methods.addSource).toHaveBeenCalledTimes(1);
+    expect([...fixture.sources]).toEqual(['flights', 'satellite-tiles']);
+    dispose();
+    const retry = attachTerrain(fixture.map, status);
+    vi.advanceTimersByTime(TERRAIN_SETTLE_MS);
+    expect(fixture.methods.addSource).toHaveBeenCalledTimes(2);
+    retry();
+  });
+
+  it('removes listeners and ignores late callbacks after switching modes', () => {
+    const fixture = createMap();
+    const status = vi.fn();
+    const dispose = attachTerrain(fixture.map, status);
+    vi.advanceTimersByTime(TERRAIN_SETTLE_MS);
+    const queuedCallback = [...fixture.listeners.get('sourcedata')!][0];
+    dispose();
+    dispose();
+    expect(fixture.operations).toEqual(['enable terrain', 'disable terrain', 'remove source']);
+    expect([...fixture.listeners.values()].every(listeners => listeners.size === 0)).toBe(true);
+    queuedCallback({ sourceId: TERRAIN_SOURCE, sourceDataType: 'content', isSourceLoaded: true });
+    expect(status.mock.calls).toEqual([['idle'], ['waiting'], ['loading']]);
+  });
+
+  it.each([2, 7, 8, 9, 9.99])('never creates terrain or requests elevation at zoom %s', zoom => {
+    const fixture = createMap(zoom);
+    const dispose = attachTerrain(fixture.map, vi.fn());
+    fixture.emit('moveend');
+    vi.advanceTimersByTime(5000);
+    expect(fixture.methods.addSource).not.toHaveBeenCalled();
+    expect(fixture.methods.setTerrain).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it('cancels pending activation when movement resumes or the mode is closed', () => {
+    const fixture = createMap();
+    const dispose = attachTerrain(fixture.map, vi.fn());
+    vi.advanceTimersByTime(TERRAIN_SETTLE_MS - 1);
+    fixture.moveTo(11, true);
+    fixture.emit('movestart');
+    vi.advanceTimersByTime(5000);
+    expect(fixture.methods.addSource).not.toHaveBeenCalled();
+    fixture.moveTo(11);
+    fixture.emit('moveend');
+    dispose();
+    vi.advanceTimersByTime(5000);
+    expect(fixture.methods.addSource).not.toHaveBeenCalled();
+  });
+
+  it('does not start tile work in a background tab', () => {
+    const page = new EventTarget();
+    Object.assign(page, { hidden: true });
+    vi.stubGlobal('document', page);
+    const fixture = createMap();
+    const dispose = attachTerrain(fixture.map, vi.fn());
+    vi.advanceTimersByTime(5000);
+    expect(fixture.methods.addSource).not.toHaveBeenCalled();
+    Object.assign(page, { hidden: false });
+    page.dispatchEvent(new Event('visibilitychange'));
+    vi.advanceTimersByTime(TERRAIN_SETTLE_MS);
+    expect(fixture.methods.addSource).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it('cancels deferred tile loading if React removes the map first', () => {
+    const fixture = createMap();
+    const dispose = attachTerrain(fixture.map, vi.fn());
+    fixture.emit('remove');
+    vi.advanceTimersByTime(5000);
+    expect(fixture.methods.addSource).not.toHaveBeenCalled();
+    dispose();
+    expect(fixture.methods.removeSource).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/map-terrain.ts
+++ b/src/lib/map-terrain.ts
@@ -1,0 +1,137 @@
+import type { Map, MapSourceDataEvent, ErrorEvent } from 'maplibre-gl';
+import { batchTerrainLayers } from './terrain-layer-order';
+
+export const TERRAIN_SOURCE = 'osiris-terrain-dem';
+export type TerrainStatus = 'idle' | 'waiting' | 'loading' | 'ready' | 'error';
+
+// Hysteresis prevents reloading tiles when hovering around the activation zoom.
+export const TERRAIN_MIN_ZOOM = 10;
+const DISABLE_ZOOM = 9.5;
+export const TERRAIN_SETTLE_MS = 500;
+
+/** Lazy, bounded terrain using the existing renderer; no second map or imagery. */
+export function attachTerrain(map: Map, onStatus: (status: TerrainStatus) => void) {
+  let disposed = false;
+  let active = false;
+  let failed = false;
+  let restoreLayerOrder: (() => void) | undefined;
+  let status: TerrainStatus | undefined;
+  let activationTimer: ReturnType<typeof setTimeout> | undefined;
+  const originalPitchLimit = map.getMaxPitch();
+  const originalPixelRatio = map.getPixelRatio();
+  map.setMaxPitch(Math.min(originalPitchLimit, 60));
+  // Retina screens otherwise multiply the terrain framebuffers' pixel count.
+  if (originalPixelRatio > 1.5) map.setPixelRatio(1.5);
+
+  const report = (next: TerrainStatus) => {
+    if (disposed || next === status) return;
+    status = next;
+    onStatus(next);
+  };
+  const release = () => {
+    active = false;
+    if (map.getTerrain()?.source === TERRAIN_SOURCE) map.setTerrain(null);
+    if (map.getSource(TERRAIN_SOURCE)) map.removeSource(TERRAIN_SOURCE);
+    restoreLayerOrder?.();
+    restoreLayerOrder = undefined;
+  };
+  const cancelActivation = () => {
+    clearTimeout(activationTimer);
+    activationTimer = undefined;
+  };
+  const hidden = () => typeof document !== 'undefined' && document.hidden;
+  const activate = () => {
+    activationTimer = undefined;
+    if (disposed || active || failed || map.isMoving() || hidden() || map.getZoom() < TERRAIN_MIN_ZOOM) return;
+    active = true;
+    report('loading');
+    try {
+      map.addSource(TERRAIN_SOURCE, {
+        type: 'raster-dem',
+        tiles: ['osiris-dem://{z}/{x}/{y}'],
+        encoding: 'terrarium',
+        tileSize: 256,
+        maxzoom: 10,
+        attribution: '<a href="https://github.com/tilezen/joerd/blob/master/docs/attribution.md">Terrain data credits</a>',
+      });
+      // DEM maxzoom only limits downloads, not terrain render-tile density.
+      // Bound the latter too, especially the distant tiles in a pitched view.
+      map.setSourceTileLodParams(10, 1.25, TERRAIN_SOURCE);
+      restoreLayerOrder = batchTerrainLayers(map);
+      map.setTerrain({ source: TERRAIN_SOURCE, exaggeration: 1 });
+    } catch (error) {
+      failed = true;
+      release();
+      report('error');
+      console.warn('[OSIRIS] Terrain unavailable:', error);
+    }
+  };
+  const update = () => {
+    if (disposed || active || failed) return;
+    cancelActivation();
+    if (map.getZoom() < TERRAIN_MIN_ZOOM) {
+      report('idle');
+      return;
+    }
+    report('waiting');
+    if (!map.isMoving() && !hidden()) activationTimer = setTimeout(activate, TERRAIN_SETTLE_MS);
+  };
+  const onZoom = () => {
+    if (!active && map.getZoom() < TERRAIN_MIN_ZOOM) {
+      cancelActivation();
+      if (!failed) report('idle');
+    }
+    // Stop terrain requests during the zoom-out, before reaching the globe.
+    if (active && map.getZoom() < DISABLE_ZOOM) {
+      release();
+      report('idle');
+    }
+  };
+  const onData = (event: MapSourceDataEvent) => {
+    // Individual raster tile completions carry `tile`, not sourceDataType:
+    // 'content'. Waiting for 'content' alone leaves the indicator spinning.
+    if (active && !failed && event.sourceId === TERRAIN_SOURCE &&
+        event.isSourceLoaded && (event.tile || event.sourceDataType === 'idle')) report('ready');
+  };
+  const onError = (event: ErrorEvent & { sourceId?: string }) => {
+    if (!active || event.sourceId !== TERRAIN_SOURCE) return;
+    failed = true;
+    report('error');
+    // Let MapLibre finish its source callback before removing its resources.
+    queueMicrotask(() => { if (!disposed) release(); });
+  };
+
+  map.on('movestart', cancelActivation);
+  map.on('zoom', onZoom);
+  map.on('moveend', update);
+  map.on('sourcedata', onData);
+  map.on('error', onError);
+  const onVisibility = () => { if (hidden()) cancelActivation(); else update(); };
+  if (typeof document !== 'undefined') document.addEventListener('visibilitychange', onVisibility);
+  // React removes the map before running this effect's cleanup on a theme
+  // change. Cancel deferred work without touching its already-destroyed style.
+  const onRemove = () => {
+    disposed = true;
+    cancelActivation();
+    if (typeof document !== 'undefined') document.removeEventListener('visibilitychange', onVisibility);
+  };
+  map.on('remove', onRemove);
+  report('idle');
+  update();
+
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    cancelActivation();
+    map.off('remove', onRemove);
+    if (typeof document !== 'undefined') document.removeEventListener('visibilitychange', onVisibility);
+    map.off('movestart', cancelActivation);
+    map.off('zoom', onZoom);
+    map.off('moveend', update);
+    map.off('sourcedata', onData);
+    map.off('error', onError);
+    release();
+    map.setMaxPitch(originalPitchLimit);
+    if (originalPixelRatio > 1.5) map.setPixelRatio(originalPixelRatio);
+  };
+}

--- a/src/lib/satellite-layer.ts
+++ b/src/lib/satellite-layer.ts
@@ -1,5 +1,6 @@
 import type { CustomLayerInterface, CustomRenderMethodInput, Map as MlMap } from 'maplibre-gl';
 import { MercatorCoordinate } from 'maplibre-gl';
+import { createSatelliteProgramCache } from './satellite-programs';
 
 /**
  * OSIRIS — satellites drawn at their real altitude
@@ -255,7 +256,7 @@ export function createSatelliteLayer(id: string): CustomLayerInterface & {
   let gl: WebGL2RenderingContext | null = null;
   let map: MlMap | null = null;
   let program: WebGLProgram | null = null;
-  let variant = '';
+  let activeShader: CustomRenderMethodInput['shaderData'] | null = null;
   let buffer: WebGLBuffer | null = null;
   let quad: WebGLBuffer | null = null;
   let pickProgram: WebGLProgram | null = null;
@@ -296,11 +297,11 @@ export function createSatelliteLayer(id: string): CustomLayerInterface & {
     return pr;
   };
 
-  const buildProgram = (prelude: string, define: string) => {
-    if (!gl) return;
-    if (program) gl.deleteProgram(program);
-    program = link(prelude, define, VERT, FRAG);
-  };
+  const programs = createSatelliteProgramCache<WebGLProgram>((kind, prelude, define) => {
+    if (kind === 'pick') return link(prelude, define, PICK_VERT, PICK_FRAG);
+    if (kind === 'orbit') return link(prelude, define, ORBIT_VERT, ORBIT_FRAG);
+    return link(prelude, define, VERT, FRAG);
+  }, pr => gl?.deleteProgram(pr));
 
   /** Lazily sized colour+depth target for the pick pass. */
   const ensurePickTargets = (w: number, h: number) => {
@@ -389,17 +390,17 @@ export function createSatelliteLayer(id: string): CustomLayerInterface & {
 
     onRemove() {
       if (gl) {
-        if (program) gl.deleteProgram(program);
+        programs.clear();
         if (buffer) gl.deleteBuffer(buffer);
         if (quad) gl.deleteBuffer(quad);
-        if (pickProgram) gl.deleteProgram(pickProgram);
         if (pickTex) gl.deleteTexture(pickTex);
         if (pickDepth) gl.deleteRenderbuffer(pickDepth);
         if (pickFbo) gl.deleteFramebuffer(pickFbo);
-        if (orbitProgram) gl.deleteProgram(orbitProgram);
         for (const o of orbitBuffers) gl.deleteBuffer(o.buf);
       }
       program = null;
+      activeShader = null;
+      lastProjection = null;
       buffer = null;
       quad = null;
       pickProgram = null;
@@ -446,7 +447,9 @@ export function createSatelliteLayer(id: string): CustomLayerInterface & {
      * may be larger on a scaled display, so they are converted first.
      */
     pick(x: number, y: number): number | null {
-      if (!gl || !pickProgram || !buffer || !lastProjection || count === 0) return null;
+      if (!gl || !activeShader || !buffer || !lastProjection || count === 0) return null;
+      try { pickProgram = programs.get(activeShader, 'pick'); }
+      catch (error) { console.warn('[OSIRIS] Satellite picking unavailable:', error); return null; }
       const w = gl.drawingBufferWidth, h = gl.drawingBufferHeight;
       ensurePickTargets(w, h);
       if (!pickFbo) return null;
@@ -502,22 +505,19 @@ export function createSatelliteLayer(id: string): CustomLayerInterface & {
     },
     render(_context: WebGL2RenderingContext | WebGLRenderingContext, args: CustomRenderMethodInput) {
       if (!gl || !buffer) return;
+      // An inactive satellite layer must not compile three GPU programs on
+      // startup or whenever the map switches between globe and flat views.
+      if (!points.length) { count = 0; lastProjection = null; return; }
       const shader = args?.shaderData;
       if (!shader?.vertexShaderPrelude) return;
 
-      // Recompile when the projection changes — globe and mercator ship
-      // different preludes, and the old program silently draws nothing.
-      if (!program || variant !== shader.variantName) {
-        try {
-          buildProgram(shader.vertexShaderPrelude, shader.define || '');
-          pickProgram = link(shader.vertexShaderPrelude, shader.define || '', PICK_VERT, PICK_FRAG);
-          orbitProgram = link(shader.vertexShaderPrelude, shader.define || '', ORBIT_VERT, ORBIT_FRAG);
-          orbitDirty = true;
-          variant = shader.variantName || '';
-        } catch (err) {
-          console.error('[OSIRIS] satellite layer:', err instanceof Error ? err.message : err);
-          return;
-        }
+      try {
+        program = programs.get(shader, 'marker');
+        orbitProgram = orbitSegments?.length ? programs.get(shader, 'orbit') : null;
+        activeShader = shader;
+      } catch (err) {
+        console.error('[OSIRIS] satellite layer:', err instanceof Error ? err.message : err);
+        return;
       }
       if (!program) return;
 

--- a/src/lib/satellite-programs.test.ts
+++ b/src/lib/satellite-programs.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSatelliteProgramCache } from './satellite-programs';
+const shader = (variantName: string) => ({ variantName, vertexShaderPrelude: 'prelude', define: '' });
+
+describe('satellite GPU program lifecycle', () => {
+  it('allocates nothing until asked, and reuses programs across view switches', () => {
+    const compile = vi.fn((kind: string) => ({ kind }));
+    const cache = createSatelliteProgramCache(compile, vi.fn());
+    expect(compile).not.toHaveBeenCalled();
+    const first = cache.get(shader('globe'), 'marker');
+    cache.get(shader('mercator'), 'marker');
+    for (let i = 0; i < 30; i++) cache.get(shader(i % 2 ? 'globe' : 'mercator'), 'marker');
+    expect(cache.get(shader('globe'), 'marker')).toBe(first);
+    expect(compile).toHaveBeenCalledTimes(2);
+    // No hidden pick/orbit compilation when merely drawing markers.
+    expect(compile.mock.calls.every(args => args[0] === 'marker')).toBe(true);
+  });
+  it('releases all programs, including pick/orbit, when evicting or removing a map', () => {
+    const compile = vi.fn(() => ({})); const destroy = vi.fn();
+    const cache = createSatelliteProgramCache(compile, destroy, 2);
+    for (const kind of ['marker', 'pick', 'orbit'] as const) cache.get(shader('a'), kind);
+    cache.get(shader('b'), 'marker'); cache.get(shader('c'), 'marker');
+    expect(destroy).toHaveBeenCalledTimes(3);
+    cache.clear(); cache.clear();
+    expect(destroy).toHaveBeenCalledTimes(5);
+    expect(new Set(destroy.mock.calls.map(args => args[0])).size).toBe(5);
+  });
+  it('does not cache failed compiles or destroy a working program', () => {
+    const compile = vi.fn().mockReturnValueOnce({}).mockImplementationOnce(() => { throw new Error('compile'); }).mockReturnValue({});
+    const destroy = vi.fn(); const cache = createSatelliteProgramCache(compile, destroy);
+    const first = cache.get(shader('globe'), 'marker');
+    expect(() => cache.get(shader('globe'), 'pick')).toThrow('compile');
+    expect(cache.get(shader('globe'), 'marker')).toBe(first);
+    cache.get(shader('globe'), 'pick');
+    expect(compile).toHaveBeenCalledTimes(3);
+    expect(destroy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/satellite-programs.ts
+++ b/src/lib/satellite-programs.ts
@@ -1,0 +1,34 @@
+export type SatelliteProgramKind = 'marker' | 'pick' | 'orbit';
+type Shader = { variantName: string; vertexShaderPrelude: string; define?: string };
+
+/** Bounded per-context shader cache; picking and orbit programs are demand-only. */
+export function createSatelliteProgramCache<T>(
+  compile: (kind: SatelliteProgramKind, prelude: string, define: string) => T,
+  destroy: (program: T) => void,
+  maxVariants = 4,
+) {
+  const variants = new Map<string, Map<SatelliteProgramKind, T>>();
+  return {
+    get(shader: Shader, kind: SatelliteProgramKind): T {
+      const key = `${shader.variantName}\0${shader.define ?? ''}`;
+      const programs = variants.get(key) ?? new Map<SatelliteProgramKind, T>();
+      let program = programs.get(kind);
+      if (!program) {
+        program = compile(kind, shader.vertexShaderPrelude, shader.define ?? '');
+        programs.set(kind, program);
+      }
+      variants.delete(key);
+      variants.set(key, programs);
+      while (variants.size > maxVariants) {
+        const oldest = variants.keys().next().value!;
+        variants.get(oldest)!.forEach(destroy);
+        variants.delete(oldest);
+      }
+      return program;
+    },
+    clear() {
+      variants.forEach(programs => programs.forEach(destroy));
+      variants.clear();
+    },
+  };
+}

--- a/src/lib/terrain-layer-order.test.ts
+++ b/src/lib/terrain-layer-order.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Map as MapLibreMap } from 'maplibre-gl';
+import { batchTerrainLayers } from './terrain-layer-order';
+
+type Layer = { id: string; type: string };
+
+// Representative ordering from OsirisMap: live circles and symbols separate
+// day/night, network lines, scan connections, SDK paths and drawn regions.
+const layers: Layer[] = [
+  { id: 'background', type: 'background' },
+  { id: 'roads', type: 'line' },
+  { id: 'places', type: 'symbol' },
+  { id: 'day-night-fill', type: 'fill' },
+  { id: 'eq-circles', type: 'circle' },
+  { id: 'cyber-arcs', type: 'line' },
+  { id: 'satellites', type: 'custom' },
+  { id: 'sweep-connections', type: 'line' },
+  { id: 'news-dots', type: 'circle' },
+  { id: 'sdk-air', type: 'line' },
+  { id: 'buildings', type: 'fill-extrusion' },
+];
+const groundIds = ['background', 'roads', 'day-night-fill', 'cyber-arcs', 'sweep-connections', 'sdk-air'];
+const overlayIds = ['places', 'eq-circles', 'satellites', 'news-dots', 'buildings'];
+
+function createMap(initialLayers = layers) {
+  let order = initialLayers.map(layer => layer.id);
+  const byId = new Map(initialLayers.map(layer => [layer.id, layer]));
+  const listeners = new Set<() => void>();
+  const emit = () => listeners.forEach(fn => fn());
+  const map = {
+    getLayersOrder: () => [...order],
+    getLayer: (id: string) => byId.get(id),
+    moveLayer: vi.fn((id: string, before?: string) => {
+      if (!byId.has(id) || (before && !byId.has(before))) throw new Error('Layer missing');
+      order = order.filter(item => item !== id);
+      order.splice(before ? order.indexOf(before) : order.length, 0, id);
+      // Exercise the guard even if a style implementation emits synchronously.
+      emit();
+    }),
+    on: (_: string, callback: () => void) => listeners.add(callback),
+    off: (_: string, callback: () => void) => listeners.delete(callback),
+  };
+  return {
+    map: map as unknown as MapLibreMap, methods: map, emit, listeners,
+    add: (layer: Layer, before?: string) => {
+      byId.set(layer.id, layer);
+      order.splice(before ? order.indexOf(before) : order.length, 0, layer.id);
+      emit();
+    },
+    remove: (id: string) => {
+      order = order.filter(item => item !== id);
+      byId.delete(id);
+      emit();
+    },
+  };
+}
+
+function terrainPasses(order: string[], ground: string[]) {
+  const draped = new Set(ground);
+  return order.filter((id, i) => draped.has(id) && (i === 0 || !draped.has(order[i - 1]))).length;
+}
+
+describe('terrain layer batching', () => {
+  it('reduces five separated terrain stacks to one, preserving every layer and within-group order', () => {
+    const fixture = createMap();
+    const original = fixture.map.getLayersOrder();
+    expect(terrainPasses(original, groundIds)).toBe(5);
+    const restore = batchTerrainLayers(fixture.map);
+    expect(fixture.map.getLayersOrder()).toEqual([...groundIds, ...overlayIds]);
+    expect(terrainPasses(fixture.map.getLayersOrder(), groundIds)).toBe(1);
+    restore();
+    expect(fixture.map.getLayersOrder()).toEqual(original);
+  });
+
+  it('does not reorder on repeated paint or source updates', () => {
+    const fixture = createMap();
+    const restore = batchTerrainLayers(fixture.map);
+    fixture.methods.moveLayer.mockClear();
+    for (let i = 0; i < 100; i++) fixture.emit();
+    expect(fixture.methods.moveLayer).not.toHaveBeenCalled();
+    restore();
+  });
+
+  it('batches dynamically drawn areas and preserves satellite imagery insertion when leaving terrain', () => {
+    const fixture = createMap();
+    const restore = batchTerrainLayers(fixture.map);
+    fixture.add({ id: 'satellite-layer', type: 'raster' }, 'day-night-fill');
+    fixture.add({ id: 'drawn-fill', type: 'fill' });
+    fixture.add({ id: 'drawn-label', type: 'symbol' });
+    expect(terrainPasses(fixture.map.getLayersOrder(), [...groundIds, 'satellite-layer', 'drawn-fill'])).toBe(1);
+    expect(fixture.map.getLayersOrder().at(-1)).toBe('drawn-label');
+    restore();
+    const expected = layers.map(layer => layer.id);
+    expected.splice(expected.indexOf('day-night-fill'), 0, 'satellite-layer');
+    expect(fixture.map.getLayersOrder()).toEqual([...expected, 'drawn-fill', 'drawn-label']);
+  });
+
+  it('does not restore deleted layers, handles re-entry, and cleans up listeners', () => {
+    const fixture = createMap();
+    const restore = batchTerrainLayers(fixture.map);
+    fixture.remove('cyber-arcs');
+    restore();
+    restore();
+    expect(fixture.map.getLayersOrder()).toEqual(layers.filter(layer => layer.id !== 'cyber-arcs').map(layer => layer.id));
+    expect(fixture.listeners.size).toBe(0);
+    const secondRestore = batchTerrainLayers(fixture.map);
+    expect(terrainPasses(fixture.map.getLayersOrder(), groundIds)).toBe(1);
+    secondRestore();
+    expect(fixture.listeners.size).toBe(0);
+  });
+
+  it('does no work on an already batched style', () => {
+    const fixture = createMap([{ id: 'ground', type: 'fill' }, { id: 'label', type: 'symbol' }]);
+    const restore = batchTerrainLayers(fixture.map);
+    expect(fixture.methods.moveLayer).not.toHaveBeenCalled();
+    restore();
+    expect(fixture.methods.moveLayer).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/terrain-layer-order.ts
+++ b/src/lib/terrain-layer-order.ts
@@ -1,0 +1,73 @@
+import type { Map } from 'maplibre-gl';
+
+// These layer types are draped onto MapLibre's terrain textures. Interleaving
+// them with markers makes it draw the same terrain mesh in multiple passes.
+const DRAPED_TYPES = new Set(['background', 'fill', 'line', 'raster', 'hillshade', 'color-relief']);
+
+/** Batch the ground surface below labels/markers, without hiding any data. */
+export function batchTerrainLayers(map: Map): () => void {
+  let originalOrder = map.getLayersOrder();
+  let lastOrder: string[] = [];
+  let reordering = false;
+  let disposed = false;
+
+  const rememberAddedLayers = (current: string[]) => {
+    const surviving = new Set(current);
+    originalOrder = originalOrder.filter(id => surviving.has(id));
+    const known = new Set(originalOrder);
+    // Preserve newly added layers' insertion anchors when restoring the style.
+    // For example, satellite imagery belongs immediately below day/night fill.
+    for (let i = current.length - 1; i >= 0; i--) {
+      const id = current[i];
+      if (known.has(id)) continue;
+      const before = i + 1 < current.length ? originalOrder.indexOf(current[i + 1]) : -1;
+      originalOrder.splice(before < 0 ? originalOrder.length : before, 0, id);
+      known.add(id);
+    }
+  };
+
+  const applyOrder = (desired: string[], current: string[]) => {
+    // Move only layers that need it. A paint/data update should do no moves.
+    const order = [...current];
+    for (let i = desired.length - 1; i >= 0; i--) {
+      const id = desired[i];
+      const index = order.indexOf(id);
+      const before = desired[i + 1];
+      if (order[index + 1] === before) continue;
+      map.moveLayer(id, before);
+      order.splice(index, 1);
+      order.splice(before ? order.indexOf(before) : order.length, 0, id);
+    }
+  };
+
+  const refresh = () => {
+    if (disposed || reordering) return;
+    // getLayersOrder is a small ID array, unlike getStyle which serializes all
+    // the live GeoJSON sources as well. No work is scheduled on camera frames.
+    const current = map.getLayersOrder();
+    if (current.length === lastOrder.length && current.every((id, i) => id === lastOrder[i])) return;
+    rememberAddedLayers(current);
+    const ground: string[] = [];
+    const overlays: string[] = [];
+    for (const id of current) {
+      const layer = map.getLayer(id);
+      (layer && DRAPED_TYPES.has(layer.type) ? ground : overlays).push(id);
+    }
+    lastOrder = [...ground, ...overlays];
+    reordering = true;
+    try { applyOrder(lastOrder, current); }
+    finally { reordering = false; }
+  };
+
+  map.on('styledata', refresh);
+  refresh();
+
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    map.off('styledata', refresh);
+    const current = map.getLayersOrder();
+    rememberAddedLayers(current);
+    applyOrder(originalOrder, current);
+  };
+}

--- a/src/lib/terrain-tiles.test.ts
+++ b/src/lib/terrain-tiles.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createTerrainTileLoader, TERRAIN_REQUEST_TIMEOUT_MS } from './terrain-tiles';
+
+const url = (x: number) => `osiris-dem://10/${x}/100`;
+const signal = () => new AbortController().signal;
+const response = () => new Response(new Uint8Array([1, 2, 3, 4]));
+afterEach(() => { vi.unstubAllGlobals(); vi.useRealTimers(); });
+
+describe('terrain tile loading', () => {
+  it('shares in-flight tiles without one consumer cancelling another', async () => {
+    let finish!: (value: Response) => void;
+    const fetcher = vi.fn<(url: string, options: RequestInit) => Promise<Response>>(() => new Promise<Response>(resolve => { finish = resolve; }));
+    vi.stubGlobal('fetch', fetcher);
+    const load = createTerrainTileLoader();
+    const cancelled = new AbortController();
+    const first = load(url(1), cancelled.signal);
+    const rejected = expect(first).rejects.toMatchObject({ name: 'AbortError' });
+    const second = load(url(1), signal());
+    cancelled.abort(); await rejected;
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher.mock.calls[0][1].signal?.aborted).toBe(false);
+    finish(response());
+    expect(new Uint8Array(await second)).toEqual(new Uint8Array([1, 2, 3, 4]));
+    await load(url(1), signal());
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts abandoned in-flight work and allows the same tile to be retried', async () => {
+    const fetcher = vi.fn((_url: string, options: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      options.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true });
+    })).mockResolvedValueOnce(response());
+    vi.stubGlobal('fetch', fetcher);
+    const load = createTerrainTileLoader();
+    await load(url(0), signal());
+    const cancelled = new AbortController();
+    const first = load(url(1), cancelled.signal);
+    const rejected = expect(first).rejects.toMatchObject({ name: 'AbortError' });
+    cancelled.abort(); await rejected;
+    expect(fetcher.mock.calls[1][1].signal?.aborted).toBe(true);
+    fetcher.mockResolvedValueOnce(response());
+    await load(url(1), signal());
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
+  it('times out stalled downloads and releases queue slots', async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn((_url: string, options: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      options.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true });
+    }));
+    vi.stubGlobal('fetch', fetcher);
+    const load = createTerrainTileLoader();
+    const first = expect(load(url(1), signal())).rejects.toMatchObject({ name: 'TimeoutError' });
+    const second = expect(load(url(2), signal())).rejects.toMatchObject({ name: 'TimeoutError' });
+    const queued = load(url(3), signal());
+    fetcher.mockResolvedValueOnce(response());
+    await vi.advanceTimersByTimeAsync(TERRAIN_REQUEST_TIMEOUT_MS);
+    await Promise.all([first, second, queued]);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+  it('reuses cached tiles and never hands a transferable cache buffer to MapLibre', async () => {
+    const fetcher = vi.fn(async () => response());
+    vi.stubGlobal('fetch', fetcher);
+    const load = createTerrainTileLoader();
+    const first = await load(url(1), signal());
+    structuredClone(first, { transfer: [first] });
+    const second = await load(url(1), signal());
+    expect(new Uint8Array(second)).toEqual(new Uint8Array([1, 2, 3, 4]));
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith(expect.stringContaining('/10/1/100.png'), expect.objectContaining({ cache: 'force-cache', credentials: 'omit' }));
+  });
+
+  it('evicts the least-recently-used tile when the byte budget is reached', async () => {
+    const fetcher = vi.fn(async () => response());
+    vi.stubGlobal('fetch', fetcher);
+    const load = createTerrainTileLoader(8);
+    await load(url(1), signal());
+    await load(url(2), signal());
+    await load(url(1), signal());
+    await load(url(3), signal());
+    await load(url(1), signal());
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    await load(url(2), signal());
+    expect(fetcher).toHaveBeenCalledTimes(4);
+  });
+
+  it('limits concurrent downloads to two and drops cancelled queued tiles', async () => {
+    const finish: Array<(response: Response) => void> = [];
+    const fetcher = vi.fn(() => new Promise<Response>(resolve => finish.push(resolve)));
+    vi.stubGlobal('fetch', fetcher);
+    const load = createTerrainTileLoader();
+    const first = load(url(1), signal());
+    const second = load(url(2), signal());
+    const cancelled = new AbortController();
+    const third = load(url(3), cancelled.signal);
+    const rejected = expect(third).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    cancelled.abort();
+    await rejected;
+    finish[0](response());
+    finish[1](response());
+    await Promise.all([first, second]);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache failed requests and rejects invalid tile coordinates', async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(new Response('', { status: 503 })).mockImplementation(async () => response());
+    vi.stubGlobal('fetch', fetcher);
+    const load = createTerrainTileLoader();
+    await expect(load(url(1), signal())).rejects.toThrow('HTTP 503');
+    await load(url(1), signal());
+    await expect(load('osiris-dem://11/1/1', signal())).rejects.toThrow('out of range');
+    await expect(load('osiris-dem://10/1024/1', signal())).rejects.toThrow('out of range');
+    await expect(load('https://other.example/tile', signal())).rejects.toThrow('Invalid');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/terrain-tiles.ts
+++ b/src/lib/terrain-tiles.ts
@@ -1,0 +1,104 @@
+import type { AddProtocolAction } from 'maplibre-gl';
+
+const MAX_BYTES = 8 * 1024 * 1024;
+const MAX_REQUESTS = 2;
+export const TERRAIN_REQUEST_TIMEOUT_MS = 12_000;
+const BASE_URL = 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/';
+
+/** Encoded-tile LRU, shared in-flight work and a cancellable two-request queue. */
+export function createTerrainTileLoader(maxBytes = MAX_BYTES) {
+  type Consumer = { resolve: (data: ArrayBuffer) => void; reject: (error: unknown) => void; cleanup: () => void };
+  type Job = { key: string; controller: AbortController; consumers: Set<Consumer>; started: boolean };
+  const cache = new Map<string, ArrayBuffer>();
+  const jobs = new Map<string, Job>();
+  const queue: Job[] = [];
+  let bytes = 0;
+  let running = 0;
+  const read = (key: string) => {
+    const data = cache.get(key);
+    if (!data) return undefined;
+    cache.delete(key); cache.set(key, data);
+    // MapLibre transfers buffers to workers; its copy must not detach the LRU.
+    return data.slice(0);
+  };
+  const pump = () => {
+    while (running < MAX_REQUESTS && queue.length) {
+      const job = queue.shift()!;
+      if (!job.consumers.size) continue;
+      job.started = true;
+      running++;
+      const timeout = setTimeout(() => job.controller.abort(new DOMException('Terrain request timed out', 'TimeoutError')), TERRAIN_REQUEST_TIMEOUT_MS);
+      void (async () => {
+        try {
+          const response = await fetch(`${BASE_URL}${job.key}.png`, {
+            signal: job.controller.signal, cache: 'force-cache', credentials: 'omit',
+          });
+          if (!response.ok) throw new Error(`Terrain tile HTTP ${response.status}`);
+          const data = await response.arrayBuffer();
+          job.controller.signal.throwIfAborted();
+          if (data.byteLength <= maxBytes && job.consumers.size) {
+            bytes -= cache.get(job.key)?.byteLength ?? 0;
+            cache.delete(job.key); cache.set(job.key, data); bytes += data.byteLength;
+            while (bytes > maxBytes) {
+              const oldest = cache.keys().next().value!;
+              bytes -= cache.get(oldest)!.byteLength; cache.delete(oldest);
+            }
+          }
+          job.consumers.forEach(consumer => consumer.resolve(data.slice(0)));
+        } catch (error) {
+          job.consumers.forEach(consumer => consumer.reject(error));
+        } finally {
+          clearTimeout(timeout);
+          job.consumers.forEach(consumer => consumer.cleanup());
+          job.consumers.clear();
+          if (jobs.get(job.key) === job) jobs.delete(job.key);
+          running--;
+          pump();
+        }
+      })();
+    }
+  };
+
+  return (url: string, signal: AbortSignal): Promise<ArrayBuffer> => {
+    const match = /^osiris-dem:\/\/(\d+)\/(\d+)\/(\d+)$/.exec(url);
+    if (!match) return Promise.reject(new Error('Invalid terrain tile'));
+    const [z, x, y] = match.slice(1).map(Number);
+    if (z > 10 || x >= 2 ** z || y >= 2 ** z) return Promise.reject(new Error('Terrain tile out of range'));
+    if (signal.aborted) return Promise.reject(signal.reason);
+    const key = `${z}/${x}/${y}`;
+    const hit = read(key);
+    if (hit) return Promise.resolve(hit);
+    let job = jobs.get(key);
+    if (!job) {
+      job = { key, controller: new AbortController(), consumers: new Set(), started: false };
+      jobs.set(key, job); queue.push(job);
+    }
+    const task = job;
+    return new Promise((resolve, reject) => {
+      const consumer: Consumer = { resolve, reject, cleanup: () => signal.removeEventListener('abort', abort) };
+      const abort = () => {
+        consumer.cleanup(); task.consumers.delete(consumer); reject(signal.reason);
+        if (task.consumers.size) return; // Another tile consumer still needs it.
+        task.controller.abort();
+        if (jobs.get(key) === task) jobs.delete(key);
+        if (!task.started) {
+          const index = queue.indexOf(task);
+          if (index >= 0) queue.splice(index, 1);
+        }
+      };
+      task.consumers.add(consumer);
+      signal.addEventListener('abort', abort, { once: true });
+      pump();
+    });
+  };
+}
+
+let installed = false;
+export function installTerrainTileProtocol(addProtocol: (name: string, handler: AddProtocolAction) => void) {
+  if (installed) return;
+  const load = createTerrainTileLoader();
+  addProtocol('osiris-dem', async (request, controller) => ({
+    data: await load(request.url, controller.signal), cacheControl: 'max-age=86400',
+  }));
+  installed = true;
+}

--- a/tools/maplibre-url-loader.cjs
+++ b/tools/maplibre-url-loader.cjs
@@ -1,0 +1,6 @@
+// MapLibre 6 constructs a cross-origin worker URL at runtime. Turbopack
+// mistakes `new URL(variable, import.meta.url)` for a build-time asset import.
+// Qualifying the same native URL constructor preserves runtime behavior.
+module.exports = function maplibreUrlLoader(source) {
+  return source.replace(/new URL\(([$\w]+),\s*import\.meta\.url\)/g, 'new globalThis.URL($1,import.meta.url)');
+};

--- a/tools/prepare-map-worker.mjs
+++ b/tools/prepare-map-worker.mjs
@@ -1,0 +1,12 @@
+import { copyFile, mkdir, readFile } from 'node:fs/promises';
+
+// MapLibre 6's module worker imports a sibling shared module. Self-host both
+// from the installed version, rather than relying on a CDN or bundler-relative URL.
+const root = new URL('../', import.meta.url);
+const source = new URL('node_modules/maplibre-gl/', root);
+const { version } = JSON.parse(await readFile(new URL('package.json', source), 'utf8'));
+const target = new URL(`public/vendor/maplibre/${version}/`, root);
+await mkdir(target, { recursive: true });
+for (const file of ['maplibre-gl-worker.mjs', 'maplibre-gl-shared.mjs', '../LICENSE.txt']) {
+  await copyFile(new URL(`dist/${file}`, source), new URL(file.split('/').at(-1), target));
+}

--- a/tools/preview-smoke.mjs
+++ b/tools/preview-smoke.mjs
@@ -1,0 +1,282 @@
+// Isolated production-browser smoke test. No runtime dependency or user profile.
+import { spawn } from 'node:child_process';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const url = process.env.PREVIEW_URL || 'http://127.0.0.1:3001';
+if (!['127.0.0.1', 'localhost'].includes(new URL(url).hostname)) {
+  throw new Error('This smoke test only accepts localhost previews.');
+}
+const profile = await mkdtemp(join(tmpdir(), 'osiris-smoke-'));
+const chrome = spawn(process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe', [
+  '--headless=new', '--no-first-run', '--no-default-browser-check',
+  '--remote-debugging-pipe', `--user-data-dir=${profile}`, '--window-size=1440,1000', 'about:blank',
+], { windowsHide: true, stdio: ['ignore', 'ignore', 'pipe', 'pipe', 'pipe'] });
+const pending = new Map();
+const errors = [];
+const requests = [];
+const requestUrls = new Map();
+const network = new Map();
+const warnings = [];
+const checks = [];
+const measurements = {};
+const scenario = process.env.SMOKE_SCENARIO || 'startup';
+let sequence = 0;
+let buffer = '';
+let session;
+chrome.stdio[4].on('data', chunk => {
+  buffer += chunk.toString();
+  let end;
+  while ((end = buffer.indexOf('\0')) !== -1) {
+    const message = JSON.parse(buffer.slice(0, end));
+    buffer = buffer.slice(end + 1);
+    if (message.id) {
+      const task = pending.get(message.id);
+      pending.delete(message.id);
+      if (message.error) task?.reject(new Error(JSON.stringify(message.error)));
+      else task?.resolve(message.result);
+    } else if (message.method === 'Runtime.exceptionThrown') {
+      errors.push(message.params.exceptionDetails);
+    } else if (message.method === 'Runtime.consoleAPICalled' && message.params.type === 'error') {
+      errors.push(message.params.args.map(value => value.description || value.value));
+    } else if (message.method === 'Runtime.consoleAPICalled' && message.params.type === 'warning') {
+      warnings.push(message.params.args.map(value => value.description || value.value));
+    } else if (message.method === 'Network.requestWillBeSent') {
+      requestUrls.set(message.params.requestId, message.params.request.url);
+      network.set(message.params.requestId, { url: message.params.request.url, state: 'pending' });
+    } else if (message.method === 'Network.responseReceived') {
+      const record = network.get(message.params.requestId);
+      if (record) record.status = message.params.response.status;
+    } else if (message.method === 'Network.loadingFinished') {
+      const record = network.get(message.params.requestId);
+      if (record) record.state = 'complete';
+    } else if (message.method === 'Network.loadingFailed') {
+      const record = network.get(message.params.requestId);
+      if (record) record.state = 'failed';
+      requests.push({ ...message.params, url: requestUrls.get(message.params.requestId) });
+    } else if (message.method === 'Fetch.requestPaused') {
+      // Deterministic visual-test locations, confined to the localhost geo API.
+      const location = scenario === 'buildings' ? { lat: 40.7128, lon: -74.006 } : { lat: 46.02, lon: 7.75 };
+      const satelliteFixture = {
+        satellites: Array.from({ length: 200 }, (_, i) => ({ name: `RENDER TEST ${i}`, noradId: String(90000 + i),
+          lat: -60 + (i % 20) * 6, lng: -170 + Math.floor(i / 20) * 34, alt: 550, color: '#38bdf8', category: 'comms', mission: 'Render test' })),
+        timestamp: new Date().toISOString(), total: 200, category_counts: { comms: 200 },
+      };
+      const payload = new URL(message.params.request.url).pathname === '/api/satellites'
+        ? satelliteFixture : { status: 'success', city: 'Visual test location', ...location };
+      void command('Fetch.fulfillRequest', { requestId: message.params.requestId, responseCode: 200,
+        responseHeaders: [{ name: 'Content-Type', value: 'application/json' }],
+        body: Buffer.from(JSON.stringify(payload)).toString('base64'),
+      }).catch(error => errors.push(String(error)));
+    }
+  }
+});
+function command(method, params = {}, sessionId = session) {
+  const id = ++sequence;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    chrome.stdio[3].write(`${JSON.stringify({ id, method, params, sessionId: sessionId ?? undefined })}\0`);
+  });
+}
+async function evaluate(expression) {
+  const result = await command('Runtime.evaluate', { expression, awaitPromise: true, returnByValue: true });
+  if (result.exceptionDetails) throw new Error(JSON.stringify(result.exceptionDetails));
+  return result.result.value;
+}
+async function check(name, expression) {
+  checks.push({ name, passed: Boolean(await evaluate(expression)) });
+}
+async function click(label) {
+  await evaluate(`(() => { const button = [...document.querySelectorAll('button')].find(b => [b.getAttribute('aria-label'), b.getAttribute('title'), b.textContent.trim()].some(text => text?.toLowerCase() === ${JSON.stringify(label.toLowerCase())})); if (!button) throw new Error('Missing button: ' + ${JSON.stringify(label)}); button.scrollIntoView({block: 'nearest'}); button.click(); })()`);
+}
+async function openDisplay() {
+  if (scenario === 'mobile') { await click('LAYERS'); await pause(400); }
+  else if (!await evaluate(`document.querySelector('button[title="DISPLAY"]')?.getAttribute('aria-expanded') === 'true'`)) { await click('DISPLAY'); await pause(250); }
+}
+const pause = ms => new Promise(resolve => setTimeout(resolve, ms));
+const deadline = setTimeout(() => {
+  console.error('Browser test timed out');
+  chrome.kill();
+  process.exitCode = 1;
+}, 100_000);
+try {
+  const { targetId } = await command('Target.createTarget', { url: 'about:blank' });
+  ({ sessionId: session } = await command('Target.attachToTarget', { targetId, flatten: true }));
+  await command('Page.bringToFront');
+  await command('Emulation.setFocusEmulationEnabled', { enabled: true });
+  await command('Runtime.enable');
+  await command('Page.enable');
+  await command('Network.enable');
+  const system = await command('SystemInfo.getInfo', {}, null);
+  measurements.graphics = { devices: system.gpu.devices, renderer: system.gpu.auxAttributes?.glRenderer, features: system.gpu.featureStatus };
+  if (['imagery', 'buildings', 'terrain-camera'].includes(scenario)) await command('Fetch.enable', { patterns: [{ urlPattern: `${new URL(url).origin}/api/geo*` }] });
+  if (scenario === 'satellites') await command('Fetch.enable', { patterns: [{ urlPattern: `${new URL(url).origin}/api/satellites` }] });
+  await command('Page.addScriptToEvaluateOnNewDocument', { source: `window.__previewLongTasks = []; new PerformanceObserver(list => { for (const e of list.getEntries()) window.__previewLongTasks.push({start: Math.round(e.startTime), ms: Math.round(e.duration)}); }).observe({type: 'longtask', buffered: true});` });
+  if (scenario === 'recovery') await command('Network.setBlockedURLs', { urls: [`${new URL(url).origin}/dark-matter-style.json*`] });
+  await command('Emulation.setDeviceMetricsOverride', scenario === 'mobile'
+    ? { width: 390, height: 844, deviceScaleFactor: 2, mobile: true }
+    : { width: 1440, height: 1000, deviceScaleFactor: 1, mobile: false });
+  await command('Page.navigate', { url });
+  if (process.env.PROBE_MAP_NETWORK) {
+    const probe = await command('Runtime.evaluate', {
+      expression: `Promise.all(['https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json','https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json','https://tiles-a.basemaps.cartocdn.com/vectortiles/carto.streets/v1/2/2/1.mvt','https://s3.amazonaws.com/elevation-tiles-prod/terrarium/10/531/363.png'].map(async url => { try { const r = await fetch(url, {signal: AbortSignal.timeout(12000)}); return {url, status:r.status, bytes:(await r.arrayBuffer()).byteLength}; } catch(e) { return {url, error:String(e)}; } }))`,
+      awaitPromise: true, returnByValue: true,
+    });
+    console.log('Network probe:', JSON.stringify(probe.result));
+  }
+  // Wait for asynchronous module workers, style loading and initial data layers.
+  await new Promise(resolve => setTimeout(resolve, 25_000));
+  if (process.env.PROFILE_TERRAIN) { await command('Profiler.enable'); await command('Profiler.start'); }
+  if (scenario === 'recovery') {
+    await check('Failed style shows recovery state', `document.querySelector('[data-map-status]')?.dataset.mapStatus === 'error' && document.body.innerText.includes('Retry map')`);
+    await command('Network.setBlockedURLs', { urls: [] });
+    measurements.retryVisibility = await evaluate(`({hidden: document.hidden, state: document.visibilityState})`);
+    await command('Page.bringToFront');
+    await click('Retry map');
+    const retryStarted = Date.now();
+    while (Date.now() - retryStarted < 25_000 && !await evaluate(`document.querySelector('[data-map-status]')?.dataset.mapStatus === 'ready'`)) await pause(250);
+    measurements.recoveryMs = Date.now() - retryStarted;
+    await check('Retry restores one working map', `document.querySelector('[data-map-status]')?.dataset.mapStatus === 'ready' && document.querySelectorAll('.maplibregl-canvas').length === 1`);
+  } else {
+    await check('Fresh map finishes loading', `document.querySelector('[data-map-status]')?.dataset.mapStatus === 'ready'`);
+    await check('Globe projection is actually initialized', `document.querySelector('[data-map-status]')?.dataset.mapProjection === 'globe'`);
+    await check('Terrain is not fetched during startup', `!performance.getEntriesByType('resource').some(r => r.name.includes('elevation-tiles-prod'))`);
+    if (scenario === 'zoom') {
+      await openDisplay();
+      const zoom = () => evaluate(`Number(document.body.innerText.match(/ZOOM\\s+([\\d.]+)/)?.[1])`);
+      measurements.beforeZoom = await zoom();
+      for (let i = 0; i < 3; i++) { await click('Zoom in'); await pause(60); }
+      await pause(1000);
+      measurements.afterRapidZoom = await zoom();
+      checks.push({ name: 'Three rapid zoom taps preserve all three steps', passed: Math.abs(measurements.afterRapidZoom - measurements.beforeZoom - 3) < 0.15 });
+      await click('3D Terrain');
+      await pause(2000);
+      for (let i = 0; i < 12; i++) { await click(i % 2 ? '2D Map' : '3D Terrain'); await pause(80); }
+      await pause(2000);
+      await check('Rapid projection switching keeps one usable map', `document.querySelector('[data-map-status]')?.dataset.mapStatus === 'ready' && document.querySelectorAll('.maplibregl-canvas').length === 1`);
+      await check('Final flat projection is applied', `document.querySelector('[data-map-status]')?.dataset.mapProjection === 'mercator'`);
+      measurements.longTasks = await evaluate('window.__previewLongTasks');
+      measurements.heap = await command('Runtime.getHeapUsage');
+    }
+    if (scenario === 'terrain-camera') {
+      await openDisplay();
+      const camera = () => evaluate(`JSON.parse(document.querySelector('[data-map-status]').dataset.mapCamera)`);
+      const unchanged = (name, before, after) => checks.push({ name, passed: ['zoom', 'pitch', 'bearing', 'lat', 'lng'].every(key => Math.abs(before[key] - after[key]) < 0.00001) });
+      measurements.overviewBefore = await camera();
+      await click('3D Terrain'); await pause(1500);
+      measurements.overviewAfter = await camera();
+      unchanged('Enabling terrain at overview zoom leaves the camera alone', measurements.overviewBefore, measurements.overviewAfter);
+      await click('3D Terrain'); await pause(500);
+      for (let i = 0; i < 5; i++) { await click('Zoom in'); await pause(60); }
+      await pause(2000);
+      measurements.closeupBefore = await camera();
+      await click('3D Terrain'); await pause(8000);
+      measurements.closeupAfter = await camera();
+      await check('Terrain is rendered for the close-up camera check', `document.body.innerText.includes('Terrain on')`);
+      unchanged('Loading mountain elevation does not auto-zoom or tilt', measurements.closeupBefore, measurements.closeupAfter);
+      await click('3D Terrain'); await pause(1500);
+      measurements.disabled = await camera();
+      unchanged('Disabling terrain preserves the chosen camera', measurements.closeupBefore, measurements.disabled);
+      await click('2D Map'); await pause(750);
+      measurements.flatBefore = await camera();
+      await click('3D Terrain'); await pause(4000);
+      measurements.flatAfter = await camera();
+      unchanged('Enabling terrain from flat mode does not zoom or tilt', measurements.flatBefore, measurements.flatAfter);
+    }
+    if (scenario === 'mobile') {
+      await openDisplay();
+      await click('3D Terrain');
+      await pause(1_500);
+      await check('Mobile terrain selection remains zoom gated', `document.body.innerText.includes('Terrain at zoom 10+') && !performance.getEntriesByType('resource').some(r => r.name.includes('elevation-tiles-prod'))`);
+      await check('Mobile viewport has no horizontal overflow', `document.documentElement.scrollWidth === window.innerWidth`);
+      await evaluate(`[...document.querySelectorAll('button')].find(b => b.textContent === 'Zoom to terrain')?.scrollIntoView({block: 'nearest'})`);
+      await pause(250);
+    }
+    if (scenario === 'terrain') {
+      await openDisplay();
+      await check('Terrain sits beside Buildings, not in the view strip', `!!document.querySelector('button[aria-label="3D Buildings"]') && !!document.querySelector('button[aria-label="3D Terrain"]') && !document.querySelector('button[title="3D Terrain Globe"]')`);
+      await click('3D Terrain');
+      await pause(1_500);
+      await check('Globe terrain selection is zoom gated', `document.body.innerText.includes('Terrain at zoom 10+') && !performance.getEntriesByType('resource').some(r => r.name.includes('elevation-tiles-prod'))`);
+      await click('Zoom to terrain');
+      await pause(8_000);
+      await check('Zoomed terrain finishes loading', `document.body.innerText.includes('Terrain on')`);
+      const terrainScreenshot = await command('Page.captureScreenshot', { format: 'png' });
+      await writeFile(join(profile, 'terrain.png'), Buffer.from(terrainScreenshot.data, 'base64'));
+      await click('3D Terrain');
+      await pause(1_500);
+      await check('Terrain toggles off without replacing the canvas', `document.querySelector('[data-map-status]')?.dataset.mapStatus === 'ready' && document.querySelectorAll('.maplibregl-canvas').length === 1 && !document.body.innerText.includes('Terrain on')`);
+      const before = await evaluate(`performance.getEntriesByType('resource').filter(r => r.name.includes('elevation-tiles-prod')).length`);
+      const reenableStarted = Date.now();
+      await click('3D Terrain');
+      while (Date.now() - reenableStarted < 12000 && !await evaluate(`document.body.innerText.includes('Terrain on')`)) await pause(200);
+      measurements.terrainReenableMs = Date.now() - reenableStarted;
+      const after = await evaluate(`performance.getEntriesByType('resource').filter(r => r.name.includes('elevation-tiles-prod')).length`);
+      measurements.terrainRequestsBeforeReenable = before; measurements.terrainRequestsAfterReenable = after;
+      checks.push({ name: 'Same-area re-enable reuses elevation cache', passed: after === before });
+      await check('Cached re-enable finishes loading', `document.body.innerText.includes('Terrain on')`);
+      await click('Ghost Protocol'); await pause(8000);
+      await openDisplay();
+      await check('Theme remount does not replay an earlier terrain zoom request', `document.querySelector('[data-map-status]')?.dataset.mapStatus === 'ready' && JSON.parse(document.querySelector('[data-map-status]').dataset.mapCamera).zoom < 10 && document.querySelector('button[aria-label="3D Terrain"]')?.getAttribute('aria-pressed') === 'true'`);
+      await click('2D Map'); await pause(1000);
+      await check('2D mode disables terrain and buildings', `document.querySelector('button[aria-label="3D Terrain"]')?.getAttribute('aria-pressed') === 'false' && document.querySelector('button[aria-label="3D Buildings"]')?.getAttribute('aria-pressed') === 'false'`);
+    }
+    if (scenario === 'imagery') {
+      await openDisplay();
+      await click('Day / Night Cycle');
+      await click('3D Terrain'); await pause(500);
+      await click('Zoom to terrain'); await pause(8000);
+      for (let i = 0; i < 2; i++) { await click('Zoom in'); await pause(60); }
+      await click('Satellite View'); await pause(8000);
+      await check('Mountain terrain works with satellite imagery', `document.body.innerText.includes('Terrain on') && performance.getEntriesByType('resource').some(r => r.name.includes('World_Imagery'))`);
+      measurements.longTasks = await evaluate('window.__previewLongTasks');
+    }
+    if (scenario === 'buildings') {
+      await openDisplay();
+      await click('Day / Night Cycle'); await click('3D Buildings');
+      for (let i = 0; i < 8; i++) { await click('Zoom in'); await pause(60); }
+      await pause(8000);
+      await check('Building close-up keeps the map usable', `document.querySelector('[data-map-status]')?.dataset.mapStatus === 'ready' && document.querySelector('button[aria-label="3D Buildings"]')?.getAttribute('aria-pressed') === 'true'`);
+      await check('Buildings reuse the existing vector tiles without elevation', `!performance.getEntriesByType('resource').some(r => /openfreemap|elevation-tiles-prod/.test(r.name))`);
+      if (process.env.COMBINED_TERRAIN) {
+        await click('3D Terrain'); await pause(7000);
+        await check('Buildings and terrain work together on one canvas', `document.body.innerText.includes('Terrain on') && document.querySelector('button[aria-label="3D Buildings"]')?.getAttribute('aria-pressed') === 'true' && document.querySelectorAll('.maplibregl-canvas').length === 1`);
+      }
+    }
+    if (scenario === 'satellites') {
+      await click('SPACE TRACKING'); await pause(250); await click('All Satellites'); await pause(2000);
+      await check('Satellite renderer receives the 200-object fixture', `document.querySelector('button[aria-label="All Satellites"]')?.textContent.includes('200')`);
+      for (let i = 0; i < 8; i++) { await click('Zoom out'); await pause(60); }
+      await pause(2000);
+      for (let i = 0; i < 4; i++) { await click('2D Map'); await pause(750); await click('3D Globe'); await pause(750); }
+      await check('Active satellite layer survives projection changes', `document.querySelector('[data-map-status]')?.dataset.mapStatus === 'ready' && document.querySelectorAll('.maplibregl-canvas').length === 1`);
+    }
+  }
+  const result = await command('Runtime.evaluate', {
+    expression: `JSON.stringify({title: document.title, text: document.body.innerText.slice(0, 6000), canvases: [...document.querySelectorAll('canvas')].map(c => ({width: c.width, height: c.height})), resources: performance.getEntriesByType('resource').filter(r => /maplibre|\\.js|\\.mjs|proxy-tiles/.test(r.name)).map(r => ({url: r.name, bytes: r.transferSize, duration: Math.round(r.duration)}))})`,
+    returnByValue: true,
+  });
+  if (process.env.PROFILE_TERRAIN) {
+    const { profile: cpu } = await command('Profiler.stop');
+    await writeFile(join(profile, 'terrain.cpuprofile'), JSON.stringify(cpu));
+    const totals = new Map();
+    cpu.samples?.forEach((id, i) => totals.set(id, (totals.get(id) ?? 0) + cpu.timeDeltas[i]));
+    measurements.cpuTop = [...totals].sort((a, b) => b[1] - a[1]).slice(0, 25).map(([id, us]) => ({ ms: Math.round(us / 1000), frame: cpu.nodes.find(n => n.id === id)?.callFrame }));
+  }
+  const visual = await command('Page.captureScreenshot', { format: 'jpeg', quality: 75 });
+  await writeFile(join(profile, 'visual.jpg'), Buffer.from(visual.data, 'base64'));
+  const screenshot = await command('Page.captureScreenshot', { format: 'png' });
+  await writeFile(join(profile, 'preview.png'), Buffer.from(screenshot.data, 'base64'));
+  checks.push({ name: 'No camera or renderer failures', passed: !warnings.some(w => /Projection switch failed|TypeError|Satellite picking unavailable|Map initialization failed/.test(JSON.stringify(w))) });
+  measurements.mapNetwork = [...network.values()].filter(r => /cartocdn|maplibre|dark-matter-style/.test(r.url));
+  measurements.visibility = await evaluate(`({hidden: document.hidden, state: document.visibilityState})`);
+  const report = { scenario, checks, measurements, page: JSON.parse(result.result.value), errors, warnings, failedRequests: requests, screenshot: join(profile, 'preview.png') };
+  await writeFile(join(profile, 'report.json'), JSON.stringify(report, null, 2));
+  console.log(JSON.stringify({ scenario, checks, measurements, errors, warnings, failedRequests: requests, report: join(profile, 'report.json'), screenshot: report.screenshot }, null, 2));
+  process.exitCode = errors.length || checks.some(c => !c.passed) ? 1 : 0;
+} finally {
+  clearTimeout(deadline);
+  await command('Browser.close', {}, undefined).catch(() => {});
+  chrome.kill();
+}


### PR DESCRIPTION
## Summary

- Add lightweight 3D Terrain beside 3D Buildings in Display, on desktop and mobile.
- Preserve zoom, center, and tilt when terrain is toggled. Keep Zoom to terrain as an explicit action and prevent old zoom requests replaying after a map remount.
- Load elevation only from zoom 10 after camera movement settles, with bounded tile detail, two concurrent requests, cancellation, and an 8 MiB cache. Reuse the existing renderer and building tiles.
- Improve map startup/retry handling, rapid zoom controls, scale accuracy, satellite rendering, and partial CCTV catalog retries.
- Update production dependencies and self-host the matching MapLibre worker assets.

## Validation

- Rebased onto latest master at fac8d1b, preserving the current nuclear/GDELT updates.
- Production build and TypeScript checks pass.
- 603 tests pass; 14 opt-in/live-network tests are skipped.
- Scoped ESLint and patch checks pass.
- Production dependency audit reports zero known vulnerabilities.
- Fresh production-browser checks pass for camera preservation, zoom gating, elevation cache reuse, 2D switching, and theme-remount recovery, with no renderer exceptions.
- Additional local checks cover rapid zoom, mobile layout, Alpine satellite imagery, combined buildings/terrain, satellite layers, and Chrome/Edge startup recovery.

- Vercel's automatic preview check is currently failing. Its remote failure logs could not be retrieved without authenticated Vercel access; the local production build and browser checks pass.

## Review notes

MapLibre 6 requires WebGL2. Physical Safari/iOS and low-end Android testing remains outstanding. External feed availability and existing repository-wide lint/development-tool audit issues remain documented in the [review notes](https://github.com/simplifaisoul/osiris/blob/feat/globe-terrain/docs/terrain-local-review.md). This PR does not merge or deploy to production.

Signed-off-by: Simplifai-1.com 