### PR TITLE
fix(dev): allow opening the dev server from another device

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,12 @@ AIS_API_KEY=
 # Change this if 3000 is already taken on your host.
 OSIRIS_PORT=3000
 
+# Dev only. Opening the dev server from another device on your network (a
+# phone, a second desktop) makes Next treat its own dev resources as
+# cross-origin and block them: the page loads but the app never leaves the
+# splash screen. List the hosts you open it from, comma-separated.
+# OSIRIS_DEV_ORIGINS=192.168.1.50,10.0.0.20
+
 # Comma-separated list of public Telegram channel usernames (no @) to scrape
 # for the "Telegram OSINT" map layer. Overrides the curated default set.
 # Channels must have web preview enabled (most well-known OSINT channels do).

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,15 @@ const nextConfig: NextConfig = {
      everywhere except Vercel, so Docker and the platform both get what they
      expect. */
   output: process.env.VERCEL ? undefined : 'standalone',
+  /* Dev only. Opening the dev server from another machine on the LAN (a phone,
+     a second desktop) makes Next treat its own dev resources as cross-origin
+     and block them: the page arrives, the HMR socket is refused, and the app
+     sits on the splash screen forever. Hosts come from the environment so no
+     address is baked into the repo - e.g. OSIRIS_DEV_ORIGINS=192.168.1.50 */
+  allowedDevOrigins: (process.env.OSIRIS_DEV_ORIGINS ?? '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean),
   serverExternalPackages: ['ws'],
   transpilePackages: ['react-map-gl', 'mapbox-gl', 'maplibre-gl'],
   // Type errors block the build again. They were suppressed while 17 stood


### PR DESCRIPTION
## The symptom

Open `npm run dev` from a phone or a second machine on the LAN and it looks like the app is broken:

- the HTML arrives (byte-for-byte the same as from `localhost`)
- every `/_next/static/chunks/*` returns `200`
- and the page then sits on the **splash screen** forever — no map canvas, no panels

Nothing in the browser explains it. You get failed HMR WebSockets and a handful of *"preloaded but not used within a few seconds"* warnings, both of which point away from the real cause.

## The cause

It is in the **dev server log**, not the browser:

```
⚠ Blocked cross-origin request to Next.js dev resource /_next/hmr from "10.0.0.x".
  Cross-origin access to Next.js dev resources is blocked by default for safety.
```

That default is correct and I am not changing it. This PR only makes the documented escape hatch reachable without editing the config by hand.

## The change

`allowedDevOrigins` fed from the environment, so **no address is baked into the repo**:

```bash
OSIRIS_DEV_ORIGINS=192.168.1.50,10.0.0.20 npm run dev
```

Unset — which is the case for everyone who does not need it — the list is empty and behaviour is identical to today. Documented in `.env.example` beside `OSIRIS_PORT`, since both answer "how do I reach this dev server".

## Why it is worth having

Anything you can only check on a real device — the mobile bottom nav, touch targets, the map on a phone — currently requires either a tunnel or hand-editing `next.config.ts`. This is two lines of env instead.

## Verified

Clean build on this branch (`rm -rf .next && npm run build`): `✓ Running next.config.ts took 41ms`, `✓ Compiled successfully`, 56 static pages. Confirmed in the browser that with the variable set the app boots fully from a LAN address — map canvas and panels — and that the "Blocked cross-origin" warning no longer appears in the log.

Separate from #339 and touching different files, so the two can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
