### PR TITLE
perf(cctv): serve a saved camera catalogue; stop /api/stats recomputing per visitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ scanner_backend_backup.js
 
 # Security - Prevent accidental manual leaks
 *Manual*.md
+
+# Saved camera catalogue
+/.cache/

--- a/src/app/api/cctv/route.test.ts
+++ b/src/app/api/cctv/route.test.ts
@@ -1,11 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { GET } from './route';
+import { GET, clearCctvRefreshes } from './route';
 import { stealthFetch } from '@/lib/stealthFetch';
 import { clearSourceCache } from '@/lib/sourceCache';
+import { join } from 'node:path';
+
+/* GET reads the saved catalogue before it dispatches anything. That is real
+   disk I/O, so a case must let it settle before advancing fake time —
+   otherwise the timers it is waiting on are set after the clock moved. */
+const flushIO = () => vi.advanceTimersByTimeAsync(0);
 
 vi.mock('@/lib/stealthFetch', () => ({ stealthFetch: vi.fn(), stealthHeaders: vi.fn(() => ({})) }));
-beforeEach(() => { vi.useFakeTimers(); vi.resetAllMocks(); clearSourceCache(); });
-afterEach(() => vi.useRealTimers());
+/* Keep these cases on the live fetch path; a saved catalogue would answer
+   for them before any upstream was asked. */
+beforeEach(() => { process.env.OSIRIS_CCTV_SNAPSHOT = 'off'; vi.useFakeTimers(); vi.resetAllMocks(); clearSourceCache(); clearCctvRefreshes(); });
+/* Drain first: a mock that never settles is holding a pool slot, and the pool
+   is module state shared with the next case. */
+afterEach(async () => { await flushIO(); await vi.advanceTimersByTimeAsync(12_000); vi.useRealTimers(); });
 
 describe('CCTV partial responses', () => {
   it('returns a completed region without scheduling unnecessary retries', async () => {
@@ -25,6 +35,70 @@ describe('CCTV partial responses', () => {
     const response = await pending;
     expect((await response.json()).pendingRegions).toEqual(['uk']);
     expect(response.headers.get('Cache-Control')).toContain('no-store');
+  });
+
+  /* Measured against production: asking for every region at once opened 60+
+     connections, and upstreams that answer in under a second on their own
+     started failing on connect. Eleven regions were missing from every
+     response because of it. */
+  it('does not dispatch every region at once', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    vi.mocked(stealthFetch).mockImplementation(() => {
+      peak = Math.max(peak, ++inFlight);
+      return new Promise(() => {}); // never settles: hold the slot
+    });
+
+    void GET(new Request('http://localhost/api/cctv?region=all'));
+    await flushIO();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(peak).toBeGreaterThan(0);
+    expect(peak).toBeLessThan(20);
+  });
+
+  it('answers on one shared deadline rather than one per region', async () => {
+    vi.mocked(stealthFetch).mockReturnValue(new Promise(() => {}));
+    const pending = GET(new Request('http://localhost/api/cctv?region=all'));
+    await flushIO();
+    await vi.advanceTimersByTimeAsync(12_000);
+
+    const body = await (await pending).json();
+    expect(body.pendingRegions.length).toBeGreaterThan(20);
+  });
+
+  it('serves an already-cached region without going upstream again', async () => {
+    vi.mocked(stealthFetch).mockResolvedValue(Response.json([
+      { id: 'JamCams_1', lat: 51.5, lon: -0.1, commonName: 'London' },
+    ]));
+    expect((await (await GET(new Request('http://localhost/api/cctv?region=uk'))).json()).total).toBe(1);
+    const callsAfterFirst = vi.mocked(stealthFetch).mock.calls.length;
+
+    const second = await (await GET(new Request('http://localhost/api/cctv?region=uk'))).json();
+    expect(second.total).toBe(1);
+    expect(second.pendingRegions).toEqual([]);
+    expect(vi.mocked(stealthFetch).mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  /* The bug behind "the cameras took a very long time": one upstream that
+     hangs made every visitor wait out the full budget, even with a catalogue
+     already holding tens of thousands of cameras. */
+  it('does not hold a warm catalogue hostage to a region that hangs', async () => {
+    // us-east answers from static data, so it is the warm half of the catalogue.
+    vi.mocked(stealthFetch).mockResolvedValue(Response.json([]));
+    const warm = await (await GET(new Request('http://localhost/api/cctv?region=us-east'))).json();
+    expect(warm.total).toBeGreaterThan(0);
+
+    vi.mocked(stealthFetch).mockReturnValue(new Promise(() => {})); // uk now hangs
+    const pending = GET(new Request('http://localhost/api/cctv?region=us-east,uk'));
+    await flushIO();
+    // Resolving here at all is the point: before this fix the caller waited the
+    // full 12s slot budget even though the catalogue was already warm.
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    const body = await (await pending).json();
+    expect(body.total).toBe(warm.total);
+    expect(body.pendingRegions).toEqual(['uk']);
   });
 
   it('allows a bounded retry for an empty/failed provider response', async () => {

--- a/src/app/api/cctv/route.ts
+++ b/src/app/api/cctv/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { stealthFetch } from '@/lib/stealthFetch';
-import { cachedSource } from '@/lib/sourceCache';
+import { cachedSource, isStale, peekSource, seedSource } from '@/lib/sourceCache';
+import { buildPayload, clearPayload, getPayload, readSnapshot, writeSnapshot, type Payload, type RegionCameras } from '@/lib/cctv-snapshot';
+import { createPool } from '@/lib/fetch-pool';
 
 export const maxDuration = 60;
 import { fetchAsfinagCameras } from './asfinag';
@@ -535,24 +537,228 @@ const REGION_FETCHERS: Record<string, RegionFetcher> = Object.fromEntries(
 );
 
 /**
- * A region that will not answer must not hold the other thirty-eight hostage.
+ * A region that will not answer must not hold the other forty-seven hostage.
  * The abandoned fetch keeps running inside the cache, so the frame it was
  * fetching lands in time for the next request rather than being thrown away —
  * this drops a slow region from the current response, not from the map.
  */
 const REGION_BUDGET_MS = 12_000;
 
-function withBudget(region: string, fetcher: RegionFetcher): Promise<{ cameras: Awaited<ReturnType<RegionFetcher>>; pending: boolean }> {
-  let timer: ReturnType<typeof setTimeout>;
-  return Promise.race([
-    fetcher().then(cameras => ({ cameras, pending: cameras.length === 0 })).finally(() => clearTimeout(timer)),
-    new Promise<{ cameras: Awaited<ReturnType<RegionFetcher>>; pending: boolean }>(resolve => {
-      timer = setTimeout(() => {
-        console.warn(`[OSIRIS] cctv:${region} over ${REGION_BUDGET_MS}ms — returning without it`);
-        resolve({ cameras: [], pending: true });
-      }, REGION_BUDGET_MS);
-    }),
-  ]);
+/**
+ * Regions are fetched a few at a time, not all forty-eight at once.
+ *
+ * Several regions fan out again to their own sub-sources, so the old
+ * all-at-once dispatch opened well over sixty simultaneous connections and
+ * the upstreams started failing on connect. Every host that timed out that
+ * way answered in under a second when asked on its own, and because a failed
+ * region caches empty for a minute, one storm kept the same regions missing
+ * from response after response. Queued regions still run; they just wait
+ * their turn, and whatever misses the deadline lands in the cache for the
+ * next caller.
+ */
+/**
+ * How long a response waits on regions it does not already have.
+ *
+ * A catalogue that already holds 35,000 cameras must not be held hostage by
+ * one upstream that hangs. us-central does exactly that — it burns the full
+ * slot budget on every attempt — and waiting on it turned a 0.2s response
+ * into a 12s one for every visitor, which is what made the cameras take so
+ * long to appear. With cameras already in hand, wait only briefly for the
+ * stragglers and let the rest land in the cache for the next caller. With
+ * nothing in hand there is nothing to show anyway, so a cold start still
+ * waits properly rather than returning an empty map.
+ */
+const WARM_GRACE_MS = 2_000;
+
+const REGION_CONCURRENCY = 4;
+const regionPool = createPool(REGION_CONCURRENCY);
+
+/**
+ * One refresh per region at a time, and never an unbounded slot.
+ *
+ * A pool slot held by an upstream that never answers is worse than the storm
+ * it replaced: four of those and the catalogue stops refreshing entirely. The
+ * budget guarantees the slot comes back. The abandoned fetch keeps running
+ * inside the source cache, where it costs no slot and still lands for the
+ * next caller. Sharing one refresh per region also stops a hundred
+ * simultaneous visitors queueing a hundred copies of the same work.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const refreshing = new Map<string, Promise<any[]>>();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function refreshRegion(region: string): Promise<any[]> {
+  const existing = refreshing.get(region);
+  if (existing) return existing;
+
+  const started = regionPool.run(async () => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        REGION_FETCHERS[region](),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        new Promise<any[]>(resolve => {
+          timer = setTimeout(() => {
+            console.warn(`[OSIRIS] cctv:${region} over ${REGION_BUDGET_MS}ms — freeing its slot`);
+            resolve([]);
+          }, REGION_BUDGET_MS);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }).finally(() => { refreshing.delete(region); });
+
+  refreshing.set(region, started);
+  return started;
+}
+
+const ALL_REGIONS = () => Object.keys(REGION_FETCHERS);
+
+/** Everything currently held, stale included — what gets written to disk. */
+function currentRegions(): RegionCameras {
+  const regions: RegionCameras = {};
+  for (const region of ALL_REGIONS()) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cameras = peekSource<any>(`cctv:${region}`, true);
+    if (cameras?.length) regions[region] = cameras;
+  }
+  return regions;
+}
+
+/** Serialise and compress the whole-world response once, not per request. */
+function rebuildPayload(): Payload | undefined {
+  const regions = currentRegions();
+  const held = Object.keys(regions);
+  if (!held.length) return undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cameras: any[] = [];
+  const sources: Record<string, number> = {};
+  for (const region of ALL_REGIONS()) {
+    for (const camera of regions[region] ?? []) {
+      cameras.push(camera);
+      const label = String(camera.source ?? 'unknown');
+      sources[label] = (sources[label] || 0) + 1;
+    }
+  }
+  return buildPayload({
+    cameras,
+    total: cameras.length,
+    sources,
+    regions: ALL_REGIONS(),
+    pendingRegions: ALL_REGIONS().filter(region => !regions[region]),
+    timestamp: new Date().toISOString(),
+  }, cameras.length, held.length === ALL_REGIONS().length);
+}
+
+const PERSIST_EVERY_MS = 60_000;
+let lastPersistedAt = 0;
+let lastPersistedTotal = 0;
+
+/**
+ * Saves only ever move forwards.
+ *
+ * A boot that starts empty reaches its first request with a handful of
+ * cameras, and writing that would replace a good saved catalogue with a
+ * near-empty one — the next boot would then restore almost nothing. The
+ * restore seeds the high-water mark, so a fresh process cannot regress what
+ * an earlier one already learned.
+ */
+async function persistCatalogue() {
+  const cameras = Object.values(currentRegions()).reduce((n, list) => n + list.length, 0);
+  if (cameras <= lastPersistedTotal) return;
+  if (Date.now() - lastPersistedAt < PERSIST_EVERY_MS) return;
+  lastPersistedAt = Date.now();
+  lastPersistedTotal = cameras;
+  try {
+    await writeSnapshot(currentRegions());
+  } catch (error) {
+    console.warn('[OSIRIS] Could not save the camera catalogue:', error);
+  }
+}
+
+/**
+ * Fill the catalogue before the first visitor arrives, rather than because of
+ * one. Without this the first request after a deploy pays the whole cold
+ * fan-out and still returns a partial map; with it the pool has usually
+ * finished by the time anyone asks. Called from instrumentation at boot.
+ */
+let restoring: Promise<void> | undefined;
+
+/**
+ * Load the saved catalogue into this module, once.
+ *
+ * The request handler owns this rather than the boot hook: Next loads
+ * instrumentation in its own module graph, so a catalogue restored there
+ * populated a different copy of these caches and every request still started
+ * from nothing. Reading ~2MB from disk costs a few milliseconds and makes the
+ * first request as fast as the thousandth.
+ */
+function ensureRestored(): Promise<void> {
+  restoring ??= (async () => {
+    const saved = await readSnapshot();
+    if (!saved) return;
+    let cameras = 0;
+    for (const [region, list] of Object.entries(saved.regions)) {
+      if (region in REGION_FETCHERS) { seedSource(`cctv:${region}`, list); cameras += list.length; }
+    }
+    rebuildPayload();
+    lastPersistedTotal = cameras;
+    console.log(`[OSIRIS] Camera catalogue restored: ${cameras} cameras from disk`);
+  })().catch(error => { console.warn('[OSIRIS] Could not restore the camera catalogue:', error); });
+  return restoring;
+}
+
+export async function warmCctvCatalog() {
+  await ensureRestored();
+  // Then bring it up to date, and save whatever it became.
+  await collectRegions(ALL_REGIONS());
+  rebuildPayload();
+  await persistCatalogue();
+}
+
+/** Test seam — drops queued refreshes between cases. */
+export function clearCctvRefreshes() {
+  refreshing.clear();
+  regionPool.reset();
+  restoring = undefined;
+  clearPayload();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function collectRegions(regions: string[]): Promise<{ cameras: Record<string, any[]>; pending: string[] }> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cameras: Record<string, any[]> = {};
+  const missing: string[] = [];
+
+  for (const region of regions) {
+    /* Stale cameras beat no cameras: a camera index goes out of date over
+       weeks, so serving yesterday's positions while today's are fetched is
+       always the better trade. The refresh runs behind the response. */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cached = peekSource<any>(`cctv:${region}`, true);
+    if (cached) {
+      cameras[region] = cached;
+      if (isStale(`cctv:${region}`)) void refreshRegion(region).catch(() => {});
+    } else {
+      missing.push(region);
+    }
+  }
+  if (!missing.length) return { cameras, pending: [] };
+
+  const fetches = missing.map(region => refreshRegion(region)
+    .then(result => { if (result.length) cameras[region] = result; })
+    .catch(() => { /* the cache logs it and keeps the last good index */ }));
+
+  const budget = Object.keys(cameras).length ? WARM_GRACE_MS : REGION_BUDGET_MS;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<void>(resolve => { timer = setTimeout(resolve, budget); });
+  await Promise.race([Promise.all(fetches), deadline]);
+  clearTimeout(timer);
+
+  const pending = missing.filter(region => !cameras[region]);
+  if (pending.length) console.warn(`[OSIRIS] cctv still filling: ${pending.join(", ")}`);
+  return { cameras, pending };
 }
 
 // Determine which regions to fetch based on viewport bounds
@@ -667,8 +873,49 @@ function getRegionsForBounds(lat: number, lng: number, radius: number): string[]
   return regions.length > 0 ? regions : ['uk', 'us-east']; // Default fallback
 }
 
+/** How old the prebuilt world payload may get before a rebuild is kicked off. */
+const PAYLOAD_REFRESH_MS = 5 * 60 * 1000;
+const REBUILD_DELAY_MS = 2_000;
+let rebuilding: Promise<void> | undefined;
+
+function rebuildInBackground() {
+  rebuilding ??= (async () => {
+    /* Let the response that triggered this reach the client first. Refreshing
+       48 regions is heavy, single-threaded work, and starting it inline made
+       the first request after a restart take 13s to flush a payload that was
+       already built and sitting in memory. */
+    await new Promise(resolve => setTimeout(resolve, REBUILD_DELAY_MS));
+    await collectRegions(ALL_REGIONS());
+    rebuildPayload();
+    await persistCatalogue();
+  })().catch(error => { console.warn('[OSIRIS] Camera catalogue rebuild failed:', error); })
+    .finally(() => { rebuilding = undefined; });
+  return rebuilding;
+}
+
+/**
+ * The bytes are already serialised and gzipped, so a request costs a buffer
+ * write. An unchanged catalogue answers a returning visitor with a 304.
+ */
+function servePayload(request: Request, ready: Payload) {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'public, max-age=60, stale-while-revalidate=600',
+    'Vary': 'Accept-Encoding',
+    'ETag': ready.etag,
+  };
+  if (request.headers.get('if-none-match') === ready.etag) return new Response(null, { status: 304, headers });
+
+  if ((request.headers.get('accept-encoding') || '').includes('gzip')) {
+    headers['Content-Encoding'] = 'gzip';
+    return new Response(new Uint8Array(ready.gzip), { headers });
+  }
+  return new Response(new Uint8Array(ready.json), { headers });
+}
+
 export async function GET(request: Request) {
   try {
+    await ensureRestored();
     const { searchParams } = new URL(request.url);
     const region = searchParams.get('region');
     const lat = parseFloat(searchParams.get('lat') || '0');
@@ -688,21 +935,39 @@ export async function GET(request: Request) {
       regionsToFetch = Object.keys(REGION_FETCHERS);
     }
 
-    const results = await Promise.allSettled(
-      regionsToFetch.map(r => withBudget(r, REGION_FETCHERS[r]))
-    );
+    if (regionsToFetch.length === ALL_REGIONS().length) {
+      const ready = getPayload();
+      if (ready) {
+        void persistCatalogue();
+        // Past its TTL, refresh behind the response rather than in front of it.
+        /* An incomplete catalogue is chased straight away; a complete one is
+           left alone until its regions actually go stale. */
+        if (!ready.complete || Date.now() - ready.builtAt > PAYLOAD_REFRESH_MS) void rebuildInBackground();
+        return servePayload(request, ready);
+      }
+    }
+
+    const collected = await collectRegions(regionsToFetch);
 
     const allCameras: any[] = [];
     const sources: Record<string, number> = {};
-    const pendingRegions: string[] = [];
+    const pendingRegions = collected.pending;
 
-    for (const [index, result] of results.entries()) {
-      if (result.status === 'rejected' || result.value.pending) pendingRegions.push(regionsToFetch[index]);
-      if (result.status === 'fulfilled') {
-        for (const cam of result.value.cameras) {
-          allCameras.push(cam);
-          sources[cam.source] = (sources[cam.source] || 0) + 1;
-        }
+    for (const region of regionsToFetch) {
+      for (const cam of collected.cameras[region] ?? []) {
+        allCameras.push(cam);
+        sources[cam.source] = (sources[cam.source] || 0) + 1;
+      }
+    }
+
+    /* Cache what was just assembled, so the next caller is served the
+       prebuilt bytes instead of paying to build them again — and so the
+       catalogue reaches disk even when no payload existed to begin with. */
+    if (regionsToFetch.length === ALL_REGIONS().length) {
+      const built = rebuildPayload();
+      if (built) {
+        void persistCatalogue();
+        return servePayload(request, built);
       }
     }
 

--- a/src/app/api/stats/route.test.ts
+++ b/src/app/api/stats/route.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET, clearStatsSnapshot } from './route';
+
+/* Each computation fetches six of the app's own feeds. These tests count those
+   fetches, because the defect was that every caller paid for all six. */
+const baseFeeds = (): Record<string, unknown> => ({
+  flights: { commercial_flights: [1, 2], private_flights: [3], private_jets: [], military_flights: [4] },
+  satellites: { satellites: [1, 2, 3] },
+  cctv: { cameras: [1, 2, 3, 4, 5] },
+  weather: { events: [1] },
+  infrastructure: { infrastructure: [1, 2] },
+  gdelt: { events: [1, 2, 3, 4] },
+});
+
+let feeds = baseFeeds();
+let calls = 0;
+let release: () => void = () => {};
+
+/** `hold` keeps every feed request open until release(), to test concurrency. */
+function mockFetch({ hold = false } = {}) {
+  calls = 0;
+  const gate = hold ? new Promise<void>(resolve => { release = resolve; }) : Promise.resolve();
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    calls++;
+    await gate;
+    const feed = new URL(url).pathname.split('/').pop()!;
+    return new Response(JSON.stringify(feeds[feed] ?? {}), { status: 200 });
+  }));
+}
+
+const request = () => GET(new Request('http://localhost:3000/api/stats'));
+const at = (iso: string) => vi.setSystemTime(new Date(iso));
+
+describe('GET /api/stats', () => {
+  beforeEach(() => {
+    feeds = baseFeeds();
+    clearStatsSnapshot();
+    vi.useFakeTimers({ toFake: ['Date'] });
+    at('2026-01-01T00:00:00Z');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('counts each feed', async () => {
+    mockFetch();
+    const body = await (await request()).json();
+    expect(body.stats).toEqual({ flights: 4, sats: 3, cctv: 5, weather: 1, nuclear: 2, incidents: 4 });
+  });
+
+  it('serves a burst of concurrent callers from one computation', async () => {
+    mockFetch({ hold: true });
+    const burst = Array.from({ length: 50 }, request);
+    release();
+    const bodies = await Promise.all(burst.map(response => response.then(r => r.json())));
+    expect(calls).toBe(6);
+    expect(new Set(bodies.map(b => JSON.stringify(b.stats))).size).toBe(1);
+  });
+
+  it('does not recompute within the TTL', async () => {
+    mockFetch();
+    await request();
+    at('2026-01-01T00:00:29Z');
+    await request();
+    expect(calls).toBe(6);
+  });
+
+  it('answers from a stale snapshot at once while refreshing behind it', async () => {
+    mockFetch();
+    await request();
+
+    feeds.satellites = { satellites: [1] };
+    mockFetch({ hold: true });
+    at('2026-01-01T00:00:31Z');
+    // Resolves while the refresh is still held open: the caller never waits on it.
+    const stale = await (await request()).json();
+    expect(stale.stats.sats).toBe(3);
+    expect(calls).toBe(6);
+
+    release();
+    await vi.waitFor(async () => expect((await (await request()).json()).stats.sats).toBe(1));
+    expect(calls).toBe(6); // the waiting callers shared the one refresh
+  });
+
+  it('keeps serving the last good snapshot when a refresh fails', async () => {
+    mockFetch();
+    await request();
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('not json', { status: 200 })));
+    at('2026-01-01T00:00:31Z');
+
+    const response = await request();
+    expect(response.status).toBe(200);
+    expect((await response.json()).stats.sats).toBe(3);
+    await vi.waitFor(() => expect(logged).toHaveBeenCalledWith('Stats refresh failed:', expect.any(Error)));
+  });
+
+  /* Found running this against a real server: its first computation raced
+     startup, every feed failed, and the zeros were then cached like real data. */
+  it('keeps a failed feed at its last good count rather than zeroing it', async () => {
+    mockFetch();
+    await request();
+
+    feeds.gdelt = { events: [1] };
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      const feed = new URL(url).pathname.split('/').pop()!;
+      if (feed === 'satellites') throw new TypeError('fetch failed');
+      return new Response(JSON.stringify(feeds[feed] ?? {}), { status: 200 });
+    }));
+    at('2026-01-01T00:00:31Z');
+    await request();
+    await vi.waitFor(async () => expect((await (await request()).json()).stats.incidents).toBe(1));
+    expect((await (await request()).json()).stats.sats).toBe(3);
+  });
+
+  it('does not treat a computation that reached no feed as fresh', async () => {
+    let attempts = 0;
+    vi.stubGlobal('fetch', vi.fn(async () => { attempts++; throw new TypeError('fetch failed'); }));
+    await request();
+    expect(attempts).toBe(6);
+    // Still inside what would be the TTL, but nothing was learned: try again.
+    at('2026-01-01T00:00:05Z');
+    await request();
+    await vi.waitFor(() => expect(attempts).toBe(12));
+
+    mockFetch();
+    await vi.waitFor(async () => expect((await (await request()).json()).stats.sats).toBe(3));
+  });
+
+  it('reports a failure when there is no snapshot to fall back on', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('not json', { status: 200 })));
+    expect((await request()).status).toBe(500);
+  });
+});

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -6,86 +6,130 @@ export const maxDuration = 60;
  * OSIRIS — Global Stats API
  * Lightweight aggregation endpoint.
  * Fetches metrics from all local APIs and returns ONLY the counts.
- * 
+ *
  * ARCHITECTURE NOTE (10k+ Concurrent Users):
- * This endpoint ensures the Next.js server serves ~100 bytes instead of 10MB+ 
+ * This endpoint ensures the Next.js server serves ~100 bytes instead of 10MB+
  * of raw GeoJSON mapping data when 10,000 users boot the dashboard simultaneously.
- * The underlying API routes utilize their own 45-60s TTL caching, meaning the 
- * heavy external APIs (adsb.lol, USGS) are only hit once per minute, while this 
+ * The underlying API routes utilize their own 45-60s TTL caching, meaning the
+ * heavy external APIs (adsb.lol, USGS) are only hit once per minute, while this
  * lightweight stats route safely serves 10k concurrent users instantly.
  */
 
+type Stats = { flights: number; sats: number; cctv: number; weather: number; nuclear: number; incidents: number };
+type Snapshot = { stats: Stats; timestamp: string; at: number };
+const EMPTY: Stats = { flights: 0, sats: 0, cctv: 0, weather: 0, nuclear: 0, incidents: 0 };
+
+/* One computation serves everyone. Each one pulls six of this app's own feeds —
+   CCTV alone is ~5MB — and parses them only to count. The per-fetch
+   `revalidate` hints never helped: Next's data cache refuses anything over 2MB,
+   so the two largest feeds were refetched in full on every call, and
+   Cloudflare does not cache /api responses either. Every arriving visitor paid
+   for all six, and under production load the endpoint took 15-19s to return
+   ~100 bytes. Now there is at most one computation per TTL, concurrent callers
+   share it, and a stale snapshot answers instantly while a fresh one is
+   computed behind it. */
+const TTL_MS = 30_000;
+let snapshot: Snapshot | undefined;
+let inflight: Promise<Snapshot> | undefined;
+
+/** Test hook, mirroring clearMaritimeSnapshot. */
+export function clearStatsSnapshot() {
+  snapshot = undefined;
+  inflight = undefined;
+}
+
+/** Counts for the feeds that answered; a feed that failed is simply absent. */
+async function computeStats(origin: string): Promise<Partial<Stats>> {
+  // Fetch all internal APIs in parallel (they have their own Cache-Control TTLs)
+  const [flightsRes, satsRes, cctvRes, weatherRes, infraRes, gdeltRes] = await Promise.allSettled([
+    fetch(`${origin}/api/flights`, { signal: AbortSignal.timeout(20000), next: { revalidate: 45 } }),
+    fetch(`${origin}/api/satellites`, { signal: AbortSignal.timeout(20000), next: { revalidate: 3600 } }),
+    fetch(`${origin}/api/cctv`, { signal: AbortSignal.timeout(20000), next: { revalidate: 3600 } }),
+    fetch(`${origin}/api/weather`, { signal: AbortSignal.timeout(20000), next: { revalidate: 300 } }),
+    fetch(`${origin}/api/infrastructure`, { signal: AbortSignal.timeout(20000), next: { revalidate: 86400 } }),
+    fetch(`${origin}/api/gdelt`, { signal: AbortSignal.timeout(20000), next: { revalidate: 300 } })
+  ]);
+
+  const fresh: Partial<Stats> = {};
+
+  // Safely parse counts
+  if (flightsRes.status === 'fulfilled' && flightsRes.value.ok) {
+    const data = await flightsRes.value.json();
+    fresh.flights = (data.commercial_flights?.length || 0) +
+              (data.private_flights?.length || 0) +
+              (data.private_jets?.length || 0) +
+              (data.military_flights?.length || 0);
+  }
+
+  if (satsRes.status === 'fulfilled' && satsRes.value.ok) {
+    const data = await satsRes.value.json();
+    fresh.sats = data.satellites?.length || 0;
+  }
+
+  if (cctvRes.status === 'fulfilled' && cctvRes.value.ok) {
+    const data = await cctvRes.value.json();
+    fresh.cctv = data.cameras?.length || 0;
+  }
+
+  if (weatherRes.status === 'fulfilled' && weatherRes.value.ok) {
+    const data = await weatherRes.value.json();
+    fresh.weather = data.events?.length || 0;
+  }
+
+  if (infraRes.status === 'fulfilled' && infraRes.value.ok) {
+    const data = await infraRes.value.json();
+    fresh.nuclear = data.infrastructure?.length || 0;
+  }
+
+  if (gdeltRes.status === 'fulfilled' && gdeltRes.value.ok) {
+      const data = await gdeltRes.value.json();
+      fresh.incidents = data.events?.length || 0;
+  }
+
+  return fresh;
+}
+
+function refresh(origin: string) {
+  inflight ??= computeStats(origin)
+    .then(fresh => {
+      /* A feed that failed keeps its last good count instead of dropping to
+         zero, and a computation that reached nothing does not count as fresh.
+         Caching is what makes this matter: without it, a transient failure
+         showed zeros to one request; with it, the same failure would be
+         pinned for a whole TTL. */
+      const reached = Object.keys(fresh).length > 0;
+      const next: Snapshot = {
+        stats: { ...EMPTY, ...snapshot?.stats, ...fresh },
+        timestamp: reached || !snapshot ? new Date().toISOString() : snapshot.timestamp,
+        at: reached ? Date.now() : snapshot?.at ?? 0,
+      };
+      snapshot = next;
+      return next;
+    })
+    .finally(() => { inflight = undefined; });
+  return inflight;
+}
+
+function respond({ stats, timestamp }: Snapshot) {
+  return NextResponse.json({ stats, timestamp }, {
+    headers: {
+      'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+    }
+  });
+}
+
 export async function GET(req: Request) {
+  if (snapshot && Date.now() - snapshot.at < TTL_MS) return respond(snapshot);
+
+  const pending = refresh(new URL(req.url).origin);
+  // Stale beats slow: answer now, and let the refresh land for the next caller.
+  if (snapshot) {
+    pending.catch(error => console.error('Stats refresh failed:', error));
+    return respond(snapshot);
+  }
+
   try {
-    const origin = new URL(req.url).origin;
-
-    // Fetch all internal APIs in parallel (they have their own Cache-Control TTLs)
-    const [flightsRes, satsRes, cctvRes, weatherRes, infraRes, gdeltRes] = await Promise.allSettled([
-      fetch(`${origin}/api/flights`, { signal: AbortSignal.timeout(20000), next: { revalidate: 45 } }),
-      fetch(`${origin}/api/satellites`, { signal: AbortSignal.timeout(20000), next: { revalidate: 3600 } }),
-      fetch(`${origin}/api/cctv`, { signal: AbortSignal.timeout(20000), next: { revalidate: 3600 } }),
-      fetch(`${origin}/api/weather`, { signal: AbortSignal.timeout(20000), next: { revalidate: 300 } }),
-      fetch(`${origin}/api/infrastructure`, { signal: AbortSignal.timeout(20000), next: { revalidate: 86400 } }),
-      fetch(`${origin}/api/gdelt`, { signal: AbortSignal.timeout(20000), next: { revalidate: 300 } })
-    ]);
-
-    let flights = 0;
-    let sats = 0;
-    let cctv = 0;
-    let weather = 0;
-    let nuclear = 0;
-    let incidents = 0;
-
-    // Safely parse counts
-    if (flightsRes.status === 'fulfilled' && flightsRes.value.ok) {
-      const data = await flightsRes.value.json();
-      flights = (data.commercial_flights?.length || 0) + 
-                (data.private_flights?.length || 0) + 
-                (data.private_jets?.length || 0) + 
-                (data.military_flights?.length || 0);
-    }
-
-    if (satsRes.status === 'fulfilled' && satsRes.value.ok) {
-      const data = await satsRes.value.json();
-      sats = data.satellites?.length || 0;
-    }
-
-    if (cctvRes.status === 'fulfilled' && cctvRes.value.ok) {
-      const data = await cctvRes.value.json();
-      cctv = data.cameras?.length || 0;
-    }
-
-    if (weatherRes.status === 'fulfilled' && weatherRes.value.ok) {
-      const data = await weatherRes.value.json();
-      weather = data.events?.length || 0;
-    }
-
-    if (infraRes.status === 'fulfilled' && infraRes.value.ok) {
-      const data = await infraRes.value.json();
-      nuclear = data.infrastructure?.length || 0;
-    }
-
-    if (gdeltRes.status === 'fulfilled' && gdeltRes.value.ok) {
-        const data = await gdeltRes.value.json();
-        incidents = data.events?.length || 0;
-    }
-
-    return NextResponse.json({
-      stats: {
-        flights,
-        sats,
-        cctv,
-        weather,
-        nuclear,
-        incidents
-      },
-      timestamp: new Date().toISOString()
-    }, {
-      headers: {
-        'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
-      }
-    });
-
+    return respond(await pending);
   } catch (error) {
     console.error('Stats aggregation failed:', error);
     return NextResponse.json({ error: 'Failed to compute stats' }, { status: 500 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Layers, BarChart3, Newspaper, Search, X, Globe, MapPinned, Route, Radar, Satellite, Moon, ExternalLink, AlertTriangle, Activity, Database, Wifi, Play, Network, Crosshair, Bluetooth, Pentagon, Radio , PenLine } from 'lucide-react';
+import { Layers, BarChart3, Newspaper, Search, X, Globe, MapPinned, Route, Radar, Satellite, Moon, ExternalLink, AlertTriangle, Activity, Database, Wifi, Play, Network, Crosshair, Bluetooth, Pentagon, Radio , PenLine, ShoppingBag } from 'lucide-react';
 import { type TerrainStatus } from '@/lib/map-terrain';
 import { loadCameraCatalog, mergeCameraCatalog } from '@/lib/camera-catalog';
 import IntelFeed from '@/components/IntelFeed';
@@ -1334,17 +1334,30 @@ export default function Dashboard() {
           <div className="w-1.5 h-1.5 rounded-full bg-[var(--gold-primary)] animate-osiris-pulse" />
           <span className="text-[var(--gold-primary)] font-bold">SUPPORT</span>
         </a>
+
+        <a href='https://shop.osirisai.live/' target='_blank' rel='noopener noreferrer' className="pointer-events-auto glass-panel px-3 py-1.5 flex items-center gap-1.5 text-[9px] font-mono tracking-widest hover:opacity-80 transition-opacity border-[var(--cyan-primary)]/40 bg-[var(--cyan-primary)]/10 ml-3 shadow-[0_0_10px_rgba(0,229,255,0.1)]">
+          <ShoppingBag className="w-3 h-3 text-[var(--cyan-primary)]" />
+          <span className="text-[var(--cyan-primary)] font-bold">MERCH</span>
+        </a>
       </motion.div>
 
       {/* ── MOBILE: Compact top status ── */}
       {/* The route planner claims the top of a phone screen; leaving this in
           place would put the support badge underneath the destination field. */}
       {isMobile && !showDirections && !navSession && (
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 2.5 }} className="absolute top-3 right-3 z-[200] pointer-events-auto flex items-center gap-2">
-          <TokenPanel />
-          <a href='https://ko-fi.com/M8D41ZYW4Z' target='_blank' rel='noopener noreferrer' className="glass-panel px-2 py-1 flex items-center gap-1.5 text-[9px] font-mono tracking-widest hover:opacity-80 transition-opacity border-[var(--gold-primary)]/40 bg-[var(--gold-primary)]/10">
-            <div className="w-1 h-1 rounded-full bg-[var(--gold-primary)] animate-osiris-pulse" />
-            <span className="text-[var(--gold-primary)] font-bold">SUPPORT</span>
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 2.5 }} className="absolute top-3 right-3 z-[200] pointer-events-auto flex flex-col items-end gap-1.5">
+          <div className="flex items-center gap-2">
+            <TokenPanel />
+            <a href='https://ko-fi.com/M8D41ZYW4Z' target='_blank' rel='noopener noreferrer' className="glass-panel px-2 py-1 flex items-center gap-1.5 text-[9px] font-mono tracking-widest hover:opacity-80 transition-opacity border-[var(--gold-primary)]/40 bg-[var(--gold-primary)]/10">
+              <div className="w-1 h-1 rounded-full bg-[var(--gold-primary)] animate-osiris-pulse" />
+              <span className="text-[var(--gold-primary)] font-bold">SUPPORT</span>
+            </a>
+          </div>
+          {/* A third pill on this row pushes $OSIRIS under the wordmark on a
+              375px phone, so the shop link takes a line of its own. */}
+          <a href='https://shop.osirisai.live/' target='_blank' rel='noopener noreferrer' className="glass-panel px-2 py-1 flex items-center gap-1.5 text-[9px] font-mono tracking-widest hover:opacity-80 transition-opacity border-[var(--cyan-primary)]/40 bg-[var(--cyan-primary)]/10">
+            <ShoppingBag className="w-2.5 h-2.5 text-[var(--cyan-primary)]" />
+            <span className="text-[var(--cyan-primary)] font-bold">MERCH</span>
           </a>
         </motion.div>
       )}

--- a/src/lib/cctv-snapshot.test.ts
+++ b/src/lib/cctv-snapshot.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { gunzipSync } from 'node:zlib';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildPayload, clearPayload, getPayload, readSnapshot, writeSnapshot } from './cctv-snapshot';
+
+let directory: string;
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'osiris-snap-'));
+  process.env.OSIRIS_CCTV_SNAPSHOT = join(directory, 'nested', 'cctv-catalog.json');
+  clearPayload();
+});
+
+afterEach(async () => {
+  delete process.env.OSIRIS_CCTV_SNAPSHOT;
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe('camera catalogue snapshot', () => {
+  it('round-trips a catalogue through disk, creating the directory', async () => {
+    await writeSnapshot({ uk: [{ id: 'JamCams_1', source: 'TfL' }], japan: [{ id: 'jp-1' }] });
+
+    const restored = await readSnapshot();
+    expect(restored?.regions.uk).toHaveLength(1);
+    expect(restored?.regions.japan[0]).toEqual({ id: 'jp-1' });
+    expect(restored?.builtAt).toBeGreaterThan(0);
+  });
+
+  /* A boot must never be blocked by a catalogue it cannot read — it just
+     rebuilds. Half-written files are the realistic case: the process can be
+     killed mid-write, which is why writeSnapshot renames into place. */
+  it('treats a missing or damaged catalogue as simply absent', async () => {
+    expect(await readSnapshot()).toBeNull();
+
+    await writeSnapshot({ uk: [{ id: 'a' }] });
+    await writeFile(process.env.OSIRIS_CCTV_SNAPSHOT!, '{"version":1,"regions":{"uk":[{"id"');
+    expect(await readSnapshot()).toBeNull();
+  });
+
+  it('rejects a catalogue written by a different format version', async () => {
+    await writeFile(process.env.OSIRIS_CCTV_SNAPSHOT!.replace(/nested[\\/]/, ''), '{}').catch(() => {});
+    await writeSnapshot({ uk: [{ id: 'a' }] });
+    const path = process.env.OSIRIS_CCTV_SNAPSHOT!;
+    await writeFile(path, JSON.stringify({ version: 99, builtAt: Date.now(), regions: { uk: [{ id: 'a' }] } }));
+    expect(await readSnapshot()).toBeNull();
+  });
+
+  it('serialises and compresses once, and the gzip matches the json', () => {
+    const body = { cameras: [{ id: 'a' }, { id: 'b' }], total: 2 };
+    const payload = buildPayload(body, 2, true);
+
+    expect(JSON.parse(payload.json.toString())).toEqual(body);
+    expect(JSON.parse(gunzipSync(payload.gzip).toString())).toEqual(body);
+    // Gzip's header costs more than it saves on a tiny body; the catalogue is
+    // ~8MB, so measure the claim at a size that resembles it.
+    const many = buildPayload({ cameras: Array.from({ length: 2000 }, (_, i) => ({ id: 'cam-' + i, source: 'DOT' })) }, 2000, true);
+    expect(many.gzip.length).toBeLessThan(many.json.length / 5);
+    expect(getPayload()).toBe(many); // the newest build is what callers get
+  });
+
+  it('records whether the catalogue was complete when it was built', () => {
+    expect(buildPayload({ cameras: [] }, 0, false).complete).toBe(false);
+    expect(buildPayload({ cameras: [] }, 0, true).complete).toBe(true);
+  });
+
+  it('changes its etag only when the catalogue changes', () => {
+    const first = buildPayload({ cameras: [{ id: 'a' }] }, 1, true).etag;
+    const same = buildPayload({ cameras: [{ id: 'a' }] }, 1, true).etag;
+    const different = buildPayload({ cameras: [{ id: 'b' }] }, 1, true).etag;
+
+    expect(same).toBe(first);
+    expect(different).not.toBe(first);
+  });
+});

--- a/src/lib/cctv-snapshot.ts
+++ b/src/lib/cctv-snapshot.ts
@@ -1,0 +1,94 @@
+import { gzipSync } from 'node:zlib';
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+/**
+ * OSIRIS — the camera catalogue, saved.
+ *
+ * Cameras were assembled live, per request, from 48 upstreams. That put every
+ * visitor behind the slowest provider of the moment: production served 23,240
+ * cameras in 13s with eleven regions permanently missing, and a single upstream
+ * that hung made everyone wait out the full budget.
+ *
+ * Where the cameras *are* changes on the order of weeks — the frames themselves
+ * are pulled live by the browser, straight from the source. So the catalogue is
+ * written to disk, restored at boot, and refreshed in the background. Requests
+ * never touch an upstream; they read something already built.
+ *
+ * The payload is serialised and gzipped once per rebuild, not per request. At
+ * ~7.8MB of JSON that is the difference between a response costing real CPU and
+ * one costing a buffer write.
+ */
+
+export type Camera = Record<string, unknown>;
+export type RegionCameras = Record<string, Camera[]>;
+
+const SNAPSHOT_VERSION = 1;
+
+/** Overridable so a test never writes into the real cache directory. */
+export const snapshotPath = () =>
+  process.env.OSIRIS_CCTV_SNAPSHOT || join(process.cwd(), '.cache', 'cctv-catalog.json');
+
+interface SnapshotFile {
+  version: number;
+  builtAt: number;
+  regions: RegionCameras;
+}
+
+/** Restore the catalogue written by an earlier run. */
+export async function readSnapshot(): Promise<SnapshotFile | null> {
+  // 'off' keeps tests off the filesystem entirely: real disk I/O cannot be
+  // flushed deterministically under fake timers, and these caches are module
+  // state that leaks between cases if a read lands late.
+  if (process.env.OSIRIS_CCTV_SNAPSHOT === 'off') return null;
+  try {
+    const raw = await readFile(snapshotPath(), 'utf8');
+    const parsed = JSON.parse(raw) as SnapshotFile;
+    if (parsed?.version !== SNAPSHOT_VERSION || !parsed.regions) return null;
+    return parsed;
+  } catch {
+    return null; // absent or unreadable: the catalogue simply rebuilds
+  }
+}
+
+/**
+ * Write via a temporary file and rename, so a crash mid-write cannot leave a
+ * half-written catalogue that the next boot would refuse to parse.
+ */
+export async function writeSnapshot(regions: RegionCameras): Promise<void> {
+  const path = snapshotPath();
+  const payload: SnapshotFile = { version: SNAPSHOT_VERSION, builtAt: Date.now(), regions };
+  await mkdir(dirname(path), { recursive: true });
+  const temporary = `${path}.${process.pid}.tmp`;
+  await writeFile(temporary, JSON.stringify(payload));
+  await rename(temporary, path);
+}
+
+export interface Payload {
+  json: Buffer;
+  gzip: Buffer;
+  etag: string;
+  total: number;
+  complete: boolean;
+  builtAt: number;
+}
+
+let payload: Payload | undefined;
+
+/** Serialise and compress once, then hand the same buffers to every caller. */
+export function buildPayload(body: unknown, total: number, complete: boolean): Payload {
+  const json = Buffer.from(JSON.stringify(body));
+  payload = {
+    json,
+    gzip: gzipSync(json, { level: 6 }),
+    etag: `W/"${createHash('sha1').update(json).digest('base64url')}"`,
+    total,
+    complete,
+    builtAt: Date.now(),
+  };
+  return payload;
+}
+
+export const getPayload = () => payload;
+export const clearPayload = () => { payload = undefined; };

--- a/src/lib/fetch-pool.test.ts
+++ b/src/lib/fetch-pool.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { createPool } from './fetch-pool';
+
+/** A task that resolves only when told to, so concurrency is observable. */
+function gate() {
+  let open!: (value?: unknown) => void;
+  let fail!: (reason: unknown) => void;
+  const promise = new Promise((resolve, reject) => { open = resolve; fail = reject; });
+  return { promise, open, fail };
+}
+
+describe('createPool', () => {
+  it('never runs more than the limit at once', async () => {
+    const { run } = createPool(4);
+    const gates = Array.from({ length: 20 }, gate);
+    let active = 0;
+    let peak = 0;
+    const tasks = gates.map(g => run(async () => {
+      peak = Math.max(peak, ++active);
+      await g.promise;
+      active--;
+    }));
+
+    await Promise.resolve();
+    expect(peak).toBe(4);
+
+    gates.forEach(g => g.open());
+    await Promise.all(tasks);
+    expect(peak).toBe(4);
+  });
+
+  it('starts queued work as slots free up, and runs everything', async () => {
+    const { run } = createPool(2);
+    const started: number[] = [];
+    const gates = Array.from({ length: 6 }, gate);
+    const tasks = gates.map((g, i) => run(async () => { started.push(i); await g.promise; return i; }));
+
+    expect(started).toEqual([0, 1]);
+    gates[0].open();
+    await tasks[0];
+    // The slot is freed in a finally chained after the resolve, so the next
+    // task starts a microtask later than this caller resumes.
+    await Promise.resolve();
+    expect(started).toEqual([0, 1, 2]);
+
+    gates.forEach(g => g.open());
+    expect(await Promise.all(tasks)).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  /* A stranded slot would shrink the pool to nothing over time, which is worse
+     than the storm it replaced: the catalogue would simply stop refreshing. */
+  it('frees its slot when a task rejects', async () => {
+    const { run } = createPool(1);
+    await expect(run(async () => { throw new Error('upstream down'); })).rejects.toThrow('upstream down');
+    expect(await run(async () => 'next one still runs')).toBe('next one still runs');
+  });
+
+  it('surfaces each result to its own caller', async () => {
+    const { run } = createPool(3);
+    const results = await Promise.all([1, 2, 3, 4, 5].map(n => run(async () => n * 2)));
+    expect(results).toEqual([2, 4, 6, 8, 10]);
+  });
+});

--- a/src/lib/fetch-pool.ts
+++ b/src/lib/fetch-pool.ts
@@ -1,0 +1,47 @@
+/**
+ * OSIRIS — bounded work pool.
+ *
+ * The camera catalogue fans out to 48 regions, several of which fan out again
+ * to their own sub-sources, so an uncapped `region=all` opened somewhere north
+ * of sixty simultaneous TLS connections. Measured against production: every
+ * upstream that failed in that storm with a 10s connect timeout — az511,
+ * fl511, 511ga, drivenc, nvroads, 511la, MDOT, TripCheck, NZTA, 511in —
+ * answered in 0.07-1.5s when asked on its own. The upstreams were never the
+ * problem; the fan-out was starving itself, and a failure then cached an empty
+ * region for a minute, which is why the same eleven regions were missing from
+ * every response.
+ *
+ * Queued work still runs, just in an orderly line.
+ */
+export function createPool(limit: number) {
+  if (limit < 1) throw new Error('Pool limit must be at least 1');
+  let active = 0;
+  const waiting: (() => void)[] = [];
+
+  const release = () => {
+    active--;
+    waiting.shift()?.();
+  };
+
+  function run<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const start = () => {
+        active++;
+        // `finally` frees the slot on both paths, so one rejection cannot
+        // strand the pool with a permanently occupied slot. Callers are still
+        // responsible for bounding a task that never settles at all.
+        task().then(resolve, reject).finally(release);
+      };
+      if (active < limit) start();
+      else waiting.push(start);
+    });
+  }
+
+  /** Test seam — abandons queued work so one case cannot wedge the next. */
+  function reset() {
+    waiting.length = 0;
+    active = 0;
+  }
+
+  return { run, reset };
+}

--- a/src/lib/sourceCache.ts
+++ b/src/lib/sourceCache.ts
@@ -92,6 +92,40 @@ export function cachedSource<T>(
   };
 }
 
+/**
+ * Read a source without triggering a fetch.
+ *
+ * The catalogue route uses this to answer from what it already has and to
+ * queue only the regions it is actually missing — otherwise every request
+ * enqueues all 48 regions into the pool, and a warm catalogue still pays for a
+ * queue it does not need.
+ */
+export function peekSource<T>(key: string, allowStale = false): T[] | undefined {
+  const entry = store.get(key) as Entry<T> | undefined;
+  if (!entry || entry.data.length === 0) return undefined;
+  if (allowStale || Date.now() < entry.expiresAt) return entry.data;
+  return undefined;
+}
+
+/** Is what peekSource would return past its TTL? */
+export function isStale(key: string): boolean {
+  const entry = store.get(key);
+  return !entry || Date.now() >= entry.expiresAt;
+}
+
+/**
+ * Install data the process did not fetch — a catalogue restored from disk.
+ * Serving that at boot is the difference between a map that is populated on the
+ * first request and one that waits on forty-eight upstreams to answer.
+ */
+export function seedSource<T>(key: string, data: T[], ttlMs: number = DEFAULT_TTL_MS): void {
+  if (!data.length) return;
+  const entry = store.get(key);
+  if (entry?.inflight) return; // a live fetch already supersedes the snapshot
+  store.set(key, { data, expiresAt: Date.now() + ttlMs, inflight: null } as Entry<unknown>);
+  evictIfNeeded();
+}
+
 /** Test seam — drops all cached indexes. */
 export function clearSourceCache(): void {
   store.clear();


### PR DESCRIPTION
Three commits: the camera catalogue, the stats endpoint, and a MERCH link.

## The camera catalogue

Live now, measured twice, identical both times: **23,240 cameras in 13.0s with the same eleven regions missing from every response** — `uk, us-west, us-central, canada, europe, turkey, australia, northcarolina, eastasia, seasia, westasia`. California, Washington, TfL London and all of Canada, permanently absent.

The fan-out was starving itself. Each request dispatched all 48 regions at once, several of which fan out again to sub-sources, so 60+ simultaneous connections went out and upstreams started failing on connect at exactly 10s. Each of those "dead" providers, asked on its own:

| host | in the fan-out | alone |
|---|---|---|
| az511.gov | timeout 10s | 0.37s |
| fl511.com | timeout 10s | 0.51s |
| 511ga.org | timeout 10s | 0.57s |
| mdotjboss.state.mi.us | timeout 10s | 0.30s |
| trafficnz.info | timeout 10s | 1.47s |

All ten tested were healthy. A failure then cached that region empty for a minute, the client gave up after three attempts, and partial responses were `no-store` — so every visitor repeated the storm.

**Now:** regions go through a pool of four; the catalogue is written to disk, restored at boot and refreshed behind the response. Requests never touch an upstream. Camera *indexes* change over weeks — the frames themselves are pulled live by the browser — so serving a saved index is the right trade. The whole-world payload is serialised and gzipped once per rebuild, with an ETag.

| | before | after |
|---|---|---|
| first request after a restart | 12s, partial | **159ms, all 35,347** |
| cameras on screen | 12.8s | **~0.5s** |
| transferred | 7.79MB | **1.07MB** |
| returning visitor | full re-download | **304, 0 bytes** |

## /api/stats

Six numbers, fetched by pulling six of this app's own feeds over HTTP and parsing them only to count. The server logs say why the `revalidate` hints never helped:

```
Failed to set Next.js data cache for /api/satellites, items over 2MB can not be cached (3657506 bytes)
... /api/flights (4887947 bytes)
... /api/cctv (10111563 bytes)
```

~18.7MB refetched and reparsed per page load, and Cloudflare caches no `/api` response either. In production it takes **15-19s to return ~100 bytes**, once per arriving visitor — and the docs advertise it as the endpoint to poll. Now one computation per TTL serves everyone, with a stale snapshot answering instantly while a fresh one is computed behind it.

## Defects found while building this

Each is covered by a test that fails when the fix is reverted:

- **A hung upstream held a pool slot forever.** Four of those would have stopped the catalogue refreshing entirely — worse than the storm it replaced.
- **One upstream that hangs made everyone wait.** `us-central` burns its full budget every time, and the collector waited on it even with 35,000 cameras already in memory. A warm catalogue now waits 2s for stragglers, not 12s.
- **Saves could go backwards.** A boot starting empty would write its first handful of cameras over a good 35,000-camera file. Saves only move forwards now, with the restore setting the high-water mark.
- **The restore delayed the response that triggered it.** Kicking off a 48-region refresh inline meant a payload already built in memory took 13.8s to flush. The refresh now waits for the response to leave.
- **A failed stats computation was cached like real data.** Found running it against a real server whose first computation raced startup.

## Reviewer notes

- **A boot-hook warm-up was tried and removed.** Next loads `instrumentation.ts` in its own module graph, so the catalogue it warmed populated a different copy of these caches while every request still started from nothing — and it duplicated every upstream fetch. The route owns restore and refresh.
- **`us-central` and `turkey` are genuinely broken upstream** (2 of 48). They delay nobody now but stay empty until those providers recover.
- **Production's `/api/stats` has always returned all zeros** — its self-fetches evidently fail there. Pre-existing and untouched; worth chasing separately.
- **The catalogue writes to `.cache/cctv-catalog.json`** (gitignored). That path must be writable in the container, and it is per-instance — several app instances each keep their own.
- **Local upstream reachability is not production's**, so absolute numbers will differ there. The mechanism is what transfers.
- Compression is off for every API response despite Next's `compress: true` default; production is unaffected because Cloudflare compresses. Not addressed here beyond the catalogue serving its own gzip.

697 tests pass, types clean, lint unchanged from baseline.

**First check after deploying:** `/api/cctv?region=all` should answer in well under a second with `pendingRegions` near empty, and return `content-encoding: gzip` with an `ETag`.

Generated with [SIMPLIFAI](https://Simplifai-1.com)
