### PR TITLE
fix(ui): keep every tool-strip flyout inside the window

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1369,20 +1369,25 @@ export default function Dashboard() {
             )}
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">RECON</span>
-          <AnimatePresence>
-            {showIntel && (
-              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
-                <OsintPanel onSweepVisualize={setSweepData} onScanGeolocate={(target, data) => {
-                  setScanTargets(prev => {
-                    const existing = prev.filter(t => t.id !== target);
-                    return [{ id: target, timestamp: Date.now(), ...data }, ...existing].slice(0, 10);
-                  });
-                  setFlyToLocation({ lat: data.lat, lng: data.lng, ts: Date.now() });
-                }} />
-              </motion.div>
-            )}
-          </AnimatePresence>
         </div>
+        {/* Every flyout is a child of the strip rather than of its button's
+            wrapper, so top-1/2 centres it on the strip, which is itself centred
+            in the window. Centred on their own buttons, the panels at either end
+            of the strip ran off the top or bottom of a 720px-tall screen.
+            right-13 keeps the old gap: the strip's padding used to add 4px. */}
+        <AnimatePresence>
+          {showIntel && (
+            <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-13 top-1/2 -translate-y-1/2 w-80">
+              <OsintPanel onSweepVisualize={setSweepData} onScanGeolocate={(target, data) => {
+                setScanTargets(prev => {
+                  const existing = prev.filter(t => t.id !== target);
+                  return [{ id: target, timestamp: Date.now(), ...data }, ...existing].slice(0, 10);
+                });
+                setFlyToLocation({ lat: data.lat, lng: data.lng, ts: Date.now() });
+              }} />
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         <div className="relative group">
           <button onClick={() => { setShowIntel(false); setShowAlerts(false); setShowMarkets(false); setShowSpaceCam(v => !v); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showSpaceCam ? 'bg-[#00E5FF]/20' : 'hover:bg-white/10'}`} title="Live from Space — 24/7 video downlink from the ISS" aria-label="Live from Space" aria-expanded={showSpaceCam}>
@@ -1395,14 +1400,14 @@ export default function Dashboard() {
             )}
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">SPACE</span>
-          <AnimatePresence>
-            {showSpaceCam && (
-              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
-                <SpaceCam />
-              </motion.div>
-            )}
-          </AnimatePresence>
         </div>
+        <AnimatePresence>
+          {showSpaceCam && (
+            <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-13 top-1/2 -translate-y-1/2 w-80">
+              <SpaceCam />
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         <div className="relative group">
           <button onClick={() => { setShowMarkets(!showMarkets); setShowIntel(false); setShowAlerts(false); setShowSpaceCam(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showMarkets ? 'bg-[var(--gold-primary)]/20' : 'hover:bg-white/10'}`} title="Markets — crypto prices, space weather, global indices" aria-label="Markets" aria-expanded={showMarkets}>
@@ -1415,14 +1420,14 @@ export default function Dashboard() {
             )}
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">MARKETS</span>
-          <AnimatePresence>
-            {showMarkets && (
-              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
-                <MarketsPanel data={data} spaceWeather={spaceWeather} />
-              </motion.div>
-            )}
-          </AnimatePresence>
         </div>
+        <AnimatePresence>
+          {showMarkets && (
+            <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-13 top-1/2 -translate-y-1/2 w-80">
+              <MarketsPanel data={data} spaceWeather={spaceWeather} />
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         <div className="relative group">
           <button onClick={() => { setShowAlerts(!showAlerts); setShowIntel(false); setShowMarkets(false); setShowDrawing(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showAlerts ? 'bg-[#FF3D3D]/20' : 'hover:bg-white/10'}`} title="Live Alerts — earthquakes, conflicts, breaking news" aria-label="Live Alerts" aria-expanded={showAlerts}>
@@ -1435,14 +1440,14 @@ export default function Dashboard() {
             )}
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">ALERTS</span>
-          <AnimatePresence>
-            {showAlerts && (
-              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
-                <LiveAlerts data={data} onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
-              </motion.div>
-            )}
-          </AnimatePresence>
         </div>
+        <AnimatePresence>
+          {showAlerts && (
+            <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-13 top-1/2 -translate-y-1/2 w-80">
+              <LiveAlerts data={data} onLocate={(lat, lng) => setFlyToLocation({ lat, lng, ts: Date.now() })} onWatchFeed={(url, name) => { setLiveFeedUrl(url); setLiveFeedName(name); }} />
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         <div className="relative group">
           <button onClick={() => { setShowDrawing(!showDrawing); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showDrawing ? 'bg-[#00E5FF]/20' : 'hover:bg-white/10'}`} title="Draw — measure areas of interest on the map" aria-label="Draw" aria-expanded={showDrawing}>
@@ -1481,14 +1486,14 @@ export default function Dashboard() {
             )}
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">SEARCH</span>
-          <AnimatePresence>
-            {showDesktopSearch && (
-              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
-                <SearchBar alwaysExpanded onLocate={(lat, lng, zoom) => { setFlyToLocation({ lat, lng, zoom, ts: Date.now() }); setShowDesktopSearch(false); }} />
-              </motion.div>
-            )}
-          </AnimatePresence>
         </div>
+        <AnimatePresence>
+          {showDesktopSearch && (
+            <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-13 top-1/2 -translate-y-1/2 w-80">
+              <SearchBar alwaysExpanded onLocate={(lat, lng, zoom) => { setFlyToLocation({ lat, lng, zoom, ts: Date.now() }); setShowDesktopSearch(false); }} />
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         {/* Separator */}
         <div className="w-4 h-px bg-white/10 mx-auto" />
@@ -1506,22 +1511,22 @@ export default function Dashboard() {
             {arcgisLayers.length > 0 && <span className="absolute -top-0.5 -right-0.5 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-[var(--gold-primary)] text-black text-[9px] font-mono font-bold leading-none px-0.5">{arcgisLayers.length}</span>}
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">ARCGIS</span>
-          <AnimatePresence>
-            {showArcGIS && (
-              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-[340px]">
-                <div className="glass-panel p-3 max-h-[70vh] overflow-y-auto styled-scrollbar">
-                  <ArcGISPanel
-                    onImportLayer={(layer) => setArcgisLayers(prev => [...prev.filter(l => l.id !== layer.id), { ...layer, color: layer.color || '#D4AF37', visible: true, opacity: layer.opacity ?? 0.8 }])}
-                    onRemoveLayer={(id) => setArcgisLayers(prev => prev.filter(l => l.id !== id))}
-                    onUpdateLayer={(id, updates) => setArcgisLayers(prev => prev.map(l => l.id === id ? { ...l, ...updates } : l))}
-                    importedLayers={arcgisLayers}
-                    mapBounds={mapCenter?.bounds || null}
-                  />
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
         </div>
+        <AnimatePresence>
+          {showArcGIS && (
+            <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-13 top-1/2 -translate-y-1/2 w-[340px]">
+              <div className="glass-panel p-3 max-h-[70vh] overflow-y-auto styled-scrollbar">
+                <ArcGISPanel
+                  onImportLayer={(layer) => setArcgisLayers(prev => [...prev.filter(l => l.id !== layer.id), { ...layer, color: layer.color || '#D4AF37', visible: true, opacity: layer.opacity ?? 0.8 }])}
+                  onRemoveLayer={(id) => setArcgisLayers(prev => prev.filter(l => l.id !== id))}
+                  onUpdateLayer={(id, updates) => setArcgisLayers(prev => prev.map(l => l.id === id ? { ...l, ...updates } : l))}
+                  importedLayers={arcgisLayers}
+                  mapBounds={mapCenter?.bounds || null}
+                />
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
 
 
         {/* Separator */}
@@ -1539,22 +1544,22 @@ export default function Dashboard() {
             )}
           </button>
           <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">REMOTE</span>
-          <AnimatePresence>
-            {showRemote && (
-              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-80">
-                <WorldRemote onClose={() => setShowRemote(false)} onPlaceOnMap={(devs) => {
-                  setScanTargets(prev => {
-                    const ids = new Set(prev.map((t: any) => t.id));
-                    const next = [...prev];
-                    devs.forEach(d => { if (!ids.has(d.id)) next.unshift({ id: d.id, name: d.name, lat: d.lat, lng: d.lng, type: d.type, color: d.color, timestamp: Date.now(), source: 'BLE' }); });
-                    return next.slice(0, 20);
-                  });
-                  if (devs.length > 0) setFlyToLocation({ lat: devs[0].lat, lng: devs[0].lng, ts: Date.now() });
-                }} />
-              </motion.div>
-            )}
-          </AnimatePresence>
         </div>
+        <AnimatePresence>
+          {showRemote && (
+            <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-13 top-1/2 -translate-y-1/2 w-80">
+              <WorldRemote onClose={() => setShowRemote(false)} onPlaceOnMap={(devs) => {
+                setScanTargets(prev => {
+                  const ids = new Set(prev.map((t: any) => t.id));
+                  const next = [...prev];
+                  devs.forEach(d => { if (!ids.has(d.id)) next.unshift({ id: d.id, name: d.name, lat: d.lat, lng: d.lng, type: d.type, color: d.color, timestamp: Date.now(), source: 'BLE' }); });
+                  return next.slice(0, 20);
+                });
+                if (devs.length > 0) setFlyToLocation({ lat: devs[0].lat, lng: devs[0].lng, ts: Date.now() });
+              }} />
+            </motion.div>
+          )}
+        </AnimatePresence>
 
 
       </div>}


### PR DESCRIPTION
## Summary

Each panel on the right-hand tool strip was centred vertically on **its own button**, so panels near the ends of the strip spilled out of the window on laptop-height screens. At 1280×720:

- the **RECON** toolkit started 59px above the top, hiding its header along with the full-screen and collapse controls, which could not be scrolled back into view
- **Markets** started 39px above the top
- **ArcGIS** and **World Remote** ran 4px and 59px past the bottom (30px and 109px at 600px tall), sliding under the news ticker

Anchoring each panel to the top or bottom of its button can't fix this: Markets is 86% of the window height.

## Change

Every flyout is now a child of the strip itself rather than of its button's wrapper, so `top-1/2 -translate-y-1/2` centres it on the strip, which is already centred in the window. Each panel's existing height cap then keeps it on screen.

`right-13` replaces `right-12` because the containing block no longer includes the strip's 4px padding. The gap between panel and strip stays at 11px.

Most of the diff is re-indentation from moving each `AnimatePresence` block out one level.

## Testing

Measured each panel's top and bottom edges in the browser (window 1280 wide):

| Panel | 600 tall | 720 tall | 1000 tall |
|---|---|---|---|
| RECON | 60–540 | 110–610 (was −59 top) | 250–750 |
| Space | fits | fits | 351–649 |
| Markets | 34–566 (was −55 top) | 34–686 (was −39 top) | 162–838 |
| Alerts | 60–540 | 110–610 | 250–750 |
| Search | 281–319 | 341–379 | 481–519 |
| ArcGIS | 90–510 (was 630 bottom) | 124–596 (was 724 bottom) | 264–736 |
| World Remote | 60–540 (was 709 bottom) | 110–610 (was 779 bottom) | 250–750 |

Also checked:
- the hover labels still line up with their buttons
- the strip's own layout is unchanged (the RECON button stays at y=175 at 720)
- the gap to the strip is 11px for every panel, as before

Full `npx vitest run` passes on a local branch combining this PR with #334 and #337 on current `master` (8781ae3): **49 test files passed, 614 tests passed**. The 2 skipped files and 16 skipped tests are pre-existing skips of the network-gated tests. This is a layout change, so there is no unit test for it; the measurements above are the check.

## Notes

- Independent of #334 and #337: neither of them touches `src/app/page.tsx`, and the three merge cleanly together.
- The Draw toolbar isn't on the strip and already fit, so it's unchanged.
- If `right-13` doesn't apply in a dev server that was already running, delete `.next/` and restart. Turbopack's dev cache kept serving CSS without the new class until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
