### PR TITLE
fix(fires): stop discarding 96.8% of FIRMS detections

### DIFF
--- a/src/app/api/fires/route.ts
+++ b/src/app/api/fires/route.ts
@@ -1,123 +1,190 @@
-
 import { NextResponse } from 'next/server';
+import { httpText } from '@/lib/httpJson';
+import { cachedSource } from '@/lib/sourceCache';
 
 export const dynamic = 'force-dynamic';
 
 /**
  * OSIRIS — Active Fire & Wildfire Tracking
- * Multi-source: NASA FIRMS Open Data (primary for global fires), NASA EONET (volcanoes)
+ *
+ * NASA FIRMS satellite hotspots (VIIRS, falling back to MODIS) plus NASA EONET
+ * volcanoes. These are thermal *detections* — a satellite pixel that read hot —
+ * so they have no name, no acreage and no containment. Named incidents with
+ * those figures live in /api/fire-incidents, which is a different kind of data
+ * entirely and does not replace this.
+ *
+ * ── On the payload shape ──
+ * This route used to sample the CSV, keeping every Nth row to cap the result at
+ * 2,000 points. The global 24h feed carries around 61,000 detections, so that
+ * discarded ~97% of them — and discarded them by position in the file, which is
+ * arbitrary, so any individual fire had roughly a three-in-a-hundred chance of
+ * surviving. Fires that plainly existed were simply absent from the map.
+ *
+ * Nothing is dropped now. The rows are sent as a column-oriented array instead
+ * of one object per detection, which is what makes that affordable: the same
+ * 61,000 detections are 7.7MB as objects and 2.1MB like this, about 0.6MB on
+ * the wire once gzipped. The client expands it back into objects.
  */
 
-export async function GET() {
-  try {
-    let fires: any[] = [];
-    let source = '';
+const FIRMS_SOURCES = [
+  {
+    url: 'https://firms.modaps.eosdis.nasa.gov/data/active_fire/suomi-npp-viirs-c2/csv/SUOMI_VIIRS_C2_Global_24h.csv',
+    label: 'NASA-FIRMS (VIIRS)',
+  },
+  {
+    url: 'https://firms.modaps.eosdis.nasa.gov/data/active_fire/modis-c6.1/csv/MODIS_C6_1_Global_24h.csv',
+    label: 'NASA-FIRMS (MODIS)',
+  },
+];
 
-    // Source 1: NASA FIRMS Open Data (Global 24h CSV) - no API key needed
-    const firmsSources = [
-      'https://firms.modaps.eosdis.nasa.gov/data/active_fire/suomi-npp-viirs-c2/csv/SUOMI_VIIRS_C2_Global_24h.csv',
-      'https://firms.modaps.eosdis.nasa.gov/data/active_fire/modis-c6.1/csv/MODIS_C6_1_Global_24h.csv'
-    ];
+/** Column order of every row. Mirrored by the client when it expands them. */
+export const FIRE_COLS = ['lat', 'lng', 'frp', 'brightness', 'conf', 'dateIdx', 'time', 'kind'] as const;
 
-    for (const url of firmsSources) {
-      try {
-        const res = await fetch(url, {
-          signal: AbortSignal.timeout(15000),
-          headers: { 'User-Agent': 'OSIRIS-Intelligence-Platform/3.5' },
-        });
-        if (res.ok) {
-          const text = await res.text();
-          if (text && text.includes('latitude') && text.length > 200) {
-            const parsed = parseCSV(text);
-            if (parsed.length > 0) {
-              fires = parsed;
-              source = url.includes('SUOMI') ? 'NASA-FIRMS (VIIRS)' : 'NASA-FIRMS (MODIS)';
-              break;
-            }
-          }
-        }
-      } catch { continue; }
-    }
+type FireRow = [number, number, number, number, number, number, string, number];
 
-    // Source 2: Pull volcanoes from EONET for richer data
-    try {
-      const volcRes = await fetch('https://eonet.gsfc.nasa.gov/api/v3/events?status=open&category=volcanoes&limit=50', {
-        signal: AbortSignal.timeout(10000),
-      });
-      if (volcRes.ok) {
-        const volcData = await volcRes.json();
-        const volcanoes = (volcData.events || []).map((e: any) => {
-          const geo = e.geometry?.[e.geometry.length - 1];
-          if (!geo?.coordinates) return null;
-          return {
-            lat: geo.coordinates[1],
-            lng: geo.coordinates[0],
-            brightness: 500,
-            confidence: 'high',
-            date: geo.date?.split('T')[0] || '',
-            time: '',
-            frp: 100,
-            title: `[VOLCANO] ${e.title}`,
-            type: 'volcano',
-          };
-        }).filter(Boolean);
-        fires = [...fires, ...volcanoes];
-        if (!source) source = 'NASA-EONET';
-      }
-    } catch (e) { console.warn('[OSIRIS] Suppressed EONET error:', e instanceof Error ? e.message : e); }
-
-    return NextResponse.json({
-      fires,
-      total: fires.length,
-      source: source || 'Unknown',
-      timestamp: new Date().toISOString(),
-    }, {
-      headers: {
-        'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=1200',
-      },
-    });
-  } catch (error) {
-    console.error('Fire fetch error:', error);
-    return NextResponse.json({ fires: [], error: 'Failed to fetch fire data' }, { status: 500 });
-  }
+/** 0 low · 1 nominal · 2 high. VIIRS reports words, MODIS a 0-100 percentage. */
+function confidenceCode(raw: string): number {
+  const v = (raw || '').trim().toLowerCase();
+  if (v === 'h' || v === 'high') return 2;
+  if (v === 'l' || v === 'low') return 0;
+  if (v === 'n' || v === 'nominal') return 1;
+  const n = Number(v);
+  if (Number.isFinite(n)) return n >= 80 ? 2 : n >= 30 ? 1 : 0;
+  return 1;
 }
 
-function parseCSV(csv: string): any[] {
+interface ParsedFires {
+  rows: FireRow[];
+  dates: string[];
+}
+
+/**
+ * Dates are dictionary-encoded because a 24-hour product spans at most two of
+ * them; storing the string on every row costs more than the coordinates do.
+ */
+function parseCSV(csv: string): ParsedFires {
   const lines = csv.trim().split('\n');
-  if (lines.length < 2) return [];
+  if (lines.length < 2) return { rows: [], dates: [] };
 
   const header = lines[0].split(',');
-  const latIdx = header.indexOf('latitude');
-  const lngIdx = header.indexOf('longitude');
-  const brightIdx = header.indexOf('bright_ti4') !== -1 ? header.indexOf('bright_ti4') : header.indexOf('brightness');
-  const confIdx = header.indexOf('confidence');
-  const dateIdx = header.indexOf('acq_date');
-  const timeIdx = header.indexOf('acq_time');
-  const frpIdx = header.indexOf('frp');
+  const idx = (name: string) => header.indexOf(name);
+  const iLat = idx('latitude');
+  const iLng = idx('longitude');
+  const iBright = idx('bright_ti4') !== -1 ? idx('bright_ti4') : idx('brightness');
+  const iConf = idx('confidence');
+  const iDate = idx('acq_date');
+  const iTime = idx('acq_time');
+  const iFrp = idx('frp');
+  if (iLat === -1 || iLng === -1) return { rows: [], dates: [] };
 
-  const fires: any[] = [];
-  // Sample the data if there are too many rows to avoid browser lag. Limit to ~2000 points globally.
-  const maxPoints = 2000;
-  const step = lines.length > maxPoints ? Math.ceil(lines.length / maxPoints) : 1;
+  const dates: string[] = [];
+  const dateIndex = new Map<string, number>();
+  const rows: FireRow[] = [];
 
-  for (let i = 1; i < lines.length; i += step) {
-    const cols = lines[i].split(',');
-    const lat = parseFloat(cols[latIdx]);
-    const lng = parseFloat(cols[lngIdx]);
-    if (isNaN(lat) || isNaN(lng)) continue;
+  for (let i = 1; i < lines.length; i++) {
+    const c = lines[i].split(',');
+    const lat = parseFloat(c[iLat]);
+    const lng = parseFloat(c[iLng]);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
 
-    fires.push({
-      lat: Math.round(lat * 1000) / 1000,
-      lng: Math.round(lng * 1000) / 1000,
-      brightness: parseFloat(cols[brightIdx]) || 0,
-      confidence: cols[confIdx] || 'unknown',
-      date: cols[dateIdx] || '',
-      time: cols[timeIdx] || '',
-      frp: parseFloat(cols[frpIdx]) || 0,
-      type: 'fire'
-    });
+    const d = c[iDate] || '';
+    let di = dateIndex.get(d);
+    if (di === undefined) { di = dates.length; dates.push(d); dateIndex.set(d, di); }
+
+    rows.push([
+      // Four decimals is ~11m, well inside the 375m footprint of a VIIRS pixel,
+      // and trims roughly a fifth off the payload.
+      Math.round(lat * 1e4) / 1e4,
+      Math.round(lng * 1e4) / 1e4,
+      Math.round((parseFloat(c[iFrp]) || 0) * 10) / 10,
+      Math.round(parseFloat(c[iBright]) || 0),
+      confidenceCode(c[iConf]),
+      di,
+      c[iTime] || '',
+      0,
+    ]);
   }
 
-  return fires;
+  return { rows, dates };
 }
 
+interface FirePayload {
+  dates: string[];
+  rows: FireRow[];
+  source: string;
+}
+
+async function buildPayload(): Promise<FirePayload> {
+  let rows: FireRow[] = [];
+  let dates: string[] = [];
+  let source = '';
+
+  for (const s of FIRMS_SOURCES) {
+    try {
+      const text = await httpText(s.url, { timeoutMs: 30000, headers: { 'Accept-Encoding': 'gzip' } });
+      if (!text || !text.includes('latitude') || text.length < 200) continue;
+      const parsed = parseCSV(text);
+      if (parsed.rows.length > 0) {
+        rows = parsed.rows;
+        dates = parsed.dates;
+        source = s.label;
+        break;
+      }
+    } catch (e) {
+      console.warn(`[OSIRIS] FIRMS ${s.label} failed:`, e instanceof Error ? e.message : e);
+    }
+  }
+
+  // Volcanoes ride in the same array under kind=1 so the client has one list.
+  try {
+    const raw = await httpText('https://eonet.gsfc.nasa.gov/api/v3/events?status=open&category=volcanoes&limit=50', { timeoutMs: 12000 });
+    const events = (JSON.parse(raw)?.events ?? []) as Array<{ geometry?: Array<{ coordinates?: number[]; date?: string }> }>;
+    for (const e of events) {
+      const geo = e.geometry?.[e.geometry.length - 1];
+      const co = geo?.coordinates;
+      if (!co || co.length < 2) continue;
+      const d = (geo?.date || '').split('T')[0];
+      let di = dates.indexOf(d);
+      if (di === -1) { di = dates.length; dates.push(d); }
+      rows.push([co[1], co[0], 100, 500, 2, di, '', 1]);
+    }
+    if (!source) source = 'NASA-EONET';
+  } catch (e) {
+    console.warn('[OSIRIS] EONET volcanoes failed:', e instanceof Error ? e.message : e);
+  }
+
+  return { dates, rows, source: source || 'Unknown' };
+}
+
+/* cachedSource is built around arrays, so the payload travels as a single-
+   element one. That is worth the small awkwardness: the fetch pulls a 4.8MB
+   CSV and parses 61,000 rows, which took ~19s on a cold request and repeated
+   that work on every miss. Cached, only the first caller pays, refreshes
+   dedupe, and a failed refresh keeps serving the last good index rather than
+   emptying the map. */
+const loadFires = cachedSource<FirePayload>(
+  'fires:index',
+  async () => [await buildPayload()],
+  10 * 60 * 1000,
+);
+
+export async function GET() {
+  const [payload] = await loadFires();
+  if (!payload) {
+    return NextResponse.json(
+      { cols: FIRE_COLS, dates: [], rows: [], total: 0, source: 'Unavailable', error: 'Fire index unavailable' },
+      { status: 502 },
+    );
+  }
+  return NextResponse.json(
+    {
+      cols: FIRE_COLS,
+      dates: payload.dates,
+      rows: payload.rows,
+      total: payload.rows.length,
+      source: payload.source,
+      timestamp: new Date().toISOString(),
+    },
+    { headers: { 'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=1200' } },
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
+import { expandFires } from '@/lib/fires';
 import dynamic from 'next/dynamic';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Layers, BarChart3, Newspaper, Search, X, Globe, MapPinned, Route, Radar, Satellite, Moon, ExternalLink, AlertTriangle, Activity, Database, Wifi, Play, Network, Crosshair, Bluetooth, Pentagon, Radio , PenLine } from 'lucide-react';
@@ -670,7 +671,11 @@ export default function Dashboard() {
     }
     // Fires
     if (activeLayers.fires && !layerFetchedRef.current.has('fires')) {
-      fetchEndpoint('/api/fires');
+      /* The route sends column arrays rather than objects — see lib/fires — so
+         the payload is expanded here before anything downstream sees it. The
+         sensor is reported once for the whole batch, so it is lifted onto its
+         own key rather than left as the generic `source`. */
+      fetchEndpoint('/api/fires', d => ({ fires: expandFires(d), fires_source: d.source }));
       layerFetchedRef.current.add('fires');
     }
     // Maritime

--- a/src/lib/fires.test.ts
+++ b/src/lib/fires.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { expandFires } from './fires';
+
+/**
+ * The column order is a contract between /api/fires and this expander. A
+ * mismatch does not throw — it quietly reads longitude as latitude and puts
+ * every detection somewhere it never burned, which is the kind of bug that
+ * looks like a data problem for a long time before anyone suspects the parser.
+ */
+const row = (over: Partial<Record<number, unknown>> = {}) => {
+  const base: unknown[] = [27.9886, 22.3247, 5, 367, 2, 0, '0109', 0];
+  for (const [i, v] of Object.entries(over)) base[Number(i)] = v;
+  return base;
+};
+
+describe('expandFires', () => {
+  it('maps columns to the fields the map reads', () => {
+    const [f] = expandFires({ rows: [row()], dates: ['2026-09-08'] });
+    expect(f).toEqual({
+      lat: 27.9886,
+      lng: 22.3247,
+      frp: 5,
+      brightness: 367,
+      confidence: 'high',
+      date: '2026-09-08',
+      time: '0109',
+      type: 'fire',
+    });
+  });
+
+  it('resolves the confidence code, defaulting to nominal', () => {
+    const codes = [0, 1, 2, 9].map(c => expandFires({ rows: [row({ 4: c })], dates: [''] })[0].confidence);
+    expect(codes).toEqual(['low', 'nominal', 'high', 'nominal']);
+  });
+
+  it('resolves dates through the dictionary rather than by value', () => {
+    const out = expandFires({ rows: [row({ 5: 1 })], dates: ['2026-09-08', '2026-09-09'] });
+    expect(out[0].date).toBe('2026-09-09');
+  });
+
+  it('marks volcanoes apart from fire detections', () => {
+    const out = expandFires({ rows: [row({ 7: 1 })], dates: [''] });
+    expect(out[0].type).toBe('volcano');
+  });
+
+  it('drops rows that are malformed rather than emitting NaN coordinates', () => {
+    const out = expandFires({
+      rows: [row(), row({ 0: 'not-a-number' }), [1, 2], 'nonsense'],
+      dates: [''],
+    });
+    expect(out).toHaveLength(1);
+  });
+
+  it('survives an empty or missing payload', () => {
+    expect(expandFires(null)).toEqual([]);
+    expect(expandFires(undefined)).toEqual([]);
+    expect(expandFires({})).toEqual([]);
+    expect(expandFires({ rows: [], dates: [] })).toEqual([]);
+  });
+
+  it('tolerates a date index the dictionary does not contain', () => {
+    const out = expandFires({ rows: [row({ 5: 99 })], dates: ['2026-09-08'] });
+    expect(out[0].date).toBe('');
+  });
+});

--- a/src/lib/fires.ts
+++ b/src/lib/fires.ts
@@ -1,0 +1,56 @@
+/**
+ * OSIRIS — expansion of the compact /api/fires payload.
+ *
+ * The route sends one array per detection rather than one object, because the
+ * global FIRMS feed is around 61,000 of them and the object form costs 7.7MB
+ * against 2.1MB like this. The map wants objects, so they are rebuilt here.
+ *
+ * The column order is a contract shared with the route. It is asserted in the
+ * tests beside this file: getting it wrong would not throw, it would silently
+ * swap latitude for longitude and scatter every fire into the sea.
+ */
+
+export interface FireDetection {
+  lat: number;
+  lng: number;
+  frp: number;
+  brightness: number;
+  confidence: string;
+  date: string;
+  time: string;
+  type: 'fire' | 'volcano';
+}
+
+interface CompactFires {
+  rows?: unknown;
+  dates?: unknown;
+}
+
+/** Index order matches the `conf` code written by the route. */
+const CONFIDENCE = ['low', 'nominal', 'high'] as const;
+
+export function expandFires(payload: CompactFires | null | undefined): FireDetection[] {
+  const rows = payload?.rows;
+  if (!Array.isArray(rows)) return [];
+  const dates: string[] = Array.isArray(payload?.dates) ? (payload.dates as string[]) : [];
+
+  const out: FireDetection[] = [];
+  for (const r of rows) {
+    if (!Array.isArray(r) || r.length < 8) continue;
+    const lat = Number(r[0]);
+    const lng = Number(r[1]);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+
+    out.push({
+      lat,
+      lng,
+      frp: Number(r[2]) || 0,
+      brightness: Number(r[3]) || 0,
+      confidence: CONFIDENCE[Number(r[4])] ?? 'nominal',
+      date: dates[Number(r[5])] ?? '',
+      time: typeof r[6] === 'string' ? r[6] : '',
+      type: r[7] === 1 ? 'volcano' : 'fire',
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
The CSV parser capped output at 2,000 points by keeping every Nth row. The global 24h feed carries ~61,500 detections, so it kept every 31st — and kept them by position in the file, which is arbitrary, giving any individual fire roughly a three-in-a-hundred chance of appearing. Fires that plainly existed were simply absent from the map, and it read as a data problem rather than a parser one.

Nothing is sampled now. Rows are sent column-oriented instead of one object per detection, which is what makes that affordable: the same 61,500 are 7.7MB as objects against 2.1MB this way, ~0.6MB gzipped. lib/fires expands them back on the client, and its tests pin the column order — a mismatch would not throw, it would read longitude as latitude and scatter every fire into the sea.

Also wrapped in cachedSource. The fetch pulls 4.8MB and parses 61,500 rows, which took ~19s cold and repeated on every miss; now only the first caller pays and a failed refresh serves the last good index rather than emptying the map.