### PR TITLE
fix(map): retry a failed basemap request instead of leaving the map black

### DIFF
--- a/src/components/OsirisMap.tsx
+++ b/src/components/OsirisMap.tsx
@@ -13,6 +13,7 @@ import CctvPreviews, { type PreviewCamera } from '@/components/CctvPreviews';
 import MapControls from '@/components/MapControls';
 import LiveNewsPreviews, { type PreviewFeed } from '@/components/LiveNewsPreviews';
 import { attachTerrain, type TerrainStatus } from '@/lib/map-terrain';
+import { watchBasemap, BASEMAP_MAX_ATTEMPTS, type BasemapStatus } from '@/lib/map-basemap';
 
 import { applyMapProjection } from '@/lib/map-projection';
 
@@ -110,6 +111,15 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   const mapRef = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
   const [mapReady, setMapReady] = useState(false);
+  const [basemap, setBasemap] = useState<BasemapStatus>({ state: 'loading' });
+  const basemapRetryRef = useRef<() => void>(() => {});
+  // A healthy load draws its first tile while the splash is still up, so
+  // the loading chip waits before it says anything.
+  const [basemapSlow, setBasemapSlow] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setBasemapSlow(true), 4000);
+    return () => clearTimeout(timer);
+  }, []);
 
   // Do not replay an earlier explicit zoom request after theme/retry remounts.
   const lastTerrainFocus = useRef(terrainFocus);
@@ -288,6 +298,8 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       }
     }
     if (!map) return;
+    const basemapWatch = watchBasemap(map, styleUrl, setBasemap);
+    basemapRetryRef.current = basemapWatch.retry;
 
     map.on('load', () => {
       mapRef.current = map;
@@ -1565,7 +1577,7 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
       });
     });
 
-    return () => { cancelAnimationFrame(hoverFrame); map.remove(); mapRef.current = null; };
+    return () => { basemapWatch.dispose(); cancelAnimationFrame(hoverFrame); map.remove(); mapRef.current = null; };
   }, []);
 
   // Day/Night
@@ -3030,6 +3042,23 @@ function OsirisMap({ data, activeLayers, onEntityClick, onMouseCoords, onRightCl
   return (
     <>
       <div ref={containerRef} className="absolute inset-0 w-full h-full" />
+      {basemap.state !== 'ready' && (basemap.state !== 'loading' || basemapSlow) && (
+        <div className="pointer-events-none absolute inset-x-0 bottom-14 z-[500] flex justify-center px-3">
+          <div role="status" className="pointer-events-auto flex items-center gap-2 rounded-lg border border-[var(--border-primary)] bg-[var(--bg-panel)]/95 px-3 py-1.5 shadow-[0_10px_40px_rgba(0,0,0,0.6)] backdrop-blur-2xl">
+            <span className={`h-2 w-2 rounded-full ${basemap.state === 'failed' ? 'bg-[var(--alert-red)]' : 'animate-pulse bg-[var(--cyan-primary)]'}`} />
+            <span className="text-[11px] font-mono font-bold tracking-[0.2em] text-[var(--text-primary)]">
+              {basemap.state === 'loading' && 'BASEMAP LOADING'}
+              {basemap.state === 'retrying' && `BASEMAP RETRY ${basemap.attempt}/${BASEMAP_MAX_ATTEMPTS}`}
+              {basemap.state === 'failed' && 'BASEMAP UNAVAILABLE'}
+            </span>
+            {basemap.state === 'failed' && (
+              <button type="button" onClick={() => basemapRetryRef.current()} className="rounded-md border border-[var(--border-primary)] px-2 py-0.5 text-[10px] font-mono tracking-[0.2em] text-[var(--gold-primary)] hover:bg-[var(--hover-accent)]">
+                RETRY
+              </button>
+            )}
+          </div>
+        </div>
+      )}
       {mapReady && mapRef.current && (
         <CctvPreviews
           mapRef={mapRef}

--- a/src/lib/map-basemap.test.ts
+++ b/src/lib/map-basemap.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Map as MapLibreMap } from 'maplibre-gl';
+import { BASEMAP_MAX_ATTEMPTS, basemapRetryDelay, isRetryableBasemapError, watchBasemap } from './map-basemap';
+
+const STYLE_URL = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
+const TILEJSON_URL = 'https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json';
+
+function ajaxError(status: number, url: string) {
+  return Object.assign(new Error(`AJAXError: ${status} (${url})`), { status, url });
+}
+
+function createMap() {
+  const listeners = new Map<string, Set<(event: Record<string, unknown>) => void>>();
+  const source = { url: TILEJSON_URL, setUrl: vi.fn() };
+  let hasSource = false;
+  const map = {
+    on: vi.fn((name: string, callback: (event: Record<string, unknown>) => void) => {
+      if (!listeners.has(name)) listeners.set(name, new Set());
+      listeners.get(name)!.add(callback);
+    }),
+    off: vi.fn((name: string, callback: (event: Record<string, unknown>) => void) => listeners.get(name)?.delete(callback)),
+    setStyle: vi.fn(),
+    getSource: vi.fn(() => (hasSource ? source : undefined)),
+  };
+  return {
+    map: map as unknown as MapLibreMap,
+    methods: map, source, listeners,
+    emit: (name: string, event: Record<string, unknown> = {}) => listeners.get(name)?.forEach(callback => callback(event)),
+    styleLoads: () => { hasSource = true; listeners.get('style.load')?.forEach(callback => callback({})); },
+    tileLoads: () => listeners.get('sourcedata')?.forEach(callback => callback({ sourceId: 'carto', tile: { state: 'loaded' } })),
+  };
+}
+
+describe('basemap retry', () => {
+  beforeEach(() => { vi.useFakeTimers(); vi.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); });
+
+  it('reports loading, then ready on the first basemap tile, without touching a clean load', () => {
+    const fixture = createMap();
+    const status = vi.fn();
+    watchBasemap(fixture.map, STYLE_URL, status);
+    expect(status).toHaveBeenLastCalledWith({ state: 'loading' });
+    fixture.styleLoads();
+    fixture.tileLoads();
+    expect(status).toHaveBeenLastCalledWith({ state: 'ready' });
+    vi.advanceTimersByTime(60_000);
+    expect(fixture.methods.setStyle).not.toHaveBeenCalled();
+    expect(fixture.source.setUrl).not.toHaveBeenCalled();
+  });
+
+  it('asks for the style again, with backoff, while style.json keeps failing', () => {
+    const fixture = createMap();
+    const status = vi.fn();
+    watchBasemap(fixture.map, STYLE_URL, status);
+    fixture.emit('error', { error: ajaxError(500, STYLE_URL) });
+    expect(status).toHaveBeenLastCalledWith({ state: 'retrying', attempt: 1 });
+    vi.advanceTimersByTime(999);
+    expect(fixture.methods.setStyle).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(fixture.methods.setStyle).toHaveBeenCalledWith(STYLE_URL, { diff: false });
+
+    fixture.emit('error', { error: ajaxError(500, STYLE_URL) });
+    expect(status).toHaveBeenLastCalledWith({ state: 'retrying', attempt: 2 });
+    vi.advanceTimersByTime(2000);
+    expect(fixture.methods.setStyle).toHaveBeenCalledTimes(2);
+
+    fixture.styleLoads();
+    fixture.tileLoads();
+    expect(status).toHaveBeenLastCalledWith({ state: 'ready' });
+  });
+
+  it('reloads the source rather than the style once the style is in', () => {
+    const fixture = createMap();
+    watchBasemap(fixture.map, STYLE_URL, vi.fn());
+    fixture.styleLoads();
+    // tiles.json failed: MapLibre treats the source as loaded with no tiles.
+    fixture.emit('error', { error: ajaxError(500, TILEJSON_URL), sourceId: 'carto' });
+    vi.advanceTimersByTime(1000);
+    expect(fixture.source.setUrl).toHaveBeenCalledWith(TILEJSON_URL);
+    expect(fixture.methods.setStyle).not.toHaveBeenCalled();
+  });
+
+  it('folds a burst of tile failures into one retry', () => {
+    const fixture = createMap();
+    const status = vi.fn();
+    watchBasemap(fixture.map, STYLE_URL, status);
+    fixture.styleLoads();
+    for (let i = 0; i < 12; i++) fixture.emit('error', { error: ajaxError(500, `${TILEJSON_URL}/${i}`), sourceId: 'carto' });
+    expect(status).toHaveBeenLastCalledWith({ state: 'retrying', attempt: 1 });
+    vi.advanceTimersByTime(1000);
+    expect(fixture.source.setUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves other sources, missing tiles and a working basemap alone', () => {
+    const fixture = createMap();
+    const status = vi.fn();
+    watchBasemap(fixture.map, STYLE_URL, status);
+    fixture.styleLoads();
+    fixture.emit('error', { error: ajaxError(500, '/api/flights'), sourceId: 'flights' });
+    fixture.emit('error', { error: ajaxError(404, `${TILEJSON_URL}/14/1/1`), sourceId: 'carto' });
+    fixture.emit('error', { error: ajaxError(403, STYLE_URL) });
+    fixture.emit('error', { error: new Error('layers[3]: invalid') });
+    // Sprite and glyph ranges arrive after the style; tiles draw without them.
+    fixture.emit('error', { error: ajaxError(500, 'https://tiles.basemaps.cartocdn.com/fonts/Open%20Sans/0-255.pbf') });
+    fixture.tileLoads();
+    fixture.emit('error', { error: ajaxError(500, `${TILEJSON_URL}/3/4/2`), sourceId: 'carto' });
+    vi.advanceTimersByTime(60_000);
+    expect(fixture.methods.setStyle).not.toHaveBeenCalled();
+    expect(fixture.source.setUrl).not.toHaveBeenCalled();
+    expect(status.mock.calls.map(([s]) => s.state)).toEqual(['loading', 'ready']);
+  });
+
+  it('gives up after the last attempt and starts over on demand', () => {
+    const fixture = createMap();
+    const status = vi.fn();
+    const watch = watchBasemap(fixture.map, STYLE_URL, status);
+    for (let i = 1; i <= BASEMAP_MAX_ATTEMPTS; i++) {
+      fixture.emit('error', { error: ajaxError(500, STYLE_URL) });
+      expect(status).toHaveBeenLastCalledWith({ state: 'retrying', attempt: i });
+      vi.advanceTimersByTime(basemapRetryDelay(i));
+    }
+    expect(fixture.methods.setStyle).toHaveBeenCalledTimes(BASEMAP_MAX_ATTEMPTS);
+    fixture.emit('error', { error: ajaxError(500, STYLE_URL) });
+    expect(status).toHaveBeenLastCalledWith({ state: 'failed', attempt: BASEMAP_MAX_ATTEMPTS });
+    vi.advanceTimersByTime(60_000);
+    expect(fixture.methods.setStyle).toHaveBeenCalledTimes(BASEMAP_MAX_ATTEMPTS);
+
+    watch.retry();
+    expect(status).toHaveBeenLastCalledWith({ state: 'retrying', attempt: 1 });
+    expect(fixture.methods.setStyle).toHaveBeenCalledTimes(BASEMAP_MAX_ATTEMPTS + 1);
+  });
+
+  it('stops on dispose', () => {
+    const fixture = createMap();
+    const status = vi.fn();
+    const watch = watchBasemap(fixture.map, STYLE_URL, status);
+    fixture.emit('error', { error: ajaxError(500, STYLE_URL) });
+    watch.dispose();
+    vi.advanceTimersByTime(60_000);
+    expect(fixture.methods.setStyle).not.toHaveBeenCalled();
+    expect(fixture.listeners.get('error')?.size ?? 0).toBe(0);
+  });
+
+  it('caps the delay and classifies failures', () => {
+    expect([1, 2, 3, 4, 5, 6].map(basemapRetryDelay)).toEqual([1000, 2000, 4000, 8000, 15000, 15000]);
+    expect(isRetryableBasemapError(ajaxError(500, STYLE_URL))).toBe(true);
+    expect(isRetryableBasemapError(ajaxError(429, STYLE_URL))).toBe(true);
+    expect(isRetryableBasemapError(new TypeError('Failed to fetch'))).toBe(true);
+    expect(isRetryableBasemapError(ajaxError(404, STYLE_URL))).toBe(false);
+    expect(isRetryableBasemapError(ajaxError(403, STYLE_URL))).toBe(false);
+    expect(isRetryableBasemapError(new Error('validation'))).toBe(false);
+    expect(isRetryableBasemapError(undefined)).toBe(false);
+  });
+});

--- a/src/lib/map-basemap.ts
+++ b/src/lib/map-basemap.ts
@@ -1,0 +1,125 @@
+import type { ErrorEvent, Map, MapSourceDataEvent, VectorTileSource } from 'maplibre-gl';
+
+/** The source id CARTO's style.json gives its vector tiles. */
+export const BASEMAP_SOURCE = 'carto';
+export const BASEMAP_MAX_ATTEMPTS = 8;
+export const BASEMAP_RETRY_CAP_MS = 15_000;
+
+export type BasemapStatus =
+  | { state: 'loading' }
+  | { state: 'retrying'; attempt: number }
+  | { state: 'ready' }
+  | { state: 'failed'; attempt: number };
+
+/** 1s, 2s, 4s, 8s, then 15s: the proxy's own connect timeout is 10s, so a
+ *  retry that lands in the same contention window still has to wait it out. */
+export function basemapRetryDelay(attempt: number): number {
+  return Math.min(1000 * 2 ** (attempt - 1), BASEMAP_RETRY_CAP_MS);
+}
+
+/* A request the proxy answered with a 5xx, a rate limit, or no answer at all
+   is worth repeating; a 404 or 403 is a fact about the URL and is not. A
+   network failure rejects with a TypeError and carries no status. Anything
+   else — a style validation error, say — is not a request and is left alone. */
+export function isRetryableBasemapError(error: unknown): boolean {
+  const status = (error as { status?: unknown } | undefined)?.status;
+  if (typeof status === 'number') return status === 0 || status >= 500 || status === 429 || status === 408;
+  return error instanceof Error && error.name === 'TypeError';
+}
+
+/**
+ * Retries the basemap until it draws. MapLibre asks for the style once: a
+ * failed style.json means `load` never fires, and a failed tiles.json is
+ * treated as a loaded source with no tiles, so either leaves the map black
+ * for the rest of the session. Both are single failed requests through
+ * /api/proxy-tiles, which turns one connect timeout into a 500 while the
+ * cold-start feed fetches are still in flight (#250).
+ *
+ * Nothing here runs on a timer. A retry is only ever a reply to an error
+ * event from a basemap request, and the watcher stands down for good the
+ * moment the first basemap tile loads, so a working map is never touched.
+ */
+export function watchBasemap(map: Map, styleUrl: string, onStatus: (status: BasemapStatus) => void) {
+  let disposed = false;
+  let styleLoaded = false;
+  let ready = false;
+  let attempt = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let last: BasemapStatus | undefined;
+
+  const report = (status: BasemapStatus) => {
+    if (disposed) return;
+    if (last && last.state === status.state && ('attempt' in last ? last.attempt : 0) === ('attempt' in status ? status.attempt : 0)) return;
+    last = status;
+    onStatus(status);
+  };
+
+  const retry = () => {
+    timer = undefined;
+    if (disposed || ready) return;
+    // Once the style is in, the layers OsirisMap adds on `load` may be too;
+    // reloading the source's TileJSON refetches its tiles and keeps them.
+    const source = styleLoaded ? map.getSource(BASEMAP_SOURCE) as VectorTileSource | undefined : undefined;
+    if (source?.url) {
+      source.setUrl(source.url);
+    } else {
+      styleLoaded = false;
+      map.setStyle(styleUrl, { diff: false });
+    }
+  };
+
+  const schedule = () => {
+    if (disposed || ready || timer !== undefined) return;
+    if (attempt >= BASEMAP_MAX_ATTEMPTS) {
+      report({ state: 'failed', attempt });
+      return;
+    }
+    attempt += 1;
+    report({ state: 'retrying', attempt });
+    timer = setTimeout(retry, basemapRetryDelay(attempt));
+  };
+
+  const onStyleLoad = () => { styleLoaded = true; };
+  const onSourceData = (event: MapSourceDataEvent) => {
+    if (ready || event.sourceId !== BASEMAP_SOURCE || event.tile?.state !== 'loaded') return;
+    ready = true;
+    clearTimeout(timer);
+    timer = undefined;
+    report({ state: 'ready' });
+  };
+  const onError = (event: ErrorEvent & { sourceId?: string }) => {
+    // Registering for `error` stops MapLibre printing these itself.
+    console.warn('[OSIRIS] Map resource unavailable:', event.error);
+    if (ready || !isRetryableBasemapError(event.error)) return;
+    // Entity, terrain and imagery sources are not the basemap. Without a
+    // sourceId the request was the style's own: style.json before it loaded,
+    // a sprite or glyph range after, and the latter do not stop tiles drawing.
+    if (event.sourceId ? event.sourceId !== BASEMAP_SOURCE : styleLoaded) return;
+    schedule();
+  };
+
+  map.on('style.load', onStyleLoad);
+  map.on('sourcedata', onSourceData);
+  map.on('error', onError);
+  report({ state: 'loading' });
+
+  return {
+    /** Starts the attempts over, immediately, for the button on the chip. */
+    retry: () => {
+      if (disposed || ready) return;
+      clearTimeout(timer);
+      timer = undefined;
+      attempt = 1;
+      report({ state: 'retrying', attempt });
+      retry();
+    },
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      clearTimeout(timer);
+      map.off('style.load', onStyleLoad);
+      map.off('sourcedata', onSourceData);
+      map.off('error', onError);
+    },
+  };
+}


### PR DESCRIPTION
Every basemap request goes through `/api/proxy-tiles`, and on a cold start that route races the app's own feed fetches for the same Node process. One undici connect timeout on `style.json` or `tiles.json` comes back as a hard 500 (#250). MapLibre asks for each of those exactly once: a failed `style.json` means `load` never fires, and a failed `tiles.json` is treated as a loaded source with no tiles. Either way the map is black for the rest of the session, and because the splash clears after 2.5 s regardless, what the viewer sees is the header, the tool rails and nothing else — with no sign that anything is still being tried, because nothing is.

## What this does

`src/lib/map-basemap.ts` adds `watchBasemap`, which answers a retryable basemap error — a 5xx, a 429, or a network failure; never a 404 or 403 — by asking again with backoff: 1 s, 2 s, 4 s, 8 s, then 15 s, eight attempts.

- Before the style has loaded, that is `setStyle` on the same URL.
- Once it has, the layers `OsirisMap` adds on `load` may be present too, so the source's TileJSON is reloaded instead (`setUrl`), which refetches its tiles and keeps everything else.
- Errors from entity, terrain and imagery sources are ignored, as are sprite and glyph ranges, which do not stop tiles drawing. A burst of tile failures folds into one retry.

**Nothing here runs on a timer.** #335 removed a watcher that measured silence and put a failure banner over a working map. This one only ever reacts to an error event from a basemap request, and stands down for good the moment the first basemap tile loads, so a map that is drawing is never touched.

While it is working, a small chip at the bottom of the map says so: `BASEMAP LOADING` once a load has gone past 4 s, `BASEMAP RETRY n/8` while a retry is pending, and `BASEMAP UNAVAILABLE` with a `RETRY` button after the last attempt. It is gone the moment the basemap draws.

## Verification

Reproduced on a fresh container of the current image with the six cartocdn hosts blackholed (`--add-host …:10.255.255.1`), which gives the proxy the same `UND_ERR_CONNECT_TIMEOUT` as the report:

| | `master` (8781ae3) | this branch |
|---|---|---|
| `style.json` through the proxy | one request, 500 | three 500s at 1 s / 2 s / 4 s spacing (each after the proxy's 10 s connect timeout), chip counting `BASEMAP RETRY 1/8` → `3/8` |
| DNS restored inside the container | nothing — the map stays black | the next scheduled attempt (4 s later) gets a 200, tiles draw, chip gone |
| clean start (no blackhole) | map draws | map draws, nothing is retried; the chip reads `BASEMAP LOADING` from 4 s until the first tile lands behind the feed JSON the page parses on the same thread, then clears |

- `npx vitest run`: 49 files / 613 tests pass (2 files / 16 tests are the pre-existing `RUN_LIVE_TESTS` skips). The 8 new tests in `src/lib/map-basemap.test.ts` cover the backoff, the style-vs-source choice, burst folding, what is ignored, giving up, the manual retry and dispose.
- `npx tsc --noEmit` clean.
- `eslint` clean on the new files; `OsirisMap.tsx` reports the same 138 pre-existing findings before and after.

## Notes

- The proxy still turns one connect timeout into a 500 with no retry of its own. A server-side retry would shorten the wait on a cold start but is a separate change.
- `tools/preview-smoke.mjs` still queries the `data-map-status` attribute that #335 removed; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
