### PR TITLE
fix(arcgis): query the layer a service actually has instead of assuming 0

### DIFF
--- a/src/app/api/arcgis/route.test.ts
+++ b/src/app/api/arcgis/route.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, resolveQueryUrl } from './route';
+
+const ROOT = 'https://services1.arcgis.com/abc/arcgis/rest/services/Transmission_Line/FeatureServer';
+const EMPTY = { type: 'FeatureCollection', features: [] };
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+/* Answers the service root from `root` and every query with `EMPTY`, and
+   keeps the URLs so a test can see which layer was asked. */
+function stubService(root: Response) {
+  const urls: string[] = [];
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    urls.push(url);
+    return url.includes('/query?') ? json(EMPTY) : root;
+  }));
+  return urls;
+}
+
+describe('GET /api/arcgis?service=', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('asks the service root which layer to query instead of assuming 0', async () => {
+    const urls = stubService(json({ layers: [{ id: 100, name: 'Transmission_Line', geometryType: 'esriGeometryPolyline' }] }));
+    const res = await GET(new NextRequest(`http://localhost/api/arcgis?service=${encodeURIComponent(ROOT)}&bbox=-109,31,-103,37`));
+    expect(res.status).toBe(200);
+    expect(urls[0]).toBe(`${ROOT}?f=json`);
+    expect(urls[1]).toMatch(new RegExp(`^${ROOT}/100/query\\?`));
+    const query = new URL(urls[1]).searchParams;
+    expect(query.get('f')).toBe('geojson');
+    expect(query.get('geometry')).toBe('-109,31,-103,37');
+  });
+
+  it('skips the lookup when the URL already names a layer', async () => {
+    const urls = stubService(json({}));
+    await GET(new NextRequest(`http://localhost/api/arcgis?service=${encodeURIComponent(`${ROOT}/3/`)}`));
+    expect(urls).toHaveLength(1);
+    expect(urls[0]).toMatch(new RegExp(`^${ROOT}/3/query\\?`));
+  });
+
+  it('passes over group layers, which have no geometry', async () => {
+    const urls = stubService(json({ layers: [{ id: 0, type: 'Group Layer' }, { id: 7, geometryType: 'esriGeometryPoint' }] }));
+    await GET(new NextRequest(`http://localhost/api/arcgis?service=${encodeURIComponent(ROOT)}`));
+    expect(urls[1]).toMatch(new RegExp(`^${ROOT}/7/query\\?`));
+  });
+
+  it('says so when a catalog hit is not a REST service at all', async () => {
+    const urls = stubService(new Response('<!doctype html><title>Experience</title>', { status: 200 }));
+    const res = await GET(new NextRequest('http://localhost/api/arcgis?service=https%3A%2F%2Fexperience.arcgis.com%2Fexperience%2Fabc'));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Not an ArcGIS REST service');
+    expect(urls).toHaveLength(1);
+  });
+
+  it('reports a service with nothing to query, and a root that errors', async () => {
+    stubService(json({ layers: [], tables: [{ id: 0 }] }));
+    expect(await resolveQueryUrl(ROOT)).toEqual({ error: 'Service has no layers to query', status: 400 });
+    stubService(json({ error: { code: 499, message: 'Token Required' } }));
+    expect(await resolveQueryUrl(ROOT)).toEqual({ error: 'Token Required', status: 502 });
+    stubService(json({}, 404));
+    expect(await resolveQueryUrl(ROOT)).toEqual({ error: 'Feature Service lookup failed (404)', status: 404 });
+  });
+});

--- a/src/app/api/arcgis/route.ts
+++ b/src/app/api/arcgis/route.ts
@@ -9,12 +9,40 @@ import { NextRequest, NextResponse } from 'next/server';
  *
  *   2. Query:   ?service=<FeatureServiceURL>&bbox=-105,35,-94,42
  *      Runs a spatial query against a specific Feature Service layer and
- *      returns raw GeoJSON.
+ *      returns raw GeoJSON. A service root is resolved to its first
+ *      feature layer first.
  *
  * No API key required — all requests target public data only.
  */
 
 const ARCGIS_SEARCH_URL = 'https://www.arcgis.com/sharing/rest/search';
+
+interface ServiceLayer { id: number; geometryType?: string }
+
+/**
+ * Turns a catalog URL into the layer query URL it needs. Layer ids are
+ * whatever the publisher assigned — Transmission_Line's only layer is 100 —
+ * so a service root is asked for its layer list rather than assumed to hold
+ * a layer 0, which ArcGIS answers with 400 "Invalid URL".
+ */
+export async function resolveQueryUrl(service: string): Promise<{ url: string } | { error: string; status: number }> {
+  const base = service.replace(/\/+$/, '');
+  if (base.endsWith('/query')) return { url: base };
+  if (/\/\d+$/.test(base)) return { url: `${base}/query` };
+
+  const res = await fetch(`${base}?f=json`, { signal: AbortSignal.timeout(20000) });
+  if (!res.ok) return { error: `Feature Service lookup failed (${res.status})`, status: res.status };
+  // Catalog hits include app pages and portals that answer with HTML.
+  const info = await res.json().catch(() => null);
+  if (!info || typeof info !== 'object') return { error: 'Not an ArcGIS REST service', status: 400 };
+  if (info.error) return { error: info.error.message || 'Feature Service error', status: 502 };
+
+  const layers: ServiceLayer[] = Array.isArray(info.layers) ? info.layers : [];
+  // Group layers carry no geometry and cannot be queried.
+  const layer = layers.find(l => l.geometryType) ?? layers[0];
+  if (!layer) return { error: 'Service has no layers to query', status: 400 };
+  return { url: `${base}/${layer.id}/query` };
+}
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -95,15 +123,11 @@ export async function GET(request: NextRequest) {
   // ── Mode 2: Feature Service Spatial Query ───────────────────────────
   if (service) {
     try {
-      // Normalise the URL — ensure it ends with /query
-      let serviceUrl = service.replace(/\/+$/, '');
-      if (!serviceUrl.endsWith('/query')) {
-        // If the URL points at the service root, pick layer 0 by default
-        if (!/\/\d+$/.test(serviceUrl)) {
-          serviceUrl += '/0';
-        }
-        serviceUrl += '/query';
+      const resolved = await resolveQueryUrl(service);
+      if ('error' in resolved) {
+        return NextResponse.json({ error: resolved.error }, { status: resolved.status });
       }
+      const serviceUrl = resolved.url;
 
       const params = new URLSearchParams({
         where: '1=1',


### PR DESCRIPTION
Importing a catalog result whose URL is a service root appends `/0/query` and sends that. ArcGIS layer ids are whatever the publisher assigned, so a service whose only layer is not 0 answers 400 "Invalid URL", which the panel shows as **Feature Service query failed (400)**. `Transmission_Line` (Lauren.Connor) has a single layer with id 100. Of the 20 results for "power grid transmission", 7 fail this way, including National Grid Lines and the New England substations layer.

## What this does

`resolveQueryUrl` in `src/app/api/arcgis/route.ts` asks the service root for its layer list (`?f=json`) and queries the first layer that has a geometry, so group layers are passed over. A URL that already names a layer, or ends in `/query`, is used as before with no extra request.

Two failure modes that used to surface as a 500 with a JSON parse message now say what happened: a catalog hit that is an app page or portal (HTML back from the lookup) returns **Not an ArcGIS REST service**, and a service with tables but no layers returns **Service has no layers to query**.

## Verification

Against the live services through the route, on a production build:

| | `master` | this branch |
|---|---|---|
| `…/Transmission_Line/FeatureServer` | 400 (`/0/query` → "Invalid URL") | 200 from `/100/query`; 2,000 features (the cap) over Northern California, 0 over New Mexico, which is where the dataset ends rather than a failure |
| `…/National_Grid_Lines/FeatureServer` | 400 | 200 |
| `https://experience.arcgis.com/experience/…` | 500, JSON parse message | 400 **Not an ArcGIS REST service** |
| `…/US_Electric_Power_Transmission_Lines/FeatureServer` (layer 0) | 200 | 200, one extra lookup request |
| `…/FeatureServer/3/` | queried directly | queried directly, no lookup |

- `npx vitest run`: 49 files / 610 tests pass (2 files / 16 tests are the pre-existing `RUN_LIVE_TESTS` skips). The 5 new tests in `src/app/api/arcgis/route.test.ts` stub `fetch` and check which layer is asked for, that a layer URL skips the lookup, group-layer skipping, the HTML case and the empty case.
- `npx tsc --noEmit` clean.
- `eslint`: the test file is clean; `route.ts` keeps its 3 pre-existing `no-explicit-any` findings.

## Notes

- MapServer roots resolve to a layer too but may still reject `f=geojson`; that surfaces as the existing 502 and is not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
