### PR TITLE
feat(recon): let GITHUB_TOKEN lift the GitHub recon rate limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,20 @@ HELIUS_API_KEY=
 
 
 # ─────────────────────────────────────────────────────────────────────────
+#  GITHUB  ── read by the code; optional, raises a rate limit ──
+#  The RECON "GITHUB RECON" tool works without it: /api/osint/github calls
+#  api.github.com unauthenticated, which GitHub caps at 60 requests / hour PER
+#  IP — shared by every visitor to a deployment, so a busy instance exhausts it
+#  and the route then reports a generic "GitHub lookup failed". A token lifts
+#  that to 5000 req / hour.
+#  Public profile and repo data needs no permissions: issue the token with NO
+#  scopes selected.
+#   Get it: https://github.com/settings/tokens  (no scopes required)
+# ─────────────────────────────────────────────────────────────────────────
+GITHUB_TOKEN=
+
+
+# ─────────────────────────────────────────────────────────────────────────
 #  OPTIONAL DATA-SOURCE KEYS  (not read by current code — future / upgrades)
 # ─────────────────────────────────────────────────────────────────────────
 

--- a/src/app/api/osint/github/route.ts
+++ b/src/app/api/osint/github/route.ts
@@ -7,9 +7,15 @@ export async function GET(req: Request) {
   if (!username) return NextResponse.json({ error: 'Missing username parameter' }, { status: 400 });
 
   try {
+    // GITHUB_TOKEN is optional. Without it GitHub allows 60 requests/hour per
+    // IP, shared by every visitor to a deployment; a scopeless token lifts that
+    // to 5000. Public profile and repo data needs no scopes.
+    const headers: Record<string, string> = { 'User-Agent': 'OSIRIS-Recon' };
+    if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+
     const [userRes, reposRes] = await Promise.all([
-      fetch(`https://api.github.com/users/${encodeURIComponent(username)}`, { signal: AbortSignal.timeout(15000), headers: { 'User-Agent': 'OSIRIS-Recon' } }),
-      fetch(`https://api.github.com/users/${encodeURIComponent(username)}/repos?sort=updated&per_page=5`, { signal: AbortSignal.timeout(15000), headers: { 'User-Agent': 'OSIRIS-Recon' } })
+      fetch(`https://api.github.com/users/${encodeURIComponent(username)}`, { signal: AbortSignal.timeout(15000), headers }),
+      fetch(`https://api.github.com/users/${encodeURIComponent(username)}/repos?sort=updated&per_page=5`, { signal: AbortSignal.timeout(15000), headers })
     ]);
 
     if (userRes.status === 404) return NextResponse.json({ error: 'User not found' }, { status: 404 });


### PR DESCRIPTION
## Summary

The RECON **GitHub Recon** tool calls `api.github.com` with no credentials, so a deployment shares GitHub's anonymous allowance of **60 requests per hour per IP** across every visitor. A handful of lookups exhausts it, and the route then reports the 403 as a generic `"GitHub lookup failed"` with no hint that waiting is the fix.

This sends an `Authorization` header when `GITHUB_TOKEN` is set, which raises the limit to **5,000 requests per hour**. It stays optional: with no token the tool behaves exactly as before, which is how the public demo runs.

## Changes

- `src/app/api/osint/github/route.ts` builds the request headers once and adds `Authorization: Bearer $GITHUB_TOKEN` when the variable is set. Both GitHub calls (profile and recent repos) use them.
- `.env.example` documents `GITHUB_TOKEN` in its own block beside the other keys the code actually reads. It notes that the token needs **no scopes**, since profile and repo data are public.

## Testing

Checked against the running dev server:

| Condition | Result |
|---|---|
| No token | `200` with full profile and 5 recent repos |
| Missing `user` param | `400 Missing username parameter` |
| Unknown user | `404 User not found` |
| Deliberately fake `GITHUB_TOKEN` | `502` with `detail: "GitHub API HTTP 401"` |

The 401 is what proves the header is attached: GitHub only rejects a request that carries credentials. Before this change the same request returned 200.

Full `npx vitest run` passes on a local branch combining this PR with #334 and #338 on current `master` (8781ae3): **49 test files passed, 614 tests passed**. The 2 skipped files and 16 skipped tests are pre-existing skips of the network-gated tests. No unit test added for the header itself; the live check above covers it.

## Notes

- Independent of #334 and #338: this touches only the GitHub route and `.env.example`. #334 also edits `.env.example`, but a different block, and the three merge cleanly together.
- The file header in `.env.example` still says the code "only actually reads SCANNER_URL and SCANNER_KEY". That was already out of date for `CLOUDFLARE_API_TOKEN`, `ETHERSCAN_API_KEY` and `HELIUS_API_KEY`; I left it alone to keep this PR focused.
- A rate-limited response still surfaces as the generic 502. Distinguishing it (`403` with `x-ratelimit-remaining: 0`) would be a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
