### PR TITLE
feat(ai): run the AI analyst through any Gemini-compatible gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,26 @@ AIS_API_KEY=
 
 
 # ─────────────────────────────────────────────────────────────────────────
+#  AI ANALYST  ── optional; the one-click overview falls back to a built-in
+#                 heuristic analyst, but /api/ai/analyze and /briefing need one
+# ─────────────────────────────────────────────────────────────────────────
+# Google Gemini keys, rotated round-robin. Up to 8 (GEMINI_API_KEY_1..8).
+#   Get it: https://aistudio.google.com/apikey
+# GEMINI_API_KEY_1=
+
+# Or point the Gemini SDK at any Gemini-compatible gateway instead of Google,
+# e.g. a local OmniRoute (serves /v1beta/models/{model}:generateContent).
+# No Gemini key is needed then. From Docker, use host.docker.internal
+# instead of 127.0.0.1.
+# OSIRIS_AI_BASE_URL=http://127.0.0.1:20128
+# Model id sent to the backend. Default gemini-2.0-flash; 'auto' lets
+# OmniRoute pick.
+# OSIRIS_AI_MODEL=auto
+# Only if the gateway requires its own API key.
+# OSIRIS_AI_API_KEY=
+
+
+# ─────────────────────────────────────────────────────────────────────────
 #  RUNTIME
 # ─────────────────────────────────────────────────────────────────────────
 # Host port the web UI is published on (container always listens on 3000).

--- a/src/app/api/ai/analyze/route.ts
+++ b/src/app/api/ai/analyze/route.ts
@@ -8,7 +8,9 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import {
+  aiModel,
   createGeminiClient,
+  getServerApiKeys,
   rotateApiKey,
   analyzeIntelligence,
   type IntelligenceContext,
@@ -55,21 +57,6 @@ setInterval(() => {
     }
   }
 }, 120_000);
-
-/* ─────────────────────────────────────────────────────────────
-   Collect API keys from environment
-   ───────────────────────────────────────────────────────────── */
-
-function getEnvApiKeys(): string[] {
-  const keys: string[] = [];
-  for (let i = 1; i <= 8; i++) {
-    const key = process.env[`GEMINI_API_KEY_${i}`];
-    if (key && key.trim().length > 0) {
-      keys.push(key.trim());
-    }
-  }
-  return keys;
-}
 
 /* ─────────────────────────────────────────────────────────────
    Request / Response types
@@ -132,12 +119,12 @@ export async function POST(
   if (userKey && userKey.length > 0) {
     apiKey = userKey;
   } else {
-    const envKeys = getEnvApiKeys();
+    const envKeys = getServerApiKeys();
     if (envKeys.length === 0) {
       return NextResponse.json(
         {
           error:
-            'No Gemini API key configured. Set GEMINI_API_KEY_1 in environment or provide a key via the settings panel.',
+            'No Gemini API key configured. Set GEMINI_API_KEY_1 or OSIRIS_AI_BASE_URL in environment, or provide a key via the settings panel.',
           code: 'NO_API_KEY',
         },
         { status: 503 }
@@ -179,7 +166,7 @@ export async function POST(
     return NextResponse.json(
       {
         analysis,
-        model: 'gemini-2.0-flash',
+        model: aiModel(),
         timestamp: new Date().toISOString(),
       },
       {

--- a/src/app/api/ai/briefing/route.ts
+++ b/src/app/api/ai/briefing/route.ts
@@ -9,6 +9,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import {
   createGeminiClient,
+  getServerApiKeys,
   rotateApiKey,
   generateBriefing,
   type IntelligenceContext,
@@ -54,21 +55,6 @@ setInterval(() => {
     }
   }
 }, 120_000);
-
-/* ─────────────────────────────────────────────────────────────
-   Environment Key Collection
-   ───────────────────────────────────────────────────────────── */
-
-function getEnvApiKeys(): string[] {
-  const keys: string[] = [];
-  for (let i = 1; i <= 8; i++) {
-    const key = process.env[`GEMINI_API_KEY_${i}`];
-    if (key && key.trim().length > 0) {
-      keys.push(key.trim());
-    }
-  }
-  return keys;
-}
 
 /* ─────────────────────────────────────────────────────────────
    Request / Response types
@@ -125,12 +111,12 @@ export async function POST(
   if (userKey && userKey.length > 0) {
     apiKey = userKey;
   } else {
-    const envKeys = getEnvApiKeys();
+    const envKeys = getServerApiKeys();
     if (envKeys.length === 0) {
       return NextResponse.json(
         {
           error:
-            'No Gemini API key configured. Set GEMINI_API_KEY_1 in environment or provide a key via the settings panel.',
+            'No Gemini API key configured. Set GEMINI_API_KEY_1 or OSIRIS_AI_BASE_URL in environment, or provide a key via the settings panel.',
           code: 'NO_API_KEY',
         },
         { status: 503 }

--- a/src/app/api/ai/overview/route.ts
+++ b/src/app/api/ai/overview/route.ts
@@ -11,20 +11,18 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createGeminiClient, rotateApiKey } from '@/lib/ai-engine';
+import {
+  aiModel,
+  createGeminiClient,
+  getModel,
+  getServerApiKeys,
+  responseText,
+  rotateApiKey,
+} from '@/lib/ai-engine';
 
 export const dynamic = 'force-dynamic';
 
 type Mode = 'alerts' | 'markets' | 'chain';
-
-function getEnvApiKeys(): string[] {
-  const keys: string[] = [];
-  for (let i = 1; i <= 8; i++) {
-    const key = process.env[`GEMINI_API_KEY_${i}`];
-    if (key && key.trim().length > 0) keys.push(key.trim());
-  }
-  return keys;
-}
 
 /* ─────────────────────────── Digest builders ─────────────────────────── */
 
@@ -225,14 +223,13 @@ function heuristicOverview(mode: Mode, digest: Digest): string {
 async function geminiOverview(mode: Mode, digest: Digest, keys: string[]): Promise<string | null> {
   try {
     const client = createGeminiClient(rotateApiKey(keys));
-    const model = client.getGenerativeModel({
-      model: 'gemini-2.0-flash',
-      systemInstruction:
-        'You are OSIRIS, a terse intelligence analyst. Given structured facts, write a sharp 2-4 sentence situational read-out. No preamble, no markdown headers, no hedging. Lead with the bottom line.',
-    });
+    const model = getModel(
+      client,
+      'You are OSIRIS, a terse intelligence analyst. Given structured facts, write a sharp 2-4 sentence situational read-out. No preamble, no markdown headers, no hedging. Lead with the bottom line.'
+    );
     const prompt = `MODE: ${mode.toUpperCase()}\nBOTTOM LINE: ${digest.summaryLine}\nFACTS:\n${digest.facts.map(f => `- ${f}`).join('\n')}\n\nWrite the read-out now.`;
     const result = await model.generateContent(prompt);
-    const text = result.response.text().trim();
+    const text = responseText(result.response).trim();
     return text || null;
   } catch (e) {
     console.warn('[OSIRIS] Gemini overview failed, using heuristic:', e);
@@ -257,7 +254,7 @@ export async function POST(request: NextRequest) {
     : mode === 'chain' ? digestChain(body.payload)
     : digestAlerts(body.payload);
 
-  const keys = getEnvApiKeys();
+  const keys = getServerApiKeys();
   let overview: string | null = null;
   let generatedBy: 'gemini' | 'analyst' = 'analyst';
 
@@ -272,6 +269,7 @@ export async function POST(request: NextRequest) {
     overview,
     highlights: digest.highlights,
     generatedBy,
+    model: generatedBy === 'gemini' ? aiModel() : null,
     generatedAt: new Date().toISOString(),
   });
 }

--- a/src/components/AiOverview.tsx
+++ b/src/components/AiOverview.tsx
@@ -22,6 +22,7 @@ interface OverviewResult {
   overview: string;
   highlights: string[];
   generatedBy: 'gemini' | 'analyst';
+  model?: string | null;
   generatedAt: string;
 }
 
@@ -125,7 +126,10 @@ export default function AiOverview({ mode, payload, accent = '#7C4DFF' }: AiOver
                   )}
 
                   <div className="mt-2 text-[9px] font-mono text-[var(--text-muted)] tracking-wide">
-                    {result.generatedBy === 'gemini' ? 'GEMINI 2.0 FLASH' : 'HEURISTIC ANALYST'} ·{' '}
+                    {result.generatedBy === 'gemini'
+                      ? (result.model ?? 'gemini-2.0-flash').toUpperCase()
+                      : 'HEURISTIC ANALYST'}{' '}
+                    ·{' '}
                     {new Date(result.generatedAt).toLocaleTimeString()}
                   </div>
                 </>

--- a/src/lib/ai-engine.test.ts
+++ b/src/lib/ai-engine.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  analyzeIntelligence,
+  createGeminiClient,
+  getServerApiKeys,
+  type IntelligenceContext,
+} from './ai-engine';
+
+/**
+ * The engine can run against Google or any Gemini-compatible gateway (e.g. a
+ * local OmniRoute). These tests stub fetch and assert on what the real SDK
+ * sends, so they cover the SDK's own URL building rather than a mock of it.
+ */
+
+const CONTEXT: IntelligenceContext = {
+  earthquakes: [],
+  news: [],
+  threats: [],
+  cyberAlerts: [],
+  timestamp: '2026-09-11T00:00:00Z',
+};
+
+function geminiReply(parts: Array<{ text: string; thought?: boolean }>) {
+  return new Response(
+    JSON.stringify({
+      candidates: [{ content: { role: 'model', parts }, finishReason: 'STOP', index: 0 }],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+function clearAiEnv() {
+  for (let i = 1; i <= 8; i++) vi.stubEnv(`GEMINI_API_KEY_${i}`, '');
+  vi.stubEnv('OSIRIS_AI_BASE_URL', '');
+  vi.stubEnv('OSIRIS_AI_MODEL', '');
+  vi.stubEnv('OSIRIS_AI_API_KEY', '');
+}
+
+beforeEach(clearAiEnv);
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe('model backend', () => {
+  it('talks to Google with gemini-2.0-flash by default', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(geminiReply([{ text: 'ok' }]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await analyzeIntelligence(createGeminiClient('k'), CONTEXT, 'q');
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent'
+    );
+  });
+
+  it('sends requests to the configured gateway and model', async () => {
+    vi.stubEnv('OSIRIS_AI_BASE_URL', 'http://127.0.0.1:20128/');
+    vi.stubEnv('OSIRIS_AI_MODEL', 'auto');
+    const fetchMock = vi.fn().mockResolvedValue(geminiReply([{ text: 'ok' }]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await analyzeIntelligence(createGeminiClient('k'), CONTEXT, 'q');
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'http://127.0.0.1:20128/v1beta/models/auto:generateContent'
+    );
+  });
+});
+
+describe('response text', () => {
+  it('drops reasoning parts a gateway model returns as thought: true', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        geminiReply([
+          { text: 'We need to answer tersely.', thought: true },
+          { text: '## BLUF\n' },
+          { text: 'Nominal.' },
+        ])
+      )
+    );
+
+    const text = await analyzeIntelligence(createGeminiClient('k'), CONTEXT, 'q');
+
+    expect(text).toBe('## BLUF\nNominal.');
+  });
+
+  it('returns plain replies unchanged', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(geminiReply([{ text: 'Nominal.' }])));
+
+    const text = await analyzeIntelligence(createGeminiClient('k'), CONTEXT, 'q');
+
+    expect(text).toBe('Nominal.');
+  });
+});
+
+describe('getServerApiKeys', () => {
+  it('returns nothing when neither Gemini keys nor a gateway are configured', () => {
+    expect(getServerApiKeys()).toEqual([]);
+  });
+
+  it('returns the Gemini keys in order', () => {
+    vi.stubEnv('GEMINI_API_KEY_1', ' a ');
+    vi.stubEnv('GEMINI_API_KEY_3', 'c');
+
+    expect(getServerApiKeys()).toEqual(['a', 'c']);
+  });
+
+  it('supplies a stand-in key for a keyless gateway', () => {
+    vi.stubEnv('OSIRIS_AI_BASE_URL', 'http://127.0.0.1:20128');
+
+    expect(getServerApiKeys()).toEqual(['no-key-required']);
+  });
+
+  it('prefers OSIRIS_AI_API_KEY for a gateway that wants one', () => {
+    vi.stubEnv('OSIRIS_AI_BASE_URL', 'http://127.0.0.1:20128');
+    vi.stubEnv('OSIRIS_AI_API_KEY', 'gw-key');
+
+    expect(getServerApiKeys()).toEqual(['gw-key']);
+  });
+
+  it('uses real Gemini keys over the stand-in when both are set', () => {
+    vi.stubEnv('OSIRIS_AI_BASE_URL', 'http://127.0.0.1:20128');
+    vi.stubEnv('GEMINI_API_KEY_1', 'a');
+
+    expect(getServerApiKeys()).toEqual(['a']);
+  });
+});

--- a/src/lib/ai-engine.ts
+++ b/src/lib/ai-engine.ts
@@ -6,7 +6,12 @@
  * ═══════════════════════════════════════════════════════════════
  */
 
-import { GoogleGenerativeAI, type GenerativeModel } from '@google/generative-ai';
+import {
+  GoogleGenerativeAI,
+  type EnhancedGenerateContentResponse,
+  type GenerativeModel,
+  type Part,
+} from '@google/generative-ai';
 
 /* ─────────────────────────────────────────────────────────────
    Data Interfaces — Zero `any` types
@@ -148,6 +153,78 @@ export function createGeminiClient(apiKey: string): GoogleGenerativeAI {
 }
 
 /* ─────────────────────────────────────────────────────────────
+   Model Backend — Google by default, or a Gemini-compatible gateway
+
+   OSIRIS_AI_BASE_URL points the SDK at any server that speaks the Gemini
+   REST API instead of Google — e.g. a local OmniRoute at
+   http://127.0.0.1:20128, which serves /v1beta/models/{model}:generateContent
+   and routes it to whichever provider it picks. OSIRIS_AI_MODEL overrides the
+   model id ('auto' lets OmniRoute choose). Read per call, not at import, so a
+   changed env takes effect on the next request.
+   ───────────────────────────────────────────────────────────── */
+
+const DEFAULT_MODEL = 'gemini-2.0-flash';
+
+export function aiModel(): string {
+  return process.env.OSIRIS_AI_MODEL?.trim() || DEFAULT_MODEL;
+}
+
+function aiBaseUrl(): string | undefined {
+  return process.env.OSIRIS_AI_BASE_URL?.trim().replace(/\/+$/, '') || undefined;
+}
+
+export function getModel(client: GoogleGenerativeAI, systemInstruction: string): GenerativeModel {
+  const baseUrl = aiBaseUrl();
+  return client.getGenerativeModel(
+    { model: aiModel(), systemInstruction },
+    baseUrl ? { baseUrl } : undefined
+  );
+}
+
+/**
+ * Server-side keys: GEMINI_API_KEY_1..8. With a gateway configured and no
+ * Gemini keys, a single stand-in key is returned (OSIRIS_AI_API_KEY, else a
+ * placeholder) — the SDK refuses to run without one, and a keyless local
+ * gateway ignores it.
+ */
+export function getServerApiKeys(): string[] {
+  const keys: string[] = [];
+  for (let i = 1; i <= 8; i++) {
+    const key = process.env[`GEMINI_API_KEY_${i}`];
+    if (key && key.trim().length > 0) {
+      keys.push(key.trim());
+    }
+  }
+  if (keys.length === 0 && aiBaseUrl()) {
+    keys.push(process.env.OSIRIS_AI_API_KEY?.trim() || 'no-key-required');
+  }
+  return keys;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Response Text — without the model's reasoning
+
+   Reasoning models behind a gateway return their chain of thought as parts
+   flagged `thought: true`. SDK 0.24's text() concatenates every part, so the
+   briefing would open with the model talking to itself.
+   ───────────────────────────────────────────────────────────── */
+
+function isThought(part: Part): boolean {
+  return (part as Part & { thought?: boolean }).thought === true;
+}
+
+export function responseText(response: EnhancedGenerateContentResponse): string {
+  // Called first: it throws on a blocked response, which the routes map to SAFETY_BLOCKED.
+  const full = response.text();
+  const parts = response.candidates?.[0]?.content?.parts ?? [];
+  if (!parts.some(isThought)) return full;
+  return parts
+    .filter(part => !isThought(part))
+    .map(part => part.text ?? '')
+    .join('');
+}
+
+/* ─────────────────────────────────────────────────────────────
    API Key Rotation — Round-robin through available keys
    ───────────────────────────────────────────────────────────── */
 
@@ -222,10 +299,7 @@ export async function analyzeIntelligence(
   context: IntelligenceContext,
   userQuery: string
 ): Promise<string> {
-  const model: GenerativeModel = client.getGenerativeModel({
-    model: 'gemini-2.0-flash',
-    systemInstruction: SYSTEM_PROMPT,
-  });
+  const model = getModel(client, SYSTEM_PROMPT);
 
   const contextData = serializeContext(context);
 
@@ -238,8 +312,7 @@ ${userQuery}
 Provide your intelligence assessment based on the operational data above and the analyst's query.`;
 
   const result = await model.generateContent(prompt);
-  const response = result.response;
-  return response.text();
+  return responseText(result.response);
 }
 
 /* ─────────────────────────────────────────────────────────────
@@ -250,10 +323,7 @@ export async function generateBriefing(
   client: GoogleGenerativeAI,
   context: IntelligenceContext
 ): Promise<string> {
-  const model: GenerativeModel = client.getGenerativeModel({
-    model: 'gemini-2.0-flash',
-    systemInstruction: SYSTEM_PROMPT,
-  });
+  const model = getModel(client, SYSTEM_PROMPT);
 
   const contextData = serializeContext(context);
 
@@ -265,6 +335,5 @@ ${contextData}
 Generate the briefing now.`;
 
   const result = await model.generateContent(prompt);
-  const response = result.response;
-  return response.text();
+  return responseText(result.response);
 }


### PR DESCRIPTION
Lets the AI analyst (`/api/ai/analyze`, `/api/ai/briefing`, `/api/ai/overview`) run against any server that speaks the Gemini REST API, not just Google. With neither new variable set, nothing changes.

## Why

The analyst could only talk to `generativelanguage.googleapis.com`, and only with a `GEMINI_API_KEY_*` set. Without one, analyze and briefing return `503 NO_API_KEY` and the one-click overview drops to the heuristic analyst. `.env.example` didn't mention the Gemini keys at all, so a fresh self-hosted install never gets a model.

Gateways such as [OmniRoute](https://github.com/diegosouzapw/OmniRoute) serve Gemini's own endpoint (`/v1beta/models/{model}:generateContent`) and route each request to whatever provider they're configured with, free-tier ones included. The Gemini SDK already accepts a `baseUrl`, so a gateway needs no second client.

## What changed

- **`OSIRIS_AI_BASE_URL`** points the existing SDK at the gateway. **`OSIRIS_AI_MODEL`** overrides the model id (default stays `gemini-2.0-flash`; `auto` lets OmniRoute choose). Both are read per request, not at import.
- **No Gemini key needed behind a gateway.** The SDK refuses to run without a key, so a stand-in is passed. `OSIRIS_AI_API_KEY` is used if the gateway wants a real one. Real `GEMINI_API_KEY_*` values still win when both are set.
- **Reasoning no longer leaks into the output.** Reasoning models behind a gateway return their chain of thought as parts flagged `thought: true`. SDK 0.24's `response.text()` concatenates every part, so a briefing opened with the model talking to itself. The new `responseText()` drops those parts. It still calls `text()` first, so a blocked response keeps surfacing as `SAFETY_BLOCKED`.
- **One shared key lookup.** The three routes each carried their own copy of the `GEMINI_API_KEY_1..8` loop; they now share `getServerApiKeys()`.
- **Truthful overview label.** The overview footer said "GEMINI 2.0 FLASH" whatever answered. The route now returns the model id and the label shows that.
- **`.env.example`** gains an AI ANALYST section covering the Gemini keys and the gateway variables, including the Docker note: use `host.docker.internal`, not `127.0.0.1`.

## Testing

- `src/lib/ai-engine.test.ts` (9 tests) stubs `fetch` and asserts on what the real SDK sends. That covers the default Google URL, the gateway URL and model, thought-part stripping, plain replies unchanged, and key selection.
- `tsc --noEmit` is clean. `eslint` on the touched files reports only `no-explicit-any` errors that already exist on `master`, at the same count per file.
- End to end against a local OmniRoute (`OSIRIS_AI_BASE_URL=http://127.0.0.1:20128`, `OSIRIS_AI_MODEL=auto`): overview and briefing both answered through the gateway, and the briefing came back without reasoning text. **AI OVERVIEW** in the Live Alerts panel rendered a model read-out labelled `AUTO`.
- After rebasing onto `master` (8781ae3, #335): the full `npx vitest run` passes on a local branch that combines this PR with #337 and #338 — **49 test files passed, 614 tests passed**. The 2 skipped files and 16 skipped tests are pre-existing skips of the network-gated tests.

## Notes

- Touches only the AI routes, `AiOverview.tsx`, `ai-engine.ts` and `.env.example`, so it doesn't conflict with #337 or #338; both of those are also one commit on current `master`, and the three merge cleanly together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
