### PR TITLE
feat(lab): AI LAB menu backed by a local AI node

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,3 +106,15 @@ OSIRIS_PORT=3000
 # NODE_ENV=production
 # PORT=3000
 # HOSTNAME=0.0.0.0
+
+# ── LAB — local AI node (Delfi) ────────────────────────────────────────
+# The LAB menu (image intel, EXIF/GPS, face, image editing) is served by a
+# local AI node, not by a cloud API. Server-side calls go to OSIRIS_DELFI_URL;
+# the browser never talks to the node directly, because Chrome blocks
+# private-network requests from the page to a LAN address.
+# OSIRIS_DELFI_URL=http://localhost:7863
+#
+# Same address, but exposed to the browser: used only for the "open the
+# console" link in the LAB panel. The node's own console is the single place
+# where every tool lives; the LAB is a window onto it.
+# NEXT_PUBLIC_DELFI_URL=http://localhost:7863

--- a/src/app/api/ai/exif/route.ts
+++ b/src/app/api/ai/exif/route.ts
@@ -1,0 +1,21 @@
+/**
+ * OSIRIS — EXIF / metadati immagine (Delfi)
+ * POST /api/ai/exif   multipart: file
+ * Puro OSINT: camera, timestamp, software e GPS decodificato in lat/lon.
+ * Nessuna GPU coinvolta.
+ */
+import { proxyDelfi } from '@/lib/delfi';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+export async function POST(req: Request) {
+  return proxyDelfi(req, {
+    bucket: 'ai-exif',
+    path: '/intel/exif',
+    campi: ['file'],
+    obbligatori: ['file'],
+    max: 30,          // leggero: tetto piu' alto delle route con GPU
+    timeoutMs: 60_000,
+  });
+}

--- a/src/app/api/ai/face/route.ts
+++ b/src/app/api/ai/face/route.ts
@@ -1,0 +1,42 @@
+/**
+ * OSIRIS — Face Intel (Delfi / DeepFace)
+ * POST /api/ai/face   multipart: image           -> eta', genere, emozione
+ * POST /api/ai/face   multipart: image1, image2  -> confronto fra due volti
+ * ⚠ Delfi usa i campi `image` / `image1`+`image2`, NON `file`.
+ */
+import { proxyDelfi } from '@/lib/delfi';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+export async function POST(req: Request) {
+  // il confronto si riconosce dalla presenza di image2: instrada su /df/verify
+  const ct = req.headers.get('content-type') || '';
+  if (!ct.includes('multipart/form-data')) {
+    return Response.json({ error: 'Attesa una form multipart.' }, { status: 400 });
+  }
+  const clone = req.clone();
+  let confronto = false;
+  try {
+    const peek = await clone.formData();
+    confronto = peek.get('image2') !== null;
+  } catch {
+    /* lascia decidere alla validazione sotto */
+  }
+
+  return confronto
+    ? proxyDelfi(req, {
+        bucket: 'ai-face',
+        path: '/df/verify',
+        campi: ['image1', 'image2'],
+        obbligatori: ['image1', 'image2'],
+        max: 10,
+      })
+    : proxyDelfi(req, {
+        bucket: 'ai-face',
+        path: '/df/analyze',
+        campi: ['image'],
+        obbligatori: ['image'],
+        max: 10,
+      });
+}

--- a/src/app/api/ai/generate/route.ts
+++ b/src/app/api/ai/generate/route.ts
@@ -1,0 +1,21 @@
+/**
+ * OSIRIS — AI Inpainting generativo (Delfi / SDXL)
+ * POST /api/ai/generate   multipart: file, maschera, prompt, [forza], [passi]
+ * Pesante: su Delfi gira in un sottoprocesso, ~30 s, 1-2 in parallelo.
+ * Per questo il tetto qui e' piu' basso delle altre route.
+ */
+import { proxyDelfi } from '@/lib/delfi';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 600;
+
+export async function POST(req: Request) {
+  return proxyDelfi(req, {
+    bucket: 'ai-generate',
+    path: '/foto/generativo',
+    campi: ['file', 'maschera', 'prompt', 'forza', 'passi'],
+    obbligatori: ['file', 'maschera', 'prompt'],
+    max: 4,                 // Delfi regge 1-2 generazioni insieme: non invitare la coda
+    timeoutMs: 600_000,
+  });
+}

--- a/src/app/api/ai/image-edit/route.ts
+++ b/src/app/api/ai/image-edit/route.ts
@@ -1,0 +1,20 @@
+/**
+ * OSIRIS — AI Image Edit classico (Delfi)
+ * POST /api/ai/image-edit   multipart: file, prompt
+ * Il modello propone una ricetta da whitelist, Delfi la applica con PIL.
+ * Le richieste generative tornano con generativo_necessario=true, non fingono.
+ */
+import { proxyDelfi } from '@/lib/delfi';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+export async function POST(req: Request) {
+  return proxyDelfi(req, {
+    bucket: 'ai-image-edit',
+    path: '/foto/modifica',
+    campi: ['file', 'prompt'],
+    obbligatori: ['file', 'prompt'],
+    max: 10,
+  });
+}

--- a/src/app/api/ai/mask/route.ts
+++ b/src/app/api/ai/mask/route.ts
@@ -1,0 +1,19 @@
+/**
+ * OSIRIS — AI Mask da testo (Delfi)
+ * POST /api/ai/mask   multipart: file, testo, [soglia], [allarga], [sam]
+ * CLIPSeg trova l'area descritta, SAM ne rende netti i bordi.
+ */
+import { proxyDelfi } from '@/lib/delfi';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+export async function POST(req: Request) {
+  return proxyDelfi(req, {
+    bucket: 'ai-mask',
+    path: '/foto/maschera',
+    campi: ['file', 'testo', 'soglia', 'allarga', 'sam'],
+    obbligatori: ['file', 'testo'],
+    max: 10,
+  });
+}

--- a/src/app/api/ai/vision/route.ts
+++ b/src/app/api/ai/vision/route.ts
@@ -1,0 +1,19 @@
+/**
+ * OSIRIS — AI Vision (Delfi)
+ * POST /api/ai/vision   multipart: file, [domanda]
+ * Analizza un'immagine col modello di visione locale (qwen2.5vl su Delfi).
+ */
+import { proxyDelfi } from '@/lib/delfi';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+export async function POST(req: Request) {
+  return proxyDelfi(req, {
+    bucket: 'ai-vision',
+    path: '/foto/analizza',
+    campi: ['file', 'domanda'],
+    obbligatori: ['file'],
+    max: 10,
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Layers, BarChart3, Newspaper, Search, X, Globe, MapPinned, Route, Radar, Satellite, Moon, ExternalLink, AlertTriangle, Activity, Database, Wifi, Play, Network, Crosshair, Bluetooth, Pentagon, Radio , PenLine } from 'lucide-react';
+import { Layers, BarChart3, Newspaper, Search, X, Globe, MapPinned, Route, Radar, Satellite, Moon, ExternalLink, AlertTriangle, Activity, Database, Wifi, Play, Network, Crosshair, Bluetooth, Pentagon, Radio , PenLine, Wand2 } from 'lucide-react';
 import { type TerrainStatus } from '@/lib/map-terrain';
 import { loadCameraCatalog, mergeCameraCatalog } from '@/lib/camera-catalog';
 import IntelFeed from '@/components/IntelFeed';
@@ -30,6 +30,8 @@ const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
 const SpaceCam = dynamic(() => import('@/components/SpaceCam'), { ssr: false });
 const CameraViewer = dynamic(() => import('@/components/CameraViewer'));
 const OsintPanel = dynamic(() => import('@/components/OsintPanel'));
+// LAB — strumenti AI serviti dal nodo locale (Delfi), via /api/ai/*
+const LabPanel = dynamic(() => import('@/components/LabPanel'));
 const DrawingToolbar = dynamic(() => import('@/components/DrawingToolbar'), { ssr: false });
 const DrawHud = dynamic(() => import('@/components/DrawHud'), { ssr: false });
 // The measurement helpers are pure functions — importing them directly keeps
@@ -255,11 +257,12 @@ export default function Dashboard() {
     return () => navigator.geolocation.clearWatch(id);
   }, [navSession]);
   const [showRemote, setShowRemote] = useState(false);
+  const [showLab, setShowLab] = useState(false);
   const [showArcGIS, setShowArcGIS] = useState(false);
   const [arcgisLayers, setArcgisLayers] = useState<Array<{ id: string; title: string; url: string; geojson: any; color: string; visible: boolean; opacity: number }>>([]);
   const [mapCenter, setMapCenter] = useState<{ lat: number; lng: number; bounds?: { west: number; south: number; east: number; north: number } } | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [mobilePanel, setMobilePanel] = useState<'layers'|'markets'|'intel'|'search'|'recon'|'remote'|null>(null);
+  const [mobilePanel, setMobilePanel] = useState<'layers'|'markets'|'intel'|'search'|'recon'|'remote'|'lab'|null>(null);
   const [mapProjection, setMapProjection] = useState<'globe'|'mercator'>('globe');
   const [terrainFocus, setTerrainFocus] = useState(0);
   const [terrainStatus, setTerrainStatus] = useState<TerrainStatus>('idle');
@@ -1556,6 +1559,30 @@ export default function Dashboard() {
           </AnimatePresence>
         </div>
 
+        {/* ── AI LAB ── strumenti AI serviti dal nodo locale (Delfi) */}
+        <div className="relative group">
+          <button onClick={() => { setShowLab(!showLab); setShowRemote(false); setShowArcGIS(false); setShowIntel(false); setShowMarkets(false); setShowAlerts(false); setShowSpaceCam(false); setShowDrawing(false); setShowDesktopSearch(false); }} className={`relative w-8 h-8 rounded-full flex items-center justify-center transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-white/50 ${showLab ? 'bg-[var(--cyan-primary)]/20' : 'hover:bg-white/10'}`} title="AI Lab — analisi immagini, EXIF/GPS, volti e ritocco (nodo locale)" aria-label="AI Lab" aria-expanded={showLab}>
+            <Wand2 className={`w-4 h-4 ${showLab ? 'text-[var(--cyan-primary)]' : 'text-white/60'}`} />
+            {showLab && (
+              <span
+                aria-hidden="true"
+                className="absolute -right-1 top-1/2 -translate-y-1/2 h-4 w-[2px] rounded-full bg-current text-[var(--cyan-primary)]"
+              />
+            )}
+          </button>
+          <span className="absolute right-11 top-1/2 -translate-y-1/2 px-2 py-1 text-[9px] font-mono tracking-wider text-white/80 bg-black/80 backdrop-blur-sm rounded whitespace-nowrap opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity pointer-events-none">LAB</span>
+          <AnimatePresence>
+            {showLab && (
+              <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-[340px] max-h-[80vh] overflow-auto glass-panel rounded-lg p-3">
+                <LabPanel
+                  onClose={() => setShowLab(false)}
+                  onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setShowLab(false); }}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
 
       </div>}
 
@@ -1665,6 +1692,10 @@ export default function Dashboard() {
                 // because both answer "take me somewhere".
                 { id: 'route' as const, icon: Route, label: 'ROUTE' },
                 { id: 'remote' as const, icon: Bluetooth, label: 'REMOTE' },
+                // LAB — analisi immagini, EXIF/GPS, volti e ritocco, serviti dal
+                // nodo AI locale. Sta in fondo perche' opera su file caricati,
+                // non sulla mappa.
+                { id: 'lab' as const, icon: Wand2, label: 'LAB' },
               ].map(tab => {
                 // Routing opens the planner at the top of the screen rather than
                 // the bottom drawer — it needs the room above the keyboard, and
@@ -1715,7 +1746,7 @@ export default function Dashboard() {
                 <div className="px-3 pb-3">
                   <div className="flex items-center justify-between mb-2">
                     <span className="hud-text text-[10px] text-[var(--text-primary)]">
-                      {mobilePanel === 'layers' ? 'LAYERS & STATS' : mobilePanel === 'markets' ? 'MARKETS & INTEL' : mobilePanel === 'intel' ? 'INTEL FEED' : mobilePanel === 'recon' ? 'OSIRIS RECON' : mobilePanel === 'remote' ? 'WORLD REMOTE' : 'SEARCH'}
+                      {mobilePanel === 'layers' ? 'LAYERS & STATS' : mobilePanel === 'markets' ? 'MARKETS & INTEL' : mobilePanel === 'intel' ? 'INTEL FEED' : mobilePanel === 'recon' ? 'OSIRIS RECON' : mobilePanel === 'remote' ? 'WORLD REMOTE' : mobilePanel === 'lab' ? 'AI LAB' : 'SEARCH'}
                     </span>
                     <button onClick={() => setMobilePanel(null)} className="text-[var(--text-muted)] p-1"><X className="w-4 h-4" /></button>
                   </div>
@@ -1748,6 +1779,13 @@ export default function Dashboard() {
                     <div className="space-y-2">
                       <OsintPanel isOpen={true} onClose={() => setMobilePanel(null)} isMobile={true} onSweepVisualize={setSweepData} />
                     </div>
+                  )}
+                  {mobilePanel === 'lab' && (
+                    <LabPanel
+                      isMobile={true}
+                      onClose={() => setMobilePanel(null)}
+                      onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }}
+                    />
                   )}
                   {mobilePanel === 'remote' && (
                     <WorldRemote onClose={() => setMobilePanel(null)} onPlaceOnMap={(devs) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,7 @@ import GlobalStatusBar from '@/components/GlobalStatusBar';
 import LiveAlerts from '@/components/LiveAlerts';
 import WorldRemote from '@/components/WorldRemote';
 import ArcGISPanel from '@/components/ArcGISPanel';
+import { isToolId, type ToolId } from '@/components/LabPanel';
 const OsirisMap = dynamic(() => import('@/components/OsirisMap'), { ssr: false });
 const LayerPanel = dynamic(() => import('@/components/LayerPanel'));
 const SpaceCam = dynamic(() => import('@/components/SpaceCam'), { ssr: false });
@@ -258,15 +259,21 @@ export default function Dashboard() {
   }, [navSession]);
   const [showRemote, setShowRemote] = useState(false);
   const [showLab, setShowLab] = useState(false);
-  /* Deep link: ?panel=lab apre direttamente il LAB. Serve a chi arriva da un
-     altro cruscotto con un collegamento allo strumento, non alla mappa. Si
-     impostano entrambi perche' la barra desktop e la nav mobile si escludono
-     a vicenda per larghezza: vince quella visibile. */
+  const [labTool, setLabTool] = useState<ToolId | undefined>(undefined);
+  /* Deep link: ?panel=lab apre direttamente il LAB, e ?tool=exif lo apre gia'
+     sullo strumento giusto. Serve a chi arriva da un altro cruscotto con un
+     collegamento a UNO strumento, non alla mappa. Si legge qui e non nel
+     pannello perche' l'app riscrive la query poco dopo l'avvio, mentre il
+     pannello (import dinamico) monta più tardi: leggerlo lì lo troverebbe
+     gia' sparito. Si impostano entrambi i contenitori perche' barra desktop e
+     nav mobile si escludono per larghezza: vince quello visibile. */
   useEffect(() => {
-    if (new URLSearchParams(window.location.search).get('panel') === 'lab') {
-      setShowLab(true);
-      setMobilePanel('lab');
-    }
+    const q = new URLSearchParams(window.location.search);
+    if (q.get('panel') !== 'lab') return;
+    const t = q.get('tool');
+    if (isToolId(t)) setLabTool(t);
+    setShowLab(true);
+    setMobilePanel('lab');
   }, []);
   const [showArcGIS, setShowArcGIS] = useState(false);
   const [arcgisLayers, setArcgisLayers] = useState<Array<{ id: string; title: string; url: string; geojson: any; color: string; visible: boolean; opacity: number }>>([]);
@@ -1585,6 +1592,7 @@ export default function Dashboard() {
             {showLab && (
               <motion.div initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: 20 }} className="absolute right-12 top-1/2 -translate-y-1/2 w-[340px] max-h-[80vh] overflow-auto glass-panel rounded-lg p-3">
                 <LabPanel
+                  strumento={labTool}
                   onClose={() => setShowLab(false)}
                   onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setShowLab(false); }}
                 />
@@ -1793,6 +1801,7 @@ export default function Dashboard() {
                   {mobilePanel === 'lab' && (
                     <LabPanel
                       isMobile={true}
+                      strumento={labTool}
                       onClose={() => setMobilePanel(null)}
                       onLocate={(lat, lng) => { setFlyToLocation({ lat, lng, ts: Date.now() }); setMobilePanel(null); }}
                     />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -258,6 +258,16 @@ export default function Dashboard() {
   }, [navSession]);
   const [showRemote, setShowRemote] = useState(false);
   const [showLab, setShowLab] = useState(false);
+  /* Deep link: ?panel=lab apre direttamente il LAB. Serve a chi arriva da un
+     altro cruscotto con un collegamento allo strumento, non alla mappa. Si
+     impostano entrambi perche' la barra desktop e la nav mobile si escludono
+     a vicenda per larghezza: vince quella visibile. */
+  useEffect(() => {
+    if (new URLSearchParams(window.location.search).get('panel') === 'lab') {
+      setShowLab(true);
+      setMobilePanel('lab');
+    }
+  }, []);
   const [showArcGIS, setShowArcGIS] = useState(false);
   const [arcgisLayers, setArcgisLayers] = useState<Array<{ id: string; title: string; url: string; geojson: any; color: string; visible: boolean; opacity: number }>>([]);
   const [mapCenter, setMapCenter] = useState<{ lat: number; lng: number; bounds?: { west: number; south: number; east: number; north: number } } | null>(null);

--- a/src/components/LabPanel.tsx
+++ b/src/components/LabPanel.tsx
@@ -20,7 +20,12 @@ import {
  */
 const PLANCIA_URL = process.env.NEXT_PUBLIC_DELFI_URL || 'http://localhost:7863';
 
-type ToolId = 'intel' | 'exif' | 'face' | 'media';
+export type ToolId = 'intel' | 'exif' | 'face' | 'media';
+
+/** Riconosce un identificativo di strumento arrivato da fuori (query string). */
+export function isToolId(v: unknown): v is ToolId {
+  return v === 'intel' || v === 'exif' || v === 'face' || v === 'media';
+}
 
 const TOOLS: { id: ToolId; label: string; icon: typeof Eye; color: string; blurb: string }[] = [
   { id: 'intel', label: 'IMAGE INTEL', icon: Eye, color: '#00E5FF', blurb: 'Descrive la scena, legge insegne e testo' },
@@ -34,13 +39,31 @@ interface Props {
   isMobile?: boolean;
   /** Porta la mappa sulle coordinate trovate nell'EXIF. */
   onLocate?: (lat: number, lng: number) => void;
+  /** Strumento su cui aprirsi, quando si arriva da un link diretto. */
+  strumento?: ToolId;
 }
 
-async function postForm(url: string, form: FormData) {
+/* Forme delle risposte del nodo, per i soli campi che questo pannello legge. */
+interface RispVision { analisi?: string }
+interface RispFace { eta?: number; genere?: string; emozione?: string; etnia?: string }
+interface RispExif {
+  base?: { formato?: string; larghezza?: number; altezza?: number };
+  presente?: boolean;
+  sintesi?: Record<string, string>;
+  gps?: { lat: number; lon: number } | null;
+}
+interface RispMask { maschera: string; copertura: number; sam?: boolean; vuota?: boolean }
+interface RispEdit {
+  immagine: string; nota?: string; applicate?: string[]; generativo_necessario?: boolean;
+}
+interface RispGen { immagine: string }
+
+async function postForm<T>(url: string, form: FormData): Promise<T> {
   const r = await fetch(url, { method: 'POST', body: form });
-  const j = await r.json().catch(() => null);
-  if (!r.ok || (j && j.error)) throw new Error((j && j.error) || `HTTP ${r.status}`);
-  return j as Record<string, any>;
+  const j: unknown = await r.json().catch(() => null);
+  const err = (j as { error?: string } | null)?.error;
+  if (!r.ok || err) throw new Error(err || `HTTP ${r.status}`);
+  return j as T;
 }
 
 /** data:image/...;base64,... -> Blob, per rispedire la maschera al generatore. */
@@ -53,8 +76,8 @@ function dataUrlToBlob(dataUrl: string): Blob {
   return new Blob([buf], { type: mime });
 }
 
-export default function LabPanel({ onClose, isMobile, onLocate }: Props) {
-  const [tool, setTool] = useState<ToolId>('intel');
+export default function LabPanel({ onClose, isMobile, onLocate, strumento }: Props) {
+  const [tool, setTool] = useState<ToolId>(strumento ?? 'intel');
   const [file, setFile] = useState<File | null>(null);
   const [anteprima, setAnteprima] = useState<string | null>(null);
   const [domanda, setDomanda] = useState('');
@@ -63,7 +86,7 @@ export default function LabPanel({ onClose, isMobile, onLocate }: Props) {
   const [busy, setBusy] = useState(false);
   const [errore, setErrore] = useState<string | null>(null);
   const [testo, setTesto] = useState<string | null>(null);
-  const [exif, setExif] = useState<Record<string, any> | null>(null);
+  const [exif, setExif] = useState<RispExif | null>(null);
   const [risultato, setRisultato] = useState<string | null>(null);
   const [nota, setNota] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -86,16 +109,16 @@ export default function LabPanel({ onClose, isMobile, onLocate }: Props) {
         const fd = new FormData();
         fd.append('file', file);
         if (domanda.trim()) fd.append('domanda', domanda.trim());
-        const d = await postForm('/api/ai/vision', fd);
+        const d = await postForm<RispVision>('/api/ai/vision', fd);
         setTesto(String(d.analisi || ''));
       } else if (tool === 'exif') {
         const fd = new FormData();
         fd.append('file', file);
-        setExif(await postForm('/api/ai/exif', fd));
+        setExif(await postForm<RispExif>('/api/ai/exif', fd));
       } else if (tool === 'face') {
         const fd = new FormData();
         fd.append('image', file);           // Delfi vuole "image", non "file"
-        const d = await postForm('/api/ai/face', fd);
+        const d = await postForm<RispFace>('/api/ai/face', fd);
         setTesto(
           [d.eta != null ? `Età stimata: ${d.eta}` : null,
            d.genere ? `Genere: ${d.genere}` : null,
@@ -108,20 +131,20 @@ export default function LabPanel({ onClose, isMobile, onLocate }: Props) {
           // area descritta => percorso GENERATIVO: prima la maschera, poi l'inpainting
           const fm = new FormData();
           fm.append('file', file); fm.append('testo', area.trim());
-          const m = await postForm('/api/ai/mask', fm);
+          const m = await postForm<RispMask>('/api/ai/mask', fm);
           if (m.vuota) { setErrore('Non ho trovato quell\'area: descrivila diversamente.'); setBusy(false); return; }
           const fg = new FormData();
           fg.append('file', file);
           fg.append('maschera', dataUrlToBlob(String(m.maschera)), 'mask.png');
           fg.append('prompt', prompt.trim());
           fg.append('forza', '0.95');
-          const g = await postForm('/api/ai/generate', fg);
+          const g = await postForm<RispGen>('/api/ai/generate', fg);
           setRisultato(String(g.immagine));
           setNota(`Rigenerata l'area «${area.trim()}» (${m.copertura}%${m.sam ? ', bordi netti con SAM' : ''}).`);
         } else {
           const fe = new FormData();
           fe.append('file', file); fe.append('prompt', prompt.trim());
-          const d = await postForm('/api/ai/image-edit', fe);
+          const d = await postForm<RispEdit>('/api/ai/image-edit', fe);
           setRisultato(String(d.immagine));
           setNota(d.generativo_necessario
             ? `${d.nota} — descrivi l'area qui sopra per usare il generativo.`
@@ -135,6 +158,9 @@ export default function LabPanel({ onClose, isMobile, onLocate }: Props) {
   }, [file, tool, domanda, prompt, area]);
 
   const attivo = TOOLS.find(t => t.id === tool)!;
+  /* Copia locale: dentro una closure TypeScript non puo' restringere un campo
+     di stato (potrebbe cambiare fra il controllo e il clic). */
+  const gps = exif?.gps ?? null;
 
   return (
     <div className={`flex flex-col gap-3 ${isMobile ? '' : 'w-[340px]'} text-white/90`}>
@@ -245,18 +271,18 @@ export default function LabPanel({ onClose, isMobile, onLocate }: Props) {
             {String(exif.base?.formato)} · {String(exif.base?.larghezza)}×{String(exif.base?.altezza)}
           </div>
           {!exif.presente && <div className="text-white/45">Nessun metadato EXIF in questa immagine.</div>}
-          {exif.sintesi && Object.entries(exif.sintesi as Record<string, string>).map(([k, v]) => (
+          {exif.sintesi && Object.entries(exif.sintesi).map(([k, v]) => (
             <div key={k} className="flex gap-2">
               <span className="text-white/45 w-28 shrink-0">{k}</span><span className="break-all">{v}</span>
             </div>
           ))}
-          {exif.gps && (
+          {gps && (
             <button
-              onClick={() => onLocate?.(Number(exif.gps.lat), Number(exif.gps.lon))}
+              onClick={() => onLocate?.(gps.lat, gps.lon)}
               className="mt-1 flex items-center gap-2 text-[#D4AF37] hover:underline"
             >
               <MapPin className="w-3.5 h-3.5" />
-              {Number(exif.gps.lat).toFixed(5)}, {Number(exif.gps.lon).toFixed(5)} — porta la mappa qui
+              {gps.lat.toFixed(5)}, {gps.lon.toFixed(5)} — porta la mappa qui
             </button>
           )}
         </div>

--- a/src/components/LabPanel.tsx
+++ b/src/components/LabPanel.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+/**
+ * ═══════════════════════════════════════════════════════════════
+ *  OSIRIS — LAB : strumenti AI serviti dal nodo locale (Delfi)
+ *  Image Intel · EXIF/GPS · Face Intel · Media Lab (ritocco e generativo)
+ *  Tutte le chiamate passano dalle route /api/ai/* (server-side).
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+import { useState, useCallback, useRef } from 'react';
+import {
+  Eye, MapPin, ScanFace, Wand2, Loader2, Upload, AlertTriangle, X, ExternalLink,
+} from 'lucide-react';
+
+/**
+ * Console unica del nodo: questi strumenti sono una finestra su di essa, non un
+ * secondo cruscotto. Il collegamento resta sempre visibile, cosi' da qui si
+ * arriva a tutto il resto (voce, volto, agente, risorse) invece di duplicarlo.
+ */
+const PLANCIA_URL = process.env.NEXT_PUBLIC_DELFI_URL || 'http://localhost:7863';
+
+type ToolId = 'intel' | 'exif' | 'face' | 'media';
+
+const TOOLS: { id: ToolId; label: string; icon: typeof Eye; color: string; blurb: string }[] = [
+  { id: 'intel', label: 'IMAGE INTEL', icon: Eye, color: '#00E5FF', blurb: 'Descrive la scena, legge insegne e testo' },
+  { id: 'exif', label: 'EXIF / GPS', icon: MapPin, color: '#D4AF37', blurb: 'Camera, timestamp e coordinate' },
+  { id: 'face', label: 'FACE INTEL', icon: ScanFace, color: '#FF9F1C', blurb: 'Età, genere, emozione stimate' },
+  { id: 'media', label: 'MEDIA LAB', icon: Wand2, color: '#B57BFF', blurb: 'Ritocco e modifica generativa' },
+];
+
+interface Props {
+  onClose?: () => void;
+  isMobile?: boolean;
+  /** Porta la mappa sulle coordinate trovate nell'EXIF. */
+  onLocate?: (lat: number, lng: number) => void;
+}
+
+async function postForm(url: string, form: FormData) {
+  const r = await fetch(url, { method: 'POST', body: form });
+  const j = await r.json().catch(() => null);
+  if (!r.ok || (j && j.error)) throw new Error((j && j.error) || `HTTP ${r.status}`);
+  return j as Record<string, any>;
+}
+
+/** data:image/...;base64,... -> Blob, per rispedire la maschera al generatore. */
+function dataUrlToBlob(dataUrl: string): Blob {
+  const [head, b64] = dataUrl.split(',');
+  const mime = /:(.*?);/.exec(head)?.[1] || 'image/png';
+  const bin = atob(b64);
+  const buf = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+  return new Blob([buf], { type: mime });
+}
+
+export default function LabPanel({ onClose, isMobile, onLocate }: Props) {
+  const [tool, setTool] = useState<ToolId>('intel');
+  const [file, setFile] = useState<File | null>(null);
+  const [anteprima, setAnteprima] = useState<string | null>(null);
+  const [domanda, setDomanda] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [area, setArea] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [errore, setErrore] = useState<string | null>(null);
+  const [testo, setTesto] = useState<string | null>(null);
+  const [exif, setExif] = useState<Record<string, any> | null>(null);
+  const [risultato, setRisultato] = useState<string | null>(null);
+  const [nota, setNota] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const reset = () => { setErrore(null); setTesto(null); setExif(null); setRisultato(null); setNota(null); };
+
+  const scegli = useCallback((f: File | null) => {
+    if (!f) return;
+    setFile(f);
+    setAnteprima(URL.createObjectURL(f));
+    reset();
+  }, []);
+
+  const esegui = useCallback(async () => {
+    if (!file) { setErrore('Scegli prima un\'immagine.'); return; }
+    reset();
+    setBusy(true);
+    try {
+      if (tool === 'intel') {
+        const fd = new FormData();
+        fd.append('file', file);
+        if (domanda.trim()) fd.append('domanda', domanda.trim());
+        const d = await postForm('/api/ai/vision', fd);
+        setTesto(String(d.analisi || ''));
+      } else if (tool === 'exif') {
+        const fd = new FormData();
+        fd.append('file', file);
+        setExif(await postForm('/api/ai/exif', fd));
+      } else if (tool === 'face') {
+        const fd = new FormData();
+        fd.append('image', file);           // Delfi vuole "image", non "file"
+        const d = await postForm('/api/ai/face', fd);
+        setTesto(
+          [d.eta != null ? `Età stimata: ${d.eta}` : null,
+           d.genere ? `Genere: ${d.genere}` : null,
+           d.emozione ? `Emozione: ${d.emozione}` : null,
+           d.etnia ? `Etnia stimata: ${d.etnia}` : null].filter(Boolean).join('\n') || JSON.stringify(d),
+        );
+      } else {
+        if (!prompt.trim()) { setErrore('Scrivi cosa vuoi ottenere.'); setBusy(false); return; }
+        if (area.trim()) {
+          // area descritta => percorso GENERATIVO: prima la maschera, poi l'inpainting
+          const fm = new FormData();
+          fm.append('file', file); fm.append('testo', area.trim());
+          const m = await postForm('/api/ai/mask', fm);
+          if (m.vuota) { setErrore('Non ho trovato quell\'area: descrivila diversamente.'); setBusy(false); return; }
+          const fg = new FormData();
+          fg.append('file', file);
+          fg.append('maschera', dataUrlToBlob(String(m.maschera)), 'mask.png');
+          fg.append('prompt', prompt.trim());
+          fg.append('forza', '0.95');
+          const g = await postForm('/api/ai/generate', fg);
+          setRisultato(String(g.immagine));
+          setNota(`Rigenerata l'area «${area.trim()}» (${m.copertura}%${m.sam ? ', bordi netti con SAM' : ''}).`);
+        } else {
+          const fe = new FormData();
+          fe.append('file', file); fe.append('prompt', prompt.trim());
+          const d = await postForm('/api/ai/image-edit', fe);
+          setRisultato(String(d.immagine));
+          setNota(d.generativo_necessario
+            ? `${d.nota} — descrivi l'area qui sopra per usare il generativo.`
+            : `${d.nota || ''} Applicate: ${(d.applicate || []).join(', ') || '—'}`);
+        }
+      }
+    } catch (e) {
+      setErrore(e instanceof Error ? e.message : 'errore sconosciuto');
+    }
+    setBusy(false);
+  }, [file, tool, domanda, prompt, area]);
+
+  const attivo = TOOLS.find(t => t.id === tool)!;
+
+  return (
+    <div className={`flex flex-col gap-3 ${isMobile ? '' : 'w-[340px]'} text-white/90`}>
+      {/* intestazione */}
+      {!isMobile && (
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] font-mono tracking-[0.2em] text-[#D4AF37]">LAB — AI LOCALE</span>
+          {onClose && (
+            <button onClick={onClose} className="text-white/50 hover:text-white" aria-label="Chiudi">
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* scelta strumento */}
+      <div className="grid grid-cols-2 gap-1.5">
+        {TOOLS.map(t => {
+          const on = t.id === tool;
+          return (
+            <button
+              key={t.id}
+              onClick={() => { setTool(t.id); reset(); }}
+              className={`flex items-center gap-2 px-2.5 py-2 rounded border text-[10px] font-mono tracking-wider transition-colors ${
+                on ? 'bg-white/10 border-white/30 text-white' : 'bg-black/40 border-white/10 text-white/60 hover:text-white/90'
+              }`}
+              style={on ? { borderColor: t.color, color: t.color } : undefined}
+            >
+              <t.icon className="w-3.5 h-3.5 shrink-0" />
+              <span className="truncate">{t.label}</span>
+            </button>
+          );
+        })}
+      </div>
+      <p className="text-[10px] text-white/45 font-mono -mt-1">{attivo.blurb}</p>
+
+      {/* immagine */}
+      <div
+        onClick={() => inputRef.current?.click()}
+        onDragOver={e => e.preventDefault()}
+        onDrop={e => { e.preventDefault(); scegli(e.dataTransfer.files?.[0] || null); }}
+        className="border border-dashed border-white/20 rounded p-3 text-center cursor-pointer hover:border-white/40 transition-colors"
+      >
+        {anteprima ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={anteprima} alt="immagine scelta" className="max-h-36 mx-auto rounded" />
+        ) : (
+          <span className="text-[11px] font-mono text-white/50 flex items-center justify-center gap-2">
+            <Upload className="w-3.5 h-3.5" /> trascina o scegli un&apos;immagine
+          </span>
+        )}
+        <input
+          ref={inputRef} type="file" accept="image/*" hidden
+          onChange={e => scegli(e.target.files?.[0] || null)}
+        />
+      </div>
+
+      {/* ingressi specifici */}
+      {tool === 'intel' && (
+        <input
+          value={domanda} onChange={e => setDomanda(e.target.value)}
+          placeholder="domanda (facoltativa): che cosa cerco?"
+          className="bg-black/50 border border-white/15 rounded px-2.5 py-2 text-[11px] font-mono outline-none focus:border-white/40"
+        />
+      )}
+      {tool === 'media' && (
+        <>
+          <input
+            value={prompt} onChange={e => setPrompt(e.target.value)}
+            placeholder="cosa ottenere: «più contrasto» o «una giacca rossa»"
+            className="bg-black/50 border border-white/15 rounded px-2.5 py-2 text-[11px] font-mono outline-none focus:border-white/40"
+          />
+          <input
+            value={area} onChange={e => setArea(e.target.value)}
+            placeholder="area da rigenerare (facoltativa): «la giacca»"
+            className="bg-black/50 border border-white/15 rounded px-2.5 py-2 text-[11px] font-mono outline-none focus:border-white/40"
+          />
+          <p className="text-[9.5px] text-white/40 font-mono -mt-1">
+            Con un&apos;area descritta usa il generativo (~30 s). Senza, solo ritocco.
+          </p>
+        </>
+      )}
+
+      <button
+        onClick={esegui} disabled={busy}
+        className="flex items-center justify-center gap-2 px-3 py-2 rounded border border-white/20 bg-white/5 hover:bg-white/10 disabled:opacity-40 text-[11px] font-mono tracking-wider"
+        style={{ color: attivo.color }}
+      >
+        {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <attivo.icon className="w-3.5 h-3.5" />}
+        {busy ? 'ELABORO…' : 'ESEGUI'}
+      </button>
+
+      {errore && (
+        <div className="flex items-start gap-2 text-[10.5px] font-mono text-[#FF6B6B] border border-[#FF6B6B]/30 rounded p-2">
+          <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" /> <span>{errore}</span>
+        </div>
+      )}
+
+      {testo && (
+        <pre className="whitespace-pre-wrap break-words text-[11px] font-mono bg-black/50 border border-white/10 rounded p-2.5 max-h-64 overflow-auto">
+          {testo}
+        </pre>
+      )}
+
+      {exif && (
+        <div className="text-[11px] font-mono bg-black/50 border border-white/10 rounded p-2.5 space-y-1.5 max-h-72 overflow-auto">
+          <div className="text-white/50">
+            {String(exif.base?.formato)} · {String(exif.base?.larghezza)}×{String(exif.base?.altezza)}
+          </div>
+          {!exif.presente && <div className="text-white/45">Nessun metadato EXIF in questa immagine.</div>}
+          {exif.sintesi && Object.entries(exif.sintesi as Record<string, string>).map(([k, v]) => (
+            <div key={k} className="flex gap-2">
+              <span className="text-white/45 w-28 shrink-0">{k}</span><span className="break-all">{v}</span>
+            </div>
+          ))}
+          {exif.gps && (
+            <button
+              onClick={() => onLocate?.(Number(exif.gps.lat), Number(exif.gps.lon))}
+              className="mt-1 flex items-center gap-2 text-[#D4AF37] hover:underline"
+            >
+              <MapPin className="w-3.5 h-3.5" />
+              {Number(exif.gps.lat).toFixed(5)}, {Number(exif.gps.lon).toFixed(5)} — porta la mappa qui
+            </button>
+          )}
+        </div>
+      )}
+
+      {risultato && (
+        <div className="space-y-2">
+          {nota && <p className="text-[10.5px] font-mono text-white/60">{nota}</p>}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={risultato} alt="risultato" className="w-full rounded border border-white/10" />
+          <a
+            href={risultato} download="osiris-lab.png"
+            className="inline-block text-[10.5px] font-mono text-white/70 hover:text-white underline"
+          >
+            scarica il risultato
+          </a>
+        </div>
+      )}
+      {!risultato && nota && <p className="text-[10.5px] font-mono text-white/60">{nota}</p>}
+
+      {/* la plancia e' la console unica: da qui ci si torna sempre */}
+      <a
+        href={PLANCIA_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-1 flex items-center gap-1.5 text-[10px] font-mono text-white/40 hover:text-[#D4AF37] transition-colors"
+      >
+        <ExternalLink className="w-3 h-3" />
+        serviti dal nodo locale — apri la plancia
+      </a>
+    </div>
+  );
+}

--- a/src/lib/delfi.ts
+++ b/src/lib/delfi.ts
@@ -1,0 +1,106 @@
+/**
+ * ═══════════════════════════════════════════════════════════════
+ *  OSIRIS — Delfi AI bridge (client)
+ *  Server-side client verso lo Studio AI di Delfi (rete locale).
+ *  In locale Next raggiunge Delfi direttamente: nessun tunnel, nessun CORS.
+ *  Per un domani pubblico basta puntare OSIRIS_DELFI_URL al reverse-proxy.
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+export const DELFI_URL = process.env.OSIRIS_DELFI_URL || 'http://localhost:7863';
+
+export interface DelfiOptions {
+  timeoutMs?: number;
+}
+
+/**
+ * Inoltra un multipart a un endpoint dello Studio e ritorna il JSON.
+ * Solleva con il messaggio d'errore di Delfi se la risposta non è ok.
+ */
+export async function delfiPostForm(
+  path: string,
+  form: FormData,
+  opts: DelfiOptions = {},
+): Promise<Record<string, unknown>> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), opts.timeoutMs ?? 300_000);
+  try {
+    const res = await fetch(`${DELFI_URL}${path}`, {
+      method: 'POST',
+      body: form,
+      signal: controller.signal,
+      // niente cache: sono elaborazioni, non risorse
+      cache: 'no-store',
+    });
+    const text = await res.text();
+    let json: Record<string, unknown> | null = null;
+    try {
+      json = text ? (JSON.parse(text) as Record<string, unknown>) : {};
+    } catch {
+      json = null;
+    }
+    if (!res.ok) {
+      const msg = (json && (json.error as string)) || `Delfi HTTP ${res.status}`;
+      throw new Error(msg);
+    }
+    return json ?? {};
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error('Delfi non ha risposto in tempo');
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/** Ricostruisce un FormData da inoltrare, tenendo solo i campi attesi. */
+export function pickForm(src: FormData, campi: string[]): FormData {
+  const out = new FormData();
+  for (const c of campi) {
+    const v = src.get(c);
+    if (v !== null) out.append(c, v as Blob | string);
+  }
+  return out;
+}
+
+/**
+ * Route di proxy verso Delfi: rate limit → validazione campi → inoltro.
+ * Tiene le route in dieci righe invece di ripetere lo stesso schema cinque volte.
+ */
+export async function proxyDelfi(
+  req: Request,
+  opts: {
+    bucket: string;
+    path: string;
+    campi: string[];
+    obbligatori: string[];
+    max?: number;
+    timeoutMs?: number;
+  },
+): Promise<Response> {
+  const { rateLimit, clientIp } = await import('./rate-limit');
+  if (!rateLimit(opts.bucket, clientIp(req), opts.max ?? 10)) {
+    return Response.json({ error: 'Troppe richieste, riprova tra poco.' }, { status: 429 });
+  }
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return Response.json({ error: 'Attesa una form multipart.' }, { status: 400 });
+  }
+  for (const c of opts.obbligatori) {
+    if (!form.get(c)) {
+      return Response.json({ error: `Manca il campo "${c}".` }, { status: 400 });
+    }
+  }
+  try {
+    const out = await delfiPostForm(opts.path, pickForm(form, opts.campi), {
+      timeoutMs: opts.timeoutMs,
+    });
+    return Response.json(out);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'errore sconosciuto';
+    return Response.json({ error: msg }, { status: 502 });
+  }
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,43 @@
+/**
+ * ═══════════════════════════════════════════════════════════════
+ *  OSIRIS — Rate limiter condiviso (in-memory, per processo)
+ *  Stesso schema delle route ai/* esistenti, ma in un posto solo
+ *  invece che copiato in ogni file.
+ * ═══════════════════════════════════════════════════════════════
+ */
+
+interface Entry {
+  count: number;
+  resetAt: number;
+}
+
+const buckets = new Map<string, Map<string, Entry>>();
+
+export function rateLimit(bucket: string, ip: string, max = 10, windowMs = 60_000): boolean {
+  let m = buckets.get(bucket);
+  if (!m) {
+    m = new Map<string, Entry>();
+    buckets.set(bucket, m);
+  }
+  const now = Date.now();
+  const e = m.get(ip);
+  if (!e || now > e.resetAt) {
+    m.set(ip, { count: 1, resetAt: now + windowMs });
+    return true;
+  }
+  if (e.count >= max) return false;
+  e.count++;
+  return true;
+}
+
+export function clientIp(req: Request): string {
+  return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'local';
+}
+
+// pulizia periodica, altrimenti la mappa cresce con gli IP visti
+setInterval(() => {
+  const now = Date.now();
+  for (const m of buckets.values()) {
+    for (const [ip, e] of m.entries()) if (now > e.resetAt) m.delete(ip);
+  }
+}, 120_000);


### PR DESCRIPTION
## What this adds

A **LAB** entry in the navigation (mobile bottom bar + desktop rail) opening a panel with four image-intelligence tools, served by an **AI node running on the operator's own network** rather than a cloud API:

| Tool | What it does | Cost |
|---|---|---|
| **Image Intel** | describes a scene, reads signs and text in a photo | vision model |
| **EXIF / GPS** | camera, timestamp, software, GPS decoded to lat/lon | CPU only |
| **Face Intel** | age/gender/emotion, or a match between two faces | light |
| **Media Lab** | retouch from a fixed whitelist, plus inpainting over a text-selected area | heavy (~30 s) |

**EXIF coordinates feed the existing `onLocate` flow**, so a geotagged photo flies the map to where it was taken — that is the part that makes this feel like OSIRIS rather than a bolted-on image tool.

## Design decisions worth reviewing

- **Server-side proxy, not direct browser calls.** Chrome blocks private-network requests from a page to a LAN address, so everything goes through `/api/ai/*`. This is also the seam where a reverse proxy goes if the node is ever exposed beyond the LAN.
- **`src/lib/delfi.ts` exposes `proxyDelfi()`**, so each route stays ~10 lines instead of repeating the same validate/forward/error shape six times.
- **`src/lib/rate-limit.ts`** extracts the limiter that `api/ai/*` routes were each declaring inline. Existing routes are untouched; new ones share it.
- **`api/ai/generate` has a lower rate cap (4/min)** on purpose: the node handles only 1-2 concurrent generations, so a higher cap would just build a queue.
- **The panel links back to the node's own console** instead of duplicating its other tools (voice, face, agent, resources).

## Configuration

Both documented in `.env.example`, defaulting to `localhost`:

- `OSIRIS_DELFI_URL` — where the server-side routes reach the node
- `NEXT_PUBLIC_DELFI_URL` — same address, used only for the console link in the panel

## Verified

- `npx tsc --noEmit` clean; `next build` green with all six routes in the manifest
- every route exercised against a live node: EXIF GPS decoded to the exact expected coordinates, face analysis returning real values, text-driven masking, and an inpainting round trip
- panel working on both mobile and desktop breakpoints
- the EXIF → map round trip

## Open question for the maintainer

Without a node configured, the LAB menu still appears and each tool returns a `502`. I left it visible rather than guessing at your preference — happy to hide the entry unless `OSIRIS_DELFI_URL` is set, or show a "node not configured" state in the panel, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
