### PR TITLE
fix(arcgis): leave app pages and URL-less items out of the search results

### DIFF
--- a/src/app/api/arcgis/route.ts
+++ b/src/app/api/arcgis/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { queryableResults } from '@/lib/arcgis-catalog';
 
 /**
  * OSIRIS — ArcGIS Public Data Integration
  *
  * Two query modes:
  *   1. Search:  ?q=keyword&bbox=-105,35,-94,42
- *      Searches the ArcGIS Online catalog for public Feature Services.
+ *      Searches the ArcGIS Online catalog for public Feature Services
+ *      and returns the ones whose URL can actually be queried.
  *
  *   2. Query:   ?service=<FeatureServiceURL>&bbox=-105,35,-94,42
  *      Runs a spatial query against a specific Feature Service layer and
@@ -15,6 +17,7 @@ import { NextRequest, NextResponse } from 'next/server';
  */
 
 const ARCGIS_SEARCH_URL = 'https://www.arcgis.com/sharing/rest/search';
+const SEARCH_RESULTS = 20;
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -30,7 +33,9 @@ export async function GET(request: NextRequest) {
         q,
         type: 'Feature Service',
         filter: 'access:public',
-        num: '20',
+        // Roughly a third of a page is app pages and URL-less items, which
+        // are dropped below, so ask for more than one page shows.
+        num: String(SEARCH_RESULTS * 2),
         f: 'json',
       });
       if (bbox) params.set('bbox', bbox);
@@ -65,7 +70,7 @@ export async function GET(request: NextRequest) {
         );
       }
 
-      const results = (data.results || []).map((item: any) => ({
+      const results = queryableResults(data.results || [], SEARCH_RESULTS).map((item: any) => ({
         id: item.id,
         title: item.title,
         url: item.url,

--- a/src/lib/arcgis-catalog.test.ts
+++ b/src/lib/arcgis-catalog.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { isQueryableService, queryableResults } from './arcgis-catalog';
+
+describe('ArcGIS catalog results', () => {
+  it('keeps only items whose URL is a REST service', () => {
+    expect(isQueryableService('https://services1.arcgis.com/abc/arcgis/rest/services/Lines/FeatureServer')).toBe(true);
+    expect(isQueryableService('https://gis.wcc.govt.nz/arcgis/rest/services/Plan/Plan/MapServer/32')).toBe(true);
+    expect(isQueryableService('https://experience.arcgis.com/experience/06e44781378e48bab2cc352be7098c1c')).toBe(false);
+    expect(isQueryableService('https://www.arcgis.com/home/item.html?id=abc')).toBe(false);
+    expect(isQueryableService(null)).toBe(false);
+    expect(isQueryableService(undefined)).toBe(false);
+  });
+
+  it('preserves the catalog order and stops at the limit', () => {
+    const items = [
+      { id: 'a', url: 'https://x/arcgis/rest/services/A/FeatureServer' },
+      { id: 'b' },
+      { id: 'c', url: 'https://experience.arcgis.com/experience/c' },
+      { id: 'd', url: 'https://x/arcgis/rest/services/D/FeatureServer' },
+      { id: 'e', url: 'https://x/arcgis/rest/services/E/MapServer' },
+    ];
+    expect(queryableResults(items, 2).map(i => i.id)).toEqual(['a', 'd']);
+    expect(queryableResults(items, 20).map(i => i.id)).toEqual(['a', 'd', 'e']);
+  });
+});

--- a/src/lib/arcgis-catalog.ts
+++ b/src/lib/arcgis-catalog.ts
@@ -1,0 +1,10 @@
+/* The catalog's "Feature Service" type is set by the publisher, and the
+   item's URL is a separate field they can point anywhere: an Experience
+   app page, a portal, or nothing. Only a REST service can be queried. */
+export function isQueryableService(url: unknown): url is string {
+  return typeof url === 'string' && /\/rest\/services\//i.test(url);
+}
+
+export function queryableResults<T extends { url?: unknown }>(items: T[], limit: number): T[] {
+  return items.filter(item => isQueryableService(item.url)).slice(0, limit);
+}


### PR DESCRIPTION
The catalog search asks ArcGIS Online for public items of type "Feature Service", but that type is set by the publisher and the item's URL is a separate field they can point anywhere. The results therefore include Experience app pages, portal items and entries with no URL at all, and the panel offers an import button for every result that has a URL. None of those can be queried. For "power grid transmission", 4 of the 20 results were an app page or had no URL, and the app page only failed after being clicked.

## What this does

`src/lib/arcgis-catalog.ts` keeps only results whose URL is under `/rest/services/`, and the search asks the catalog for two pages' worth so the list is still full after the drop. MapServers stay: some do answer a GeoJSON query, and the ones that do not fail at import as before.

Independent of #342, which changes the query mode of the same route; the two merge cleanly.

## Verification

- Through the route on a production build, "power grid transmission" returns a full 20 results, none without a URL and none outside `/rest/services/`. On `master` the same search returned 20 with 3 URL-less entries and 1 Experience app page.
- `npx vitest run`: 49 files / 607 tests pass (2 files / 16 tests are the pre-existing `RUN_LIVE_TESTS` skips), including the 2 new tests in `src/lib/arcgis-catalog.test.ts`.
- `npx tsc --noEmit` clean. `eslint` clean on the new files; `route.ts` keeps its 3 pre-existing `no-explicit-any` findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
